### PR TITLE
cherry-pick: platform: stm32u5xx: Release GPIOI before going to non-secure

### DIFF
--- a/platform/ext/target/stm/common/stm32u5xx/secure/target_cfg.c
+++ b/platform/ext/target/stm/common/stm32u5xx/secure/target_cfg.c
@@ -230,6 +230,7 @@ void pinmux_init_cfg(void)
   __HAL_RCC_GPIOF_CLK_ENABLE();
   __HAL_RCC_GPIOG_CLK_ENABLE();
   __HAL_RCC_GPIOH_CLK_ENABLE();
+  __HAL_RCC_GPIOI_CLK_ENABLE();
   GPIOA_S->SECCFGR = 0x0;
   GPIOB_S->SECCFGR = 0x0;
   GPIOC_S->SECCFGR = 0x0;
@@ -238,6 +239,7 @@ void pinmux_init_cfg(void)
   GPIOF_S->SECCFGR = 0x0;
   GPIOG_S->SECCFGR = 0x0;
   GPIOH_S->SECCFGR = 0x0;
+  GPIOI_S->SECCFGR = 0x0;
 
 }
 /*------------------- SAU/IDAU configuration functions -----------------------*/


### PR DESCRIPTION
GPIOI bank was not set to non-secure in final step of TFM configuration. This lead to issues in non secure operations with this bank.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>
Change-Id: Ia153e7ad8d206d5c8d88038b2d0c6ba91f5de2ec