### PR TITLE
CMakeLists.txt: fix incorrect check of 'OPTION' args

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ function(trusted_firmware_build)
   endif()
   set(TFM_BL2_ARG "-DBL2=${TFM_BL2}")
 
-  if(DEFINED TFM_IPC)
+  if(TFM_IPC)
     set(TFM_IPC_ARG -DTFM_PSA_API=ON)
     # PSA API awareness for the Non-Secure application
     target_compile_definitions(app PRIVATE "TFM_PSA_API")
@@ -49,7 +49,7 @@ function(trusted_firmware_build)
     set(TFM_ISOLATION_LEVEL_ARG -DTFM_ISOLATION_LEVEL=${TFM_ISOLATION_LEVEL})
   endif()
 
-  if(DEFINED TFM_REGRESSION)
+  if(TFM_REGRESSION)
     set(TFM_REGRESSION_ARG -DTEST_S=ON)
   endif()
 


### PR DESCRIPTION
'IPC' and 'REGRESSION' are passed to the <option>
argument of cmake_parse_arguments, hence they are always defined.

Use 'if' directly instead of 'if DENIFED' to check if these
options are set or not.

Ref: NCSDK-7702

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>