### PR TITLE
CMakeLists.txt: Add support for running PSA tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@
 # BINARY_DIR: The location where the build outputs will be written
 # BOARD: The string identifying the board target for TF-M (AN521, etc.)
 # CMAKE_BUILD_TYPE: The TF-M build type to use, (Debug, Release, etc.)
+# PSA_TEST_SUITE: A PSA test suite to add, choose one of
+#                 STORAGE/CRYPTO/INITIAL_ATTESTATION
 # IPC: Build TFM IPC library. This library allows a non-secure application to
 #      interface to secure domain using IPC.
 # ISOLATION_LEVEL: The TF-M isolation level to use
@@ -31,7 +33,7 @@
 #                        BUILD_PROFILE profile_small)
 function(trusted_firmware_build)
   set(options IPC REGRESSION)
-  set(oneValueArgs BINARY_DIR BOARD BL2 ISOLATION_LEVEL CMAKE_BUILD_TYPE BUILD_PROFILE)
+  set(oneValueArgs BINARY_DIR BOARD BL2 ISOLATION_LEVEL CMAKE_BUILD_TYPE BUILD_PROFILE PSA_TEST_SUITE)
   cmake_parse_arguments(TFM "${options}" "${oneValueArgs}" "" ${ARGN})
 
   if(NOT DEFINED TFM_BL2)
@@ -49,7 +51,7 @@ function(trusted_firmware_build)
     set(TFM_ISOLATION_LEVEL_ARG -DTFM_ISOLATION_LEVEL=${TFM_ISOLATION_LEVEL})
   endif()
 
-  if(DEFINED TFM_REGRESSION)
+  if(TFM_REGRESSION)
     set(TFM_REGRESSION_ARG -DTEST_S=ON)
   endif()
 
@@ -63,10 +65,21 @@ function(trusted_firmware_build)
     set(TFM_PROFILE_ARG -DTFM_PROFILE=${TFM_BUILD_PROFILE})
   endif()
 
+  if(DEFINED TFM_PSA_TEST_SUITE)
+    set(PSA_TEST_ARG -DTEST_PSA_API=${TFM_PSA_TEST_SUITE})
+  endif()
 
   set(VENEERS_FILE ${TFM_BINARY_DIR}/secure_fw/s_veneers.o)
   set(PSA_API_NS_PATH ${TFM_BINARY_DIR}/interface/libpsa_api_ns.a)
   set(TFM_GENERATED_INCLUDES ${TFM_BINARY_DIR}/generated/interface/include)
+  set(PLATFORM_NS_FILE ${TFM_BINARY_DIR}/platform/libplatform_ns.a)
+
+  if (TFM_PSA_TEST_SUITE)
+    set(PSA_TEST_VAL_FILE ${TFM_BINARY_DIR}/app/psa_api_tests/val/val_nspe.a)
+    set(PSA_TEST_PAL_FILE ${TFM_BINARY_DIR}/app/psa_api_tests/platform/pal_nspe.a)
+    string(TOLOWER ${TFM_PSA_TEST_SUITE} COMBINE_DIR)
+    set(PSA_TEST_COMBINE_FILE ${TFM_BINARY_DIR}/app/psa_api_tests/dev_apis/${COMBINE_DIR}/test_combine.a)
+  endif()
 
   if(TFM_BL2)
     set(BL2_BIN_FILE ${TFM_BINARY_DIR}/bin/bl2.bin)
@@ -84,6 +97,10 @@ function(trusted_firmware_build)
     ${VENEERS_FILE}
     ${PSA_API_NS_PATH}
     ${TFM_GENERATED_INCLUDES}/psa_manifest/sid.h
+    ${PSA_TEST_VAL_FILE}
+    ${PSA_TEST_PAL_FILE}
+    ${PSA_TEST_COMBINE_FILE}
+    ${PLATFORM_NS_FILE}
     ${BL2_BIN_FILE}
     ${BL2_HEX_FILE}
     ${TFM_S_BIN_FILE}
@@ -125,8 +142,10 @@ function(trusted_firmware_build)
                ${TFM_ISOLATION_LEVEL_ARG}
                ${TFM_REGRESSION_ARG}
                ${TFM_PROFILE_ARG}
+               ${PSA_TEST_ARG}
                -DTFM_TEST_REPO_PATH=${ZEPHYR_TFM_MODULE_DIR}/tf-m-tests
                -DMCUBOOT_PATH=${ZEPHYR_TFM_MODULE_DIR}/../tfm-mcuboot
+               -DPSA_ARCH_TESTS_PATH=${ZEPHYR_TFM_MODULE_DIR}/psa-arch-tests
     BUILD_ALWAYS True
     USES_TERMINAL_BUILD True
     BUILD_BYPRODUCTS ${BUILD_BYPRODUCTS}
@@ -156,7 +175,7 @@ function(trusted_firmware_build)
     )
 
   add_library(tfm_api
-    ${ZEPHYR_TFM_MODULE_DIR}/tf-m-tests/app/os_wrapper_cmsis_rtos_v2.c
+    ${ZEPHYR_BASE}/modules/tfm/src/zephyr_tfm_log.c
   )
 
   target_include_directories(tfm_api
@@ -172,6 +191,10 @@ function(trusted_firmware_build)
     PUBLIC
     zephyr_interface
     INTERFACE
+    ${PSA_TEST_VAL_FILE}
+    ${PSA_TEST_PAL_FILE}
+    ${PSA_TEST_COMBINE_FILE}
+    ${PLATFORM_NS_FILE}
     ${PSA_API_NS_PATH}
     ${VENEERS_FILE}
     $<TARGET_FILE:tfm_api>
@@ -198,6 +221,13 @@ if (CONFIG_BUILD_WITH_TFM)
   if (CONFIG_TFM_PROFILE)
     set(TFM_PROFILE_ARG BUILD_PROFILE ${CONFIG_TFM_PROFILE})
   endif()
+  if (CONFIG_TFM_PSA_TEST_CRYPTO)
+    set(TFM_PSA_TEST_ARG PSA_TEST_SUITE CRYPTO)
+  elseif (CONFIG_TFM_PSA_TEST_STORAGE)
+    set(TFM_PSA_TEST_ARG PSA_TEST_SUITE STORAGE)
+  elseif (CONFIG_TFM_PSA_TEST_INITIAL_ATTESTATION)
+    set(TFM_PSA_TEST_ARG PSA_TEST_SUITE INITIAL_ATTESTATION)
+  endif()
 
   trusted_firmware_build(
     BINARY_DIR ${CMAKE_BINARY_DIR}/tfm
@@ -207,7 +237,10 @@ if (CONFIG_BUILD_WITH_TFM)
     ${TFM_BL2_ARG}
     ${TFM_IPC_ARG}
     ${TFM_REGRESSION_ARG}
+    ${TFM_PSA_TEST_ARG}
   )
 
   zephyr_link_libraries(tfm_api)
+  zephyr_sources(
+    ${ZEPHYR_BASE}/modules/tfm/src/zephyr_tfm_ns_interface.c)
 endif()


### PR DESCRIPTION
Add necessary libs and files to the build
Add support for new kconfigs
Add Zephyr-only implementations of tfm_log and tfm_ns_interface.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>