### PR TITLE
platform: nordic_nrf: Fix missing header include

### DIFF
--- a/platform/ext/target/nordic_nrf/common/core/services/src/tfm_ioctl_core_ns_api.c
+++ b/platform/ext/target/nordic_nrf/common/core/services/src/tfm_ioctl_core_ns_api.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#include "nrf.h"
 #include <stdint.h>
 #include <tfm_platform_api.h>
 #include <tfm_ioctl_core_api.h>

--- a/platform/ext/target/nordic_nrf/common/core/services/src/tfm_ioctl_core_s_api.c
+++ b/platform/ext/target/nordic_nrf/common/core/services/src/tfm_ioctl_core_s_api.c
@@ -5,6 +5,7 @@
  */
 
 
+#include "nrf.h"
 #include <stdint.h>
 #include "tfm_platform_api.h"
 #include "tfm_ioctl_core_api.h"


### PR DESCRIPTION
Fix missing header include needed in order to compile in the
tfm_platform_gpio_pin_mcu_select implementation based on whether
GPIO_PIN_CNF_MCUSEL_Msk is defined or not.

Change-Id: Ia7875f6906b6d32c6eede3f728ee6d3bca5d3589
Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>
(cherry picked from commit 3827151d3a0f82100f21ff432c757d1dc94f1c21)