### PR TITLE
platform: musca_s1: only declare tfm_ns if NS is enabled

### DIFF
--- a/platform/ext/target/arm/musca_s1/CMakeLists.txt
+++ b/platform/ext/target/arm/musca_s1/CMakeLists.txt
@@ -171,14 +171,16 @@ target_include_directories(platform_ns
         ${CMAKE_SOURCE_DIR}/platform/ext/cmsis
 )
 
-# Adding new defined handler function to the library where the weak handler
-# funtion symbol are, to override weak handler funtion.
-# Otherwise the weak handler funtion cannot be replaced by the new defined
-# hanlder function which symbol is in another library.
-target_sources(tfm_ns
-    PRIVATE
-        $<$<BOOL:${TEST_NS_FPU}>:${CMAKE_CURRENT_SOURCE_DIR}/ns_fp_test_interrupt.c>
-)
+if(NS)
+    # Adding new defined handler function to the library where the weak handler
+    # funtion symbol are, to override weak handler funtion.
+    # Otherwise the weak handler funtion cannot be replaced by the new defined
+    # hanlder function which symbol is in another library.
+    target_sources(tfm_ns
+        PRIVATE
+            $<$<BOOL:${TEST_NS_FPU}>:${CMAKE_CURRENT_SOURCE_DIR}/ns_fp_test_interrupt.c>
+    )
+endif()
 
 #========================= Platform BL2 =======================================#
 


### PR DESCRIPTION
Make the last target_sources(tfm_ns...) conditional to NS=TRUE. The
current setup is causing bulid issues for musca_s1 since:

c51505f661 modules: tfm: Exclude non-secure TF-M application from build

Fails with:

CMake Error at platform/ext/target/arm/musca_s1/CMakeLists.txt:179:
  Cannot specify sources for target "tfm_ns" which is not built by this
  project.