### PR TITLE
build: remove the warning when the version Git tag is not found

### DIFF
--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -19,7 +19,6 @@ execute_process(COMMAND git describe --tags --always
 string(FIND ${TFM_VERSION_FULL} "TF-M" TFM_TAG)
 if(TFM_TAG EQUAL -1)
     set(TFM_VERSION_FULL v${TFM_VERSION_MANUAL})
-    message(WARNING "Actual TF-M version is not available from Git repository. Settled to " ${TFM_VERSION_FULL})
 endif()
 
 string(REGEX REPLACE "TF-M" "" TFM_VERSION_FULL ${TFM_VERSION_FULL})


### PR DESCRIPTION
Cherry picked from https://review.trustedfirmware.org/c/TF-M/trusted-firmware-m/+/29897.