### PR TITLE
Run PSA tests via a Zephyr NS app.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,9 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-# Adds trusted-firmware-m as an external project, and provides output values
-# that are required to link against the secure TF-M binary.
+# Adds trusted-firmware-m as an external project.
+# Also creates a target called 'tfm_api'
+# which can be linked into the app.
 #
 # When called from a Zephyr module, the following input values can be provided
 # to configure the TF-M build:
@@ -20,12 +21,6 @@ cmake_minimum_required(VERSION 3.13.1)
 # REGRESSION: Boolean if TF-M build includes building the TF-M regression tests
 # BL2: Boolean if build uses MCUboot.
 #
-# The following output values can also be used:
-#
-# OUT_VENEERS_FILE: The path and filename of the veneer library to link against,
-#                   which identifies where the veneer functions are in memory.
-#                   Should be added via "target_link_libraries"
-#
 # Example usage:
 #
 # trusted_firmware_build(BINARY_DIR ${CMAKE_BINARY_DIR}/tfm
@@ -34,10 +29,10 @@ cmake_minimum_required(VERSION 3.13.1)
 #                        IPC
 #                        ISOLATION_LEVEL 2
 #                        REGRESSION
-#                        BL2 True
+#                        BL2 True)
 function(trusted_firmware_build)
   set(options IPC REGRESSION)
-  set(oneValueArgs BINARY_DIR BOARD OUT_INCLUDE_PATH BL2 ISOLATION_LEVEL CMAKE_BUILD_TYPE)
+  set(oneValueArgs BINARY_DIR BOARD BL2 ISOLATION_LEVEL CMAKE_BUILD_TYPE)
   cmake_parse_arguments(TFM "${options}" "${oneValueArgs}" "" ${ARGN})
 
   if(DEFINED TFM_BL2)
@@ -65,10 +60,13 @@ function(trusted_firmware_build)
   endif()
 
   set(VENEERS_FILE ${TFM_BINARY_DIR}/secure_fw/s_veneers.o)
-  set(${TFM_OUT_VENEERS_FILE} ${VENEERS_FILE} PARENT_SCOPE)
-  set(${TFM_OUT_INCLUDE_PATH} ${TFM_BINARY_DIR}/install/export/tfm/include PARENT_SCOPE)
-
   set(PSA_API_NS_PATH ${TFM_BINARY_DIR}/interface/libpsa_api_ns.a)
+
+  set(BUILD_BYPRODUCTS
+    ${VENEERS_FILE}
+    ${PSA_API_NS_PATH}
+    ${BL2_HEX_FILE}
+    )
 
   # Get the toolchain variant
   # TODO: Add support for cross-compile toolchain variant
@@ -105,10 +103,9 @@ function(trusted_firmware_build)
                -DTFM_TOOLCHAIN_PREFIX=${TFM_TOOLCHAIN_PREFIX}
     BUILD_ALWAYS True
     USES_TERMINAL_BUILD True
-    BUILD_BYPRODUCTS ${VENEERS_FILE} ${PSA_API_NS_PATH}
+    BUILD_BYPRODUCTS ${BUILD_BYPRODUCTS}
   )
 
