### PR TITLE
Cherrypick: Boot: Extend align value and make it configurable by platform

### DIFF
--- a/bl2/ext/mcuboot/CMakeLists.txt
+++ b/bl2/ext/mcuboot/CMakeLists.txt
@@ -63,6 +63,12 @@ target_link_libraries(bl2
 set(MCUBOOT_ALLOWED_LOG_LEVELS OFF ERROR WARNING INFO DEBUG)
 list(FIND MCUBOOT_ALLOWED_LOG_LEVELS ${MCUBOOT_LOG_LEVEL} LOG_LEVEL_ID)
 
+if (MCUBOOT_ALIGN_VAL GREATER 8)
+set (MCUBOOT_BOOT_MAX_ALIGN ${MCUBOOT_ALIGN_VAL})
+else()
+set (MCUBOOT_BOOT_MAX_ALIGN 8)
+endif()
+
 configure_file(include/mcuboot_config/mcuboot_config.h.in
                ${CMAKE_CURRENT_BINARY_DIR}/mcuboot_config/mcuboot_config.h
                @ONLY)
@@ -133,7 +139,7 @@ add_custom_command(OUTPUT tfm_s_signed.bin
         --layout $<TARGET_OBJECTS:signing_layout_s>
         -k ${MCUBOOT_KEY_S}
         --public-key-format $<IF:$<BOOL:${MCUBOOT_HW_KEY}>,full,hash>
-        --align 1
+        --align ${MCUBOOT_ALIGN_VAL}
         --pad
         --pad-header
         -H ${BL2_HEADER_SIZE}
@@ -184,7 +190,7 @@ if(NS)
             --layout $<TARGET_OBJECTS:signing_layout_ns>
             -k ${MCUBOOT_KEY_NS}
             --public-key-format $<IF:$<BOOL:${MCUBOOT_HW_KEY}>,full,hash>
-            --align 1
+            --align ${MCUBOOT_ALIGN_VAL}
             --pad
             --pad-header
             -H ${BL2_HEADER_SIZE}
@@ -234,7 +240,7 @@ if(NS)
             --layout $<TARGET_OBJECTS:signing_layout_s>
             -k $<IF:$<BOOL:${FORWARD_PROT_MSG}>,${MCUBOOT_KEY_NS},${MCUBOOT_KEY_S}>
             --public-key-format $<IF:$<BOOL:${MCUBOOT_HW_KEY}>,full,hash>
-            --align 1
+            --align ${MCUBOOT_ALIGN_VAL}
             --pad
             --pad-header
             -H ${BL2_HEADER_SIZE}

--- a/bl2/ext/mcuboot/include/mcuboot_config/mcuboot_config.h.in
+++ b/bl2/ext/mcuboot/include/mcuboot_config/mcuboot_config.h.in
@@ -52,6 +52,8 @@ extern "C" {
 #cmakedefine MCUBOOT_ENC_IMAGES
 #cmakedefine MCUBOOT_ENCRYPT_RSA
 
+#define MCUBOOT_BOOT_MAX_ALIGN @MCUBOOT_BOOT_MAX_ALIGN@
+
 /*
  * Cryptographic settings
  */

--- a/bl2/ext/mcuboot/mcuboot_default_config.cmake
+++ b/bl2/ext/mcuboot/mcuboot_default_config.cmake
@@ -17,11 +17,16 @@ set(MCUBOOT_HW_KEY                      ON          CACHE BOOL      "Whether to 
 set(MCUBOOT_UPGRADE_STRATEGY            "OVERWRITE_ONLY" CACHE STRING "Upgrade strategy for images")
 set(BL2_HEADER_SIZE                     0x400       CACHE STRING    "Header size")
 set(BL2_TRAILER_SIZE                    0x400       CACHE STRING    "Trailer size")
+set(MCUBOOT_ALIGN_VAL                   1           CACHE STRING    "align option for mcuboot and build image with imgtool [1, 2, 4, 8, 16, 32]")
 
 # Specifying a scope of the accepted values of MCUBOOT_UPGRADE_STRATEGY for
 # platforms to choose a specific upgrade strategy for images. These certain
 # configurations will be used to facilitate the later validation.
 set_property(CACHE MCUBOOT_UPGRADE_STRATEGY PROPERTY STRINGS "OVERWRITE_ONLY;SWAP;DIRECT_XIP;RAM_LOAD")
+
+# Specifying a scope of the accepted values of MCUBOOT_ALIGN_VAL for
+# platforms requiring specific flash alignmnent
+set_property(CACHE MCUBOOT_ALIGN_VAL PROPERTY STRINGS "1;2;4;8;16;32")
 
 set(MCUBOOT_DIRECT_XIP_REVERT           ON          CACHE BOOL      "Enable the revert mechanism in direct-xip mode")
 set(MCUBOOT_MEASURED_BOOT               ON          CACHE BOOL      "Add boot measurement values to boot status. Used for initial attestation token")

--- a/bl2/ext/mcuboot/scripts/requirements.txt
+++ b/bl2/ext/mcuboot/scripts/requirements.txt
@@ -2,5 +2,5 @@ cryptography
 pyasn1
 pyyaml
 cbor>=1.0.0
-imgtool>=1.6.0
+imgtool>=1.9.0
 click

--- a/bl2/ext/mcuboot/scripts/wrapper/wrapper.py
+++ b/bl2/ext/mcuboot/scripts/wrapper/wrapper.py
@@ -79,7 +79,7 @@ os.environ['LANG'] = 'C.UTF-8'
               help='Specify the value of encrypt key length. Default 128.')
 @click.option('-v', '--version', callback=imgtool.main.validate_version,
               required=True)
-@click.option('--align', type=click.Choice(['1', '2', '4', '8']),
+@click.option('--align', type=click.Choice(['1', '2', '4', '8', '16', '32']),
               required=True)
 @click.option('--public-key-format', type=click.Choice(['hash', 'full']),
               default='hash', help='In what format to add the public key to '
@@ -103,6 +103,13 @@ def wrap(key, align, version, header_size, pad_header, layout, pad, confirm,
     else:
         boot_record = "NSPE_SPE"
 
+    if int(align) <= 8 :
+        #default behaviour for max_align
+        max_align=8
+    else:
+        #max_align must be set to align
+        max_align=align
+
     img = imgtool.image.Image(version=imgtool.version.decode_version(version),
                               header_size=header_size, pad_header=pad_header,
                               pad=pad, confirm=confirm, align=int(align),
@@ -111,7 +118,8 @@ def wrap(key, align, version, header_size, pad_header, layout, pad, confirm,
                               load_addr=load_addr, rom_fixed=rom_fixed,
                               erased_val=erased_val,
                               save_enctlv=save_enctlv,
-                              security_counter=security_counter)
+                              security_counter=security_counter,
+                              max_align=max_align)
 
     img.load(infile)
     key = imgtool.main.load_key(key) if key else None

--- a/config/check_config.cmake
+++ b/config/check_config.cmake
@@ -69,6 +69,9 @@ tfm_invalid_config(BL2 AND (NOT MCUBOOT_UPGRADE_STRATEGY IN_LIST MCUBOOT_STRATEG
 
 tfm_invalid_config(MCUBOOT_IMAGE_NUMBER GREATER 3)
 
+get_property(MCUBOOT_ALIGN_VAL_LIST CACHE MCUBOOT_ALIGN_VAL PROPERTY STRINGS)
+tfm_invalid_config(BL2 AND (NOT MCUBOOT_ALIGN_VAL IN_LIST MCUBOOT_ALIGN_VAL_LIST))
+
 ####################### Code sharing ###########################################
 
 set(TFM_CODE_SHARING_PLATFORM_LISTS arm/mps2/an521 arm/musca_b1/sse_200) # Without crypto hw acceleration

--- a/config/config_default.cmake
+++ b/config/config_default.cmake
@@ -150,7 +150,7 @@ to the include path of mbedtls.")
 set(TFM_MBEDCRYPTO_PLATFORM_EXTRA_CONFIG_PATH "" CACHE PATH "Config to append to standard Mbed Crypto config, used by platforms to cnfigure feature support")
 
 set(MCUBOOT_PATH                        "DOWNLOAD"        CACHE PATH      "Path to MCUboot (or DOWNLOAD to fetch automatically")
-set(MCUBOOT_VERSION                     "v1.8.0"  CACHE STRING    "The version of MCUboot to use")
+set(MCUBOOT_VERSION                     "v1.9.0"  CACHE STRING    "The version of MCUboot to use")
 
 set(PSA_ARCH_TESTS_PATH                 "DOWNLOAD"  CACHE PATH      "Path to PSA arch tests (or DOWNLOAD to fetch automatically")
 set(PSA_ARCH_TESTS_VERSION              "v21.10_API1.3_ADAC_ALPHA-1"   CACHE STRING    "The version of PSA arch tests to use")

--- a/platform/ext/target/arm/corstone1000/bl1/CMakeLists.txt
+++ b/platform/ext/target/arm/corstone1000/bl1/CMakeLists.txt
@@ -304,7 +304,7 @@ add_custom_command(OUTPUT bl2_signed.bin
     WORKING_DIRECTORY ${MCUBOOT_PATH}/scripts
 
     #Sign secure binary image with provided secret key
-    COMMAND ${PYTHON_EXECUTABLE} ${BL2_SOURCE}/ext/mcuboot/scripts/wrapper/wrapper.py
+    COMMAND ${Python3_EXECUTABLE} ${BL2_SOURCE}/ext/mcuboot/scripts/wrapper/wrapper.py
         -v ${BL2_IMAGE_VERSION}
         --layout $<TARGET_OBJECTS:signing_layout_for_bl2>
         -k ${MCUBOOT_KEY_S}

--- a/secure_fw/partitions/firmware_update/bootloader/mcuboot/tfm_mcuboot_fwu.c
+++ b/secure_fw/partitions/firmware_update/bootloader/mcuboot/tfm_mcuboot_fwu.c
@@ -51,7 +51,6 @@ typedef struct tfm_fwu_mcuboot_ctx_s {
 
 static tfm_fwu_mcuboot_ctx_t mcuboot_ctx[TFM_FWU_MAX_IMAGES];
 static fwu_image_info_data_t boot_shared_data;
-extern const uint32_t boot_img_magic[];
 
 static int convert_id_from_bl_to_mcuboot(bl_image_id_t bl_image_id,
                                          uint8_t *mcuboot_image_id)
@@ -308,7 +307,7 @@ psa_status_t fwu_bootloader_install_image(bl_image_id_t bootloader_image_id,
     struct image_version image_ver = { 0 };
     const struct flash_area *fap_secondary;
     struct image_header hdr_secondary;
-    uint32_t boot_magic[BOOT_MAGIC_ARR_SZ];
+    uint8_t boot_magic[BOOT_MAGIC_SZ];
     bool check_pass = false;
 #endif
 
@@ -412,7 +411,7 @@ psa_status_t fwu_bootloader_install_image(bl_image_id_t bootloader_image_id,
                     flash_area_close(fap_secondary);
                     return PSA_ERROR_GENERIC_ERROR;
                 }
-                if ((memcmp(boot_magic, boot_img_magic, BOOT_MAGIC_SZ) == 0) &&
+                if ((memcmp(boot_magic, &boot_img_magic, BOOT_MAGIC_SZ) == 0) &&
                     (is_version_greater_or_equal(&hdr_secondary.ih_ver,
                                                  &dep.image_min_version))) {
                     /* The dependency image in the secondary slot meet the


### PR DESCRIPTION
Since stm/b_u585i_iot02a platform needs 16 bytes align value. Align
value is now configurable up to 32 bytes and default value is fixed
to previous hardcoded settings(1 bytes). Move mcuboot for the support
of alignment larger than 8 bytes.

Change-Id: Id3cce340e10fafe74f17e0aad129bb83dbbe6e8f
Signed-off-by: Michel Jaouen <michel.jaouen@st.com>

This fixes a build issue found in https://github.com/zephyrproject-rtos/zephyr/pull/42466