### PR TITLE
Build: Add TFM_EXTRA_PARTITION_CMAKE_PATH option

### DIFF
--- a/trusted-firmware-m/config/config_default.cmake
+++ b/trusted-firmware-m/config/config_default.cmake
@@ -26,6 +26,7 @@ set(TFM_NS_CLIENT_IDENTIFICATION        OFF         CACHE BOOL      "Enable NS c
 set(TFM_EXTRA_CONFIG_PATH               ""          CACHE PATH      "Path to extra cmake config file")
 set(TFM_EXTRA_MANIFEST_LIST_PATH        ""          CACHE PATH      "Path to extra manifest file, used to declare extra partitions. Appended to standard TFM manifest")
 set(TFM_EXTRA_GENERATED_FILE_LIST_PATH  ""          CACHE PATH      "Path to extra generated file list. Appended to stardard TFM generated file list.")
+set(TFM_EXTRA_PARTITION_CMAKE_PATH      ""          CACHE PATH      "Path to cmake directory (containing a CMakeLists.txt) of extra partitions.")
 
 set(TFM_SPM_LOG_LEVEL                   TFM_SPM_LOG_LEVEL_INFO          CACHE STRING    "Set default SPM log level as INFO level")
 set(TFM_PARTITION_LOG_LEVEL             TFM_PARTITION_LOG_LEVEL_INFO    CACHE STRING    "Set default Secure Partition log level as INFO level")

--- a/trusted-firmware-m/secure_fw/CMakeLists.txt
+++ b/trusted-firmware-m/secure_fw/CMakeLists.txt
@@ -29,6 +29,9 @@ add_subdirectory(partitions/psa_proxy)
 add_subdirectory(partitions/firmware_update)
 add_subdirectory(partitions/tfm_ffm11_partition)
 add_subdirectory(partitions/ns_proxy_partition)
+if (TFM_EXTRA_PARTITION_CMAKE_PATH)
+    add_subdirectory(${TFM_EXTRA_PARTITION_CMAKE_PATH} user_partition)
+endif()
 add_subdirectory(spm)
 
 target_include_directories(secure_fw


### PR DESCRIPTION
When creating a custom partition out-of-tree, use this option to
include the partition's cmake code in the build.

Upstream PR:
https://review.trustedfirmware.org/c/TF-M/trusted-firmware-m/+/10468

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>