### PR TITLE
trusted-firmware-m: nrf5340: Fix UART pins

### DIFF
--- a/trusted-firmware-m/platform/ext/target/nordic_nrf/nrf5340dk_nrf5340_cpuapp/RTE_Device.h
+++ b/trusted-firmware-m/platform/ext/target/nordic_nrf/nrf5340dk_nrf5340_cpuapp/RTE_Device.h
@@ -40,13 +40,13 @@
 #define   RTE_USART1                    1
 //   <h> Pin Selection (0xFFFFFFFF means Disconnected)
 //     <o> TXD
-#define   RTE_USART1_TXD_PIN            25
+#define   RTE_USART1_TXD_PIN            33
 //     <o> RXD
-#define   RTE_USART1_RXD_PIN            26
+#define   RTE_USART1_RXD_PIN            32
 //     <o> RTS
-#define   RTE_USART1_RTS_PIN            0xFFFFFFFF
+#define   RTE_USART1_RTS_PIN            11
 //     <o> CTS
-#define   RTE_USART1_CTS_PIN            0xFFFFFFFF
+#define   RTE_USART1_CTS_PIN            10
 //   </h> Pin Configuration
 // </e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART1]
 


### PR DESCRIPTION
Fix UART1 (secure) pins for nrf5340dk_nrf5340_cpuapp which are different
from the pdk's pins.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>

Upstream PR: https://review.trustedfirmware.org/c/TF-M/trusted-firmware-m/+/7177