### PR TITLE
Update psa-arch-tests to support running PSA tests

### DIFF
--- a/psa-arch-tests/api-tests/CMakeLists.txt
+++ b/psa-arch-tests/api-tests/CMakeLists.txt
@@ -109,6 +109,11 @@ list(APPEND PSA_TOOLCHAIN_SUPPORT
         HOST_GCC
 )
 
+# list of supported CROSS_COMPILE toolchains
+list(APPEND CROSS_COMPILE_TOOLCHAIN_SUPPORT
+        GNUARM
+)
+
 # list of suported CPU arch
 list(APPEND PSA_CPU_ARCH_SUPPORT
 	armv8m_ml
@@ -438,6 +443,9 @@ add_custom_target(
 
 # Check for supported toolchain/s
 if(${TOOLCHAIN} IN_LIST PSA_TOOLCHAIN_SUPPORT)
+        if(CROSS_COMPILE AND NOT (${TOOLCHAIN} IN_LIST CROSS_COMPILE_TOOLCHAIN_SUPPORT))
+                message(FATAL_ERROR "[PSA] : Error: CROSS_COMPILE not supported for this toolchain, supported toolchain are : ${CROSS_COMPILE_TOOLCHAIN_SUPPORT}")
+        endif()
         include(${PSA_ROOT_DIR}/tools/cmake/compiler/${TOOLCHAIN}.cmake)
 else()
         message(FATAL_ERROR "[PSA] : Error: Unsupported value for -DTOOLCHAIN=${TOOLCHAIN}, supported toolchain are : ${PSA_TOOLCHAIN_SUPPORT}")

--- a/psa-arch-tests/api-tests/tools/cmake/compiler/GNUARM.cmake
+++ b/psa-arch-tests/api-tests/tools/cmake/compiler/GNUARM.cmake
@@ -18,7 +18,11 @@
 set(CMAKE_SYSTEM_NAME Generic)
 set(CMKE_SYSTEM_PROCESSOR ARM)
 
-set(_C_TOOLCHAIN_NAME arm-none-eabi-gcc)
+if (DEFINED CROSS_COMPILE)
+	set(_C_TOOLCHAIN_NAME ${CROSS_COMPILE}-gcc)
+else()
+	set(_C_TOOLCHAIN_NAME arm-none-eabi-gcc)
+endif()
 
 if(WIN32)
 	if (NOT DEFINED GNUARM_PATH)
@@ -40,7 +44,7 @@ find_program(
 
 if(_C_TOOLCHAIN_PATH STREQUAL "_C_TOOLCHAIN_PATH-NOTFOUND")
         message(FATAL_ERROR "[PSA] : Couldn't find ${_C_TOOLCHAIN_NAME}."
-			    " Either put ${_C_TOOLCHAIN_NAME} on the PATH or set GNUARM_PATH set properly.")
+			    " Either put ${_C_TOOLCHAIN_NAME} on the PATH or set GNUARM_PATH or CROSS_COMPILE properly.")
 endif()
 
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)

--- a/psa-arch-tests/tbsa-v8m/CMakeLists.txt
+++ b/psa-arch-tests/tbsa-v8m/CMakeLists.txt
@@ -68,6 +68,11 @@ list(APPEND TOOLCHAIN_SUPPORT
 	GNUARM
 )
 
+# list of supported CROSS_COMPILE toolchains
+list(APPEND CROSS_COMPILE_TOOLCHAIN_SUPPORT
+	GNUARM
+)
+
 # Variables of the project
 set(TBSA_PROJECT_NAME                   tbsa)
 set(TARGET_CONFIGURATION_FILE           ${TBSA_ROOT_DIR}/platform/board/${TARGET}/tbsa_tgt.cfg)
@@ -147,6 +152,9 @@ endif()
 
 # Check for supported toolchain/s
 if(${COMPILER} IN_LIST TOOLCHAIN_SUPPORT)
+	if(CROSS_COMPILE AND NOT (${TOOLCHAIN} IN_LIST CROSS_COMPILE_TOOLCHAIN_SUPPORT))
+		message(FATAL_ERROR "[PSA] : Error: CROSS_COMPILE not supported for this toolchain, supported toolchain are : ${CROSS_COMPILE_TOOLCHAIN_SUPPORT}")
+	endif()
 	include(${TBSA_ROOT_DIR}/cmake/compiler/${COMPILER}.cmake)
 else()
 	message(FATAL_ERROR "[TBSA] : ${COMPILER} toolchain support not available")

--- a/psa-arch-tests/tbsa-v8m/cmake/compiler/GNUARM.cmake
+++ b/psa-arch-tests/tbsa-v8m/cmake/compiler/GNUARM.cmake
@@ -18,7 +18,11 @@
 set(CMAKE_SYSTEM_NAME Generic)
 set(CMKE_SYSTEM_PROCESSOR ARM)
 
-set(_C_TOOLCHAIN_NAME arm-none-eabi-gcc)
+if (DEFINED CROSS_COMPILE)
+	set(_C_TOOLCHAIN_NAME ${CROSS_COMPILE}-gcc)
+else()
+	set(_C_TOOLCHAIN_NAME arm-none-eabi-gcc)
+endif()
 
 if (WIN32)
 	if (NOT DEFINED GNUARM_PATH)
@@ -40,7 +44,7 @@ find_program(
 
 if (_C_TOOLCHAIN_PATH STREQUAL "_C_TOOLCHAIN_PATH-NOTFOUND")
         message(FATAL_ERROR "[TBSA] : Couldn't find ${_C_TOOLCHAIN_NAME}."
-			    " Either put ${_C_TOOLCHAIN_NAME} on the PATH or set GNUARM_PATH set properly.")
+			    " Either put ${_C_TOOLCHAIN_NAME} on the PATH or set GNUARM_PATH or CROSS_COMPILE properly.")
 endif()
 
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)


### PR DESCRIPTION
Make psa-arch-tests support CROSS_COMPILE like TFM does. This is needed to build PSA tests with the Zephyr SDK.