### PR TITLE
trusted-firmware-m: scripts: add python requirements.txt

### DIFF
--- a/trusted-firmware-m/bl2/ext/mcuboot/scripts/requirements.txt
+++ b/trusted-firmware-m/bl2/ext/mcuboot/scripts/requirements.txt
@@ -1,0 +1,4 @@
+cryptography
+pyasn1
+pyyaml
+cbor>=1.0.0


### PR DESCRIPTION
This commit adds a requirements.txt file with the python
requirements for TF-M when signing images, etc.

Signed-off-by: Kevin Townsend <kevin.townsend@linaro.org>