### PR TITLE
platform: stm32u5xx: Enable RTC-RTC_EX on platform_s

### DIFF
--- a/platform/ext/target/stm/common/stm32u5xx/CMakeLists.txt
+++ b/platform/ext/target/stm/common/stm32u5xx/CMakeLists.txt
@@ -92,6 +92,8 @@ target_sources(platform_s
         ${CMAKE_CURRENT_SOURCE_DIR}/hal/Src/stm32u5xx_hal_rng_ex.c
         ${CMAKE_CURRENT_SOURCE_DIR}/hal/Src/stm32u5xx_hal_ospi.c
         ${CMAKE_CURRENT_SOURCE_DIR}/hal/Src/stm32u5xx_ll_dlyb.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/hal/Src/stm32u5xx_hal_rtc.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/hal/Src/stm32u5xx_hal_rtc_ex.c
     PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}/hal/Src/stm32u5xx_hal_hash.c
         ${CMAKE_CURRENT_SOURCE_DIR}/hal/Src/stm32u5xx_hal_hash_ex.c


### PR DESCRIPTION
The current stm platform not have rtc functions available on platform_s. In this case, tamper and backup registers can are not available to users consume on a secure partition. This enable those features on platform_s as private content.


Change-Id: I8edad9ff441011fe68964c2b95b7dd0bc4630201