### PR TITLE
secure_fw: crypto: add -Wno-unused-const-variable

### DIFF
--- a/secure_fw/partitions/crypto/CMakeLists.txt
+++ b/secure_fw/partitions/crypto/CMakeLists.txt
@@ -185,7 +185,9 @@ target_sources(${MBEDTLS_TARGET_PREFIX}mbedcrypto
 
 target_compile_options(${MBEDTLS_TARGET_PREFIX}mbedcrypto
     PRIVATE
+        $<$<C_COMPILER_ID:GNU>:-Wno-unused-const-variable>
         $<$<C_COMPILER_ID:GNU>:-Wno-unused-parameter>
+        $<$<C_COMPILER_ID:ARMClang>:-Wno-unused-const-variable>
         $<$<C_COMPILER_ID:ARMClang>:-Wno-unused-parameter>
 )
 

--- a/toolchain_GNUARM.cmake
+++ b/toolchain_GNUARM.cmake
@@ -39,7 +39,6 @@ macro(tfm_toolchain_reset_compiler_flags)
         -Wall
         -Wno-format
         -Wno-return-type
-        -Wno-unused-const-variable
         -Wno-unused-but-set-variable
         -c
         -fdata-sections


### PR DESCRIPTION
Update TF-M to use upstream patch for masking mbedtls warning for unused const variable.

Upstream commit:
When using TF-M with upstream MbedTLS, the upstream project
generates a warning about const variables being set but not unused.

This warning causes CI to fail in some downstream consumers of TF-M
(Zephyr in this case). Add `-Wno-unused-const-variable` avoids this
warning.

Follow-up from:
https://github.com/zephyrproject-rtos/trusted-firmware-m/pull/80#issuecomment-1302558014