### PR TITLE
Boot: Align MCUboot to the latest version

### DIFF
--- a/bl2/ext/mcuboot/bl2_main.c
+++ b/bl2/ext/mcuboot/bl2_main.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2012-2014 Wind River Systems, Inc.
- * Copyright (c) 2017-2022 Arm Limited.
+ * Copyright (c) 2017-2023 Arm Limited.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,7 +89,7 @@ static void do_boot(struct boot_rsp *rsp)
 int main(void)
 {
     struct boot_rsp rsp;
-    fih_int fih_rc = FIH_FAILURE;
+    fih_ret fih_rc = FIH_FAILURE;
     enum tfm_plat_err_t plat_err;
     int32_t image_id;
 
@@ -127,7 +127,7 @@ int main(void)
     }
 
     FIH_CALL(boot_nv_security_counter_init, fih_rc);
-    if (fih_not_eq(fih_rc, FIH_SUCCESS)) {
+    if (FIH_NOT_EQ(fih_rc, FIH_SUCCESS)) {
         BOOT_LOG_ERR("Error while initializing the security counter");
         FIH_PANIC;
     }
@@ -151,8 +151,13 @@ int main(void)
             FIH_PANIC;
         }
 
+        /* Primary goal to zeroize the 'rsp' is to avoid to accidentally load
+         * the NS image in case of a fault injection attack. However, it is
+         * done anyway as a good practice to sanitize memory.
+         */
+        memset(&rsp, 0, sizeof(struct boot_rsp));
         FIH_CALL(boot_go_for_image_id, fih_rc, &rsp, image_id);
