### PR TITLE
build: gcc: Force DWARF v4

### DIFF
--- a/toolchain_GNUARM.cmake
+++ b/toolchain_GNUARM.cmake
@@ -49,6 +49,8 @@ macro(tfm_toolchain_reset_compiler_flags)
         -mthumb
         -nostdlib
         -std=c99
+        # Force DWARF version 4 for zephyr as pyelftools does not support version 5 at present
+        -gdwarf-4
         $<$<OR:$<BOOL:${TFM_DEBUG_SYMBOLS}>,$<BOOL:${TFM_CODE_COVERAGE}>>:-g>
     )
 endmacro()


### PR DESCRIPTION
This forces DWARF version 4 output so that zephyr debugging and usage still works with the pyelftools library which does not currently support v5.