### PR TITLE
trusted-firmware-m: scripts: add required `bytes` cast when signing

### DIFF
--- a/trusted-firmware-m/bl2/ext/mcuboot/scripts/imgtool_lib/keys.py
+++ b/trusted-firmware-m/bl2/ext/mcuboot/scripts/imgtool_lib/keys.py
@@ -106,7 +106,7 @@ class RSAutil():
     def sign(self, payload):
         if sign_rsa_pss:
             signature = self.key.sign(
-                data=payload,
+                data=bytes(payload),
                 padding=PSS(
                     mgf=MGF1(SHA256()),
                     salt_length=32
@@ -115,7 +115,7 @@ class RSAutil():
             )
         else:
             signature = self.key.sign(
-                data=payload,
+                data=bytes(payload),
                 padding=PKCS1v15(),
                 algorithm=SHA256()
             )


### PR DESCRIPTION
This commit adds an explicit cast to `bytes` for the payload
when signing data with imgtool. On some systems, the data may be
provided as a `ByteArray`, which will cause the signing function
to fail since the underlying library expects `bytes`.

Signed-off-by: Kevin Townsend <kevin.townsend@linaro.org>