-        if (fih_not_eq(fih_rc, FIH_SUCCESS)) {
+        if (FIH_NOT_EQ(fih_rc, FIH_SUCCESS)) {
             BOOT_LOG_ERR("Unable to find bootable image");
             FIH_PANIC;
         }

--- a/bl2/ext/mcuboot/include/fih.h
+++ b/bl2/ext/mcuboot/include/fih.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, Arm Limited. All rights reserved.
+ * Copyright (c) 2020-2023, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -20,11 +20,11 @@ extern "C" {
 #include "stdint.h"
 
 /*
- * FIH return type macro changes the function return types to fih_int.
+ * FIH return type macro changes the function return types to fih_ret.
  * All functions that need to be protected by FIH and called via FIH_CALL must
- * return a fih_int type.
+ * return a fih_ret type.
  */
-#define FIH_RET_TYPE(type)    fih_int
+#define FIH_RET_TYPE(type)    fih_ret
 
 #include "bootutil/fault_injection_hardening.h"
 

--- a/bl2/src/security_cnt.c
+++ b/bl2/src/security_cnt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, Arm Limited. All rights reserved.
+ * Copyright (c) 2019-2023, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -36,19 +36,19 @@ static enum tfm_nv_counter_t get_nv_counter_from_image_id(uint32_t image_id)
     return (enum tfm_nv_counter_t)nv_counter;
 }
 
-fih_int boot_nv_security_counter_init(void)
+fih_ret boot_nv_security_counter_init(void)
 {
-    fih_int fih_rc = FIH_FAILURE;
+    FIH_DECLARE(fih_rc, FIH_FAILURE);
 
-    fih_rc = fih_int_encode_zero_equality(tfm_plat_init_nv_counter());
+    fih_rc = fih_ret_encode_zero_equality(tfm_plat_init_nv_counter());
 
     FIH_RET(fih_rc);
 }
 
-fih_int boot_nv_security_counter_get(uint32_t image_id, fih_int *security_cnt)
+fih_ret boot_nv_security_counter_get(uint32_t image_id, fih_int *security_cnt)
 {
     enum tfm_nv_counter_t nv_counter;
-    fih_int fih_rc = FIH_FAILURE;
+    FIH_DECLARE(fih_rc, FIH_FAILURE);
     uint32_t security_cnt_soft;
 
     /* Check if it's a null-pointer. */
@@ -61,7 +61,7 @@ fih_int boot_nv_security_counter_get(uint32_t image_id, fih_int *security_cnt)
         FIH_RET(FIH_FAILURE);
     }
 
-    fih_rc = fih_int_encode_zero_equality(
+    fih_rc = fih_ret_encode_zero_equality(
              tfm_plat_read_nv_counter(nv_counter,
                                       sizeof(security_cnt_soft),
                                       (uint8_t *)&security_cnt_soft));

--- a/config/config_base.cmake
+++ b/config/config_base.cmake
@@ -135,7 +135,7 @@ set(TFM_MBEDCRYPTO_PSA_CRYPTO_CONFIG_PATH   "${CMAKE_SOURCE_DIR}/lib/ext/mbedcry
 set(TFM_MBEDCRYPTO_PLATFORM_EXTRA_CONFIG_PATH ""    CACHE PATH      "Config to append to standard Mbed Crypto config, used by platforms to cnfigure feature support")
 
 set(MCUBOOT_PATH                        "DOWNLOAD"  CACHE PATH      "Path to MCUboot (or DOWNLOAD to fetch automatically")
-set(MCUBOOT_VERSION                     "v1.9.0"    CACHE STRING    "The version of MCUboot to use")
+set(MCUBOOT_VERSION                     "7453075"   CACHE STRING    "The version of MCUboot to use")
 
 set(PSA_ARCH_TESTS_PATH                 "DOWNLOAD"  CACHE PATH      "Path to PSA arch tests (or DOWNLOAD to fetch automatically")
 set(PSA_ARCH_TESTS_VERSION              "cf8bd71"   CACHE STRING    "The version of PSA arch tests to use")

--- a/platform/ext/target/arm/corstone1000/bl1/CMakeLists.txt
+++ b/platform/ext/target/arm/corstone1000/bl1/CMakeLists.txt
@@ -159,6 +159,7 @@ target_sources(bl1_main
     PRIVATE
         ${MCUBOOT_PATH}/boot/bootutil/src/loader.c
         ${MCUBOOT_PATH}/boot/bootutil/src/bootutil_misc.c
+        ${MCUBOOT_PATH}/boot/bootutil/src/bootutil_public.c
         ${MCUBOOT_PATH}/boot/bootutil/src/image_validate.c
         ${MCUBOOT_PATH}/boot/bootutil/src/image_rsa.c
         ${MCUBOOT_PATH}/boot/bootutil/src/tlv.c

--- a/platform/ext/target/arm/corstone1000/bl1/bl1_security_cnt.c
+++ b/platform/ext/target/arm/corstone1000/bl1/bl1_security_cnt.c
@@ -13,18 +13,18 @@
 #include "tfm_plat_provisioning.h"
 #include "fwu_agent.h"
 
-fih_int boot_nv_security_counter_init(void)
+fih_ret boot_nv_security_counter_init(void)
 {
-    fih_int fih_rc = FIH_FAILURE;
+    FIH_DECLARE(fih_rc, FIH_FAILURE);
 
-    fih_rc = fih_int_encode_zero_equality(tfm_plat_init_nv_counter());
+    fih_rc = fih_ret_encode_zero_equality(tfm_plat_init_nv_counter());
 
     FIH_RET(fih_rc);
 }
 
-fih_int boot_nv_security_counter_get(uint32_t image_id, fih_int *security_cnt)
+fih_ret boot_nv_security_counter_get(uint32_t image_id, fih_int *security_cnt)
 {
-    fih_int fih_rc = FIH_FAILURE;
+    FIH_DECLARE(fih_rc, FIH_FAILURE);
     uint32_t security_cnt_soft;
 
     /* Check if it's a null-pointer. */
@@ -36,7 +36,7 @@ fih_int boot_nv_security_counter_get(uint32_t image_id, fih_int *security_cnt)
         FIH_RET(FIH_FAILURE);
     }
 
-    fih_rc = fih_int_encode_zero_equality(
+    fih_rc = fih_ret_encode_zero_equality(
              tfm_plat_read_nv_counter(PLAT_NV_COUNTER_BL1_0,
                                       sizeof(security_cnt_soft),
                                       (uint8_t *)&security_cnt_soft));

--- a/platform/ext/target/arm/corstone1000/bl2_security_cnt.c
+++ b/platform/ext/target/arm/corstone1000/bl2_security_cnt.c
@@ -37,19 +37,19 @@ static enum tfm_nv_counter_t get_nv_counter_from_image_id(uint32_t image_id)
     return (enum tfm_nv_counter_t)nv_counter;
 }
 
-fih_int boot_nv_security_counter_init(void)
+fih_ret boot_nv_security_counter_init(void)
 {
-    fih_int fih_rc = FIH_FAILURE;
+    FIH_DECLARE(fih_rc, FIH_FAILURE);
 
-    fih_rc = fih_int_encode_zero_equality(tfm_plat_init_nv_counter());
+    fih_rc = fih_ret_encode_zero_equality(tfm_plat_init_nv_counter());
 
     FIH_RET(fih_rc);
 }
 
-fih_int boot_nv_security_counter_get(uint32_t image_id, fih_int *security_cnt)
+fih_ret boot_nv_security_counter_get(uint32_t image_id, fih_int *security_cnt)
 {
     enum tfm_nv_counter_t nv_counter;
-    fih_int fih_rc = FIH_FAILURE;
+    FIH_DECLARE(fih_rc, FIH_FAILURE);
     uint32_t security_cnt_soft;
 
     /* Check if it's a null-pointer. */
@@ -62,7 +62,7 @@ fih_int boot_nv_security_counter_get(uint32_t image_id, fih_int *security_cnt)
         FIH_RET(FIH_FAILURE);
     }
 
-    fih_rc = fih_int_encode_zero_equality(
+    fih_rc = fih_ret_encode_zero_equality(
              tfm_plat_read_nv_counter(nv_counter,
                                       sizeof(security_cnt_soft),
                                       (uint8_t *)&security_cnt_soft));


### PR DESCRIPTION
Conflict note:
bl2/ext/mcuboot/bl2_main.c: Trivial conflict with commit: 7763a477ab455ef7be32e6141e67da4b42223596
lib/ext/tf-m-tests/repo_config_default.cmake:
Ignored change to TFM_TEST_REPO_VERSION, since we supply our own through zephyrs main manifest file.
Change to tf-m-tests repository appears to not be needed in zephyr.



Change-Id: I256ab23d330bd45a93ff33f0cd93e45822c0ed2f (cherry picked from commit 8faae452712b630dc69c24da61e84c88a901d2d4)