### PR TITLE
stm32: Fix b_u585i_iot02a and regression script

### DIFF
--- a/platform/ext/target/stm/b_u585i_iot02a/config.cmake
+++ b/platform/ext/target/stm/b_u585i_iot02a/config.cmake
@@ -32,5 +32,5 @@ set(MCUBOOT_FIH_PROFILE                 LOW         CACHE STRING    "Fault injec
 set(CONFIG_TFM_USE_TRUSTZONE             ON)
 set(TFM_MULTI_CORE_TOPOLOGY              OFF)
 set(PLATFORM_HAS_FIRMWARE_UPDATE_SUPPORT ON)
-set(STSAFEA                             ON          CACHE BOOL      "Activate ST SAFE SUPPORT")
+set(STSAFEA                             OFF          CACHE BOOL      "Activate ST SAFE SUPPORT")
 set(MCUBOOT_DATA_SHARING                ON)

--- a/platform/ext/target/stm/b_u585i_iot02a/partition/flash_layout.h
+++ b/platform/ext/target/stm/b_u585i_iot02a/partition/flash_layout.h
@@ -83,7 +83,7 @@
 
 /* area for BL2 code protected by hdp */
 #define FLASH_AREA_BL2_OFFSET           (FLASH_AREA_PERSO_OFFSET+FLASH_AREA_PERSO_SIZE )
-#define FLASH_AREA_BL2_SIZE             (0x16000)
+#define FLASH_AREA_BL2_SIZE             (0x20000)
 /* HDP area end at this address */
 #define FLASH_BL2_HDP_END               (FLASH_AREA_BL2_OFFSET+FLASH_AREA_BL2_SIZE-1)
 /* area for BL2 code not protected by hdp */

--- a/platform/ext/target/stm/b_u585i_iot02a/partition/flash_layout.h
+++ b/platform/ext/target/stm/b_u585i_iot02a/partition/flash_layout.h
@@ -83,7 +83,7 @@
 
 /* area for BL2 code protected by hdp */
 #define FLASH_AREA_BL2_OFFSET           (FLASH_AREA_PERSO_OFFSET+FLASH_AREA_PERSO_SIZE )
-#define FLASH_AREA_BL2_SIZE             (0x20000)
+#define FLASH_AREA_BL2_SIZE             (0x16000)
 /* HDP area end at this address */
 #define FLASH_BL2_HDP_END               (FLASH_AREA_BL2_OFFSET+FLASH_AREA_BL2_SIZE-1)
 /* area for BL2 code not protected by hdp */

--- a/platform/ext/target/stm/common/scripts/TFM_UPDATE.sh
+++ b/platform/ext/target/stm/common/scripts/TFM_UPDATE.sh
@@ -60,7 +60,7 @@ if [ "$slot2" == $l5 ]; then
 external_loader="-el $cubedir/ExternalLoader/MX25LM51245G_STM32L562E-DK.stldr"
 fi
 connect_no_reset="-c port=SWD "$sn_option" mode=UR $external_loader"
-connect="-c port=SWD "$sn_option" mode=UR --hardRst $external_loader"
+connect="-c port=SWD "$sn_option" mode=UR $external_loader"
 
 echo "Write TFM_Appli Secure"
 # part ot be updated according to flash_layout.h

--- a/platform/ext/target/stm/common/scripts/regression.sh
+++ b/platform/ext/target/stm/common/scripts/regression.sh
@@ -21,7 +21,7 @@ PATH="/C/Program Files/STMicroelectronics/STM32Cube/STM32CubeProgrammer/bin/":$P
 stm32programmercli="STM32_Programmer_CLI"
 # remove write protection
 secbootadd0=0x180030
-connect="-c port=SWD "$sn_option" mode=UR --hardRst"
+connect="-c port=SWD "$sn_option" mode=UR"
 connect_no_reset="-c port=SWD "$sn_option" mode=HotPlug"
 rdp_0="-ob RDP=0xAA TZEN=1"
 remove_bank1_protect="-ob SECWM1_PSTRT=127 SECWM1_PEND=0 WRP1A_PSTRT=127 WRP1A_PEND=0 WRP1B_PSTRT=127 WRP1B_PEND=0"


### PR DESCRIPTION
There are 2 issues with current TF-M preventing to use on STM32 targets:

- Use of STSAFE should be disabled. This was fixed upstream with https://review.trustedfirmware.org/c/TF-M/trusted-firmware-m/+/29034/2. Note that this patch updates flash_layout which is only done for test purpose and required a flash partition update on Zephyr target which I prefer to avoid, so this particular fix is discarded
- "Hard reset" option usage in regression script actually prevent to update option bytes. Fix in upstream is under preparation but we do need to fix it for V3.7.0 