### PR TITLE
platform: nordic_nrf: Make psa_call/svc unpriv

### DIFF
--- a/platform/ext/target/nordic_nrf/common/core/gcc/nordic_nrf_s.ld
+++ b/platform/ext/target/nordic_nrf/common/core/gcc/nordic_nrf_s.ld
@@ -201,6 +201,10 @@ SECTIONS
         *psa_lifecycle.*(.rodata*)
         *tfm_log_raw.*(.text*)             /* NXP */
         *tfm_log_raw.*(.rodata*)
+        *tfm_psa_call_pack.*(.text*)
+        *tfm_psa_call_pack.*(.rodata*)
+        *psa_interface_svc.*(.text*)
+        *psa_interface_svc.*(.rodata*)
         . = ALIGN(32);
     } > FLASH
     Image$$TFM_UNPRIV_CODE$$RO$$Base = ADDR(.TFM_UNPRIV_CODE);


### PR DESCRIPTION
Add the psa_call_pack and psa_interface_svc to
the unprivilleged part of the image. When
isolation level >1 is used the PSA application
RoT partitions (such as PS) run in unprivilleged
mode and they need to be able to access these
functions when accessing any other RoT services
(such as ITS).

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>
Change-Id: Id82e8fadd1822930162b7bb8b1f434891c5f20d2
(cherry picked from commit 5fd79dc0f83b291dd7da1c8719b51e0c8214abb5)