### PR TITLE
build: gcc: Masking mbedtls warning

### DIFF
--- a/toolchain_GNUARM.cmake
+++ b/toolchain_GNUARM.cmake
@@ -39,6 +39,7 @@ macro(tfm_toolchain_reset_compiler_flags)
         -Wall
         -Wno-format
         -Wno-return-type
+        -Wno-unused-const-variable
         -Wno-unused-but-set-variable
         -c
         -fdata-sections


### PR DESCRIPTION
mbedTLS upstream code contains a warning about const variable set but unused. Just ignore it to avoid Zephyr tests to fail.

zephyr/modules/crypto/mbedtls/library/aes.c:307:23: warning: 'RT0' defined but not used [-Wunused-const-variable=]
      307 | static const uint32_t RT0[256] = { RT };
          |                       ^~~
zephyr/modules/crypto/mbedtls/library/aes.c:200:28: warning:
'RSb' defined but not used [-Wunused-const-variable=]
      200 | static const unsigned char RSb[256] =

Fixes #51025 (on Zephyr)

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>