### PR TITLE
platform: Enable instruction cache on platforms with nRF SoCs

### DIFF
--- a/trusted-firmware-m/platform/ext/target/lairdconnectivity/common/bl5340/target_cfg.c
+++ b/trusted-firmware-m/platform/ext/target/lairdconnectivity/common/bl5340/target_cfg.c
@@ -282,6 +282,11 @@ enum tfm_plat_err_t spu_periph_init_cfg(void)
     nrf_gpio_pin_mcu_select(PIN_XL1, NRF_GPIO_PIN_MCUSEL_PERIPHERAL);
     nrf_gpio_pin_mcu_select(PIN_XL2, NRF_GPIO_PIN_MCUSEL_PERIPHERAL);
 
+    /* Enable the instruction and data cache (this can be done only from secure
+     * code; that's why it is placed here).
+     */
+    NRF_CACHE->ENABLE = CACHE_ENABLE_ENABLE_Enabled;
+
     return TFM_PLAT_ERR_SUCCESS;
 }
 

--- a/trusted-firmware-m/platform/ext/target/nordic_nrf/common/nrf5340/target_cfg.c
+++ b/trusted-firmware-m/platform/ext/target/nordic_nrf/common/nrf5340/target_cfg.c
@@ -274,6 +274,11 @@ enum tfm_plat_err_t spu_periph_init_cfg(void)
     nrf_gpio_pin_mcu_select(PIN_XL1, NRF_GPIO_PIN_MCUSEL_PERIPHERAL);
     nrf_gpio_pin_mcu_select(PIN_XL2, NRF_GPIO_PIN_MCUSEL_PERIPHERAL);
 
+    /* Enable the instruction and data cache (this can be done only from secure
+     * code; that's why it is placed here).
+     */
+    NRF_CACHE->ENABLE = CACHE_ENABLE_ENABLE_Enabled;
+
     return TFM_PLAT_ERR_SUCCESS;
 }
 

--- a/trusted-firmware-m/platform/ext/target/nordic_nrf/common/nrf9160/target_cfg.c
+++ b/trusted-firmware-m/platform/ext/target/nordic_nrf/common/nrf9160/target_cfg.c
@@ -22,6 +22,7 @@
 
 #include <spu.h>
 #include <nrfx.h>
+#include <hal/nrf_nvmc.h>
 
 struct platform_data_t tfm_peripheral_timer0 = {
     NRF_TIMER0_S_BASE,
@@ -229,6 +230,11 @@ enum tfm_plat_err_t spu_periph_init_cfg(void)
 
     /* GPIO pin configuration */
     spu_gpio_config_non_secure(0, false);
+
+    /* Enable the instruction cache (this can be done only from secure code;
+     * that's why it is placed here).
+     */
+    nrf_nvmc_icache_config_set(NRF_NVMC, NRF_NVMC_ICACHE_ENABLE);
 
     return TFM_PLAT_ERR_SUCCESS;
 }


### PR DESCRIPTION
Instruction cache in both nRF5340 and nRF9160 is disabled by default
and can be enabled only from secure code. Extend configuration routines
in targets that use these SoCs with statements that enable the cache.
The affected targets are:
- lairdconnectivity/bl5340_dvk_cpuapp
- nordic_nrf/nrf5340dk_nrf5340_cpuapp
- nordic_nrf/nrf9160dk_nrf9160

Upstream PR: https://review.trustedfirmware.org/c/TF-M/trusted-firmware-m/+/10050