### PR TITLE
platform: nordic_nrf: Add IOCTL non-secure API source file to install

### DIFF
--- a/platform/ext/target/lairdconnectivity/common/core/CMakeLists.txt
+++ b/platform/ext/target/lairdconnectivity/common/core/CMakeLists.txt
@@ -161,4 +161,7 @@ if (TFM_PARTITION_PLATFORM)
 install(FILES       ${NRF_FOLDER_PATH}/services/include/tfm_ioctl_core_api.h
         DESTINATION ${TFM_INSTALL_PATH}/interface/include)
 
+install(FILES       ${NRF_FOLDER_PATH}/services/src/tfm_ioctl_core_ns_api.c
+        DESTINATION ${TFM_INSTALL_PATH}/interface/src)
+
 endif()

--- a/platform/ext/target/nordic_nrf/common/core/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/core/CMakeLists.txt
@@ -164,4 +164,7 @@ if (TFM_PARTITION_PLATFORM)
 install(FILES       services/include/tfm_ioctl_core_api.h
         DESTINATION ${TFM_INSTALL_PATH}/interface/include)
 
+install(FILES       services/src/tfm_ioctl_core_ns_api.c
+        DESTINATION ${TFM_INSTALL_PATH}/interface/src)
+
 endif()


### PR DESCRIPTION
Add the non-secure API IOCTL functions for the nordic platform to the
set of source files exported in the install folder.
In the case where this is built by an external build system instead of
the platform_ns library then this source file needs to be included in
the non-secure application and its build system.

Upstream PR:
https://review.trustedfirmware.org/c/TF-M/trusted-firmware-m/+/15646

Change-Id: Icd0312bdc3e583f5eb32cde589e2bc3c9a67ffdc
Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>