### PR TITLE
CMakeList.txt: disable TEST_NS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ function(trusted_firmware_build)
   endif()
 
   if(DEFINED TFM_REGRESSION)
-    set(TFM_REGRESSION_ARG -DTEST_S=ON -DTEST_NS=ON)
+    set(TFM_REGRESSION_ARG -DTEST_S=ON)
   endif()
 
   if(DEFINED TFM_CMAKE_BUILD_TYPE)


### PR DESCRIPTION
Removes TEST_NS, eqivalent to -DTEST_NS=OFF set as default. This
setting affects tfm_ns.bin image which is not used in Zephyr.
TEST_NS adds regression tests to TFM's non-secure image, does not
affect independent non-secure applications.

Signed-off-by: Andrei Gansari <andrei.gansari@nxp.com>