### PR TITLE
cmake: Fixes to CMake to ensure Zephyr can build TF-M using ninja

### DIFF
--- a/trusted-firmware-m/BuildMbedCrypto.cmake
+++ b/trusted-firmware-m/BuildMbedCrypto.cmake
@@ -109,6 +109,7 @@ externalproject_add(${MBEDCRYPTO_TARGET_NAME}
 #this target installation happens only when a clean mbed-crypto build is executed.
 add_custom_target(${MBEDCRYPTO_TARGET_NAME}_install
     COMMAND ${CMAKE_COMMAND} --build ${MBEDCRYPTO_BINARY_DIR}  -- install
+    BYPRODUCTS ${MBEDCRYPTO_INSTALL_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX_C}mbedcrypto${CMAKE_STATIC_LIBRARY_SUFFIX_C}
     WORKING_DIRECTORY ${MBEDCRYPTO_BINARY_DIR}
     COMMENT "Installing Mbed Crypto to ${MBEDCRYPTO_INSTALL_DIR}"
     VERBATIM)

--- a/trusted-firmware-m/cmake/Common/CompilerGNUARMCommon.cmake
+++ b/trusted-firmware-m/cmake/Common/CompilerGNUARMCommon.cmake
@@ -146,6 +146,7 @@ function(compiler_set_cmse_output TARGET FILE_PATH)
 	set_property(TARGET ${TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -Wl,--cmse-implib,--out-implib=${FILE_PATH}")
 	#Tell cmake cmse output is a generated object file.
 	SET_SOURCE_FILES_PROPERTIES("${FILE_PATH}" PROPERTIES EXTERNAL_OBJECT true GENERATED true)
+	add_custom_command(TARGET ${TARGET} POST_BUILD COMMAND ${CMAKE_COMMAND} -E echo "" BYPRODUCTS ${FILE_PATH})
 	#Tell cmake cmse output shall be removed by clean target.
 	get_directory_property(_ADDITIONAL_MAKE_CLEAN_FILES DIRECTORY "./" ADDITIONAL_MAKE_CLEAN_FILES)
 	set_directory_properties(PROPERTY ADDITIONAL_MAKE_CLEAN_FILES "${_ADDITIONAL_MAKE_CLEAN_FILES} ${FILE_PATH}")

--- a/trusted-firmware-m/cmake/Compiler/GNUARM.cmake
+++ b/trusted-firmware-m/cmake/Compiler/GNUARM.cmake
@@ -56,6 +56,6 @@ macro(__compiler_gnuarm lang)
     set(CMAKE_${lang}_CREATE_PREPROCESSED_SOURCE "<CMAKE_${lang}_COMPILER> <DEFINES> <INCLUDES> <FLAGS> -E <SOURCE> > <PREPROCESSED_SOURCE>")
     set(CMAKE_${lang}_CREATE_ASSEMBLY_SOURCE "<CMAKE_${lang}_COMPILER> <DEFINES> <INCLUDES> <FLAGS> -S <SOURCE> -o <ASSEMBLY_SOURCE>")
 
-    set(CMAKE_DEPFILE_FLAGS_${lang} "--depend=<DEPFILE> --depend_single_line --no_depend_system_headers")
+    set(CMAKE_DEPFILE_FLAGS_${lang} "-MD -MT <OBJECT> -MF <DEPFILE>")
   endif()
 endmacro()


### PR DESCRIPTION
This PR fixes dependency issues when reviewing https://github.com/zephyrproject-rtos/zephyr/pull/19985

---------
This commit fixes the following CMake issues in TF-M build system:
- armgcc depfile corrected (was using clang flags)
- mbedcrypto byproduct added
- s_veneers.o byproduct added

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>