### PR TITLE
platform: nucleo_l552ze_q: Reduce the size of the SPE partition

### DIFF
--- a/platform/ext/target/stm/nucleo_l552ze_q/include/flash_layout.h
+++ b/platform/ext/target/stm/nucleo_l552ze_q/include/flash_layout.h
@@ -115,7 +115,7 @@
 #define FLASH_ITS_AREA_OFFSET           (FLASH_PS_AREA_OFFSET+FLASH_PS_AREA_SIZE)
 #define FLASH_ITS_AREA_SIZE             (0x2000)   /* 8 KB */
 
-#define FLASH_S_PARTITION_SIZE          (0x2D000) /* S partition */
+#define FLASH_S_PARTITION_SIZE          (0x2C000) /* S partition */
 #define FLASH_NS_PARTITION_SIZE         (0x9000) /* NS partition */
 #define FLASH_PARTITION_SIZE (FLASH_S_PARTITION_SIZE+FLASH_NS_PARTITION_SIZE)
 /* Secure image primary slot */


### PR DESCRIPTION
The hex file zephyr_ns_signed.hex overlaps with something else at
0xC040E50 unless this patch, which reduces the size of the secure
partition, is applied.

When flash was allocated for OTP the intention was to maintain the
same flash usage by reducing another partition.

AFAICT from db07170a34ffe6e17bc68294bac37091023bdee1, the intention
was to remove an "unused" 4kB area.

But I cannot see that this was actually successful.

It is a bit confusing because the documented offsets appear to be
wrong. e.g. the secure image is documented in flash_layout.h to be
0x0001_4000.

But the map file tfm_s.map reports:

Memory Configuration

Name             Origin             Length             Attributes
FLASH            0x0000000011000400 0x000000000005f0c0 xr
RAM              0x0000000030000000 0x0000000000080000 xrw
VENEERS          0x000000001105f4c0 0x0000000000000340 xr
*default*        0x0000000000000000 0xffffffffffffffff

So 0x11000400, not 0x0001_4000.

There is likely a more correct solution, but this is a functional
hotfix for now.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>