### PR TITLE
lib: ext: Disable t_cose and qcbor if not required

### DIFF
--- a/lib/ext/CMakeLists.txt
+++ b/lib/ext/CMakeLists.txt
@@ -6,8 +6,10 @@
 #-------------------------------------------------------------------------------
 set(FETCHCONTENT_BASE_DIR ${CMAKE_BINARY_DIR}/lib/ext CACHE STRING "" FORCE)
 
-add_subdirectory(qcbor)
-add_subdirectory(t_cose)
+if(TFM_PARTITION_INITIAL_ATTESTATION)
+  add_subdirectory(qcbor)
+  add_subdirectory(t_cose)
+endif()
 add_subdirectory(mbedcrypto)
 add_subdirectory(CMSIS_5)
 if(BL2)


### PR DESCRIPTION
Avoids including `t_cose` and `qcbor` in the build unless the initial attestation secure partition is enabled via the
`TFM_PARTITION_INITIAL_ATTESTATION` flag.

This is required to avoid automatically downloading QCBOR at build time -- pulled in as a dependency of t_cose -- unless required.

This commit should be reverted once an acceptable upstream solution has been found for this situation, and merged there.

Signed-off-by: Kevin Townsend <kevin.townsend@linaro.org>