-  # IPC mode source dependencies
   add_library(tfm_api STATIC IMPORTED)
   set_target_properties(tfm_api PROPERTIES
     IMPORTED_LOCATION ${PSA_API_NS_PATH}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,12 @@ function(trusted_firmware_build)
   set(VENEERS_FILE ${TFM_BINARY_DIR}/secure_fw/s_veneers.o)
   set(PSA_API_NS_PATH ${TFM_BINARY_DIR}/interface/libpsa_api_ns.a)
 
+  set(BL2_HEX_FILE ${CMAKE_BINARY_DIR}/tfm/bin/bl2.hex)
+  set_property(GLOBAL PROPERTY
+    bl2_PM_HEX_FILE
+    ${BL2_HEX_FILE}
+    )
+
   set(BUILD_BYPRODUCTS
     ${VENEERS_FILE}
     ${PSA_API_NS_PATH}
@@ -86,7 +92,7 @@ function(trusted_firmware_build)
   endif()
 
   include(ExternalProject)
-  
+
   ExternalProject_Add(
     tfm
     SOURCE_DIR ${ZEPHYR_TFM_MODULE_DIR}/trusted-firmware-m
@@ -106,23 +112,38 @@ function(trusted_firmware_build)
     BUILD_BYPRODUCTS ${BUILD_BYPRODUCTS}
   )
 
-  add_library(tfm_api STATIC IMPORTED)
-  set_target_properties(tfm_api PROPERTIES
+  add_library(tfm_api
+    ${ZEPHYR_TFM_MODULE_DIR}/tf-m-tests/app/os_wrapper_cmsis_rtos_v2.c
+  )
+
+  add_library(interface_lib STATIC IMPORTED)
+  set_target_properties(interface_lib PROPERTIES
     IMPORTED_LOCATION ${PSA_API_NS_PATH}
   )
+  target_link_libraries(interface_lib INTERFACE tfm_api)
 
   add_library(veneer_lib STATIC IMPORTED)
   set_target_properties(veneer_lib PROPERTIES
     IMPORTED_LOCATION ${VENEERS_FILE}
   )
 
-  add_dependencies(tfm_api tfm)
   file(MAKE_DIRECTORY ${TFM_BINARY_DIR}/generated/interface/include)
-  target_include_directories(tfm_api INTERFACE
+
+  target_include_directories(tfm_api
+    PRIVATE
+    ${ZEPHYR_TFM_MODULE_DIR}/tf-m-tests/CMSIS/RTOS2/Include
+    PUBLIC
     ${ZEPHYR_TFM_MODULE_DIR}/trusted-firmware-m/interface/include
+    INTERFACE
     ${TFM_BINARY_DIR}/generated/interface/include
   )
+  add_dependencies(tfm_api tfm)
 
-  target_link_libraries(tfm_api INTERFACE zephyr_interface veneer_lib)
+  target_link_libraries(tfm_api
+    PUBLIC
+    zephyr_interface
+    interface_lib
+    veneer_lib
+  )
 
 endfunction()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ cmake_minimum_required(VERSION 3.13.1)
 # BINARY_DIR: The location where the build outputs will be written
 # BOARD: The string identifying the board target for TF-M (AN521, etc.)
 # CMAKE_BUILD_TYPE: The TF-M build type to use, (Debug, Release, etc.)
+# PSA_TEST_SUITE: A PSA test suite to add, choose one of
+#                 STORAGE/CRYPTO/INITIAL_ATTESTATION
 # IPC: Build TFM IPC library. This library allows a non-secure application to
 #      interface to secure domain using IPC.
 # ISOLATION_LEVEL: The TF-M isolation level to use
@@ -32,7 +34,7 @@ cmake_minimum_required(VERSION 3.13.1)
 #                        BL2 True)
 function(trusted_firmware_build)
   set(options IPC REGRESSION)
-  set(oneValueArgs BINARY_DIR BOARD BL2 ISOLATION_LEVEL CMAKE_BUILD_TYPE)
+  set(oneValueArgs BINARY_DIR BOARD BL2 ISOLATION_LEVEL CMAKE_BUILD_TYPE PSA_TEST_SUITE)
   cmake_parse_arguments(TFM "${options}" "${oneValueArgs}" "" ${ARGN})
 
   if(DEFINED TFM_BL2)
@@ -59,9 +61,17 @@ function(trusted_firmware_build)
     set(TFM_CMAKE_BUILD_TYPE_ARG -DCMAKE_BUILD_TYPE=RelWithDebInfo)
   endif()
 
+  if(DEFINED TFM_PSA_TEST_SUITE)
+    set(PSA_TEST_ARG -DTEST_PSA_API=${TFM_PSA_TEST_SUITE})
+  endif()
+
   set(VENEERS_FILE ${TFM_BINARY_DIR}/secure_fw/s_veneers.o)
   set(PSA_API_NS_PATH ${TFM_BINARY_DIR}/interface/libpsa_api_ns.a)
   set(PLATFORM_NS_PATH ${TFM_BINARY_DIR}/platform/libplatform_ns.a)
+
+  if (TFM_PSA_TEST_SUITE)
+    set(PSA_TESTS_NS_PATH ${TFM_BINARY_DIR}/app/libtfm_ns_psa_test.a)
+  endif()
 
   set(BL2_HEX_FILE ${CMAKE_BINARY_DIR}/tfm/bin/bl2.hex)
   set_property(GLOBAL PROPERTY
@@ -72,6 +82,7 @@ function(trusted_firmware_build)
   set(BUILD_BYPRODUCTS
     ${VENEERS_FILE}
     ${PSA_API_NS_PATH}
+    ${PSA_TESTS_NS_PATH}
     ${PLATFORM_NS_PATH}
     ${BL2_HEX_FILE}
     )
@@ -106,6 +117,7 @@ function(trusted_firmware_build)
                ${TFM_IPC_ARG}
                ${TFM_ISOLATION_LEVEL_ARG}
                ${TFM_REGRESSION_ARG}
+               ${PSA_TEST_ARG}
                -DTFM_TEST_REPO_PATH=${ZEPHYR_TFM_MODULE_DIR}/tf-m-tests
                -DTFM_TOOLCHAIN_PATH=${TFM_TOOLCHAIN_PATH}
                -DTFM_TOOLCHAIN_PREFIX=${TFM_TOOLCHAIN_PREFIX}
@@ -116,7 +128,16 @@ function(trusted_firmware_build)
 
   add_library(tfm_api
     ${ZEPHYR_TFM_MODULE_DIR}/tf-m-tests/app/os_wrapper_cmsis_rtos_v2.c
+    ${ZEPHYR_TFM_MODULE_DIR}/src/zephyr_tfm_log.c
   )
+
+  if (TFM_PSA_TEST_SUITE)
+    add_library(psa_test_lib STATIC IMPORTED)
+    set_target_properties(psa_test_lib PROPERTIES
+      IMPORTED_LOCATION ${PSA_TESTS_NS_PATH}
+    )
+    target_link_libraries(psa_test_lib INTERFACE tfm_api)
+  endif()
 
   add_library(interface_lib STATIC IMPORTED)
   set_target_properties(interface_lib PROPERTIES
@@ -150,6 +171,7 @@ function(trusted_firmware_build)
   target_link_libraries(tfm_api
     PUBLIC
     zephyr_interface
+    $<$<BOOL:${TFM_PSA_TEST_SUITE}>:psa_test_lib>
     interface_lib
     platform_lib
     veneer_lib
@@ -169,6 +191,13 @@ if (CONFIG_TFM)
   else()
     set(TFM_BL2_ARG BL2 False)
   endif()
+  if (CONFIG_TFM_PSA_TEST_CRYPTO)
+    set(TFM_PSA_TEST_ARG PSA_TEST_SUITE CRYPTO)
+  elseif (CONFIG_TFM_PSA_TEST_STORAGE)
+    set(TFM_PSA_TEST_ARG PSA_TEST_SUITE STORAGE)
+  elseif (CONFIG_TFM_PSA_TEST_INITIAL_ATTESTATION)
+    set(TFM_PSA_TEST_ARG PSA_TEST_SUITE INITIAL_ATTESTATION)
+  endif()
 
   message("CONFIG_TFM_BOARD: ${CONFIG_TFM_BOARD}")
   trusted_firmware_build(
@@ -178,6 +207,7 @@ if (CONFIG_TFM)
     ${TFM_BL2_ARG}
     ${TFM_IPC_ARG}
     ${TFM_REGRESSION_ARG}
+    ${TFM_PSA_TEST_ARG}
   )
 
   zephyr_link_libraries(tfm_api)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,3 +147,29 @@ function(trusted_firmware_build)
   )
 
 endfunction()
+
+if (CONFIG_TFM)
+  if (CONFIG_TFM_IPC)
+    set(TFM_IPC_ARG IPC)
+  endif()
+  if (CONFIG_TFM_REGRESSION)
+    set(TFM_REGRESSION_ARG REGRESSION)
+  endif()
+  if (CONFIG_TFM_BL2)
+    set(TFM_BL2_ARG BL2 True)
+  else()
+    set(TFM_BL2_ARG BL2 False)
+  endif()
+
+  message("CONFIG_TFM_BOARD: ${CONFIG_TFM_BOARD}")
+  trusted_firmware_build(
+    BINARY_DIR ${CMAKE_BINARY_DIR}/tfm
+    BOARD ${CONFIG_TFM_BOARD}
+    ISOLATION_LEVEL ${CONFIG_TFM_ISOLATION_LEVEL}
+    ${TFM_BL2_ARG}
+    ${TFM_IPC_ARG}
+    ${TFM_REGRESSION_ARG}
+  )
+
+  zephyr_link_libraries(tfm_api)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ function(trusted_firmware_build)
 
   set(VENEERS_FILE ${TFM_BINARY_DIR}/secure_fw/s_veneers.o)
   set(PSA_API_NS_PATH ${TFM_BINARY_DIR}/interface/libpsa_api_ns.a)
+  set(PLATFORM_NS_PATH ${TFM_BINARY_DIR}/platform/libplatform_ns.a)
 
   set(BL2_HEX_FILE ${CMAKE_BINARY_DIR}/tfm/bin/bl2.hex)
   set_property(GLOBAL PROPERTY
@@ -71,6 +72,7 @@ function(trusted_firmware_build)
   set(BUILD_BYPRODUCTS
     ${VENEERS_FILE}
     ${PSA_API_NS_PATH}
+    ${PLATFORM_NS_PATH}
     ${BL2_HEX_FILE}
     )
 
@@ -122,6 +124,12 @@ function(trusted_firmware_build)
   )
   target_link_libraries(interface_lib INTERFACE tfm_api)
 
+  add_library(platform_lib STATIC IMPORTED)
+  set_target_properties(platform_lib PROPERTIES
+    IMPORTED_LOCATION ${PLATFORM_NS_PATH}
+  )
+  target_link_libraries(platform_lib INTERFACE tfm_api)
+
   add_library(veneer_lib STATIC IMPORTED)
   set_target_properties(veneer_lib PROPERTIES
     IMPORTED_LOCATION ${VENEERS_FILE}
@@ -143,6 +151,7 @@ function(trusted_firmware_build)
     PUBLIC
     zephyr_interface
     interface_lib
+    platform_lib
     veneer_lib
   )
 

--- a/Kconfig
+++ b/Kconfig
@@ -13,4 +13,11 @@ config TFM_REGRESSION
 config TFM_BL2
 	bool "Build with MCUboot"
 	default y
+
+config TFM_PSA_TEST_CRYPTO
+	bool "Crypto tests"
+config TFM_PSA_TEST_STORAGE
+	bool "Storage tests"
+config TFM_PSA_TEST_INITIAL_ATTESTATION
+	bool "Initial attestation tests"
 endif

--- a/Kconfig
+++ b/Kconfig
@@ -1,0 +1,16 @@
+menuconfig TFM
+	bool "Build with TFM"
+
+if TFM
+config TFM_BOARD
+	string
+	default "nordic_nrf/nrf9160dk_nrf9160" if BOARD_NRF9160DK_NRF9160NS
+	default "nordic_nrf/nrf5340pdk_nrf5340_cpuapp" if BOARD_NRF5340PDK_NRF5340_CPUAPPNS
+config TFM_IPC
+	bool "IPC"
+config TFM_REGRESSION
+	bool "Regression tests"
+config TFM_BL2
+	bool "Build with MCUboot"
+	default y
+endif

--- a/src/zephyr_tfm_log.c
+++ b/src/zephyr_tfm_log.c
@@ -1,0 +1,13 @@
+
+#include <sys/printk.h>
+
+int tfm_log_printf(const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	vprintk(fmt, ap);
+	va_end(ap);
+
+	return 0;
+}

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,2 +1,3 @@
 build:
   cmake: .
+  kconfig: Kconfig


### PR DESCRIPTION
Link a lib built by TFM.
This requires the changes from https://review.trustedfirmware.org/c/TF-M/tf-m-tests/+/6895

Based on #20 and #21 