### PR TITLE
Crypto: Add FPU flags for p256m

### DIFF
--- a/secure_fw/partitions/crypto/CMakeLists.txt
+++ b/secure_fw/partitions/crypto/CMakeLists.txt
@@ -208,6 +208,12 @@ target_include_directories(${MBEDTLS_TARGET_PREFIX}p256m
         .
 )
 
+# FPU flags for p256m
+target_compile_options(${MBEDTLS_TARGET_PREFIX}p256m
+    PRIVATE
+        ${COMPILER_CP_FLAG}
+)
+
 target_link_libraries(${MBEDTLS_TARGET_PREFIX}mbedcrypto
     PRIVATE
         psa_interface


### PR DESCRIPTION
Add FPU flags for p256m.

It fixes build error found in https://github.com/zephyrproject-rtos/zephyr/issues/67751

From Upstream TFM:
Change-Id: I4ed6f6ac7c1f52fb5ced18f0006dd3eb7a6a7359