### PR TITLE
stm32l5: flash: modify script to flash zephyr

### DIFF
--- a/trusted-firmware-m/platform/ext/target/stm/stm32l5xx/boards/scripts/TFM_UPDATE.sh
+++ b/trusted-firmware-m/platform/ext/target/stm/stm32l5xx/boards/scripts/TFM_UPDATE.sh
@@ -34,12 +34,12 @@ nvcounter=
 boot=0x0c001000
 unused=
 
-$stm32programmercli $connect -d $SCRIPTPATH/../tfm_s_signed.bin $slot0 -v
+$stm32programmercli $connect -d $SCRIPTPATH/../../tfm_s_signed.bin $slot0 -v
 echo "TFM_Appli Secure Written"
 echo "Write TFM_Appli NonSecure"
-$stm32programmercli $connect -d $SCRIPTPATH/../tfm_ns_signed.bin $slot1 -v
+$stm32programmercli $connect -d $SCRIPTPATH/../../zephyr_ns_signed.bin $slot1 -v
 echo "TFM_Appli NonSecure Written"
 echo "Write TFM_SBSFU_Boot"
-$stm32programmercli $connect -d $SCRIPTPATH/../bl2/ext/mcuboot/mcuboot.bin $boot -v
+$stm32programmercli $connect -d $SCRIPTPATH/../../mcuboot.bin $boot -v
 echo "TFM_SBSFU_Boot Written"
 echo "TFM_UPDATE Done"


### PR DESCRIPTION
In the current implementation for STM32L5 MCUs, the binaries path and filenames in the script TFM_update.sh are hardcoded.
This is a minimal modification to be able to flash in zephyr, as the scripts are likely to change after the integration of the new build system.