### PR TITLE
platform: ext: add local copy of CMSIS v6 files

### DIFF
--- a/platform/ext/cmsis/.devcontainer/ubuntu-22.04/Dockerfile
+++ b/platform/ext/cmsis/.devcontainer/ubuntu-22.04/Dockerfile
@@ -1,0 +1,59 @@
+FROM  --platform=linux/amd64 ubuntu:22.04
+
+SHELL ["/bin/bash", "-c"]
+
+ARG USERNAME=user
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+ARG DEBIAN_FRONTEND=noninteractive 
+
+RUN apt-get update && \
+    apt-get -y install \
+        build-essential \
+        curl \
+        gdb \
+        gh \
+        git \
+        less \
+        libncurses5 \
+        libtinfo5 \
+        llvm-15-tools \
+        locales \
+        nano \
+        python3 \
+        python3-pip \
+        python-is-python3 \
+        software-properties-common \
+        sudo \
+        unzip && \
+    ln -s /usr/bin/FileCheck-15 /usr/bin/FileCheck
+
+RUN add-apt-repository ppa:deadsnakes/ppa && \
+    apt-get -y install libpython3.9
+
+RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
+    locale-gen
+
+RUN pip install \
+        lit \
+        python-matrix-runner
+
+# Create the user
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME -s /bin/bash \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+
+RUN mkdir -p /workspaces && \
+    chown $USER_UID:$USER_GID /workspaces
+
+ADD vcpkg-configuration.json /home/
+ADD postCreateCommand.sh /home/
+
+RUN chmod +x /home/postCreateCommand.sh
+
+USER $USERNAME
+WORKDIR /home/$USERNAME
+
+CMD ["/bin/bash"]

--- a/platform/ext/cmsis/.devcontainer/ubuntu-22.04/devcontainer.json
+++ b/platform/ext/cmsis/.devcontainer/ubuntu-22.04/devcontainer.json
@@ -1,0 +1,24 @@
+{
+    "name": "Ubuntu-22.04",
+    "build": {
+      "dockerfile": "Dockerfile",
+      "args": {
+        "USERNAME": "${localEnv:USER}"
+      }
+    },
+    "mounts": [
+      "source=${devcontainerId}-home,target=/home/${localEnv:USER},type=volume",
+      "source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/home/${localEnv:USER}/.ssh,type=bind,consistency=cached",
+      "source=${localEnv:HOME}${localEnv:USERPROFILE}/.armlm,target=/home/${localEnv:USER}/.armlm,type=bind,consistency=cached",
+      "source=${localEnv:HOME}${localEnv:USERPROFILE}/.iarlm,target=/home/${localEnv:USER}/.iarlm,type=bind,consistency=cached"
+    ],
+    "postCreateCommand": "/home/postCreateCommand.sh",
+    "customizations": {
+      "vscode": {
+        "extensions": [
+			    "ms-vscode.cpptools",
+			    "ms-vscode.cpptools-extension-pack"
+        ]
+      }
+    }
+  }

--- a/platform/ext/cmsis/.devcontainer/ubuntu-22.04/postCreateCommand.sh
+++ b/platform/ext/cmsis/.devcontainer/ubuntu-22.04/postCreateCommand.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+echo "Installing oh-my-bash ..."
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/ohmybash/oh-my-bash/master/tools/install.sh)" --unattended
+sed -i 's/OSH_THEME="font"/OSH_THEME="powerline"/' ~/.bashrc
+
+echo "Bootstrapping vcpkg ..."
+# shellcheck source=/dev/null
+. <(curl -sL https://aka.ms/vcpkg-init.sh)
+grep -q "vcpkg-init" ~/.bashrc || echo -e "\n# Initialize vcpkg\n. ~/.vcpkg/vcpkg-init" >> ~/.bashrc && \
+pushd "$(dirname "$0")" || exit 
+vcpkg x-update-registry --all
+vcpkg activate
+popd || exit 

--- a/platform/ext/cmsis/.devcontainer/ubuntu-22.04/vcpkg-configuration.json
+++ b/platform/ext/cmsis/.devcontainer/ubuntu-22.04/vcpkg-configuration.json
@@ -1,0 +1,25 @@
+{
+    "registries": [
+      {
+        "kind": "artifact",
+        "location": "https://aka.ms/vcpkg-ce-default",
+        "name": "microsoft"
+      },
+      {
+        "kind": "artifact",
+        "location": "https://artifacts.keil.arm.com/vcpkg-ce-registry/registry.zip",
+        "name": "arm"
+      }
+    ],
+    "requires": {
+      "microsoft:tools/kitware/cmake": "^3.25.2",
+      "microsoft:ninja": "^1.10.2",
+      "arm:compilers/arm/armclang":"^6.20.0",
+      "arm:compilers/arm/arm-none-eabi-gcc": "^13.2.1",
+      "arm:compilers/arm/llvm-embedded": "^17.0.1-0",
+      "arm:tools/open-cmsis-pack/cmsis-toolbox": "^2.1.0-0",
+      "arm:models/arm/avh-fvp": "^11.22.39",
+      "arm:debuggers/arm/armdbg": "^6.0.0"
+    }
+  }
+  

--- a/platform/ext/cmsis/ARM.CMSIS.pdsc
+++ b/platform/ext/cmsis/ARM.CMSIS.pdsc
@@ -1,0 +1,833 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<package schemaVersion="1.7.7" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="https://raw.githubusercontent.com/Open-CMSIS-Pack/Open-CMSIS-Pack-Spec/v1.7.7/schema/PACK.xsd">
+  <name>CMSIS</name>
+  <description>CMSIS (Common Microcontroller Software Interface Standard)</description>
+  <vendor>ARM</vendor>
+  <license>LICENSE</license>
+  <url>https://www.keil.com/pack/</url>
+
+  <releases>
+    <release version="6.0.0">
+      Active development ...
+      CMSIS-Core: 6.0.0
+        - Core(M) and Core(A) joined into single Core component
+        - Core header files reworked, aligned with TRMs
+        - Previously deprecated features removed
+        - Dropped support for Arm Compiler 5
+      CMSIS-DSP: Moved into separate pack!
+      CMSIS-NN: Moved into separate pack!
+      CMSIS-RTOS: Deprecated and removed!
+        - RTX4 Deprecated and removed!
+      CMSIS-RTOS2: 2.3.0 (see revision history for details)
+        - OS Tick moved from Device to CMSIS class
+        - Provisional support for processor affinity in SMP systems
+        - RTX5 Moved into separate pack!
+      CMSIS-Driver: 2.9.0 (see revision history for details)
+        - Updated VIO API 1.0.0
+        - Added GPIO Driver API 1.0.0
+      CMSIS-DAP: Moved into separate pack!
+      CMSIS-Pack: Moved to Open-CMSIS-Pack!
+      CMSIS-SVD: Moved to Open-CMSIS-Pack!
+      Utilities: Moved to CMSIS-Toolbox!
+    </release>
+    <release version="5.9.0" date="2022-05-02">
+      CMSIS-Core(M): 5.6.0
+       - Arm Cortex-M85 cpu support
+       - Arm China STAR-MC1 cpu support
+       - Updated system_ARMCM55.c
+      CMSIS-DSP: 1.10.0 (see revision history for details)
+      CMSIS-NN: 3.1.0 (see revision history for details)
+       - Support for int16 convolution and fully connected for reference implementation
+       - Support for DSP extension optimization for int16 convolution and fully connected
+       - Support dilation for int8 convolution
+       - Support dilation for int8 depthwise convolution
+       - Support for int16 depthwise conv for reference implementation including dilation
+       - Support for int16 average and max pooling for reference implementation
+       - Support for elementwise add and mul int16 scalar version
+       - Support for softmax int16 scalar version
+       - Support for SVDF with 8 bit state tensor
+      CMSIS-RTOS2: 2.1.3 (unchanged)
+        - RTX 5.5.4 (see revision history for details)
+      CMSIS-Pack: deprecated (moved to Open-CMSIS-Pack)
+      CMSIS-SVD: 1.3.9 (see revision history for details)
+      CMSIS-DAP: 2.1.1 (see revision history for details)
+       - Allow default clock frequency to use fast clock mode
+      Devices
+       - Support for Cortex-M85
+      Utilities
+        - SVDConv 3.3.42
+        - PackChk 1.3.95
+    </release>
+    <release version="5.8.0" date="2021-06-24">
+      CMSIS-Core(M): 5.5.0 (see revision history for details)
+        - Updated GCC LinkerDescription, GCC Assembler startup
+        - Added Armv8-M Stack Sealing (to linker, startup) for toolchain ARM, GCC
+        - Changed C-Startup to default Startup.
+        - Updated Armv8-M Assembler startup to use GAS syntax
+          Note: Updating existing projects may need manual user interaction!
+      CMSIS-Core(A): 1.2.1 (see revision history for details)
+        - Bugfixes for Cortex-A32
+      CMSIS-DAP: 2.1.0 (see revision history for details)
+        - Enhanced DAP_Info
+        - Added extra UART support
+      CMSIS-DSP: 1.9.0 (see revision history for details)
+        - Purged pre-built libs from Git
+        - Enhanced support for f16 datatype
+        - Fixed couple of GCC issues
+      CMSIS-NN: 3.0.0 (see revision history for details including version 2.0.0)
+        - Major interface change for functions compatible with TensorFlow Lite for Microcontroller
+        - Added optimization for SVDF kernel
+        - Improved MVE performance for fully Connected and max pool operator
+        - NULL bias support for fully connected operator in non-MVE case(Can affect performance)
+        - Expanded existing unit test suite along with support for FVP
+        - Removed Examples folder
+      CMSIS-RTOS2:
+        - RTX 5.5.3 (see revision history for details)
+          - CVE-2021-27431 vulnerability mitigation.
+          - Enhanced stack overrun checking.
+          - Various bug fixes and improvements.
+      CMSIS-Pack: 1.7.2 (see revision history for details)
+        - Support for Microchip XC32 compiler
+        - Support for Custom Datapath Extension
+    </release>
+    <release version="5.7.0" date="2020-04-09">
+      CMSIS-Build: 0.9.0 (beta)
+        - Draft for CMSIS Project description (CPRJ)
+      CMSIS-Core(M): 5.4.0 (see revision history for details)
+        - Cortex-M55 cpu support
+        - Enhanced MVE support for Armv8.1-MML
+        - Fixed device config define checks.
+        - L1 Cache functions for Armv7-M and later
+      CMSIS-Core(A): 1.2.0 (see revision history for details)
+        - Fixed GIC_SetPendingIRQ to use GICD_SGIR
+        - Added missing DSP intrinsics
+        - Reworked assembly intrinsics: volatile, barriers and clobber
+      CMSIS-DSP: 1.8.0 (see revision history for details)
+        - Added new functions and function groups
+        - Added MVE support
+      CMSIS-NN: 1.3.0 (see revision history for details)
+        - Added MVE support
+        - Further optimizations for kernels using DSP extension
+      CMSIS-RTOS2:
+        - RTX 5.5.2 (see revision history for details)
+      CMSIS-Driver: 2.8.0
+        - Added VIO API 0.1.0 (Preview)
+        - removed volatile from status related typedefs in APIs
+        - enhanced WiFi Interface API with support for polling Socket Receive/Send
+      CMSIS-Pack: 1.6.3 (see revision history for details)
+        - deprecating all types specific to cpdsc format. Cpdsc is replaced by Cprj with dedicated schema.
+      Devices:
+        - ARMCM55 device
+        - ARMv81MML startup code recognizing __MVE_USED macro
+        - Refactored vector table references for all Cortex-M devices
+        - Reworked ARMCM* C-StartUp files.
+        - Include L1 Cache functions in ARMv8MML/ARMv81MML devices
+      Utilities:
+        Attention: Linux binaries moved to Linux64 folder!
+        - SVDConv 3.3.35
+        - PackChk 1.3.89
+    </release>
+    <release version="5.6.0" date="2019-07-10">
+      CMSIS-Core(M): 5.3.0 (see revision history for details)
+        - Added provisions for compiler-independent C startup code.
+      CMSIS-Core(A): 1.1.4 (see revision history for details)
+        - Fixed __FPU_Enable.
+      CMSIS-DSP: 1.7.0 (see revision history for details)
+        - New Neon versions of f32 functions
+        - Python wrapper
+        - Preliminary cmake build
+        - Compilation flags for FFTs
+        - Changes to arm_math.h
+      CMSIS-NN: 1.2.0 (see revision history for details)
+        - New function for depthwise convolution with asymmetric quantization.
+        - New support functions for requantization.
+      CMSIS-RTOS:
+        - RTX 4.82.0 (updated provisions for Arm Compiler 6 when using Cortex-M0/M0+)
+      CMSIS-RTOS2:
+        - RTX 5.5.1 (see revision history for details)
+      CMSIS-Driver: 2.7.1
+        - WiFi Interface API 1.0.0
+      Devices:
+        - Generalized C startup code for all Cortex-M family devices.
+        - Updated Cortex-A default memory regions and MMU configurations
+        - Moved Cortex-A memory and system config files to avoid include path issues
+    </release>
+    <release version="5.5.1" date="2019-03-20">
+      The following folders are deprecated
+        - CMSIS/Include/ (superseded by CMSIS/DSP/Include/ and CMSIS/Core/Include/)
+
+      CMSIS-Core(M): 5.2.1 (see revision history for details)
+        - Fixed compilation issue in cmsis_armclang_ltm.h
+    </release>
+    <release version="5.5.0" date="2019-03-18">
+      The following folders have been removed:
+        - CMSIS/Lib/ (superseded by CMSIS/DSP/Lib/)
+        - CMSIS/DSP_Lib/ (superseded by CMSIS/DSP/)
+      The following folders are deprecated
+        - CMSIS/Include/ (superseded by CMSIS/DSP/Include/ and CMSIS/Core/Include/)
+
+      CMSIS-Core(M): 5.2.0 (see revision history for details)
+        - Reworked Stack/Heap configuration for ARM startup files.
+        - Added Cortex-M35P device support.
+        - Added generic Armv8.1-M Mainline device support.
+      CMSIS-Core(A): 1.1.3 (see revision history for details)
+      CMSIS-DSP: 1.6.0 (see revision history for details)
+        - reworked DSP library source files
+        - reworked DSP library documentation
+        - Changed DSP folder structure
+        - moved DSP libraries to folder ./DSP/Lib
+        - ARM DSP Libraries are built with ARMCLANG
+        - Added DSP Libraries Source variant
+      CMSIS-RTOS2:
+        - RTX 5.5.0 (see revision history for details)
+      CMSIS-Driver: 2.7.0
+        - Added WiFi Interface API 1.0.0-beta
+        - Added components for project specific driver implementations
+      CMSIS-Pack: 1.6.0 (see revision history for details)
+      Devices:
+        - Added Cortex-M35P and ARMv81MML device templates.
+        - Fixed C-Startup Code for GCC (aligned with other compilers)
+      Utilities:
+        - SVDConv 3.3.25
+        - PackChk 1.3.82
+    </release>
+    <release version="5.4.0" date="2018-08-01">
+      Aligned pack structure with repository.
+      The following folders are deprecated:
+        - CMSIS/Include/
+        - CMSIS/DSP_Lib/
+
+      CMSIS-Core(M): 5.1.2 (see revision history for details)
+        - Added Cortex-M1 support (beta).
+      CMSIS-Core(A): 1.1.2 (see revision history for details)
+      CMSIS-NN: 1.1.0
+        - Added new math functions.
+      CMSIS-RTOS2:
+        - API 2.1.3 (see revision history for details)
+        - RTX 5.4.0 (see revision history for details)
+          * Updated exception handling on Cortex-A
+      CMSIS-Driver:
+        - Flash Driver API V2.2.0
+      Utilities:
+        - SVDConv 3.3.21
+        - PackChk 1.3.71
+    </release>
+    <release version="5.3.0" date="2018-02-22">
+      Updated Arm company brand.
+      CMSIS-Core(M): 5.1.1 (see revision history for details)
+      CMSIS-Core(A): 1.1.1 (see revision history for details)
+      CMSIS-DAP: 2.0.0 (see revision history for details)
+      CMSIS-NN: 1.0.0
+        - Initial contribution of the bare metal Neural Network Library.
+      CMSIS-RTOS2:
+        - RTX 5.3.0 (see revision history for details)
+        - OS Tick API 1.0.1
+    </release>
+    <release version="5.2.0" date="2017-11-16">
+      CMSIS-Core(M): 5.1.0 (see revision history for details)
+        - Added MPU Functions for ARMv8-M for Cortex-M23/M33.
+        - Added compiler_iccarm.h to replace compiler_iar.h shipped with the compiler.
+      CMSIS-Core(A): 1.1.0 (see revision history for details)
+        - Added compiler_iccarm.h.
+        - Added additional access functions for physical timer.
+      CMSIS-DAP: 1.2.0 (see revision history for details)
+      CMSIS-DSP: 1.5.2 (see revision history for details)
+      CMSIS-Driver: 2.6.0 (see revision history for details)
+        - CAN Driver API V1.2.0
+        - NAND Driver API V2.3.0
+      CMSIS-RTOS:
+        - RTX: added variant for Infineon XMC4 series affected by PMU_CM.001 errata.
+      CMSIS-RTOS2:
+        - API 2.1.2 (see revision history for details)
+        - RTX 5.2.3 (see revision history for details)
+      Devices:
+        - Added GCC startup and linker script for Cortex-A9.
+        - Added device ARMCM0plus_MPU for Cortex-M0+ with MPU.
+        - Added IAR startup code for Cortex-A9
+    </release>
+    <release version="5.1.1" date="2017-09-19">
+      CMSIS-RTOS2:
+      - RTX 5.2.1 (see revision history for details)
+    </release>
+    <release version="5.1.0" date="2017-08-04">
+      CMSIS-Core(M): 5.0.2 (see revision history for details)
+      - Changed Version Control macros to be core agnostic.
+      - Added MPU Functions for ARMv7-M for Cortex-M0+/M3/M4/M7.
+      CMSIS-Core(A): 1.0.0 (see revision history for details)
+      - Initial release
+      - IRQ Controller API 1.0.0
+      CMSIS-Driver: 2.05 (see revision history for details)
+      - All typedefs related to status have been made volatile.
+      CMSIS-RTOS2:
+      - API 2.1.1 (see revision history for details)
+      - RTX 5.2.0 (see revision history for details)
+      - OS Tick API 1.0.0
+      CMSIS-DSP: 1.5.2 (see revision history for details)
+      - Fixed GNU Compiler specific diagnostics.
+      CMSIS-Pack: 1.5.0 (see revision history for details)
+      - added System Description File (*.SDF) Format
+      CMSIS-Zone: 0.0.1 (Preview)
+      - Initial specification draft
+    </release>
+    <release version="5.0.1" date="2017-02-03">
+      Package Description:
+      - added taxonomy for Cclass RTOS
+      CMSIS-RTOS2:
+      - API 2.1   (see revision history for details)
+      - RTX 5.1.0 (see revision history for details)
+      CMSIS-Core: 5.0.1 (see revision history for details)
+      - Added __PACKED_STRUCT macro
+      - Added uVisior support
+      - Updated cmsis_armcc.h: corrected macro __ARM_ARCH_6M__
+      - Updated template for secure main function (main_s.c)
+      - Updated template for Context Management for ARMv8-M TrustZone (tz_context.c)
+      CMSIS-DSP: 1.5.1 (see revision history for details)
+      - added ARMv8M DSP libraries.
+      CMSIS-Pack:1.4.9 (see revision history for details)
+      - added Pack Index File specification and schema file
+    </release>
+    <release version="5.0.0" date="2016-11-11">
+      Changed open source license to Apache 2.0
+      CMSIS_Core:
+       - Added support for Cortex-M23 and Cortex-M33.
+       - Added ARMv8-M device configurations for mainline and baseline.
+       - Added CMSE support and thread context management for TrustZone for ARMv8-M
+       - Added cmsis_compiler.h to unify compiler behaviour.
+       - Updated function SCB_EnableICache (for Cortex-M7).
+       - Added functions: NVIC_GetEnableIRQ, SCB_GetFPUType
+      CMSIS-RTOS:
+        - bug fix in RTX 4.82 (see revision history for details)
+      CMSIS-RTOS2:
+        - new API including compatibility layer to CMSIS-RTOS
+        - reference implementation based on RTX5
+        - supports all Cortex-M variants including TrustZone for ARMv8-M
+      CMSIS-SVD:
+       - reworked SVD format documentation
+       - removed SVD file database documentation as SVD files are distributed in packs
+       - updated SVDConv for Win32 and Linux
+      CMSIS-DSP:
+       - Moved DSP libraries from CMSIS/DSP/Lib to CMSIS/Lib.
+       - Added DSP libraries build projects to CMSIS pack.
+    </release>
+    <release version="4.5.0" date="2015-10-28">
+      - CMSIS-Core     4.30.0  (see revision history for details)
+      - CMSIS-DAP      1.1.0   (unchanged)
+      - CMSIS-Driver   2.04.0  (see revision history for details)
+      - CMSIS-DSP      1.4.7   (no source code change [still labeled 1.4.5], see revision history for details)
+      - CMSIS-Pack     1.4.1   (see revision history for details)
+      - CMSIS-RTOS     4.80.0  Restored time delay parameter 'millisec' old behavior (prior V4.79) for software compatibility. (see revision history for details)
+      - CMSIS-SVD      1.3.1   (see revision history for details)
+    </release>
+    <release version="4.4.0" date="2015-09-11">
+      - CMSIS-Core     4.20   (see revision history for details)
+      - CMSIS-DSP      1.4.6  (no source code change [still labeled 1.4.5], see revision history for details)
+      - CMSIS-Pack     1.4.0  (adding memory attributes, algorithm style)
+      - CMSIS-Driver   2.03.0 (adding CAN [Controller Area Network] API)
+      - CMSIS-RTOS
+        -- API         1.02   (unchanged)
+        -- RTX         4.79   (see revision history for details)
+      - CMSIS-SVD      1.3.0  (see revision history for details)
+      - CMSIS-DAP      1.1.0  (extended with SWO support)
+    </release>
+    <release version="4.3.0" date="2015-03-20">
+      - CMSIS-Core     4.10   (Cortex-M7 extended Cache Maintenance functions)
+      - CMSIS-DSP      1.4.5  (see revision history for details)
+      - CMSIS-Driver   2.02   (adding SAI (Serial Audio Interface) API)
+      - CMSIS-Pack     1.3.3  (Semantic Versioning, Generator extensions)
+      - CMSIS-RTOS
+        -- API         1.02   (unchanged)
+        -- RTX         4.78   (see revision history for details)
+      - CMSIS-SVD      1.2    (unchanged)
+    </release>
+    <release version="4.2.0" date="2014-09-24">
+      Adding Cortex-M7 support
+      - CMSIS-Core     4.00  (Cortex-M7 support, corrected C++ include guards in core header files)
+      - CMSIS-DSP      1.4.4 (Cortex-M7 support and corrected out of bound issues)
+      - CMSIS-Pack     1.3.1 (Cortex-M7 updates, clarification, corrected batch files in Tutorial)
+      - CMSIS-SVD      1.2   (Cortex-M7 extensions)
+      - CMSIS-RTOS RTX 4.75  (see revision history for details)
+    </release>
+    <release version="4.1.1" date="2014-06-30">
+      - fixed conditions preventing the inclusion of the DSP library in projects for Infineon XMC4000 series devices
+    </release>
+    <release version="4.1.0" date="2014-06-12">
+      - CMSIS-Driver   2.02  (incompatible update)
+      - CMSIS-Pack     1.3   (see revision history for details)
+      - CMSIS-DSP      1.4.2 (unchanged)
+      - CMSIS-Core     3.30  (unchanged)
+      - CMSIS-RTOS RTX 4.74  (unchanged)
+      - CMSIS-RTOS API 1.02  (unchanged)
+      - CMSIS-SVD      1.10  (unchanged)
+      PACK:
+      - removed G++ specific files from PACK
+      - added Component Startup variant "C Startup"
+      - added Pack Checking Utility
+      - updated conditions to reflect tool-chain dependency
+      - added Taxonomy for Graphics
+      - updated Taxonomy for unified drivers from "Drivers" to "CMSIS Drivers"
+    </release>
+    <!-- release version="4.0.0">
+      - CMSIS-Driver   2.00  Preliminary (incompatible update)
+      - CMSIS-Pack     1.1   Preliminary
+      - CMSIS-DSP      1.4.2 (see revision history for details)
+      - CMSIS-Core     3.30  (see revision history for details)
+      - CMSIS-RTOS RTX 4.74  (see revision history for details)
+      - CMSIS-RTOS API 1.02  (unchanged)
+      - CMSIS-SVD      1.10  (unchanged)
+    </release -->
+    <release version="3.20.4" date="2014-02-20">
+      - CMSIS-RTOS 4.74 (see revision history for details)
+      - PACK Extensions (Boards, Device Features, Flash Programming, Generators, Configuration Wizard). Schema version 1.1.
+    </release>
+    <!-- release version="3.20.3">
+      - CMSIS-Driver API Version 1.10 ARM prefix added (incompatible change)
+      - CMSIS-RTOS 4.73 (see revision history for details)
+    </release -->
+    <!-- release version="3.20.2">
+      - CMSIS-Pack documentation has been added
+      - CMSIS-Drivers header and documentation have been added to PACK
+      - CMSIS-CORE, CMSIS-DSP, CMSIS-RTOS API and CMSIS-SVD remain unchanged
+    </release -->
+    <!-- release version="3.20.1">
+      - CMSIS-RTOS Keil RTX V4.72 has been added to PACK
+      - CMSIS-CORE, CMSIS-DSP, CMSIS-RTOS API and CMSIS-SVD remain unchanged
+    </release -->
+    <!-- release version="3.20.0">
+      The software portions that are deployed in the application program are now under a BSD license which allows usage
+      of CMSIS components in any commercial or open source projects.  The Pack Description file Arm.CMSIS.pdsc describes the use cases
+      The individual components have been update as listed below:
+      - CMSIS-CORE adds functions for setting breakpoints, supports the latest GCC Compiler, and contains several corrections.
+      - CMSIS-DSP library is optimized for more performance and contains several bug fixes.
+      - CMSIS-RTOS API is extended with capabilities for short timeouts, Kernel initialization, and prepared for a C++ interface.
+      - CMSIS-SVD is unchanged.
+    </release -->
+  </releases>
+
+  <taxonomy>
+    <description Cclass="Audio">Software components for audio processing</description>
+    <description Cclass="Board Support">Generic Interfaces for Evaluation and Development Boards</description>
+    <description Cclass="Board Part">Drivers that support an external component available on an evaluation board</description>
+    <description Cclass="Compiler">Compiler Software Extensions</description>
+    <description Cclass="CMSIS" doc="CMSIS/Documentation/html/General/index.html">Cortex Microcontroller Software Interface Components</description>
+    <description Cclass="CMSIS Driver" doc="CMSIS/Documentation/html/Driver/index.html">Unified Device Drivers compliant to CMSIS-Driver Specifications</description>
+    <description Cclass="Device" doc="CMSIS/Documentation/html/Core/index.html">Startup, System Setup</description>
+    <description Cclass="Data Exchange">Data exchange or data formatter</description>
+    <description Cclass="Extension Board">Drivers that support an extension board or shield</description>
+    <description Cclass="File System">File Drive Support and File System</description>
+    <description Cclass="IoT Client">IoT cloud client connector</description>
+    <description Cclass="IoT Service">IoT specific services</description>
+    <description Cclass="IoT Utility">IoT specific software utility</description>
+    <description Cclass="Graphics">Graphical User Interface</description>
+    <description Cclass="Network">Network Stack using Internet Protocols</description>
+    <description Cclass="RTOS">Real-time Operating System</description>
+    <description Cclass="Security">Encryption for secure communication or storage</description>
+    <description Cclass="USB">Universal Serial Bus Stack</description>
+    <description Cclass="Utility">Generic software utility components</description>
+  </taxonomy>
+
+  <apis>
+    <!-- CMSIS Device API -->
+    <api Cclass="Device" Cgroup="IRQ Controller" Capiversion="1.0.0" exclusive="1">
+      <description>Device interrupt controller interface</description>
+      <files>
+        <file category="header" name="CMSIS/Core/Include/a-profile/irq_ctrl.h"/>
+      </files>
+    </api>
+    <!-- CMSIS OS Tick API -->
+    <api Cclass="CMSIS" Cgroup="OS Tick" Capiversion="1.0.1" exclusive="1">
+      <description>RTOS Kernel system tick timer interface</description>
+      <files>
+        <file category="header" name="CMSIS/RTOS2/Include/os_tick.h"/>
+      </files>
+    </api>
+    <!-- CMSIS-RTOS API -->
+    <api Cclass="CMSIS" Cgroup="RTOS2" Capiversion="2.3.0" exclusive="1">
+      <description>CMSIS-RTOS API for Cortex-M, SC000, and SC300</description>
+      <files>
+        <file category="doc" name="CMSIS/Documentation/html/RTOS2/index.html"/>
+        <file category="header" name="CMSIS/RTOS2/Include/cmsis_os2.h"/>
+      </files>
+    </api>
+    <!-- CMSIS Driver API -->
+    <api Cclass="CMSIS Driver" Cgroup="USART" Capiversion="2.4.0" exclusive="0">
+      <description>USART Driver API for Cortex-M</description>
+      <files>
+        <file category="doc" name="CMSIS/Documentation/html/Driver/group__usart__interface__gr.html" />
+        <file category="header" name="CMSIS/Driver/Include/Driver_USART.h" />
+      </files>
+    </api>
+    <api Cclass="CMSIS Driver" Cgroup="SPI" Capiversion="2.3.0" exclusive="0">
+      <description>SPI Driver API for Cortex-M</description>
+      <files>
+        <file category="doc" name="CMSIS/Documentation/html/Driver/group__spi__interface__gr.html" />
+        <file category="header" name="CMSIS/Driver/Include/Driver_SPI.h" />
+      </files>
+    </api>
+    <api Cclass="CMSIS Driver" Cgroup="SAI" Capiversion="1.2.0" exclusive="0">
+      <description>SAI Driver API for Cortex-M</description>
+      <files>
+        <file category="doc" name="CMSIS/Documentation/html/Driver/group__sai__interface__gr.html"/>
+        <file category="header" name="CMSIS/Driver/Include/Driver_SAI.h" />
+      </files>
+    </api>
+    <api Cclass="CMSIS Driver" Cgroup="I2C" Capiversion="2.4.0" exclusive="0">
+      <description>I2C Driver API for Cortex-M</description>
+      <files>
+        <file category="doc" name="CMSIS/Documentation/html/Driver/group__i2c__interface__gr.html"/>
+        <file category="header" name="CMSIS/Driver/Include/Driver_I2C.h" />
+      </files>
+    </api>
+    <api Cclass="CMSIS Driver" Cgroup="CAN" Capiversion="1.3.0" exclusive="0">
+      <description>CAN Driver API for Cortex-M</description>
+      <files>
+        <file category="doc" name="CMSIS/Documentation/html/Driver/group__can__interface__gr.html"/>
+        <file category="header" name="CMSIS/Driver/Include/Driver_CAN.h" />
+      </files>
+    </api>
+    <api Cclass="CMSIS Driver" Cgroup="Flash" Capiversion="2.3.0" exclusive="0">
+      <description>Flash Driver API for Cortex-M</description>
+      <files>
+        <file category="doc" name="CMSIS/Documentation/html/Driver/group__flash__interface__gr.html" />
+        <file category="header" name="CMSIS/Driver/Include/Driver_Flash.h" />
+      </files>
+    </api>
+    <api Cclass="CMSIS Driver" Cgroup="MCI" Capiversion="2.4.0" exclusive="0">
+      <description>MCI Driver API for Cortex-M</description>
+      <files>
+        <file category="doc" name="CMSIS/Documentation/html/Driver/group__mci__interface__gr.html" />
+        <file category="header" name="CMSIS/Driver/Include/Driver_MCI.h" />
+      </files>
+    </api>
+    <api Cclass="CMSIS Driver" Cgroup="NAND" Capiversion="2.4.0" exclusive="0">
+      <description>NAND Flash Driver API for Cortex-M</description>
+      <files>
+        <file category="doc" name="CMSIS/Documentation/html/Driver/group__nand__interface__gr.html" />
+        <file category="header" name="CMSIS/Driver/Include/Driver_NAND.h" />
+      </files>
+    </api>
+    <api Cclass="CMSIS Driver" Cgroup="Ethernet" Capiversion="2.2.0" exclusive="0">
+      <description>Ethernet MAC and PHY Driver API for Cortex-M</description>
+      <files>
+        <file category="doc" name="CMSIS/Documentation/html/Driver/group__eth__interface__gr.html" />
+        <file category="header" name="CMSIS/Driver/Include/Driver_ETH_MAC.h" />
+        <file category="header" name="CMSIS/Driver/Include/Driver_ETH_PHY.h" />
+      </files>
+    </api>
+    <api Cclass="CMSIS Driver" Cgroup="Ethernet MAC" Capiversion="2.2.0" exclusive="0">
+      <description>Ethernet MAC Driver API for Cortex-M</description>
+      <files>
+        <file category="doc" name="CMSIS/Documentation/html/Driver/group__eth__mac__interface__gr.html" />
+        <file category="header" name="CMSIS/Driver/Include/Driver_ETH_MAC.h" />
+      </files>
+    </api>
+    <api Cclass="CMSIS Driver" Cgroup="Ethernet PHY" Capiversion="2.2.0" exclusive="0">
+      <description>Ethernet PHY Driver API for Cortex-M</description>
+      <files>
+        <file category="doc" name="CMSIS/Documentation/html/Driver/group__eth__phy__interface__gr.html" />
+        <file category="header" name="CMSIS/Driver/Include/Driver_ETH_PHY.h" />
+      </files>
+    </api>
+    <api Cclass="CMSIS Driver" Cgroup="USB Device" Capiversion="2.3.0" exclusive="0">
+      <description>USB Device Driver API for Cortex-M</description>
+      <files>
+        <file category="doc" name="CMSIS/Documentation/html/Driver/group__usbd__interface__gr.html" />
+        <file category="header" name="CMSIS/Driver/Include/Driver_USBD.h" />
+      </files>
+    </api>
+    <api Cclass="CMSIS Driver" Cgroup="USB Host" Capiversion="2.3.0" exclusive="0">
+      <description>USB Host Driver API for Cortex-M</description>
+      <files>
+        <file category="doc" name="CMSIS/Documentation/html/Driver/group__usbh__interface__gr.html" />
+        <file category="header" name="CMSIS/Driver/Include/Driver_USBH.h" />
+      </files>
+    </api>
+    <api Cclass="CMSIS Driver" Cgroup="GPIO" Capiversion="1.0.0" exclusive="0">
+      <description>GPIO Driver API for Cortex-M</description>
+      <files>
+        <file category="doc" name="CMSIS/Documentation/html/Driver/group__gpio__interface__gr.html" />
+        <file category="header" name="CMSIS/Driver/Include/Driver_GPIO.h" />
+      </files>
+    </api>
+    <api Cclass="CMSIS Driver" Cgroup="WiFi" Capiversion="1.1.0" exclusive="0">
+      <description>WiFi driver</description>
+      <files>
+        <file category="doc" name="CMSIS/Documentation/html/Driver/group__wifi__interface__gr.html" />
+        <file category="header" name="CMSIS/Driver/Include/Driver_WiFi.h" />
+      </files>
+    </api>
+    <api Cclass="CMSIS Driver" Cgroup="VIO" Capiversion="1.0.0" exclusive="1">
+      <description>Virtual I/O</description>
+      <files>
+        <file category="doc"    name="CMSIS/Documentation/html/Driver/group__vio__interface__gr.html" />
+        <file category="header" name="CMSIS/Driver/VIO/Include/cmsis_vio.h" />
+        <file category="other"  name="CMSIS/Driver/VIO/cmsis_vio.scvd" />
+      </files>
+    </api>
+  </apis>
+
+  <!-- conditions are dependency rules that can apply to a component or an individual file -->
+  <conditions>
+    <!-- Arm architecture -->
+    <condition id="ARMv6-M Device">
+      <description>Armv6-M architecture based device</description>
+      <accept Dcore="Cortex-M0"/>
+      <accept Dcore="Cortex-M1"/>
+      <accept Dcore="Cortex-M0+"/>
+      <accept Dcore="SC000"/>
+    </condition>
+    <condition id="ARMv7-M Device">
+      <description>Armv7-M architecture based device</description>
+      <accept Dcore="Cortex-M3"/>
+      <accept Dcore="Cortex-M4"/>
+      <accept Dcore="Cortex-M7"/>
+      <accept Dcore="SC300"/>
+    </condition>
+    <condition id="ARMv8-MBL Device">
+      <description>Armv8-M base line architecture based device</description>
+      <accept Dcore="ARMV8MBL"/>
+      <accept Dcore="Cortex-M23"/>
+    </condition>
+    <condition id="ARMv8-MML Device">
+      <description>Armv8-M main line architecture based device</description>
+      <accept Dcore="ARMV8MML"/>
+      <accept Dcore="Cortex-M33"/>
+      <accept Dcore="Cortex-M35P"/>
+      <accept Dcore="Star-MC1"/>
+    </condition>
+    <condition id="ARMv81-MML Device">
+      <description>Armv8.1-M main line architecture based device</description>
+      <accept Dcore="ARMV81MML"/>
+      <accept Dcore="Cortex-M55"/>
+      <accept Dcore="Cortex-M85"/>
+    </condition>
+    <condition id="ARMv8-M Device">
+      <description>Armv8-M architecture based device</description>
+      <accept condition="ARMv8-MBL Device"/>
+      <accept condition="ARMv8-MML Device"/>
+      <accept condition="ARMv81-MML Device"/>
+    </condition>
+    <condition id="ARMv6_7_8-M Device">
+      <description>Armv6_7_8-M architecture based device</description>
+      <accept condition="ARMv6-M Device"/>
+      <accept condition="ARMv7-M Device"/>
+      <accept condition="ARMv8-M Device"/>
+    </condition>
+    <condition id="ARMv7-A Device">
+      <description>Armv7-A architecture based device</description>
+      <accept Dcore="Cortex-A5"/>
+      <accept Dcore="Cortex-A7"/>
+      <accept Dcore="Cortex-A9"/>
+    </condition>
+
+    <condition id="TrustZone">
+      <description>TrustZone</description>
+      <require Dtz="TZ"/>
+    </condition>
+    <condition id="TZ Secure">
+      <description>TrustZone (Secure)</description>
+      <require Dtz="TZ"/>
+      <require Dsecure="Secure"/>
+    </condition>
+
+    <!-- OS Tick -->
+    <condition id="OS Tick SysTick">
+      <description>Components required for OS Tick SysTick Timer</description>
+      <require condition="ARMv6_7_8-M Device"/>
+    </condition>
+
+    <condition id="OS Tick PTIM">
+      <description>Components required for OS Tick Private Timer</description>
+      <accept Dcore="Cortex-A5"/>
+      <accept Dcore="Cortex-A9"/>
+      <require Cclass="Device" Cgroup="IRQ Controller"/>
+    </condition>
+
+    <condition id="OS Tick GTIM">
+      <description>Components required for OS Tick Generic Physical Timer</description>
+      <accept Dcore="Cortex-A7"/>
+      <require Cclass="Device" Cgroup="IRQ Controller"/>
+    </condition>
+
+  </conditions>
+
+  <components>
+    <!-- CMSIS-Core component -->
+    <component Cclass="CMSIS" Cgroup="CORE" Cversion="6.0.0"  condition="ARMv6_7_8-M Device" >
+      <description>CMSIS-CORE for Cortex-M, SC000, SC300, Star-MC1, ARMv8-M, ARMv8.1-M</description>
+      <files>
+        <!-- CPU independent -->
+        <file category="doc"     name="CMSIS/Documentation/html/Core/index.html"/>
+        <file category="include" name="CMSIS/Core/Include/"/>
+        <file category="header"  name="CMSIS/Core/Include/tz_context.h" condition="TrustZone"/>
+        <!-- Code template -->
+        <file category="sourceC" attr="template" condition="TZ Secure" name="CMSIS/Core/Template/ARMv8-M/main_s.c"     version="1.1.1" select="Secure mode 'main' module for ARMv8-M"/>
+        <file category="sourceC" attr="template" condition="TZ Secure" name="CMSIS/Core/Template/ARMv8-M/tz_context.c" version="1.1.1" select="RTOS Context Management (TrustZone for ARMv8-M)" />
+      </files>
+    </component>
+
+    <component Cclass="CMSIS" Cgroup="CORE" Cversion="1.2.1"  condition="ARMv7-A Device" >
+      <description>CMSIS-CORE for Cortex-A</description>
+      <files>
+        <!-- CPU independent -->
+        <file category="doc"     name="CMSIS/Documentation/html/Core_A/index.html"/>
+        <file category="include" name="CMSIS/Core/Include/"/>
+      </files>
+    </component>
+
+    <!-- IRQ Controller -->
+    <component Cclass="Device" Cgroup="IRQ Controller" Csub="GIC" Capiversion="1.0.0" Cversion="1.2.0" condition="ARMv7-A Device">
+      <description>IRQ Controller implementation using GIC</description>
+      <files>
+        <file category="sourceC" name="CMSIS/Core/Source/irq_ctrl_gic.c"/>
+      </files>
+    </component>
+
+    <!-- OS Tick -->
+    <component Cclass="CMSIS" Cgroup="OS Tick" Csub="SysTick" Capiversion="1.0.1" Cversion="1.0.5" condition="OS Tick SysTick">
+      <description>OS Tick implementation using Cortex-M SysTick Timer</description>
+      <files>
+        <file category="sourceC" name="CMSIS/RTOS2/Source/os_systick.c"/>
+      </files>
+    </component>
+
+    <component Cclass="CMSIS" Cgroup="OS Tick" Csub="Private Timer" Capiversion="1.0.1" Cversion="1.0.2" condition="OS Tick PTIM">
+      <description>OS Tick implementation using Private Timer</description>
+      <files>
+        <file category="sourceC" name="CMSIS/RTOS2/Source/os_tick_ptim.c"/>
+      </files>
+    </component>
+
+    <component Cclass="CMSIS" Cgroup="OS Tick" Csub="Generic Physical Timer" Capiversion="1.0.1" Cversion="1.0.1" condition="OS Tick GTIM">
+      <description>OS Tick implementation using Generic Physical Timer</description>
+      <files>
+        <file category="sourceC" name="CMSIS/RTOS2/Source/os_tick_gtim.c"/>
+      </files>
+    </component>
+
+    <!-- CMSIS-Driver Custom components -->
+    <component Cclass="CMSIS Driver" Cgroup="USART" Csub="Custom" Cversion="1.0.0" Capiversion="2.4.0" custom="1">
+      <description>Access to #include Driver_USART.h file and code template for custom implementation</description>
+      <files>
+        <file category="header" name="CMSIS/Driver/Include/Driver_USART.h" />
+        <file category="sourceC" attr="template" name="CMSIS/Driver/DriverTemplates/Driver_USART.c" select="USART Driver"/>
+      </files>
+    </component>
+    <component Cclass="CMSIS Driver" Cgroup="SPI" Csub="Custom" Cversion="1.0.0" Capiversion="2.3.0" custom="1">
+      <description>Access to #include Driver_SPI.h file and code template for custom implementation</description>
+      <files>
+        <file category="header" name="CMSIS/Driver/Include/Driver_SPI.h" />
+        <file category="sourceC" attr="template" name="CMSIS/Driver/DriverTemplates/Driver_SPI.c" select="SPI Driver"/>
+      </files>
+    </component>
+    <component Cclass="CMSIS Driver" Cgroup="SAI" Csub="Custom" Cversion="1.0.0" Capiversion="1.2.0" custom="1">
+      <description>Access to #include Driver_SAI.h file and code template for custom implementation</description>
+      <files>
+        <file category="header" name="CMSIS/Driver/Include/Driver_SAI.h" />
+        <file category="sourceC" attr="template" name="CMSIS/Driver/DriverTemplates/Driver_SAI.c" select="SAI Driver"/>
+      </files>
+    </component>
+    <component Cclass="CMSIS Driver" Cgroup="I2C" Csub="Custom" Cversion="1.0.0" Capiversion="2.4.0" custom="1">
+      <description>Access to #include Driver_I2C.h file and code template for custom implementation</description>
+      <files>
+        <file category="header" name="CMSIS/Driver/Include/Driver_I2C.h" />
+        <file category="sourceC" attr="template" name="CMSIS/Driver/DriverTemplates/Driver_I2C.c" select="I2C Driver"/>
+      </files>
+    </component>
+    <component Cclass="CMSIS Driver" Cgroup="CAN" Csub="Custom" Cversion="1.0.0" Capiversion="1.3.0" custom="1">
+      <description>Access to #include Driver_CAN.h file and code template for custom implementation</description>
+      <files>
+        <file category="header" name="CMSIS/Driver/Include/Driver_CAN.h" />
+        <file category="sourceC" attr="template" name="CMSIS/Driver/DriverTemplates/Driver_CAN.c" select="CAN Driver"/>
+      </files>
+    </component>
+    <component Cclass="CMSIS Driver" Cgroup="Flash" Csub="Custom" Cversion="1.0.0" Capiversion="2.3.0" custom="1">
+      <description>Access to #include Driver_Flash.h file and code template for custom implementation</description>
+      <files>
+        <file category="header" name="CMSIS/Driver/Include/Driver_Flash.h" />
+        <file category="sourceC" attr="template" name="CMSIS/Driver/DriverTemplates/Driver_Flash.c" select="Flash Driver"/>
+      </files>
+    </component>
+    <component Cclass="CMSIS Driver" Cgroup="MCI" Csub="Custom" Cversion="1.0.0" Capiversion="2.4.0" custom="1">
+      <description>Access to #include Driver_MCI.h file and code template for custom implementation</description>
+      <files>
+        <file category="header" name="CMSIS/Driver/Include/Driver_MCI.h" />
+        <file category="sourceC" attr="template" name="CMSIS/Driver/DriverTemplates/Driver_MCI.c" select="MCI Driver"/>
+      </files>
+    </component>
+    <component Cclass="CMSIS Driver" Cgroup="NAND" Csub="Custom" Cversion="1.0.0" Capiversion="2.4.0" custom="1">
+      <description>Access to #include Driver_NAND.h file and code template for custom implementation</description>
+      <files>
+        <file category="header" name="CMSIS/Driver/Include/Driver_NAND.h" />
+        <file category="sourceC" attr="template" name="CMSIS/Driver/DriverTemplates/Driver_NAND.c" select="NAND Flash Driver"/>
+      </files>
+    </component>
+    <component Cclass="CMSIS Driver" Cgroup="Ethernet" Csub="Custom" Cversion="1.0.0" Capiversion="2.2.0" custom="1">
+      <description>Access to #include Driver_ETH_PHY/MAC.h files and code templates for custom implementation</description>
+      <files>
+        <file category="header" name="CMSIS/Driver/Include/Driver_ETH_MAC.h" />
+        <file category="header" name="CMSIS/Driver/Include/Driver_ETH_PHY.h" />
+        <file category="sourceC" attr="template" name="CMSIS/Driver/DriverTemplates/Driver_ETH_PHY.c" select="Ethernet PHY and MAC Driver"/>
+        <file category="sourceC" attr="template" name="CMSIS/Driver/DriverTemplates/Driver_ETH_MAC.c" select="Ethernet PHY and MAC Driver"/>
+      </files>
+    </component>
+    <component Cclass="CMSIS Driver" Cgroup="Ethernet MAC" Csub="Custom" Cversion="1.0.0" Capiversion="2.2.0" custom="1">
+      <description>Access to #include Driver_ETH_MAC.h file and code template for custom implementation</description>
+      <files>
+        <file category="header" name="CMSIS/Driver/Include/Driver_ETH_MAC.h" />
+        <file category="sourceC" attr="template" name="CMSIS/Driver/DriverTemplates/Driver_ETH_MAC.c" select="Ethernet MAC Driver"/>
+      </files>
+    </component>
+    <component Cclass="CMSIS Driver" Cgroup="Ethernet PHY" Csub="Custom" Cversion="1.0.0" Capiversion="2.2.0" custom="1">
+      <description>Access to #include Driver_ETH_PHY.h file and code template for custom implementation</description>
+      <files>
+        <file category="header" name="CMSIS/Driver/Include/Driver_ETH_PHY.h" />
+        <file category="sourceC" attr="template" name="CMSIS/Driver/DriverTemplates/Driver_ETH_PHY.c" select="Ethernet PHY Driver"/>
+      </files>
+    </component>
+    <component Cclass="CMSIS Driver" Cgroup="USB Device" Csub="Custom" Cversion="1.0.0" Capiversion="2.3.0" custom="1">
+      <description>Access to #include Driver_USBD.h file and code template for custom implementation</description>
+      <files>
+        <file category="header" name="CMSIS/Driver/Include/Driver_USBD.h" />
+        <file category="sourceC" attr="template" name="CMSIS/Driver/DriverTemplates/Driver_USBD.c" select="USB Device Driver"/>
+      </files>
+    </component>
+    <component Cclass="CMSIS Driver" Cgroup="USB Host" Csub="Custom" Cversion="1.0.0" Capiversion="2.3.0" custom="1">
+      <description>Access to #include Driver_USBH.h file and code template for custom implementation</description>
+      <files>
+        <file category="header" name="CMSIS/Driver/Include/Driver_USBH.h" />
+        <file category="sourceC" attr="template" name="CMSIS/Driver/DriverTemplates/Driver_USBH.c" select="USB Host Driver"/>
+      </files>
+    </component>
+    <component Cclass="CMSIS Driver" Cgroup="GPIO" Csub="Custom" Cversion="1.0.0" Capiversion="1.0.0" custom="1">
+      <description>Access to #include Driver_GPIO.h file and code template for custom implementation</description>
+      <files>
+        <file category="header" name="CMSIS/Driver/Include/Driver_GPIO.h" />
+        <file category="sourceC" attr="template" name="CMSIS/Driver/DriverTemplates/Driver_GPIO.c" select="GPIO Driver"/>
+      </files>
+    </component>
+    <component Cclass="CMSIS Driver" Cgroup="WiFi" Csub="Custom" Cversion="1.0.0" Capiversion="1.1.0" custom="1">
+      <description>Access to #include Driver_WiFi.h file</description>
+      <files>
+        <file category="header" name="CMSIS/Driver/Include/Driver_WiFi.h"/>
+        <file category="sourceC" attr="template" name="CMSIS/Driver/DriverTemplates/Driver_WiFi.c" select="WiFi Driver"/>
+      </files>
+    </component>
+
+    <!-- VIO components -->
+    <component Cclass="CMSIS Driver" Cgroup="VIO" Csub="Custom" Cversion="1.0.0" Capiversion="1.0.0" custom="1">
+      <description>Virtual I/O custom implementation template</description>
+      <files>
+        <file category="sourceC" name="CMSIS/Driver/VIO/Source/vio.c" attr="template" select="Virtual I/O"/>
+      </files>
+    </component>
+    <component Cclass="CMSIS Driver" Cgroup="VIO" Csub="Virtual" Cversion="1.0.0" Capiversion="1.0.0">
+      <description>Virtual I/O implementation using memory only</description>
+      <files>
+        <file category="sourceC" name="CMSIS/Driver/VIO/Source/vio_memory.c"/>
+      </files>
+    </component>
+
+  </components>
+
+</package>

--- a/platform/ext/cmsis/CMSIS/Core/Include/a-profile/cmsis_armclang_a.h
+++ b/platform/ext/cmsis/CMSIS/Core/Include/a-profile/cmsis_armclang_a.h
@@ -1,0 +1,775 @@
+/*
+ * Copyright (c) 2009-2024 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS-Core(A) Compiler ARMClang (Arm Compiler 6) Header File
+ */
+
+#ifndef __CMSIS_ARMCLANG_A_H
+#define __CMSIS_ARMCLANG_A_H
+
+#pragma clang system_header   /* treat file as system include file */
+
+/* CMSIS compiler specific defines */
+#ifndef   __ASM
+  #define __ASM                                  __asm
+#endif
+#ifndef   __INLINE
+  #define __INLINE                               __inline
+#endif
+#ifndef   __FORCEINLINE
+  #define __FORCEINLINE                          __attribute__((always_inline))
+#endif
+#ifndef   __STATIC_INLINE
+  #define __STATIC_INLINE                        static __inline
+#endif
+#ifndef   __STATIC_FORCEINLINE
+  #define __STATIC_FORCEINLINE                   __attribute__((always_inline)) static __inline
+#endif
+#ifndef   __NO_RETURN
+  #define __NO_RETURN                            __attribute__((__noreturn__))
+#endif
+#ifndef   CMSIS_DEPRECATED
+  #define CMSIS_DEPRECATED                       __attribute__((deprecated))
+#endif
+#ifndef   __USED
+  #define __USED                                 __attribute__((used))
+#endif
+#ifndef   __WEAK
+  #define __WEAK                                 __attribute__((weak))
+#endif
+#ifndef   __PACKED
+  #define __PACKED                               __attribute__((packed, aligned(1)))
+#endif
+#ifndef   __PACKED_STRUCT
+  #define __PACKED_STRUCT                        struct __attribute__((packed, aligned(1)))
+#endif
+#ifndef   __UNALIGNED_UINT16_WRITE
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wpacked"
+/*lint -esym(9058, T_UINT16_WRITE)*/ /* disable MISRA 2012 Rule 2.4 for T_UINT16_WRITE */
+  __PACKED_STRUCT T_UINT16_WRITE { uint16_t v; };
+  #pragma clang diagnostic pop
+  #define __UNALIGNED_UINT16_WRITE(addr, val)    (void)((((struct T_UINT16_WRITE *)(void *)(addr))->v) = (val))
+#endif
+#ifndef   __UNALIGNED_UINT16_READ
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wpacked"
+/*lint -esym(9058, T_UINT16_READ)*/ /* disable MISRA 2012 Rule 2.4 for T_UINT16_READ */
+  __PACKED_STRUCT T_UINT16_READ { uint16_t v; };
+  #pragma clang diagnostic pop
+  #define __UNALIGNED_UINT16_READ(addr)          (((const struct T_UINT16_READ *)(const void *)(addr))->v)
+#endif
+#ifndef   __UNALIGNED_UINT32_WRITE
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wpacked"
+/*lint -esym(9058, T_UINT32_WRITE)*/ /* disable MISRA 2012 Rule 2.4 for T_UINT32_WRITE */
+  __PACKED_STRUCT T_UINT32_WRITE { uint32_t v; };
+  #pragma clang diagnostic pop
+  #define __UNALIGNED_UINT32_WRITE(addr, val)    (void)((((struct T_UINT32_WRITE *)(void *)(addr))->v) = (val))
+#endif
+#ifndef   __UNALIGNED_UINT32_READ
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wpacked"
+  __PACKED_STRUCT T_UINT32_READ { uint32_t v; };
+  #pragma clang diagnostic pop
+  #define __UNALIGNED_UINT32_READ(addr)          (((const struct T_UINT32_READ *)(const void *)(addr))->v)
+#endif
+#ifndef   __ALIGNED
+  #define __ALIGNED(x)                           __attribute__((aligned(x)))
+#endif
+#ifndef   __PACKED
+  #define __PACKED                               __attribute__((packed))
+#endif
+#ifndef   __COMPILER_BARRIER
+  #define __COMPILER_BARRIER()                   __ASM volatile("":::"memory")
+#endif
+
+
+/* ##########################  Core Instruction Access  ######################### */
+/**
+  \brief   No Operation
+  \details No Operation does nothing. This instruction can be used for code alignment purposes.
+ */
+#define __NOP                             __builtin_arm_nop
+
+
+/**
+  \brief   Wait For Interrupt
+  \details Wait For Interrupt is a hint instruction that suspends execution until one of a number of events occurs.
+ */
+#define __WFI                             __builtin_arm_wfi
+
+
+/**
+  \brief   Wait For Event
+  \details Wait For Event is a hint instruction that permits the processor to enter
+           a low-power state until one of a number of events occurs.
+ */
+#define __WFE                             __builtin_arm_wfe
+
+
+/**
+  \brief   Send Event
+  \details Send Event is a hint instruction. It causes an event to be signaled to the CPU.
+ */
+#define __SEV                             __builtin_arm_sev
+
+
+/**
+  \brief   Instruction Synchronization Barrier
+  \details Instruction Synchronization Barrier flushes the pipeline in the processor,
+           so that all instructions following the ISB are fetched from cache or memory,
+           after the instruction has been completed.
+ */
+#define __ISB()                           __builtin_arm_isb(0xF)
+
+/**
+  \brief   Data Synchronization Barrier
+  \details Acts as a special kind of Data Memory Barrier.
+           It completes when all explicit memory accesses before this instruction complete.
+ */
+#define __DSB()                           __builtin_arm_dsb(0xF)
+
+
+/**
+  \brief   Data Memory Barrier
+  \details Ensures the apparent order of the explicit memory operations before
+           and after the instruction, without ensuring their completion.
+ */
+#define __DMB()                           __builtin_arm_dmb(0xF)
+
+
+/**
+  \brief   Reverse byte order (32 bit)
+  \details Reverses the byte order in unsigned integer value. For example, 0x12345678 becomes 0x78563412.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+#define __REV(value)   __builtin_bswap32(value)
+
+
+/**
+  \brief   Reverse byte order (16 bit)
+  \details Reverses the byte order within each halfword of a word. For example, 0x12345678 becomes 0x34127856.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+#define __REV16(value) __ROR(__REV(value), 16)
+
+
+/**
+  \brief   Reverse byte order (16 bit)
+  \details Reverses the byte order in a 16-bit value and returns the signed 16-bit result. For example, 0x0080 becomes 0x8000.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+#define __REVSH(value) (int16_t)__builtin_bswap16(value)
+
+
+/**
+  \brief   Rotate Right in unsigned value (32 bit)
+  \details Rotate Right (immediate) provides the value of the contents of a register rotated by a variable number of bits.
+  \param [in]    op1  Value to rotate
+  \param [in]    op2  Number of Bits to rotate
+  \return               Rotated value
+ */
+__STATIC_FORCEINLINE uint32_t __ROR(uint32_t op1, uint32_t op2)
+{
+  op2 %= 32U;
+  if (op2 == 0U)
+  {
+    return op1;
+  }
+  return (op1 >> op2) | (op1 << (32U - op2));
+}
+
+
+/**
+  \brief   Breakpoint
+  \details Causes the processor to enter Debug state.
+           Debug tools can use this to investigate system state when the instruction at a particular address is reached.
+  \param [in]    value  is ignored by the processor.
+                 If required, a debugger can use it to store additional information about the breakpoint.
+ */
+#define __BKPT(value)   __ASM volatile ("bkpt "#value)
+
+
+/**
+  \brief   Reverse bit order of value
+  \details Reverses the bit order of the given value.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+#define __RBIT          __builtin_arm_rbit
+
+
+/**
+  \brief   Count leading zeros
+  \details Counts the number of leading zeros of a data value.
+  \param [in]  value  Value to count the leading zeros
+  \return             number of leading zeros in value
+ */
+__STATIC_FORCEINLINE uint8_t __CLZ(uint32_t value)
+{
+  /* Even though __builtin_clz produces a CLZ instruction on ARM, formally
+     __builtin_clz(0) is undefined behaviour, so handle this case specially.
+     This guarantees ARM-compatible results if happening to compile on a non-ARM
+     target, and ensures the compiler doesn't decide to activate any
+     optimisations using the logic "value was passed to __builtin_clz, so it
+     is non-zero".
+     ARM Compiler 6.10 and possibly earlier will optimise this test away, leaving a
+     single CLZ instruction.
+   */
+  if (value == 0U)
+  {
+    return 32U;
+  }
+  return __builtin_clz(value);
+}
+
+
+/**
+  \brief   LDR Exclusive (8 bit)
+  \details Executes a exclusive LDR instruction for 8 bit value.
+  \param [in]    ptr  Pointer to data
+  \return             value of type uint8_t at (*ptr)
+ */
+#define __LDREXB        (uint8_t)__builtin_arm_ldrex
+
+
+/**
+  \brief   LDR Exclusive (16 bit)
+  \details Executes a exclusive LDR instruction for 16 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint16_t at (*ptr)
+ */
+#define __LDREXH        (uint16_t)__builtin_arm_ldrex
+
+
+/**
+  \brief   LDR Exclusive (32 bit)
+  \details Executes a exclusive LDR instruction for 32 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint32_t at (*ptr)
+ */
+#define __LDREXW        (uint32_t)__builtin_arm_ldrex
+
+
+/**
+  \brief   STR Exclusive (8 bit)
+  \details Executes a exclusive STR instruction for 8 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+#define __STREXB        (uint32_t)__builtin_arm_strex
+
+
+/**
+  \brief   STR Exclusive (16 bit)
+  \details Executes a exclusive STR instruction for 16 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+#define __STREXH        (uint32_t)__builtin_arm_strex
+
+
+/**
+  \brief   STR Exclusive (32 bit)
+  \details Executes a exclusive STR instruction for 32 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+#define __STREXW        (uint32_t)__builtin_arm_strex
+
+
+/**
+  \brief   Remove the exclusive lock
+  \details Removes the exclusive lock which is created by LDREX.
+ */
+#define __CLREX             __builtin_arm_clrex
+
+/**
+  \brief   Signed Saturate
+  \details Saturates a signed value.
+  \param [in]  value  Value to be saturated
+  \param [in]    sat  Bit position to saturate to (1..32)
+  \return             Saturated value
+ */
+#define __SSAT             __builtin_arm_ssat
+
+
+/**
+  \brief   Unsigned Saturate
+  \details Saturates an unsigned value.
+  \param [in]  value  Value to be saturated
+  \param [in]    sat  Bit position to saturate to (0..31)
+  \return             Saturated value
+ */
+#define __USAT             __builtin_arm_usat
+
+/**
+  \brief   Rotate Right with Extend (32 bit)
+  \details Moves each bit of a bitstring right by one bit.
+           The carry input is shifted in at the left end of the bitstring.
+  \param [in]    value  Value to rotate
+  \return               Rotated value
+ */
+__STATIC_FORCEINLINE uint32_t __RRX(uint32_t value)
+{
+  uint32_t result;
+
+  __ASM volatile ("rrx %0, %1" : "=r" (result) : "r" (value));
+  return (result);
+}
+
+
+/**
+  \brief   LDRT Unprivileged (8 bit)
+  \details Executes a Unprivileged LDRT instruction for 8 bit value.
+  \param [in]    ptr  Pointer to data
+  \return             value of type uint8_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint8_t __LDRBT(volatile uint8_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldrbt %0, %1" : "=r" (result) : "Q" (*ptr) );
+  return ((uint8_t)result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   LDRT Unprivileged (16 bit)
+  \details Executes a Unprivileged LDRT instruction for 16 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint16_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint16_t __LDRHT(volatile uint16_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldrht %0, %1" : "=r" (result) : "Q" (*ptr) );
+  return ((uint16_t)result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   LDRT Unprivileged (32 bit)
+  \details Executes a Unprivileged LDRT instruction for 32 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint32_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint32_t __LDRT(volatile uint32_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldrt %0, %1" : "=r" (result) : "Q" (*ptr) );
+  return (result);
+}
+
+
+/**
+  \brief   STRT Unprivileged (8 bit)
+  \details Executes a Unprivileged STRT instruction for 8 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__STATIC_FORCEINLINE void __STRBT(uint8_t value, volatile uint8_t *ptr)
+{
+  __ASM volatile ("strbt %1, %0, #0" : "=Q" (*ptr) : "r" ((uint32_t)value) );
+}
+
+
+/**
+  \brief   STRT Unprivileged (16 bit)
+  \details Executes a Unprivileged STRT instruction for 16 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__STATIC_FORCEINLINE void __STRHT(uint16_t value, volatile uint16_t *ptr)
+{
+  __ASM volatile ("strht %1, %0, #0" : "=Q" (*ptr) : "r" ((uint32_t)value) );
+}
+
+
+/**
+  \brief   STRT Unprivileged (32 bit)
+  \details Executes a Unprivileged STRT instruction for 32 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__STATIC_FORCEINLINE void __STRT(uint32_t value, volatile uint32_t *ptr)
+{
+  __ASM volatile ("strt %1, %0, #0" : "=Q" (*ptr) : "r" (value) );
+}
+
+/* ###################  Compiler specific Intrinsics  ########################### */
+
+#if (defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1))
+
+#define     __SADD8                 __builtin_arm_sadd8
+#define     __QADD8                 __builtin_arm_qadd8
+#define     __SHADD8                __builtin_arm_shadd8
+#define     __UADD8                 __builtin_arm_uadd8
+#define     __UQADD8                __builtin_arm_uqadd8
+#define     __UHADD8                __builtin_arm_uhadd8
+#define     __SSUB8                 __builtin_arm_ssub8
+#define     __QSUB8                 __builtin_arm_qsub8
+#define     __SHSUB8                __builtin_arm_shsub8
+#define     __USUB8                 __builtin_arm_usub8
+#define     __UQSUB8                __builtin_arm_uqsub8
+#define     __UHSUB8                __builtin_arm_uhsub8
+#define     __SADD16                __builtin_arm_sadd16
+#define     __QADD16                __builtin_arm_qadd16
+#define     __SHADD16               __builtin_arm_shadd16
+#define     __UADD16                __builtin_arm_uadd16
+#define     __UQADD16               __builtin_arm_uqadd16
+#define     __UHADD16               __builtin_arm_uhadd16
+#define     __SSUB16                __builtin_arm_ssub16
+#define     __QSUB16                __builtin_arm_qsub16
+#define     __SHSUB16               __builtin_arm_shsub16
+#define     __USUB16                __builtin_arm_usub16
+#define     __UQSUB16               __builtin_arm_uqsub16
+#define     __UHSUB16               __builtin_arm_uhsub16
+#define     __SASX                  __builtin_arm_sasx
+#define     __QASX                  __builtin_arm_qasx
+#define     __SHASX                 __builtin_arm_shasx
+#define     __UASX                  __builtin_arm_uasx
+#define     __UQASX                 __builtin_arm_uqasx
+#define     __UHASX                 __builtin_arm_uhasx
+#define     __SSAX                  __builtin_arm_ssax
+#define     __QSAX                  __builtin_arm_qsax
+#define     __SHSAX                 __builtin_arm_shsax
+#define     __USAX                  __builtin_arm_usax
+#define     __UQSAX                 __builtin_arm_uqsax
+#define     __UHSAX                 __builtin_arm_uhsax
+#define     __USAD8                 __builtin_arm_usad8
+#define     __USADA8                __builtin_arm_usada8
+#define     __SSAT16                __builtin_arm_ssat16
+#define     __USAT16                __builtin_arm_usat16
+#define     __UXTB16                __builtin_arm_uxtb16
+#define     __UXTAB16               __builtin_arm_uxtab16
+#define     __SXTB16                __builtin_arm_sxtb16
+#define     __SXTAB16               __builtin_arm_sxtab16
+#define     __SMUAD                 __builtin_arm_smuad
+#define     __SMUADX                __builtin_arm_smuadx
+#define     __SMLAD                 __builtin_arm_smlad
+#define     __SMLADX                __builtin_arm_smladx
+#define     __SMLALD                __builtin_arm_smlald
+#define     __SMLALDX               __builtin_arm_smlaldx
+#define     __SMUSD                 __builtin_arm_smusd
+#define     __SMUSDX                __builtin_arm_smusdx
+#define     __SMLSD                 __builtin_arm_smlsd
+#define     __SMLSDX                __builtin_arm_smlsdx
+#define     __SMLSLD                __builtin_arm_smlsld
+#define     __SMLSLDX               __builtin_arm_smlsldx
+#define     __SEL                   __builtin_arm_sel
+#define     __QADD                  __builtin_arm_qadd
+#define     __QSUB                  __builtin_arm_qsub
+
+#define __PKHBT(ARG1,ARG2,ARG3)          ( ((((uint32_t)(ARG1))          ) & 0x0000FFFFUL) |  \
+                                           ((((uint32_t)(ARG2)) << (ARG3)) & 0xFFFF0000UL)  )
+
+#define __PKHTB(ARG1,ARG2,ARG3)          ( ((((uint32_t)(ARG1))          ) & 0xFFFF0000UL) |  \
+                                           ((((uint32_t)(ARG2)) >> (ARG3)) & 0x0000FFFFUL)  )
+
+#define __SXTB16_RORn(ARG1, ARG2)        __SXTB16(__ROR(ARG1, ARG2))
+
+#define __SXTAB16_RORn(ARG1, ARG2, ARG3) __SXTAB16(ARG1, __ROR(ARG2, ARG3))
+
+__STATIC_FORCEINLINE int32_t __SMMLA (int32_t op1, int32_t op2, int32_t op3)
+{
+  int32_t result;
+
+  __ASM volatile ("smmla %0, %1, %2, %3" : "=r" (result): "r"  (op1), "r" (op2), "r" (op3) );
+  return (result);
+}
+
+#endif /* (__ARM_FEATURE_DSP == 1) */
+
+/* ###########################  Core Function Access  ########################### */
+
+/**
+  \brief   Enable IRQ Interrupts
+  \details Enables IRQ interrupts by clearing the I-bit in the CPSR.
+           Can only be executed in Privileged modes.
+ */
+__STATIC_FORCEINLINE void __enable_irq(void)
+{
+  __ASM volatile ("cpsie i" : : : "memory");
+}
+
+/**
+  \brief   Disable IRQ Interrupts
+  \details Disables IRQ interrupts by setting the I-bit in the CPSR.
+  Can only be executed in Privileged modes.
+ */
+__STATIC_FORCEINLINE void __disable_irq(void)
+{
+  __ASM volatile ("cpsid i" : : : "memory");
+}
+
+/**
+  \brief   Enable FIQ
+  \details Enables FIQ interrupts by clearing special-purpose register FAULTMASK.
+           Can only be executed in Privileged modes.
+ */
+__STATIC_FORCEINLINE void __enable_fault_irq(void)
+{
+  __ASM volatile ("cpsie f" : : : "memory");
+}
+
+
+/**
+  \brief   Disable FIQ
+  \details Disables FIQ interrupts by setting special-purpose register FAULTMASK.
+           Can only be executed in Privileged modes.
+ */
+__STATIC_FORCEINLINE void __disable_fault_irq(void)
+{
+  __ASM volatile ("cpsid f" : : : "memory");
+}
+
+
+/**
+  \brief   Get FPSCR
+  \details Returns the current value of the Floating Point Status/Control register.
+  \return               Floating Point Status/Control register value
+ */
+__STATIC_FORCEINLINE  uint32_t __get_FPSCR(void)
+{
+#if (defined(__ARM_FP) && (__ARM_FP >= 1))
+  return __builtin_arm_get_fpscr();
+#else
+  return(0U);
+#endif
+}
+
+
+/**
+  \brief   Set FPSCR
+  \details Assigns the given value to the Floating Point Status/Control register.
+  \param [in]    fpscr  Floating Point Status/Control value to set
+ */
+__STATIC_FORCEINLINE void __set_FPSCR(uint32_t fpscr)
+{
+#if (defined(__ARM_FP) && (__ARM_FP >= 1))
+  __builtin_arm_set_fpscr(fpscr);
+#else
+  (void)fpscr;
+#endif
+}
+
+
+/** \brief  Get CPSR Register
+    \return               CPSR Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_CPSR(void)
+{
+  uint32_t result;
+  __ASM volatile("MRS %0, cpsr" : "=r" (result) );
+  return(result);
+}
+
+/** \brief  Set CPSR Register
+    \param [in]    cpsr  CPSR value to set
+ */
+__STATIC_FORCEINLINE void __set_CPSR(uint32_t cpsr)
+{
+  __ASM volatile ("MSR cpsr, %0" : : "r" (cpsr) : "cc", "memory");
+}
+
+/** \brief  Get Mode
+    \return                Processor Mode
+ */
+__STATIC_FORCEINLINE uint32_t __get_mode(void)
+{
+  return (__get_CPSR() & 0x1FU);
+}
+
+/** \brief  Set Mode
+    \param [in]    mode  Mode value to set
+ */
+__STATIC_FORCEINLINE void __set_mode(uint32_t mode)
+{
+  __ASM volatile("MSR  cpsr_c, %0" : : "r" (mode) : "memory");
+}
+
+/** \brief  Get Stack Pointer
+    \return Stack Pointer value
+ */
+__STATIC_FORCEINLINE uint32_t __get_SP(void)
+{
+  uint32_t result;
+  __ASM volatile("MOV  %0, sp" : "=r" (result) : : "memory");
+  return result;
+}
+
+/** \brief  Set Stack Pointer
+    \param [in]    stack  Stack Pointer value to set
+ */
+__STATIC_FORCEINLINE void __set_SP(uint32_t stack)
+{
+  __ASM volatile("MOV  sp, %0" : : "r" (stack) : "memory");
+}
+
+/** \brief  Get USR/SYS Stack Pointer
+    \return USR/SYS Stack Pointer value
+ */
+__STATIC_FORCEINLINE uint32_t __get_SP_usr(void)
+{
+  uint32_t cpsr;
+  uint32_t result;
+  __ASM volatile(
+    "MRS     %0, cpsr   \n"
+    "CPS     #0x1F      \n" // no effect in USR mode
+    "MOV     %1, sp     \n"
+    "MSR     cpsr_c, %0 \n" // no effect in USR mode
+    "ISB" :  "=r"(cpsr), "=r"(result) : : "memory"
+   );
+  return result;
+}
+
+/** \brief  Set USR/SYS Stack Pointer
+    \param [in]    topOfProcStack  USR/SYS Stack Pointer value to set
+ */
+__STATIC_FORCEINLINE void __set_SP_usr(uint32_t topOfProcStack)
+{
+  uint32_t cpsr;
+  __ASM volatile(
+    "MRS     %0, cpsr   \n"
+    "CPS     #0x1F      \n" // no effect in USR mode
+    "MOV     sp, %1     \n"
+    "MSR     cpsr_c, %0 \n" // no effect in USR mode
+    "ISB" : "=r"(cpsr) : "r" (topOfProcStack) : "memory"
+   );
+}
+
+/** \brief  Get FPEXC
+    \return               Floating Point Exception Control register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_FPEXC(void)
+{
+#if (__FPU_PRESENT == 1)
+  uint32_t result;
+  __ASM volatile("VMRS %0, fpexc" : "=r" (result) : : "memory");
+  return(result);
+#else
+  return(0);
+#endif
+}
+
+/** \brief  Set FPEXC
+    \param [in]    fpexc  Floating Point Exception Control value to set
+ */
+__STATIC_FORCEINLINE void __set_FPEXC(uint32_t fpexc)
+{
+#if (__FPU_PRESENT == 1)
+  __ASM volatile ("VMSR fpexc, %0" : : "r" (fpexc) : "memory");
+#endif
+}
+
+/*
+ * Include common core functions to access Coprocessor 15 registers
+ */
+
+#define __get_CP(cp, op1, Rt, CRn, CRm, op2) __ASM volatile("MRC p" # cp ", " # op1 ", %0, c" # CRn ", c" # CRm ", " # op2 : "=r" (Rt) : : "memory" )
+#define __set_CP(cp, op1, Rt, CRn, CRm, op2) __ASM volatile("MCR p" # cp ", " # op1 ", %0, c" # CRn ", c" # CRm ", " # op2 : : "r" (Rt) : "memory" )
+#define __get_CP64(cp, op1, Rt, CRm)         __ASM volatile("MRRC p" # cp ", " # op1 ", %Q0, %R0, c" # CRm  : "=r" (Rt) : : "memory" )
+#define __set_CP64(cp, op1, Rt, CRm)         __ASM volatile("MCRR p" # cp ", " # op1 ", %Q0, %R0, c" # CRm  : : "r" (Rt) : "memory" )
+
+#include "cmsis_cp15.h"
+
+/** \brief  Enable Floating Point Unit
+
+  Critical section, called from undef handler, so systick is disabled
+ */
+__STATIC_INLINE void __FPU_Enable(void)
+{
+  __ASM volatile(
+    // Permit access to VFP/NEON, registers by modifying CPACR
+    "        MRC     p15,0,R1,c1,c0,2  \n"
+    "        ORR     R1,R1,#0x00F00000 \n"
+    "        MCR     p15,0,R1,c1,c0,2  \n"
+
+    // Ensure that subsequent instructions occur in the context of VFP/NEON access permitted
+    "        ISB                       \n"
+
+    // Enable VFP/NEON
+    "        VMRS    R1,FPEXC          \n"
+    "        ORR     R1,R1,#0x40000000 \n"
+    "        VMSR    FPEXC,R1          \n"
+
+    // Initialise VFP/NEON registers to 0
+    "        MOV     R2,#0             \n"
+
+    // Initialise D16 registers to 0
+    "        VMOV    D0, R2,R2         \n"
+    "        VMOV    D1, R2,R2         \n"
+    "        VMOV    D2, R2,R2         \n"
+    "        VMOV    D3, R2,R2         \n"
+    "        VMOV    D4, R2,R2         \n"
+    "        VMOV    D5, R2,R2         \n"
+    "        VMOV    D6, R2,R2         \n"
+    "        VMOV    D7, R2,R2         \n"
+    "        VMOV    D8, R2,R2         \n"
+    "        VMOV    D9, R2,R2         \n"
+    "        VMOV    D10,R2,R2         \n"
+    "        VMOV    D11,R2,R2         \n"
+    "        VMOV    D12,R2,R2         \n"
+    "        VMOV    D13,R2,R2         \n"
+    "        VMOV    D14,R2,R2         \n"
+    "        VMOV    D15,R2,R2         \n"
+
+#if (defined(__ARM_NEON) && (__ARM_NEON == 1))
+    // Initialise D32 registers to 0
+    "        VMOV    D16,R2,R2         \n"
+    "        VMOV    D17,R2,R2         \n"
+    "        VMOV    D18,R2,R2         \n"
+    "        VMOV    D19,R2,R2         \n"
+    "        VMOV    D20,R2,R2         \n"
+    "        VMOV    D21,R2,R2         \n"
+    "        VMOV    D22,R2,R2         \n"
+    "        VMOV    D23,R2,R2         \n"
+    "        VMOV    D24,R2,R2         \n"
+    "        VMOV    D25,R2,R2         \n"
+    "        VMOV    D26,R2,R2         \n"
+    "        VMOV    D27,R2,R2         \n"
+    "        VMOV    D28,R2,R2         \n"
+    "        VMOV    D29,R2,R2         \n"
+    "        VMOV    D30,R2,R2         \n"
+    "        VMOV    D31,R2,R2         \n"
+#endif
+
+  // Initialise FPSCR to a known state
+    "        VMRS    R1,FPSCR          \n"
+    "        LDR     R2,=0x00086060    \n" //Mask off all bits that do not have to be preserved. Non-preserved bits can/should be zero.
+    "        AND     R1,R1,R2          \n"
+    "        VMSR    FPSCR,R1            "
+    : : : "cc", "r1", "r2"
+  );
+}
+
+#endif /* __CMSIS_ARMCLANG_A_H */

--- a/platform/ext/cmsis/CMSIS/Core/Include/a-profile/cmsis_clang_a.h
+++ b/platform/ext/cmsis/CMSIS/Core/Include/a-profile/cmsis_clang_a.h
@@ -1,0 +1,913 @@
+/*
+ * Copyright (c) 2023-2024 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS-Core(A) Compiler LLVM/Clang Header File
+ */
+
+#ifndef __CMSIS_CLANG_A_H
+#define __CMSIS_CLANG_A_H
+
+#pragma clang system_header   /* treat file as system include file */
+
+#if (__ARM_ACLE >= 200)
+  #include <arm_acle.h>
+#else
+  #error Compiler must support ACLE V2.0
+#endif /* (__ARM_ACLE >= 200) */
+
+/* CMSIS compiler specific defines */
+#ifndef   __ASM
+  #define __ASM                                  __asm
+#endif
+#ifndef   __INLINE
+  #define __INLINE                               inline
+#endif
+#ifndef   __FORCEINLINE
+  #define __FORCEINLINE                          __attribute__((always_inline))
+#endif
+#ifndef   __STATIC_INLINE
+  #define __STATIC_INLINE                        static inline
+#endif
+#ifndef   __STATIC_FORCEINLINE
+  #define __STATIC_FORCEINLINE                   __attribute__((always_inline)) static inline
+#endif
+#ifndef   __NO_RETURN
+  #define __NO_RETURN                            __attribute__((__noreturn__))
+#endif
+#ifndef   CMSIS_DEPRECATED
+  #define CMSIS_DEPRECATED                       __attribute__((deprecated))
+#endif
+#ifndef   __USED
+  #define __USED                                 __attribute__((used))
+#endif
+#ifndef   __WEAK
+  #define __WEAK                                 __attribute__((weak))
+#endif
+#ifndef   __PACKED
+  #define __PACKED                               __attribute__((packed, aligned(1)))
+#endif
+#ifndef   __PACKED_STRUCT
+  #define __PACKED_STRUCT                        struct __attribute__((packed, aligned(1)))
+#endif
+#ifndef   __UNALIGNED_UINT16_WRITE
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wpacked"
+  __PACKED_STRUCT T_UINT16_WRITE { uint16_t v; };
+  #pragma clang diagnostic pop
+  #define __UNALIGNED_UINT16_WRITE(addr, val)    (void)((((struct T_UINT16_WRITE *)(void *)(addr))->v) = (val))
+#endif
+#ifndef   __UNALIGNED_UINT16_READ
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wpacked"
+  __PACKED_STRUCT T_UINT16_READ { uint16_t v; };
+  #pragma clang diagnostic pop
+  #define __UNALIGNED_UINT16_READ(addr)          (((const struct T_UINT16_READ *)(const void *)(addr))->v)
+#endif
+#ifndef   __UNALIGNED_UINT32_WRITE
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wpacked"
+  __PACKED_STRUCT T_UINT32_WRITE { uint32_t v; };
+  #pragma clang diagnostic pop
+  #define __UNALIGNED_UINT32_WRITE(addr, val)    (void)((((struct T_UINT32_WRITE *)(void *)(addr))->v) = (val))
+#endif
+#ifndef   __UNALIGNED_UINT32_READ
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wpacked"
+  __PACKED_STRUCT T_UINT32_READ { uint32_t v; };
+  #pragma clang diagnostic pop
+  #define __UNALIGNED_UINT32_READ(addr)          (((const struct T_UINT32_READ *)(const void *)(addr))->v)
+#endif
+#ifndef   __ALIGNED
+  #define __ALIGNED(x)                           __attribute__((aligned(x)))
+#endif
+#ifndef   __RESTRICT
+  #define __RESTRICT                             __restrict
+#endif
+#ifndef   __COMPILER_BARRIER
+  #define __COMPILER_BARRIER()                   __ASM volatile("":::"memory")
+#endif
+
+
+/* ##########################  Core Instruction Access  ######################### */
+/**
+  \brief   No Operation
+  \details No Operation does nothing. This instruction can be used for code alignment purposes.
+ */
+#define __NOP()                             __ASM volatile ("nop")
+
+
+/**
+  \brief   Wait For Interrupt
+  \details Wait For Interrupt is a hint instruction that suspends execution until one of a number of events occurs.
+ */
+#define __WFI()                             __ASM volatile ("wfi":::"memory")
+
+
+/**
+  \brief   Wait For Event
+  \details Wait For Event is a hint instruction that permits the processor to enter
+           a low-power state until one of a number of events occurs.
+ */
+#define __WFE()                             __ASM volatile ("wfe":::"memory")
+
+
+/**
+  \brief   Send Event
+  \details Send Event is a hint instruction. It causes an event to be signaled to the CPU.
+ */
+#define __SEV()                             __ASM volatile ("sev")
+
+
+/**
+  \brief   Instruction Synchronization Barrier
+  \details Instruction Synchronization Barrier flushes the pipeline in the processor,
+           so that all instructions following the ISB are fetched from cache or memory,
+           after the instruction has been completed.
+ */
+__STATIC_FORCEINLINE  void __ISB(void)
+{
+  __ASM volatile ("isb 0xF":::"memory");
+}
+
+
+/**
+  \brief   Data Synchronization Barrier
+  \details Acts as a special kind of Data Memory Barrier.
+           It completes when all explicit memory accesses before this instruction complete.
+ */
+__STATIC_FORCEINLINE  void __DSB(void)
+{
+  __ASM volatile ("dsb 0xF":::"memory");
+}
+
+
+/**
+  \brief   Data Memory Barrier
+  \details Ensures the apparent order of the explicit memory operations before
+           and after the instruction, without ensuring their completion.
+ */
+__STATIC_FORCEINLINE  void __DMB(void)
+{
+  __ASM volatile ("dmb 0xF":::"memory");
+}
+
+
+/**
+  \brief   Reverse byte order (32 bit)
+  \details Reverses the byte order in unsigned integer value. For example, 0x12345678 becomes 0x78563412.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+__STATIC_FORCEINLINE  uint32_t __REV(uint32_t value)
+{
+#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5)
+  return __builtin_bswap32(value);
+#else
+  uint32_t result;
+
+  __ASM ("rev %0, %1" : "=r" (result) : "r" (value) );
+  return result;
+#endif
+}
+
+
+/**
+  \brief   Reverse byte order (16 bit)
+  \details Reverses the byte order within each halfword of a word. For example, 0x12345678 becomes 0x34127856.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+__STATIC_FORCEINLINE uint32_t __REV16(uint32_t value)
+{
+  uint32_t result;
+  __ASM ("rev16 %0, %1" : "=r" (result) : "r" (value));
+  return result;
+}
+
+
+/**
+  \brief   Reverse byte order (16 bit)
+  \details Reverses the byte order in a 16-bit value and returns the signed 16-bit result. For example, 0x0080 becomes 0x8000.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+__STATIC_FORCEINLINE  int16_t __REVSH(int16_t value)
+{
+#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)
+  return (int16_t)__builtin_bswap16(value);
+#else
+  int16_t result;
+
+  __ASM ("revsh %0, %1" : "=r" (result) : "r" (value) );
+  return result;
+#endif
+}
+
+
+/**
+  \brief   Rotate Right in unsigned value (32 bit)
+  \details Rotate Right (immediate) provides the value of the contents of a register rotated by a variable number of bits.
+  \param [in]    op1  Value to rotate
+  \param [in]    op2  Number of Bits to rotate
+  \return               Rotated value
+ */
+__STATIC_FORCEINLINE uint32_t __ROR(uint32_t op1, uint32_t op2)
+{
+  op2 %= 32U;
+  if (op2 == 0U)
+  {
+    return op1;
+  }
+  return (op1 >> op2) | (op1 << (32U - op2));
+}
+
+
+/**
+  \brief   Breakpoint
+  \details Causes the processor to enter Debug state.
+           Debug tools can use this to investigate system state when the instruction at a particular address is reached.
+  \param [in]    value  is ignored by the processor.
+                 If required, a debugger can use it to store additional information about the breakpoint.
+ */
+#define __BKPT(value)   __ASM volatile ("bkpt "#value)
+
+
+/**
+  \brief   Reverse bit order of value
+  \details Reverses the bit order of the given value.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+__STATIC_FORCEINLINE  uint32_t __RBIT(uint32_t value)
+{
+  uint32_t result;
+   __ASM ("rbit %0, %1" : "=r" (result) : "r" (value) );
+  return result;
+}
+
+
+/**
+  \brief   Count leading zeros
+  \details Counts the number of leading zeros of a data value.
+  \param [in]  value  Value to count the leading zeros
+  \return             number of leading zeros in value
+ */
+__STATIC_FORCEINLINE uint8_t __CLZ(uint32_t value)
+{
+  /* Even though __builtin_clz produces a CLZ instruction on ARM, formally
+     __builtin_clz(0) is undefined behaviour, so handle this case specially.
+     This guarantees ARM-compatible results if happening to compile on a non-ARM
+     target, and ensures the compiler doesn't decide to activate any
+     optimisations using the logic "value was passed to __builtin_clz, so it
+     is non-zero".
+   */
+  if (value == 0U)
+  {
+    return 32U;
+  }
+  return __builtin_clz(value);
+}
+
+
+/**
+  \brief   LDR Exclusive (8 bit)
+  \details Executes a exclusive LDR instruction for 8 bit value.
+  \param [in]    ptr  Pointer to data
+  \return             value of type uint8_t at (*ptr)
+ */
+__STATIC_FORCEINLINE  uint8_t __LDREXB(volatile uint8_t *addr)
+{
+    uint32_t result;
+
+   __ASM volatile ("ldrexb %0, %1" : "=r" (result) : "Q" (*addr) );
+   return ((uint8_t) result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   LDR Exclusive (16 bit)
+  \details Executes a exclusive LDR instruction for 16 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint16_t at (*ptr)
+ */
+__STATIC_FORCEINLINE  uint16_t __LDREXH(volatile uint16_t *addr)
+{
+    uint32_t result;
+
+   __ASM volatile ("ldrexh %0, %1" : "=r" (result) : "Q" (*addr) );
+   return ((uint16_t) result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   LDR Exclusive (32 bit)
+  \details Executes a exclusive LDR instruction for 32 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint32_t at (*ptr)
+ */
+__STATIC_FORCEINLINE  uint32_t __LDREXW(volatile uint32_t *addr)
+{
+    uint32_t result;
+
+   __ASM volatile ("ldrex %0, %1" : "=r" (result) : "Q" (*addr) );
+   return(result);
+}
+
+
+/**
+  \brief   STR Exclusive (8 bit)
+  \details Executes a exclusive STR instruction for 8 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+__STATIC_FORCEINLINE  uint32_t __STREXB(uint8_t value, volatile uint8_t *addr)
+{
+   uint32_t result;
+
+   __ASM volatile ("strexb %0, %2, %1" : "=&r" (result), "=Q" (*addr) : "r" ((uint32_t)value) );
+   return(result);
+}
+
+
+/**
+  \brief   STR Exclusive (16 bit)
+  \details Executes a exclusive STR instruction for 16 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+__STATIC_FORCEINLINE  uint32_t __STREXH(uint16_t value, volatile uint16_t *addr)
+{
+   uint32_t result;
+
+   __ASM volatile ("strexh %0, %2, %1" : "=&r" (result), "=Q" (*addr) : "r" ((uint32_t)value) );
+   return(result);
+}
+
+
+/**
+  \brief   STR Exclusive (32 bit)
+  \details Executes a exclusive STR instruction for 32 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+__STATIC_FORCEINLINE  uint32_t __STREXW(uint32_t value, volatile uint32_t *addr)
+{
+   uint32_t result;
+
+   __ASM volatile ("strex %0, %2, %1" : "=&r" (result), "=Q" (*addr) : "r" (value) );
+   return(result);
+}
+
+
+/**
+  \brief   Remove the exclusive lock
+  \details Removes the exclusive lock which is created by LDREX.
+ */
+__STATIC_FORCEINLINE  void __CLREX(void)
+{
+  __ASM volatile ("clrex" ::: "memory");
+}
+
+/**
+  \brief   Signed Saturate
+  \details Saturates a signed value.
+  \param [in]  ARG1  Value to be saturated
+  \param [in]  ARG2  Bit position to saturate to (1..32)
+  \return             Saturated value
+ */
+#define __SSAT(ARG1, ARG2) \
+__extension__ \
+({                          \
+  int32_t __RES, __ARG1 = (ARG1); \
+  __ASM volatile ("ssat %0, %1, %2" : "=r" (__RES) :  "I" (ARG2), "r" (__ARG1) : "cc" ); \
+  __RES; \
+ })
+
+
+/**
+  \brief   Unsigned Saturate
+  \details Saturates an unsigned value.
+  \param [in]  ARG1  Value to be saturated
+  \param [in]  ARG2  Bit position to saturate to (0..31)
+  \return             Saturated value
+ */
+#define __USAT(ARG1, ARG2) \
+__extension__ \
+({                          \
+  uint32_t __RES, __ARG1 = (ARG1); \
+  __ASM volatile ("usat %0, %1, %2" : "=r" (__RES) :  "I" (ARG2), "r" (__ARG1) : "cc" ); \
+  __RES; \
+ })
+
+/**
+  \brief   Rotate Right with Extend (32 bit)
+  \details Moves each bit of a bitstring right by one bit.
+           The carry input is shifted in at the left end of the bitstring.
+  \param [in]    value  Value to rotate
+  \return               Rotated value
+ */
+__STATIC_FORCEINLINE uint32_t __RRX(uint32_t value)
+{
+  uint32_t result;
+
+  __ASM volatile ("rrx %0, %1" : "=r" (result) : "r" (value));
+  return (result);
+}
+
+
+/**
+  \brief   LDRT Unprivileged (8 bit)
+  \details Executes a Unprivileged LDRT instruction for 8 bit value.
+  \param [in]    ptr  Pointer to data
+  \return             value of type uint8_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint8_t __LDRBT(volatile uint8_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldrbt %0, %1" : "=r" (result) : "Q" (*ptr) );
+  return ((uint8_t)result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   LDRT Unprivileged (16 bit)
+  \details Executes a Unprivileged LDRT instruction for 16 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint16_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint16_t __LDRHT(volatile uint16_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldrht %0, %1" : "=r" (result) : "Q" (*ptr) );
+  return ((uint16_t)result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   LDRT Unprivileged (32 bit)
+  \details Executes a Unprivileged LDRT instruction for 32 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint32_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint32_t __LDRT(volatile uint32_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldrt %0, %1" : "=r" (result) : "Q" (*ptr) );
+  return (result);
+}
+
+
+/**
+  \brief   STRT Unprivileged (8 bit)
+  \details Executes a Unprivileged STRT instruction for 8 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__STATIC_FORCEINLINE void __STRBT(uint8_t value, volatile uint8_t *ptr)
+{
+  __ASM volatile ("strbt %1, %0, #0" : "=Q" (*ptr) : "r" ((uint32_t)value) );
+}
+
+
+/**
+  \brief   STRT Unprivileged (16 bit)
+  \details Executes a Unprivileged STRT instruction for 16 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__STATIC_FORCEINLINE void __STRHT(uint16_t value, volatile uint16_t *ptr)
+{
+  __ASM volatile ("strht %1, %0, #0" : "=Q" (*ptr) : "r" ((uint32_t)value) );
+}
+
+
+/**
+  \brief   STRT Unprivileged (32 bit)
+  \details Executes a Unprivileged STRT instruction for 32 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__STATIC_FORCEINLINE void __STRT(uint32_t value, volatile uint32_t *ptr)
+{
+  __ASM volatile ("strt %1, %0, #0" : "=Q" (*ptr) : "r" (value) );
+}
+
+/* ###########################  Core Function Access  ########################### */
+/** \ingroup  CMSIS_Core_FunctionInterface
+    \defgroup CMSIS_Core_RegAccFunctions CMSIS Core Register Access Functions
+  @{
+ */
+
+/**
+  \brief   Enable IRQ Interrupts
+  \details Enables IRQ interrupts by clearing special-purpose register PRIMASK.
+           Can only be executed in Privileged modes.
+ */
+__STATIC_FORCEINLINE void __enable_irq(void)
+{
+  __ASM volatile ("cpsie i" : : : "memory");
+}
+
+
+/**
+  \brief   Disable IRQ Interrupts
+  \details Disables IRQ interrupts by setting special-purpose register PRIMASK.
+  Can only be executed in Privileged modes.
+ */
+__STATIC_FORCEINLINE void __disable_irq(void)
+{
+  __ASM volatile ("cpsid i" : : : "memory");
+}
+
+/**
+  \brief   Enable FIQ
+  \details Enables FIQ interrupts by clearing special-purpose register FAULTMASK.
+           Can only be executed in Privileged modes.
+ */
+__STATIC_FORCEINLINE void __enable_fault_irq(void)
+{
+  __ASM volatile ("cpsie f" : : : "memory");
+}
+
+
+/**
+  \brief   Disable FIQ
+  \details Disables FIQ interrupts by setting special-purpose register FAULTMASK.
+           Can only be executed in Privileged modes.
+ */
+__STATIC_FORCEINLINE void __disable_fault_irq(void)
+{
+  __ASM volatile ("cpsid f" : : : "memory");
+}
+
+/**
+  \brief   Get FPSCR
+  \details Returns the current value of the Floating Point Status/Control register.
+  \return               Floating Point Status/Control register value
+ */
+__STATIC_FORCEINLINE  uint32_t __get_FPSCR(void)
+{
+#if (defined(__ARM_FP) && (__ARM_FP >= 1))
+  return __builtin_arm_get_fpscr();
+#else
+  return(0U);
+#endif
+}
+
+
+/**
+  \brief   Set FPSCR
+  \details Assigns the given value to the Floating Point Status/Control register.
+  \param [in]    fpscr  Floating Point Status/Control value to set
+ */
+__STATIC_FORCEINLINE void __set_FPSCR(uint32_t fpscr)
+{
+#if (defined(__ARM_FP) && (__ARM_FP >= 1))
+  __builtin_arm_set_fpscr(fpscr);
+#else
+  (void)fpscr;
+#endif
+}
+
+
+/*@} end of CMSIS_Core_RegAccFunctions */
+
+
+/* ###################  Compiler specific Intrinsics  ########################### */
+
+#if (defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1))
+
+#define     __SADD8                 __builtin_arm_sadd8
+#define     __QADD8                 __builtin_arm_qadd8
+#define     __SHADD8                __builtin_arm_shadd8
+#define     __UADD8                 __builtin_arm_uadd8
+#define     __UQADD8                __builtin_arm_uqadd8
+#define     __UHADD8                __builtin_arm_uhadd8
+#define     __SSUB8                 __builtin_arm_ssub8
+#define     __QSUB8                 __builtin_arm_qsub8
+#define     __SHSUB8                __builtin_arm_shsub8
+#define     __USUB8                 __builtin_arm_usub8
+#define     __UQSUB8                __builtin_arm_uqsub8
+#define     __UHSUB8                __builtin_arm_uhsub8
+#define     __SADD16                __builtin_arm_sadd16
+#define     __QADD16                __builtin_arm_qadd16
+#define     __SHADD16               __builtin_arm_shadd16
+#define     __UADD16                __builtin_arm_uadd16
+#define     __UQADD16               __builtin_arm_uqadd16
+#define     __UHADD16               __builtin_arm_uhadd16
+#define     __SSUB16                __builtin_arm_ssub16
+#define     __QSUB16                __builtin_arm_qsub16
+#define     __SHSUB16               __builtin_arm_shsub16
+#define     __USUB16                __builtin_arm_usub16
+#define     __UQSUB16               __builtin_arm_uqsub16
+#define     __UHSUB16               __builtin_arm_uhsub16
+#define     __SASX                  __builtin_arm_sasx
+#define     __QASX                  __builtin_arm_qasx
+#define     __SHASX                 __builtin_arm_shasx
+#define     __UASX                  __builtin_arm_uasx
+#define     __UQASX                 __builtin_arm_uqasx
+#define     __UHASX                 __builtin_arm_uhasx
+#define     __SSAX                  __builtin_arm_ssax
+#define     __QSAX                  __builtin_arm_qsax
+#define     __SHSAX                 __builtin_arm_shsax
+#define     __USAX                  __builtin_arm_usax
+#define     __UQSAX                 __builtin_arm_uqsax
+#define     __UHSAX                 __builtin_arm_uhsax
+#define     __USAD8                 __builtin_arm_usad8
+#define     __USADA8                __builtin_arm_usada8
+#define     __SSAT16                __builtin_arm_ssat16
+#define     __USAT16                __builtin_arm_usat16
+#define     __UXTB16                __builtin_arm_uxtb16
+#define     __UXTAB16               __builtin_arm_uxtab16
+#define     __SXTB16                __builtin_arm_sxtb16
+#define     __SXTAB16               __builtin_arm_sxtab16
+#define     __SMUAD                 __builtin_arm_smuad
+#define     __SMUADX                __builtin_arm_smuadx
+#define     __SMLAD                 __builtin_arm_smlad
+#define     __SMLADX                __builtin_arm_smladx
+#define     __SMLALD                __builtin_arm_smlald
+#define     __SMLALDX               __builtin_arm_smlaldx
+#define     __SMUSD                 __builtin_arm_smusd
+#define     __SMUSDX                __builtin_arm_smusdx
+#define     __SMLSD                 __builtin_arm_smlsd
+#define     __SMLSDX                __builtin_arm_smlsdx
+#define     __SMLSLD                __builtin_arm_smlsld
+#define     __SMLSLDX               __builtin_arm_smlsldx
+#define     __SEL                   __builtin_arm_sel
+#define     __QADD                  __builtin_arm_qadd
+#define     __QSUB                  __builtin_arm_qsub
+
+#define __PKHBT(ARG1,ARG2,ARG3) \
+__extension__ \
+({                          \
+  uint32_t __RES, __ARG1 = (ARG1), __ARG2 = (ARG2); \
+  __ASM ("pkhbt %0, %1, %2, lsl %3" : "=r" (__RES) :  "r" (__ARG1), "r" (__ARG2), "I" (ARG3)  ); \
+  __RES; \
+ })
+
+#define __PKHTB(ARG1,ARG2,ARG3) \
+__extension__ \
+({                          \
+  uint32_t __RES, __ARG1 = (ARG1), __ARG2 = (ARG2); \
+  if (ARG3 == 0) \
+    __ASM ("pkhtb %0, %1, %2" : "=r" (__RES) :  "r" (__ARG1), "r" (__ARG2)  ); \
+  else \
+    __ASM ("pkhtb %0, %1, %2, asr %3" : "=r" (__RES) :  "r" (__ARG1), "r" (__ARG2), "I" (ARG3)  ); \
+  __RES; \
+ })
+
+__STATIC_FORCEINLINE uint32_t __SXTB16_RORn(uint32_t op1, uint32_t rotate)
+{
+    uint32_t result;
+    if (__builtin_constant_p(rotate) && ((rotate == 8U) || (rotate == 16U) || (rotate == 24U)))
+    {
+        __ASM volatile("sxtb16 %0, %1, ROR %2" : "=r"(result) : "r"(op1), "i"(rotate));
+    }
+    else
+    {
+        result = __SXTB16(__ROR(op1, rotate));
+    }
+    return result;
+}
+
+__STATIC_FORCEINLINE uint32_t __SXTAB16_RORn(uint32_t op1, uint32_t op2, uint32_t rotate)
+{
+    uint32_t result;
+    if (__builtin_constant_p(rotate) && ((rotate == 8U) || (rotate == 16U) || (rotate == 24U)))
+    {
+        __ASM volatile("sxtab16 %0, %1, %2, ROR %3" : "=r"(result) : "r"(op1), "r"(op2), "i"(rotate));
+    }
+    else
+    {
+        result = __SXTAB16(op1, __ROR(op2, rotate));
+    }
+    return result;
+}
+
+__STATIC_FORCEINLINE int32_t __SMMLA (int32_t op1, int32_t op2, int32_t op3)
+{
+  int32_t result;
+
+  __ASM volatile ("smmla %0, %1, %2, %3" : "=r" (result): "r"  (op1), "r" (op2), "r" (op3) );
+  return (result);
+}
+
+#endif /* (__ARM_FEATURE_DSP == 1) */
+/** @} end of group CMSIS_SIMD_intrinsics */
+
+/** \defgroup CMSIS_Core_intrinsics CMSIS Core Intrinsics
+  Access to dedicated SIMD instructions
+  @{
+*/
+
+/** \brief  Get CPSR Register
+    \return               CPSR Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_CPSR(void)
+{
+  uint32_t result;
+  __ASM volatile("MRS %0, cpsr" : "=r" (result) );
+  return(result);
+}
+
+/** \brief  Set CPSR Register
+    \param [in]    cpsr  CPSR value to set
+ */
+__STATIC_FORCEINLINE void __set_CPSR(uint32_t cpsr)
+{
+  __ASM volatile ("MSR cpsr, %0" : : "r" (cpsr) : "cc", "memory");
+}
+
+/** \brief  Get Mode
+    \return                Processor Mode
+ */
+__STATIC_FORCEINLINE uint32_t __get_mode(void)
+{
+  return (__get_CPSR() & 0x1FU);
+}
+
+/** \brief  Set Mode
+    \param [in]    mode  Mode value to set
+ */
+__STATIC_FORCEINLINE void __set_mode(uint32_t mode)
+{
+  __ASM volatile("MSR  cpsr_c, %0" : : "r" (mode) : "memory");
+}
+
+/** \brief  Get Stack Pointer
+    \return Stack Pointer value
+ */
+__STATIC_FORCEINLINE uint32_t __get_SP(void)
+{
+  uint32_t result;
+  __ASM volatile("MOV  %0, sp" : "=r" (result) : : "memory");
+  return result;
+}
+
+/** \brief  Set Stack Pointer
+    \param [in]    stack  Stack Pointer value to set
+ */
+__STATIC_FORCEINLINE void __set_SP(uint32_t stack)
+{
+  __ASM volatile("MOV  sp, %0" : : "r" (stack) : "memory");
+}
+
+/** \brief  Get USR/SYS Stack Pointer
+    \return USR/SYS Stack Pointer value
+ */
+__STATIC_FORCEINLINE uint32_t __get_SP_usr(void)
+{
+  uint32_t cpsr = __get_CPSR();
+  uint32_t result;
+  __ASM volatile(
+    "CPS     #0x1F  \n"
+    "MOV     %0, sp   " : "=r"(result) : : "memory"
+   );
+  __set_CPSR(cpsr);
+  __ISB();
+  return result;
+}
+
+/** \brief  Set USR/SYS Stack Pointer
+    \param [in]    topOfProcStack  USR/SYS Stack Pointer value to set
+ */
+__STATIC_FORCEINLINE void __set_SP_usr(uint32_t topOfProcStack)
+{
+  uint32_t cpsr = __get_CPSR();
+  __ASM volatile(
+    "CPS     #0x1F  \n"
+    "MOV     sp, %0   " : : "r" (topOfProcStack) : "memory"
+   );
+  __set_CPSR(cpsr);
+  __ISB();
+}
+
+/** \brief  Get FPEXC
+    \return               Floating Point Exception Control register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_FPEXC(void)
+{
+#if (__FPU_PRESENT == 1)
+  uint32_t result;
+  __ASM volatile("VMRS %0, fpexc" : "=r" (result) : : "memory");
+  return(result);
+#else
+  return(0);
+#endif
+}
+
+/** \brief  Set FPEXC
+    \param [in]    fpexc  Floating Point Exception Control value to set
+ */
+__STATIC_FORCEINLINE void __set_FPEXC(uint32_t fpexc)
+{
+#if (__FPU_PRESENT == 1)
+  __ASM volatile ("VMSR fpexc, %0" : : "r" (fpexc) : "memory");
+#endif
+}
+
+/*
+ * Include common core functions to access Coprocessor 15 registers
+ */
+
+#define __get_CP(cp, op1, Rt, CRn, CRm, op2) __ASM volatile("MRC p" # cp ", " # op1 ", %0, c" # CRn ", c" # CRm ", " # op2 : "=r" (Rt) : : "memory" )
+#define __set_CP(cp, op1, Rt, CRn, CRm, op2) __ASM volatile("MCR p" # cp ", " # op1 ", %0, c" # CRn ", c" # CRm ", " # op2 : : "r" (Rt) : "memory" )
+#define __get_CP64(cp, op1, Rt, CRm)         __ASM volatile("MRRC p" # cp ", " # op1 ", %Q0, %R0, c" # CRm  : "=r" (Rt) : : "memory" )
+#define __set_CP64(cp, op1, Rt, CRm)         __ASM volatile("MCRR p" # cp ", " # op1 ", %Q0, %R0, c" # CRm  : : "r" (Rt) : "memory" )
+
+#include "cmsis_cp15.h"
+
+/** \brief  Enable Floating Point Unit
+
+  Critical section, called from undef handler, so systick is disabled
+ */
+__STATIC_INLINE void __FPU_Enable(void)
+{
+  // Permit access to VFP/NEON, registers by modifying CPACR
+  const uint32_t cpacr = __get_CPACR();
+  __set_CPACR(cpacr | 0x00F00000ul);
+  __ISB();
+
+  // Enable VFP/NEON
+  const uint32_t fpexc = __get_FPEXC();
+  __set_FPEXC(fpexc | 0x40000000ul);
+
+  __ASM volatile(
+    // Initialise VFP/NEON registers to 0
+    "        MOV     R2,#0             \n"
+
+    // Initialise D16 registers to 0
+    "        VMOV    D0, R2,R2         \n"
+    "        VMOV    D1, R2,R2         \n"
+    "        VMOV    D2, R2,R2         \n"
+    "        VMOV    D3, R2,R2         \n"
+    "        VMOV    D4, R2,R2         \n"
+    "        VMOV    D5, R2,R2         \n"
+    "        VMOV    D6, R2,R2         \n"
+    "        VMOV    D7, R2,R2         \n"
+    "        VMOV    D8, R2,R2         \n"
+    "        VMOV    D9, R2,R2         \n"
+    "        VMOV    D10,R2,R2         \n"
+    "        VMOV    D11,R2,R2         \n"
+    "        VMOV    D12,R2,R2         \n"
+    "        VMOV    D13,R2,R2         \n"
+    "        VMOV    D14,R2,R2         \n"
+    "        VMOV    D15,R2,R2         \n"
+
+#if (defined(__ARM_NEON) && (__ARM_NEON == 1))
+    // Initialise D32 registers to 0
+    "        VMOV    D16,R2,R2         \n"
+    "        VMOV    D17,R2,R2         \n"
+    "        VMOV    D18,R2,R2         \n"
+    "        VMOV    D19,R2,R2         \n"
+    "        VMOV    D20,R2,R2         \n"
+    "        VMOV    D21,R2,R2         \n"
+    "        VMOV    D22,R2,R2         \n"
+    "        VMOV    D23,R2,R2         \n"
+    "        VMOV    D24,R2,R2         \n"
+    "        VMOV    D25,R2,R2         \n"
+    "        VMOV    D26,R2,R2         \n"
+    "        VMOV    D27,R2,R2         \n"
+    "        VMOV    D28,R2,R2         \n"
+    "        VMOV    D29,R2,R2         \n"
+    "        VMOV    D30,R2,R2         \n"
+    "        VMOV    D31,R2,R2         \n"
+#endif
+    : : : "cc", "r2"
+  );
+
+  // Initialise FPSCR to a known state
+  const uint32_t fpscr = __get_FPSCR();
+  __set_FPSCR(fpscr & 0x00086060ul);
+}
+
+/*@} end of group CMSIS_Core_intrinsics */
+
+#pragma clang diagnostic pop
+
+#endif /* __CMSIS_CLANG_A_H */

--- a/platform/ext/cmsis/CMSIS/Core/Include/a-profile/cmsis_cp15.h
+++ b/platform/ext/cmsis/CMSIS/Core/Include/a-profile/cmsis_cp15.h
@@ -1,0 +1,564 @@
+/*
+ * Copyright (c) 2009-2017 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS-Core(A) Compiler Specific Macros, Functions, Instructions
+ */
+
+#ifndef __CMSIS_CP15_H
+#define __CMSIS_CP15_H
+
+#if   defined ( __ICCARM__ )
+  #pragma system_include         /* treat file as system include file for MISRA check */
+#elif defined (__clang__)
+  #pragma clang system_header    /* treat file as system include file */
+#endif
+
+/** \brief  Get ACTLR
+    \return               Auxiliary Control register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_ACTLR(void)
+{
+  uint32_t result;
+  __get_CP(15, 0, result, 1, 0, 1);
+  return(result);
+}
+
+/** \brief  Set ACTLR
+    \param [in]    actlr  Auxiliary Control value to set
+ */
+__STATIC_FORCEINLINE void __set_ACTLR(uint32_t actlr)
+{
+  __set_CP(15, 0, actlr, 1, 0, 1);
+}
+
+/** \brief  Get CPACR
+    \return               Coprocessor Access Control register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_CPACR(void)
+{
+  uint32_t result;
+  __get_CP(15, 0, result, 1, 0, 2);
+  return result;
+}
+
+/** \brief  Set CPACR
+    \param [in]    cpacr  Coprocessor Access Control value to set
+ */
+__STATIC_FORCEINLINE void __set_CPACR(uint32_t cpacr)
+{
+  __set_CP(15, 0, cpacr, 1, 0, 2);
+}
+
+/** \brief  Get DFSR
+    \return               Data Fault Status Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_DFSR(void)
+{
+  uint32_t result;
+  __get_CP(15, 0, result, 5, 0, 0);
+  return result;
+}
+
+/** \brief  Set DFSR
+    \param [in]    dfsr  Data Fault Status value to set
+ */
+__STATIC_FORCEINLINE void __set_DFSR(uint32_t dfsr)
+{
+  __set_CP(15, 0, dfsr, 5, 0, 0);
+}
+
+/** \brief  Get IFSR
+    \return               Instruction Fault Status Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_IFSR(void)
+{
+  uint32_t result;
+  __get_CP(15, 0, result, 5, 0, 1);
+  return result;
+}
+
+/** \brief  Set IFSR
+    \param [in]    ifsr  Instruction Fault Status value to set
+ */
+__STATIC_FORCEINLINE void __set_IFSR(uint32_t ifsr)
+{
+  __set_CP(15, 0, ifsr, 5, 0, 1);
+}
+
+/** \brief  Get ISR
+    \return               Interrupt Status Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_ISR(void)
+{
+  uint32_t result;
+  __get_CP(15, 0, result, 12, 1, 0);
+  return result;
+}
+
+/** \brief  Get CBAR
+    \return               Configuration Base Address register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_CBAR(void)
+{
+  uint32_t result;
+  __get_CP(15, 4, result, 15, 0, 0);
+  return result;
+}
+
+/** \brief  Get TTBR0
+
+    This function returns the value of the Translation Table Base Register 0.
+
+    \return               Translation Table Base Register 0 value
+ */
+__STATIC_FORCEINLINE uint32_t __get_TTBR0(void)
+{
+  uint32_t result;
+  __get_CP(15, 0, result, 2, 0, 0);
+  return result;
+}
+
+/** \brief  Set TTBR0
+
+    This function assigns the given value to the Translation Table Base Register 0.
+
+    \param [in]    ttbr0  Translation Table Base Register 0 value to set
+ */
+__STATIC_FORCEINLINE void __set_TTBR0(uint32_t ttbr0)
+{
+  __set_CP(15, 0, ttbr0, 2, 0, 0);
+}
+
+/** \brief  Get DACR
+
+    This function returns the value of the Domain Access Control Register.
+
+    \return               Domain Access Control Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_DACR(void)
+{
+  uint32_t result;
+  __get_CP(15, 0, result, 3, 0, 0);
+  return result;
+}
+
+/** \brief  Set DACR
+
+    This function assigns the given value to the Domain Access Control Register.
+
+    \param [in]    dacr   Domain Access Control Register value to set
+ */
+__STATIC_FORCEINLINE void __set_DACR(uint32_t dacr)
+{
+  __set_CP(15, 0, dacr, 3, 0, 0);
+}
+
+/** \brief  Set SCTLR
+
+    This function assigns the given value to the System Control Register.
+
+    \param [in]    sctlr  System Control Register value to set
+ */
+__STATIC_FORCEINLINE void __set_SCTLR(uint32_t sctlr)
+{
+  __set_CP(15, 0, sctlr, 1, 0, 0);
+}
+
+/** \brief  Get SCTLR
+    \return               System Control Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_SCTLR(void)
+{
+  uint32_t result;
+  __get_CP(15, 0, result, 1, 0, 0);
+  return result;
+}
+
+/** \brief  Get MPIDR
+
+    This function returns the value of the Multiprocessor Affinity Register.
+
+    \return               Multiprocessor Affinity Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_MPIDR(void)
+{
+  uint32_t result;
+  __get_CP(15, 0, result, 0, 0, 5);
+  return result;
+}
+
+/** \brief  Get VBAR
+
+    This function returns the value of the Vector Base Address Register.
+
+    \return               Vector Base Address Register
+ */
+__STATIC_FORCEINLINE uint32_t __get_VBAR(void)
+{
+  uint32_t result;
+  __get_CP(15, 0, result, 12, 0, 0);
+  return result;
+}
+
+/** \brief  Set VBAR
+
+    This function assigns the given value to the Vector Base Address Register.
+
+    \param [in]    vbar  Vector Base Address Register value to set
+ */
+__STATIC_FORCEINLINE void __set_VBAR(uint32_t vbar)
+{
+  __set_CP(15, 0, vbar, 12, 0, 0);
+}
+
+/** \brief  Get MVBAR
+
+    This function returns the value of the Monitor Vector Base Address Register.
+
+    \return               Monitor Vector Base Address Register
+ */
+__STATIC_FORCEINLINE uint32_t __get_MVBAR(void)
+{
+  uint32_t result;
+  __get_CP(15, 0, result, 12, 0, 1);
+  return result;
+}
+
+/** \brief  Set MVBAR
+
+    This function assigns the given value to the Monitor Vector Base Address Register.
+
+    \param [in]    mvbar  Monitor Vector Base Address Register value to set
+ */
+__STATIC_FORCEINLINE void __set_MVBAR(uint32_t mvbar)
+{
+  __set_CP(15, 0, mvbar, 12, 0, 1);
+}
+
+#if (defined(__TIM_PRESENT) && (__TIM_PRESENT == 1U)) || \
+    defined(DOXYGEN)
+
+/** \brief  Set CNTFRQ
+
+  This function assigns the given value to PL1 Physical Timer Counter Frequency Register (CNTFRQ).
+
+  \param [in]    value  CNTFRQ Register value to set
+*/
+__STATIC_FORCEINLINE void __set_CNTFRQ(uint32_t value)
+{
+  __set_CP(15, 0, value, 14, 0, 0);
+}
+
+/** \brief  Get CNTFRQ
+
+    This function returns the value of the PL1 Physical Timer Counter Frequency Register (CNTFRQ).
+
+    \return               CNTFRQ Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_CNTFRQ(void)
+{
+  uint32_t result;
+  __get_CP(15, 0, result, 14, 0 , 0);
+  return result;
+}
+
+/** \brief  Set CNTP_TVAL
+
+  This function assigns the given value to PL1 Physical Timer Value Register (CNTP_TVAL).
+
+  \param [in]    value  CNTP_TVAL Register value to set
+*/
+__STATIC_FORCEINLINE void __set_CNTP_TVAL(uint32_t value)
+{
+  __set_CP(15, 0, value, 14, 2, 0);
+}
+
+/** \brief  Get CNTP_TVAL
+
+    This function returns the value of the PL1 Physical Timer Value Register (CNTP_TVAL).
+
+    \return               CNTP_TVAL Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_CNTP_TVAL(void)
+{
+  uint32_t result;
+  __get_CP(15, 0, result, 14, 2, 0);
+  return result;
+}
+
+/** \brief  Get CNTPCT
+
+    This function returns the value of the 64 bits PL1 Physical Count Register (CNTPCT).
+
+    \return               CNTPCT Register value
+ */
+__STATIC_FORCEINLINE uint64_t __get_CNTPCT(void)
+{
+  uint64_t result;
+  __get_CP64(15, 0, result, 14);
+  return result;
+}
+
+/** \brief  Set CNTP_CVAL
+
+  This function assigns the given value to 64bits PL1 Physical Timer CompareValue Register (CNTP_CVAL).
+
+  \param [in]    value  CNTP_CVAL Register value to set
+*/
+__STATIC_FORCEINLINE void __set_CNTP_CVAL(uint64_t value)
+{
+  __set_CP64(15, 2, value, 14);
+}
+
+/** \brief  Get CNTP_CVAL
+
+    This function returns the value of the 64 bits PL1 Physical Timer CompareValue Register (CNTP_CVAL).
+
+    \return               CNTP_CVAL Register value
+ */
+__STATIC_FORCEINLINE uint64_t __get_CNTP_CVAL(void)
+{
+  uint64_t result;
+  __get_CP64(15, 2, result, 14);
+  return result;
+}
+
+/** \brief  Set CNTP_CTL
+
+  This function assigns the given value to PL1 Physical Timer Control Register (CNTP_CTL).
+
+  \param [in]    value  CNTP_CTL Register value to set
+*/
+__STATIC_FORCEINLINE void __set_CNTP_CTL(uint32_t value)
+{
+  __set_CP(15, 0, value, 14, 2, 1);
+}
+
+/** \brief  Get CNTP_CTL register
+    \return               CNTP_CTL Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_CNTP_CTL(void)
+{
+  uint32_t result;
+  __get_CP(15, 0, result, 14, 2, 1);
+  return result;
+}
+
+/******************************* VIRTUAL TIMER *******************************/
+/** see [ARM DDI 0406C.d] :
+    . §B4.1.31 "CNTV_CTL, Counter-timer Virtual Timer Control register"
+    . §B4.1.32 "CNTV_CVAL, Counter-timer Virtual Timer CompareValue register"
+    . §B4.1.33 "CNTV_TVAL, Counter-timer Virtual Timer TimerValue register"
+    . §B4.1.34 "CNTVCT, Counter-timer Virtual Count register"
+**/
+/** \brief  Set CNTV_TVAL
+  This function assigns the given value to VL1 Virtual Timer Value Register (CNTV_TVAL).
+  \param [in]    value  CNTV_TVAL Register value to set
+*/
+__STATIC_FORCEINLINE void __set_CNTV_TVAL(uint32_t value)
+{
+  __set_CP(15, 0, value, 14, 3, 0);
+}
+
+/** \brief  Get CNTV_TVAL
+    This function returns the value of the VL1 Virtual Timer Value Register (CNTV_TVAL).
+    \return               CNTV_TVAL Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_CNTV_TVAL(void)
+{
+  uint32_t result;
+  __get_CP(15, 0, result, 14, 3, 0);
+  return result;
+}
+
+/** \brief  Get CNTVCT
+    This function returns the value of the 64 bits VL1 Virtual Count Register (CNTVCT).
+    \return               CNTVCT Register value
+ */
+__STATIC_FORCEINLINE uint64_t __get_CNTVCT(void)
+{
+  uint64_t result;
+  __get_CP64(15, 1, result, 14);
+  return result;
+}
+
+/** \brief  Set CNTV_CVAL
+  This function assigns the given value to 64bits VL1 Virtual Timer CompareValue Register (CNTV_CVAL).
+  \param [in]    value  CNTV_CVAL Register value to set
+*/
+__STATIC_FORCEINLINE void __set_CNTV_CVAL(uint64_t value)
+{
+  __set_CP64(15, 3, value, 14);
+}
+
+/** \brief  Get CNTV_CVAL
+    This function returns the value of the 64 bits VL1 Virtual Timer CompareValue Register (CNTV_CVAL).
+    \return               CNTV_CVAL Register value
+ */
+__STATIC_FORCEINLINE uint64_t __get_CNTV_CVAL(void)
+{
+  uint64_t result;
+  __get_CP64(15, 3, result, 14);
+  return result;
+}
+
+/** \brief  Set CNTV_CTL
+  This function assigns the given value to VL1 Virtual Timer Control Register (CNTV_CTL).
+  \param [in]    value  CNTV_CTL Register value to set
+*/
+__STATIC_FORCEINLINE void __set_CNTV_CTL(uint32_t value)
+{
+  __set_CP(15, 0, value, 14, 3, 1);
+}
+
+/** \brief  Get CNTV_CTL register
+    \return               CNTV_CTL Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_CNTV_CTL(void)
+{
+  uint32_t result;
+  __get_CP(15, 0, result, 14, 3, 1);
+  return result;
+}
+
+/***************************** VIRTUAL TIMER END *****************************/
+#endif
+
+/** \brief  Set TLBIALL
+
+  TLB Invalidate All
+ */
+__STATIC_FORCEINLINE void __set_TLBIALL(uint32_t value)
+{
+  __set_CP(15, 0, value, 8, 7, 0);
+}
+
+/** \brief  Set BPIALL.
+
+  Branch Predictor Invalidate All
+ */
+__STATIC_FORCEINLINE void __set_BPIALL(uint32_t value)
+{
+  __set_CP(15, 0, value, 7, 5, 6);
+}
+
+/** \brief  Set ICIALLU
+
+  Instruction Cache Invalidate All
+ */
+__STATIC_FORCEINLINE void __set_ICIALLU(uint32_t value)
+{
+  __set_CP(15, 0, value, 7, 5, 0);
+}
+
+/** \brief  Set ICIMVAC
+
+  Instruction Cache Invalidate
+ */
+__STATIC_FORCEINLINE void __set_ICIMVAC(uint32_t value)
+{
+  __set_CP(15, 0, value, 7, 5, 1);
+}
+
+/** \brief  Set DCCMVAC
+
+  Data cache clean
+ */
+__STATIC_FORCEINLINE void __set_DCCMVAC(uint32_t value)
+{
+  __set_CP(15, 0, value, 7, 10, 1);
+}
+
+/** \brief  Set DCIMVAC
+
+  Data cache invalidate
+ */
+__STATIC_FORCEINLINE void __set_DCIMVAC(uint32_t value)
+{
+  __set_CP(15, 0, value, 7, 6, 1);
+}
+
+/** \brief  Set DCCIMVAC
+
+  Data cache clean and invalidate
+ */
+__STATIC_FORCEINLINE void __set_DCCIMVAC(uint32_t value)
+{
+  __set_CP(15, 0, value, 7, 14, 1);
+}
+
+/** \brief  Set CSSELR
+ */
+__STATIC_FORCEINLINE void __set_CSSELR(uint32_t value)
+{
+  __set_CP(15, 2, value, 0, 0, 0);
+}
+
+/** \brief  Get CSSELR
+    \return CSSELR Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_CSSELR(void)
+{
+  uint32_t result;
+  __get_CP(15, 2, result, 0, 0, 0);
+  return result;
+}
+
+/** \brief  Get CCSIDR
+    \return CCSIDR Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_CCSIDR(void)
+{
+  uint32_t result;
+  __get_CP(15, 1, result, 0, 0, 0);
+  return result;
+}
+
+/** \brief  Get CLIDR
+    \return CLIDR Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_CLIDR(void)
+{
+  uint32_t result;
+  __get_CP(15, 1, result, 0, 0, 1);
+  return result;
+}
+
+/** \brief  Set DCISW
+ */
+__STATIC_FORCEINLINE void __set_DCISW(uint32_t value)
+{
+  __set_CP(15, 0, value, 7, 6, 2);
+}
+
+/** \brief  Set DCCSW
+ */
+__STATIC_FORCEINLINE void __set_DCCSW(uint32_t value)
+{
+  __set_CP(15, 0, value, 7, 10, 2);
+}
+
+/** \brief  Set DCCISW
+ */
+__STATIC_FORCEINLINE void __set_DCCISW(uint32_t value)
+{
+  __set_CP(15, 0, value, 7, 14, 2);
+}
+
+#endif

--- a/platform/ext/cmsis/CMSIS/Core/Include/a-profile/cmsis_gcc_a.h
+++ b/platform/ext/cmsis/CMSIS/Core/Include/a-profile/cmsis_gcc_a.h
@@ -1,0 +1,936 @@
+/*
+ * Copyright (c) 2009-2024 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS-Core(A) Compiler GCC Header File
+ */
+
+#ifndef __CMSIS_GCC_A_H
+#define __CMSIS_GCC_A_H
+
+/* ignore some GCC warnings */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+
+/* Fallback for __has_builtin */
+#ifndef __has_builtin
+  #define __has_builtin(x) (0)
+#endif
+
+/* CMSIS compiler specific defines */
+#ifndef   __ASM
+  #define __ASM                                  __asm
+#endif
+#ifndef   __INLINE
+  #define __INLINE                               inline
+#endif
+#ifndef   __FORCEINLINE
+  #define __FORCEINLINE                          __attribute__((always_inline))
+#endif
+#ifndef   __STATIC_INLINE
+  #define __STATIC_INLINE                        static inline
+#endif
+#ifndef   __STATIC_FORCEINLINE
+  #define __STATIC_FORCEINLINE                   __attribute__((always_inline)) static inline
+#endif
+#ifndef   __NO_RETURN
+  #define __NO_RETURN                            __attribute__((__noreturn__))
+#endif
+#ifndef   CMSIS_DEPRECATED
+  #define CMSIS_DEPRECATED                       __attribute__((deprecated))
+#endif
+#ifndef   __USED
+  #define __USED                                 __attribute__((used))
+#endif
+#ifndef   __WEAK
+  #define __WEAK                                 __attribute__((weak))
+#endif
+#ifndef   __PACKED
+  #define __PACKED                               __attribute__((packed, aligned(1)))
+#endif
+#ifndef   __PACKED_STRUCT
+  #define __PACKED_STRUCT                        struct __attribute__((packed, aligned(1)))
+#endif
+#ifndef   __UNALIGNED_UINT16_WRITE
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wpacked"
+  #pragma GCC diagnostic ignored "-Wattributes"
+  __PACKED_STRUCT T_UINT16_WRITE { uint16_t v; };
+  #pragma GCC diagnostic pop
+  #define __UNALIGNED_UINT16_WRITE(addr, val)    (void)((((struct T_UINT16_WRITE *)(void *)(addr))->v) = (val))
+#endif
+#ifndef   __UNALIGNED_UINT16_READ
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wpacked"
+  #pragma GCC diagnostic ignored "-Wattributes"
+  __PACKED_STRUCT T_UINT16_READ { uint16_t v; };
+  #pragma GCC diagnostic pop
+  #define __UNALIGNED_UINT16_READ(addr)          (((const struct T_UINT16_READ *)(const void *)(addr))->v)
+#endif
+#ifndef   __UNALIGNED_UINT32_WRITE
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wpacked"
+  #pragma GCC diagnostic ignored "-Wattributes"
+  __PACKED_STRUCT T_UINT32_WRITE { uint32_t v; };
+  #pragma GCC diagnostic pop
+  #define __UNALIGNED_UINT32_WRITE(addr, val)    (void)((((struct T_UINT32_WRITE *)(void *)(addr))->v) = (val))
+#endif
+#ifndef   __UNALIGNED_UINT32_READ
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wpacked"
+  #pragma GCC diagnostic ignored "-Wattributes"
+  __PACKED_STRUCT T_UINT32_READ { uint32_t v; };
+  #pragma GCC diagnostic pop
+  #define __UNALIGNED_UINT32_READ(addr)          (((const struct T_UINT32_READ *)(const void *)(addr))->v)
+#endif
+#ifndef   __ALIGNED
+  #define __ALIGNED(x)                           __attribute__((aligned(x)))
+#endif
+#ifndef   __RESTRICT
+  #define __RESTRICT                             __restrict
+#endif
+#ifndef   __COMPILER_BARRIER
+  #define __COMPILER_BARRIER()                   __ASM volatile("":::"memory")
+#endif
+
+
+/* ##########################  Core Instruction Access  ######################### */
+/**
+  \brief   No Operation
+  \details No Operation does nothing. This instruction can be used for code alignment purposes.
+ */
+#define __NOP()                             __ASM volatile ("nop")
+
+
+/**
+  \brief   Wait For Interrupt
+  \details Wait For Interrupt is a hint instruction that suspends execution until one of a number of events occurs.
+ */
+#define __WFI()                             __ASM volatile ("wfi":::"memory")
+
+
+/**
+  \brief   Wait For Event
+  \details Wait For Event is a hint instruction that permits the processor to enter
+           a low-power state until one of a number of events occurs.
+ */
+#define __WFE()                             __ASM volatile ("wfe":::"memory")
+
+
+/**
+  \brief   Send Event
+  \details Send Event is a hint instruction. It causes an event to be signaled to the CPU.
+ */
+#define __SEV()                             __ASM volatile ("sev")
+
+
+/**
+  \brief   Instruction Synchronization Barrier
+  \details Instruction Synchronization Barrier flushes the pipeline in the processor,
+           so that all instructions following the ISB are fetched from cache or memory,
+           after the instruction has been completed.
+ */
+__STATIC_FORCEINLINE  void __ISB(void)
+{
+  __ASM volatile ("isb 0xF":::"memory");
+}
+
+
+/**
+  \brief   Data Synchronization Barrier
+  \details Acts as a special kind of Data Memory Barrier.
+           It completes when all explicit memory accesses before this instruction complete.
+ */
+__STATIC_FORCEINLINE  void __DSB(void)
+{
+  __ASM volatile ("dsb 0xF":::"memory");
+}
+
+
+/**
+  \brief   Data Memory Barrier
+  \details Ensures the apparent order of the explicit memory operations before
+           and after the instruction, without ensuring their completion.
+ */
+__STATIC_FORCEINLINE  void __DMB(void)
+{
+  __ASM volatile ("dmb 0xF":::"memory");
+}
+
+
+/**
+  \brief   Reverse byte order (32 bit)
+  \details Reverses the byte order in unsigned integer value. For example, 0x12345678 becomes 0x78563412.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+__STATIC_FORCEINLINE  uint32_t __REV(uint32_t value)
+{
+#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5)
+  return __builtin_bswap32(value);
+#else
+  uint32_t result;
+
+  __ASM ("rev %0, %1" : "=r" (result) : "r" (value) );
+  return result;
+#endif
+}
+
+
+/**
+  \brief   Reverse byte order (16 bit)
+  \details Reverses the byte order within each halfword of a word. For example, 0x12345678 becomes 0x34127856.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+__STATIC_FORCEINLINE uint32_t __REV16(uint32_t value)
+{
+  uint32_t result;
+  __ASM ("rev16 %0, %1" : "=r" (result) : "r" (value));
+  return result;
+}
+
+
+/**
+  \brief   Reverse byte order (16 bit)
+  \details Reverses the byte order in a 16-bit value and returns the signed 16-bit result. For example, 0x0080 becomes 0x8000.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+__STATIC_FORCEINLINE  int16_t __REVSH(int16_t value)
+{
+#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)
+  return (int16_t)__builtin_bswap16(value);
+#else
+  int16_t result;
+
+  __ASM ("revsh %0, %1" : "=r" (result) : "r" (value) );
+  return result;
+#endif
+}
+
+
+/**
+  \brief   Rotate Right in unsigned value (32 bit)
+  \details Rotate Right (immediate) provides the value of the contents of a register rotated by a variable number of bits.
+  \param [in]    op1  Value to rotate
+  \param [in]    op2  Number of Bits to rotate
+  \return               Rotated value
+ */
+__STATIC_FORCEINLINE uint32_t __ROR(uint32_t op1, uint32_t op2)
+{
+  op2 %= 32U;
+  if (op2 == 0U)
+  {
+    return op1;
+  }
+  return (op1 >> op2) | (op1 << (32U - op2));
+}
+
+
+/**
+  \brief   Breakpoint
+  \details Causes the processor to enter Debug state.
+           Debug tools can use this to investigate system state when the instruction at a particular address is reached.
+  \param [in]    value  is ignored by the processor.
+                 If required, a debugger can use it to store additional information about the breakpoint.
+ */
+#define __BKPT(value)   __ASM volatile ("bkpt "#value)
+
+
+/**
+  \brief   Reverse bit order of value
+  \details Reverses the bit order of the given value.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+__STATIC_FORCEINLINE  uint32_t __RBIT(uint32_t value)
+{
+  uint32_t result;
+   __ASM ("rbit %0, %1" : "=r" (result) : "r" (value) );
+  return result;
+}
+
+
+/**
+  \brief   Count leading zeros
+  \details Counts the number of leading zeros of a data value.
+  \param [in]  value  Value to count the leading zeros
+  \return             number of leading zeros in value
+ */
+__STATIC_FORCEINLINE uint8_t __CLZ(uint32_t value)
+{
+  /* Even though __builtin_clz produces a CLZ instruction on ARM, formally
+     __builtin_clz(0) is undefined behaviour, so handle this case specially.
+     This guarantees ARM-compatible results if happening to compile on a non-ARM
+     target, and ensures the compiler doesn't decide to activate any
+     optimisations using the logic "value was passed to __builtin_clz, so it
+     is non-zero".
+     ARM GCC 7.3 and possibly earlier will optimise this test away, leaving a
+     single CLZ instruction.
+   */
+  if (value == 0U)
+  {
+    return 32U;
+  }
+  return __builtin_clz(value);
+}
+
+
+/**
+  \brief   LDR Exclusive (8 bit)
+  \details Executes a exclusive LDR instruction for 8 bit value.
+  \param [in]    ptr  Pointer to data
+  \return             value of type uint8_t at (*ptr)
+ */
+__STATIC_FORCEINLINE  uint8_t __LDREXB(volatile uint8_t *addr)
+{
+    uint32_t result;
+
+#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)
+   __ASM volatile ("ldrexb %0, %1" : "=r" (result) : "Q" (*addr) );
+#else
+    /* Prior to GCC 4.8, "Q" will be expanded to [rx, #0] which is not
+       accepted by assembler. So has to use following less efficient pattern.
+    */
+   __ASM volatile ("ldrexb %0, [%1]" : "=r" (result) : "r" (addr) : "memory" );
+#endif
+   return ((uint8_t) result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   LDR Exclusive (16 bit)
+  \details Executes a exclusive LDR instruction for 16 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint16_t at (*ptr)
+ */
+__STATIC_FORCEINLINE  uint16_t __LDREXH(volatile uint16_t *addr)
+{
+    uint32_t result;
+
+#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)
+   __ASM volatile ("ldrexh %0, %1" : "=r" (result) : "Q" (*addr) );
+#else
+    /* Prior to GCC 4.8, "Q" will be expanded to [rx, #0] which is not
+       accepted by assembler. So has to use following less efficient pattern.
+    */
+   __ASM volatile ("ldrexh %0, [%1]" : "=r" (result) : "r" (addr) : "memory" );
+#endif
+   return ((uint16_t) result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   LDR Exclusive (32 bit)
+  \details Executes a exclusive LDR instruction for 32 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint32_t at (*ptr)
+ */
+__STATIC_FORCEINLINE  uint32_t __LDREXW(volatile uint32_t *addr)
+{
+    uint32_t result;
+
+   __ASM volatile ("ldrex %0, %1" : "=r" (result) : "Q" (*addr) );
+   return(result);
+}
+
+
+/**
+  \brief   STR Exclusive (8 bit)
+  \details Executes a exclusive STR instruction for 8 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+__STATIC_FORCEINLINE  uint32_t __STREXB(uint8_t value, volatile uint8_t *addr)
+{
+   uint32_t result;
+
+   __ASM volatile ("strexb %0, %2, %1" : "=&r" (result), "=Q" (*addr) : "r" ((uint32_t)value) );
+   return(result);
+}
+
+
+/**
+  \brief   STR Exclusive (16 bit)
+  \details Executes a exclusive STR instruction for 16 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+__STATIC_FORCEINLINE  uint32_t __STREXH(uint16_t value, volatile uint16_t *addr)
+{
+   uint32_t result;
+
+   __ASM volatile ("strexh %0, %2, %1" : "=&r" (result), "=Q" (*addr) : "r" ((uint32_t)value) );
+   return(result);
+}
+
+
+/**
+  \brief   STR Exclusive (32 bit)
+  \details Executes a exclusive STR instruction for 32 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+__STATIC_FORCEINLINE  uint32_t __STREXW(uint32_t value, volatile uint32_t *addr)
+{
+   uint32_t result;
+
+   __ASM volatile ("strex %0, %2, %1" : "=&r" (result), "=Q" (*addr) : "r" (value) );
+   return(result);
+}
+
+
+/**
+  \brief   Remove the exclusive lock
+  \details Removes the exclusive lock which is created by LDREX.
+ */
+__STATIC_FORCEINLINE  void __CLREX(void)
+{
+  __ASM volatile ("clrex" ::: "memory");
+}
+
+/**
+  \brief   Signed Saturate
+  \details Saturates a signed value.
+  \param [in]  ARG1  Value to be saturated
+  \param [in]  ARG2  Bit position to saturate to (1..32)
+  \return             Saturated value
+ */
+#define __SSAT(ARG1, ARG2) \
+__extension__ \
+({                          \
+  int32_t __RES, __ARG1 = (ARG1); \
+  __ASM volatile ("ssat %0, %1, %2" : "=r" (__RES) :  "I" (ARG2), "r" (__ARG1) : "cc" ); \
+  __RES; \
+ })
+
+
+/**
+  \brief   Unsigned Saturate
+  \details Saturates an unsigned value.
+  \param [in]  ARG1  Value to be saturated
+  \param [in]  ARG2  Bit position to saturate to (0..31)
+  \return             Saturated value
+ */
+#define __USAT(ARG1, ARG2) \
+__extension__ \
+({                          \
+  uint32_t __RES, __ARG1 = (ARG1); \
+  __ASM volatile ("usat %0, %1, %2" : "=r" (__RES) :  "I" (ARG2), "r" (__ARG1) : "cc" ); \
+  __RES; \
+ })
+
+/**
+  \brief   Rotate Right with Extend (32 bit)
+  \details Moves each bit of a bitstring right by one bit.
+           The carry input is shifted in at the left end of the bitstring.
+  \param [in]    value  Value to rotate
+  \return               Rotated value
+ */
+__STATIC_FORCEINLINE uint32_t __RRX(uint32_t value)
+{
+  uint32_t result;
+
+  __ASM volatile ("rrx %0, %1" : "=r" (result) : "r" (value));
+  return (result);
+}
+
+
+/**
+  \brief   LDRT Unprivileged (8 bit)
+  \details Executes a Unprivileged LDRT instruction for 8 bit value.
+  \param [in]    ptr  Pointer to data
+  \return             value of type uint8_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint8_t __LDRBT(volatile uint8_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldrbt %0, %1" : "=r" (result) : "Q" (*ptr) );
+  return ((uint8_t)result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   LDRT Unprivileged (16 bit)
+  \details Executes a Unprivileged LDRT instruction for 16 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint16_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint16_t __LDRHT(volatile uint16_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldrht %0, %1" : "=r" (result) : "Q" (*ptr) );
+  return ((uint16_t)result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   LDRT Unprivileged (32 bit)
+  \details Executes a Unprivileged LDRT instruction for 32 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint32_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint32_t __LDRT(volatile uint32_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldrt %0, %1" : "=r" (result) : "Q" (*ptr) );
+  return (result);
+}
+
+
+/**
+  \brief   STRT Unprivileged (8 bit)
+  \details Executes a Unprivileged STRT instruction for 8 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__STATIC_FORCEINLINE void __STRBT(uint8_t value, volatile uint8_t *ptr)
+{
+  __ASM volatile ("strbt %1, %0" : "=Q" (*ptr) : "r" ((uint32_t)value) );
+}
+
+
+/**
+  \brief   STRT Unprivileged (16 bit)
+  \details Executes a Unprivileged STRT instruction for 16 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__STATIC_FORCEINLINE void __STRHT(uint16_t value, volatile uint16_t *ptr)
+{
+  __ASM volatile ("strht %1, %0" : "=Q" (*ptr) : "r" ((uint32_t)value) );
+}
+
+
+/**
+  \brief   STRT Unprivileged (32 bit)
+  \details Executes a Unprivileged STRT instruction for 32 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__STATIC_FORCEINLINE void __STRT(uint32_t value, volatile uint32_t *ptr)
+{
+  __ASM volatile ("strt %1, %0" : "=Q" (*ptr) : "r" (value) );
+}
+
+/* ###########################  Core Function Access  ########################### */
+/** \ingroup  CMSIS_Core_FunctionInterface
+    \defgroup CMSIS_Core_RegAccFunctions CMSIS Core Register Access Functions
+  @{
+ */
+
+/**
+  \brief   Enable IRQ Interrupts
+  \details Enables IRQ interrupts by clearing special-purpose register PRIMASK.
+           Can only be executed in Privileged modes.
+ */
+__STATIC_FORCEINLINE void __enable_irq(void)
+{
+  __ASM volatile ("cpsie i" : : : "memory");
+}
+
+
+/**
+  \brief   Disable IRQ Interrupts
+  \details Disables IRQ interrupts by setting special-purpose register PRIMASK.
+  Can only be executed in Privileged modes.
+ */
+__STATIC_FORCEINLINE void __disable_irq(void)
+{
+  __ASM volatile ("cpsid i" : : : "memory");
+}
+
+/**
+  \brief   Enable FIQ
+  \details Enables FIQ interrupts by clearing special-purpose register FAULTMASK.
+           Can only be executed in Privileged modes.
+ */
+__STATIC_FORCEINLINE void __enable_fault_irq(void)
+{
+  __ASM volatile ("cpsie f" : : : "memory");
+}
+
+
+/**
+  \brief   Disable FIQ
+  \details Disables FIQ interrupts by setting special-purpose register FAULTMASK.
+           Can only be executed in Privileged modes.
+ */
+__STATIC_FORCEINLINE void __disable_fault_irq(void)
+{
+  __ASM volatile ("cpsid f" : : : "memory");
+}
+
+/**
+  \brief   Get FPSCR
+  \details Returns the current value of the Floating Point Status/Control register.
+  \return               Floating Point Status/Control register value
+ */
+__STATIC_FORCEINLINE  uint32_t __get_FPSCR(void)
+{
+#if (defined(__ARM_FP) && (__ARM_FP >= 1))
+  return __builtin_arm_get_fpscr();
+#else
+  return(0U);
+#endif
+}
+
+
+/**
+  \brief   Set FPSCR
+  \details Assigns the given value to the Floating Point Status/Control register.
+  \param [in]    fpscr  Floating Point Status/Control value to set
+ */
+__STATIC_FORCEINLINE void __set_FPSCR(uint32_t fpscr)
+{
+#if (defined(__ARM_FP) && (__ARM_FP >= 1))
+  __builtin_arm_set_fpscr(fpscr);
+#else
+  (void)fpscr;
+#endif
+}
+
+
+/*@} end of CMSIS_Core_RegAccFunctions */
+
+
+/* ###################  Compiler specific Intrinsics  ########################### */
+
+#if (defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1))
+
+#define     __SADD8                 __builtin_arm_sadd8
+#define     __QADD8                 __builtin_arm_qadd8
+#define     __SHADD8                __builtin_arm_shadd8
+#define     __UADD8                 __builtin_arm_uadd8
+#define     __UQADD8                __builtin_arm_uqadd8
+#define     __UHADD8                __builtin_arm_uhadd8
+#define     __SSUB8                 __builtin_arm_ssub8
+#define     __QSUB8                 __builtin_arm_qsub8
+#define     __SHSUB8                __builtin_arm_shsub8
+#define     __USUB8                 __builtin_arm_usub8
+#define     __UQSUB8                __builtin_arm_uqsub8
+#define     __UHSUB8                __builtin_arm_uhsub8
+#define     __SADD16                __builtin_arm_sadd16
+#define     __QADD16                __builtin_arm_qadd16
+#define     __SHADD16               __builtin_arm_shadd16
+#define     __UADD16                __builtin_arm_uadd16
+#define     __UQADD16               __builtin_arm_uqadd16
+#define     __UHADD16               __builtin_arm_uhadd16
+#define     __SSUB16                __builtin_arm_ssub16
+#define     __QSUB16                __builtin_arm_qsub16
+#define     __SHSUB16               __builtin_arm_shsub16
+#define     __USUB16                __builtin_arm_usub16
+#define     __UQSUB16               __builtin_arm_uqsub16
+#define     __UHSUB16               __builtin_arm_uhsub16
+#define     __SASX                  __builtin_arm_sasx
+#define     __QASX                  __builtin_arm_qasx
+#define     __SHASX                 __builtin_arm_shasx
+#define     __UASX                  __builtin_arm_uasx
+#define     __UQASX                 __builtin_arm_uqasx
+#define     __UHASX                 __builtin_arm_uhasx
+#define     __SSAX                  __builtin_arm_ssax
+#define     __QSAX                  __builtin_arm_qsax
+#define     __SHSAX                 __builtin_arm_shsax
+#define     __USAX                  __builtin_arm_usax
+#define     __UQSAX                 __builtin_arm_uqsax
+#define     __UHSAX                 __builtin_arm_uhsax
+#define     __USAD8                 __builtin_arm_usad8
+#define     __USADA8                __builtin_arm_usada8
+#define     __SSAT16                __builtin_arm_ssat16
+#define     __USAT16                __builtin_arm_usat16
+#define     __UXTB16                __builtin_arm_uxtb16
+#define     __UXTAB16               __builtin_arm_uxtab16
+#define     __SXTB16                __builtin_arm_sxtb16
+#define     __SXTAB16               __builtin_arm_sxtab16
+#define     __SMUAD                 __builtin_arm_smuad
+#define     __SMUADX                __builtin_arm_smuadx
+#define     __SMLAD                 __builtin_arm_smlad
+#define     __SMLADX                __builtin_arm_smladx
+#define     __SMLALD                __builtin_arm_smlald
+#define     __SMLALDX               __builtin_arm_smlaldx
+#define     __SMUSD                 __builtin_arm_smusd
+#define     __SMUSDX                __builtin_arm_smusdx
+#define     __SMLSD                 __builtin_arm_smlsd
+#define     __SMLSDX                __builtin_arm_smlsdx
+#define     __SMLSLD                __builtin_arm_smlsld
+#define     __SMLSLDX               __builtin_arm_smlsldx
+#define     __SEL                   __builtin_arm_sel
+#define     __QADD                  __builtin_arm_qadd
+#define     __QSUB                  __builtin_arm_qsub
+
+#define __PKHBT(ARG1,ARG2,ARG3) \
+__extension__ \
+({                          \
+  uint32_t __RES, __ARG1 = (ARG1), __ARG2 = (ARG2); \
+  __ASM ("pkhbt %0, %1, %2, lsl %3" : "=r" (__RES) :  "r" (__ARG1), "r" (__ARG2), "I" (ARG3)  ); \
+  __RES; \
+ })
+
+#define __PKHTB(ARG1,ARG2,ARG3) \
+__extension__ \
+({                          \
+  uint32_t __RES, __ARG1 = (ARG1), __ARG2 = (ARG2); \
+  if (ARG3 == 0) \
+    __ASM ("pkhtb %0, %1, %2" : "=r" (__RES) :  "r" (__ARG1), "r" (__ARG2)  ); \
+  else \
+    __ASM ("pkhtb %0, %1, %2, asr %3" : "=r" (__RES) :  "r" (__ARG1), "r" (__ARG2), "I" (ARG3)  ); \
+  __RES; \
+ })
+
+__STATIC_FORCEINLINE uint32_t __SXTB16_RORn(uint32_t op1, uint32_t rotate)
+{
+    uint32_t result;
+    if (__builtin_constant_p(rotate) && ((rotate == 8U) || (rotate == 16U) || (rotate == 24U)))
+    {
+        __ASM volatile("sxtb16 %0, %1, ROR %2" : "=r"(result) : "r"(op1), "i"(rotate));
+    }
+    else
+    {
+        result = __SXTB16(__ROR(op1, rotate));
+    }
+    return result;
+}
+
+__STATIC_FORCEINLINE uint32_t __SXTAB16_RORn(uint32_t op1, uint32_t op2, uint32_t rotate)
+{
+    uint32_t result;
+    if (__builtin_constant_p(rotate) && ((rotate == 8U) || (rotate == 16U) || (rotate == 24U)))
+    {
+        __ASM volatile("sxtab16 %0, %1, %2, ROR %3" : "=r"(result) : "r"(op1), "r"(op2), "i"(rotate));
+    }
+    else
+    {
+        result = __SXTAB16(op1, __ROR(op2, rotate));
+    }
+    return result;
+}
+
+__STATIC_FORCEINLINE int32_t __SMMLA (int32_t op1, int32_t op2, int32_t op3)
+{
+  int32_t result;
+
+  __ASM volatile ("smmla %0, %1, %2, %3" : "=r" (result): "r"  (op1), "r" (op2), "r" (op3) );
+  return (result);
+}
+
+#endif /* (__ARM_FEATURE_DSP == 1) */
+/** @} end of group CMSIS_SIMD_intrinsics */
+
+/** \defgroup CMSIS_Core_intrinsics CMSIS Core Intrinsics
+  Access to dedicated SIMD instructions
+  @{
+*/
+
+/** \brief  Get CPSR Register
+    \return               CPSR Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_CPSR(void)
+{
+  uint32_t result;
+  __ASM volatile("MRS %0, cpsr" : "=r" (result) );
+  return(result);
+}
+
+/** \brief  Set CPSR Register
+    \param [in]    cpsr  CPSR value to set
+ */
+__STATIC_FORCEINLINE void __set_CPSR(uint32_t cpsr)
+{
+  __ASM volatile ("MSR cpsr, %0" : : "r" (cpsr) : "cc", "memory");
+}
+
+/** \brief  Get Mode
+    \return                Processor Mode
+ */
+__STATIC_FORCEINLINE uint32_t __get_mode(void)
+{
+  return (__get_CPSR() & 0x1FU);
+}
+
+/** \brief  Set Mode
+    \param [in]    mode  Mode value to set
+ */
+__STATIC_FORCEINLINE void __set_mode(uint32_t mode)
+{
+  __ASM volatile("MSR  cpsr_c, %0" : : "r" (mode) : "memory");
+}
+
+/** \brief  Get Stack Pointer
+    \return Stack Pointer value
+ */
+__STATIC_FORCEINLINE uint32_t __get_SP(void)
+{
+  uint32_t result;
+  __ASM volatile("MOV  %0, sp" : "=r" (result) : : "memory");
+  return result;
+}
+
+/** \brief  Set Stack Pointer
+    \param [in]    stack  Stack Pointer value to set
+ */
+__STATIC_FORCEINLINE void __set_SP(uint32_t stack)
+{
+  __ASM volatile("MOV  sp, %0" : : "r" (stack) : "memory");
+}
+
+/** \brief  Get USR/SYS Stack Pointer
+    \return USR/SYS Stack Pointer value
+ */
+__STATIC_FORCEINLINE uint32_t __get_SP_usr(void)
+{
+  uint32_t cpsr = __get_CPSR();
+  uint32_t result;
+  __ASM volatile(
+    "CPS     #0x1F  \n"
+    "MOV     %0, sp   " : "=r"(result) : : "memory"
+   );
+  __set_CPSR(cpsr);
+  __ISB();
+  return result;
+}
+
+/** \brief  Set USR/SYS Stack Pointer
+    \param [in]    topOfProcStack  USR/SYS Stack Pointer value to set
+ */
+__STATIC_FORCEINLINE void __set_SP_usr(uint32_t topOfProcStack)
+{
+  uint32_t cpsr = __get_CPSR();
+  __ASM volatile(
+    "CPS     #0x1F  \n"
+    "MOV     sp, %0   " : : "r" (topOfProcStack) : "memory"
+   );
+  __set_CPSR(cpsr);
+  __ISB();
+}
+
+/** \brief  Get FPEXC
+    \return               Floating Point Exception Control register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_FPEXC(void)
+{
+#if (__FPU_PRESENT == 1)
+  uint32_t result;
+  __ASM volatile("VMRS %0, fpexc" : "=r" (result) : : "memory");
+  return(result);
+#else
+  return(0);
+#endif
+}
+
+/** \brief  Set FPEXC
+    \param [in]    fpexc  Floating Point Exception Control value to set
+ */
+__STATIC_FORCEINLINE void __set_FPEXC(uint32_t fpexc)
+{
+#if (__FPU_PRESENT == 1)
+  __ASM volatile ("VMSR fpexc, %0" : : "r" (fpexc) : "memory");
+#endif
+}
+
+/*
+ * Include common core functions to access Coprocessor 15 registers
+ */
+
+#define __get_CP(cp, op1, Rt, CRn, CRm, op2) __ASM volatile("MRC p" # cp ", " # op1 ", %0, c" # CRn ", c" # CRm ", " # op2 : "=r" (Rt) : : "memory" )
+#define __set_CP(cp, op1, Rt, CRn, CRm, op2) __ASM volatile("MCR p" # cp ", " # op1 ", %0, c" # CRn ", c" # CRm ", " # op2 : : "r" (Rt) : "memory" )
+#define __get_CP64(cp, op1, Rt, CRm)         __ASM volatile("MRRC p" # cp ", " # op1 ", %Q0, %R0, c" # CRm  : "=r" (Rt) : : "memory" )
+#define __set_CP64(cp, op1, Rt, CRm)         __ASM volatile("MCRR p" # cp ", " # op1 ", %Q0, %R0, c" # CRm  : : "r" (Rt) : "memory" )
+
+#include "cmsis_cp15.h"
+
+/** \brief  Enable Floating Point Unit
+
+  Critical section, called from undef handler, so systick is disabled
+ */
+__STATIC_INLINE void __FPU_Enable(void)
+{
+  // Permit access to VFP/NEON, registers by modifying CPACR
+  const uint32_t cpacr = __get_CPACR();
+  __set_CPACR(cpacr | 0x00F00000ul);
+  __ISB();
+
+  // Enable VFP/NEON
+  const uint32_t fpexc = __get_FPEXC();
+  __set_FPEXC(fpexc | 0x40000000ul);
+
+  __ASM volatile(
+    // Initialise VFP/NEON registers to 0
+    "        MOV     R2,#0             \n"
+
+    // Initialise D16 registers to 0
+    "        VMOV    D0, R2,R2         \n"
+    "        VMOV    D1, R2,R2         \n"
+    "        VMOV    D2, R2,R2         \n"
+    "        VMOV    D3, R2,R2         \n"
+    "        VMOV    D4, R2,R2         \n"
+    "        VMOV    D5, R2,R2         \n"
+    "        VMOV    D6, R2,R2         \n"
+    "        VMOV    D7, R2,R2         \n"
+    "        VMOV    D8, R2,R2         \n"
+    "        VMOV    D9, R2,R2         \n"
+    "        VMOV    D10,R2,R2         \n"
+    "        VMOV    D11,R2,R2         \n"
+    "        VMOV    D12,R2,R2         \n"
+    "        VMOV    D13,R2,R2         \n"
+    "        VMOV    D14,R2,R2         \n"
+    "        VMOV    D15,R2,R2         \n"
+
+#if (defined(__ARM_NEON) && (__ARM_NEON == 1))
+    // Initialise D32 registers to 0
+    "        VMOV    D16,R2,R2         \n"
+    "        VMOV    D17,R2,R2         \n"
+    "        VMOV    D18,R2,R2         \n"
+    "        VMOV    D19,R2,R2         \n"
+    "        VMOV    D20,R2,R2         \n"
+    "        VMOV    D21,R2,R2         \n"
+    "        VMOV    D22,R2,R2         \n"
+    "        VMOV    D23,R2,R2         \n"
+    "        VMOV    D24,R2,R2         \n"
+    "        VMOV    D25,R2,R2         \n"
+    "        VMOV    D26,R2,R2         \n"
+    "        VMOV    D27,R2,R2         \n"
+    "        VMOV    D28,R2,R2         \n"
+    "        VMOV    D29,R2,R2         \n"
+    "        VMOV    D30,R2,R2         \n"
+    "        VMOV    D31,R2,R2         \n"
+#endif
+    : : : "cc", "r2"
+  );
+
+  // Initialise FPSCR to a known state
+  const uint32_t fpscr = __get_FPSCR();
+  __set_FPSCR(fpscr & 0x00086060ul);
+}
+
+/*@} end of group CMSIS_Core_intrinsics */
+
+#pragma GCC diagnostic pop
+
+#endif /* __CMSIS_GCC_A_H */

--- a/platform/ext/cmsis/CMSIS/Core/Include/a-profile/cmsis_iccarm_a.h
+++ b/platform/ext/cmsis/CMSIS/Core/Include/a-profile/cmsis_iccarm_a.h
@@ -1,0 +1,558 @@
+/*
+ * Copyright (c) 2017-2018 IAR Systems
+ * Copyright (c) 2018-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS-Core(A) Compiler ICCARM (IAR Compiler for Arm) Header File
+ */
+
+#ifndef __CMSIS_ICCARM_A_H__
+#define __CMSIS_ICCARM_A_H__
+
+#ifndef __ICCARM__
+  #error This file should only be compiled by ICCARM
+#endif
+
+#pragma system_include
+
+#define __IAR_FT _Pragma("inline=forced") __intrinsic
+
+#if (__VER__ >= 8000000)
+  #define __ICCARM_V8 1
+#else
+  #define __ICCARM_V8 0
+#endif
+
+#pragma language=extended
+
+#ifndef __ALIGNED
+  #if __ICCARM_V8
+    #define __ALIGNED(x) __attribute__((aligned(x)))
+  #elif (__VER__ >= 7080000)
+    /* Needs IAR language extensions */
+    #define __ALIGNED(x) __attribute__((aligned(x)))
+  #else
+    #warning No compiler specific solution for __ALIGNED.__ALIGNED is ignored.
+    #define __ALIGNED(x)
+  #endif
+#endif
+
+
+/* Define compiler macros for CPU architecture, used in CMSIS 5.
+ */
+#if __ARM_ARCH_7A__
+/* Macro already defined */
+#else
+  #if defined(__ARM7A__)
+    #define __ARM_ARCH_7A__ 1
+  #endif
+#endif
+
+#ifndef __ASM
+  #define __ASM __asm
+#endif
+
+#ifndef   __COMPILER_BARRIER
+  #define __COMPILER_BARRIER() __ASM volatile("":::"memory")
+#endif
+
+#ifndef __INLINE
+  #define __INLINE inline
+#endif
+
+#ifndef   __NO_RETURN
+  #if __ICCARM_V8
+    #define __NO_RETURN __attribute__((__noreturn__))
+  #else
+    #define __NO_RETURN _Pragma("object_attribute=__noreturn")
+  #endif
+#endif
+
+#ifndef   __PACKED
+  #if __ICCARM_V8
+    #define __PACKED __attribute__((packed, aligned(1)))
+  #else
+    /* Needs IAR language extensions */
+    #define __PACKED __packed
+  #endif
+#endif
+
+#ifndef   __PACKED_STRUCT
+  #if __ICCARM_V8
+    #define __PACKED_STRUCT struct __attribute__((packed, aligned(1)))
+  #else
+    /* Needs IAR language extensions */
+    #define __PACKED_STRUCT __packed struct
+  #endif
+#endif
+
+#ifndef   __PACKED_UNION
+  #if __ICCARM_V8
+    #define __PACKED_UNION union __attribute__((packed, aligned(1)))
+  #else
+    /* Needs IAR language extensions */
+    #define __PACKED_UNION __packed union
+  #endif
+#endif
+
+#ifndef   __RESTRICT
+  #if __ICCARM_V8
+    #define __RESTRICT            __restrict
+  #else
+    /* Needs IAR language extensions */
+    #define __RESTRICT            restrict
+  #endif
+#endif
+
+#ifndef   __STATIC_INLINE
+  #define __STATIC_INLINE       static inline
+#endif
+
+#ifndef   __FORCEINLINE
+  #define __FORCEINLINE         _Pragma("inline=forced")
+#endif
+
+#ifndef   __STATIC_FORCEINLINE
+  #define __STATIC_FORCEINLINE  __FORCEINLINE __STATIC_INLINE
+#endif
+
+#ifndef   CMSIS_DEPRECATED
+  #define CMSIS_DEPRECATED      __attribute__((deprecated))
+#endif
+
+#ifndef __UNALIGNED_UINT16_READ
+  #pragma language=save
+  #pragma language=extended
+  __IAR_FT uint16_t __iar_uint16_read(void const *ptr)
+  {
+    return *(__packed uint16_t*)(ptr);
+  }
+  #pragma language=restore
+  #define __UNALIGNED_UINT16_READ(PTR) __iar_uint16_read(PTR)
+#endif
+
+
+#ifndef __UNALIGNED_UINT16_WRITE
+  #pragma language=save
+  #pragma language=extended
+  __IAR_FT void __iar_uint16_write(void const *ptr, uint16_t val)
+  {
+    *(__packed uint16_t*)(ptr) = val;;
+  }
+  #pragma language=restore
+  #define __UNALIGNED_UINT16_WRITE(PTR,VAL) __iar_uint16_write(PTR,VAL)
+#endif
+
+#ifndef __UNALIGNED_UINT32_READ
+  #pragma language=save
+  #pragma language=extended
+  __IAR_FT uint32_t __iar_uint32_read(void const *ptr)
+  {
+    return *(__packed uint32_t*)(ptr);
+  }
+  #pragma language=restore
+  #define __UNALIGNED_UINT32_READ(PTR) __iar_uint32_read(PTR)
+#endif
+
+#ifndef __UNALIGNED_UINT32_WRITE
+  #pragma language=save
+  #pragma language=extended
+  __IAR_FT void __iar_uint32_write(void const *ptr, uint32_t val)
+  {
+    *(__packed uint32_t*)(ptr) = val;;
+  }
+  #pragma language=restore
+  #define __UNALIGNED_UINT32_WRITE(PTR,VAL) __iar_uint32_write(PTR,VAL)
+#endif
+
+#ifndef   __USED
+  #if __ICCARM_V8
+    #define __USED __attribute__((used))
+  #else
+    #define __USED _Pragma("__root")
+  #endif
+#endif
+
+#ifndef   __WEAK
+  #if __ICCARM_V8
+    #define __WEAK __attribute__((weak))
+  #else
+    #define __WEAK _Pragma("__weak")
+  #endif
+#endif
+
+
+#ifndef __ICCARM_INTRINSICS_VERSION__
+  #define __ICCARM_INTRINSICS_VERSION__  0
+#endif
+
+#if __ICCARM_INTRINSICS_VERSION__ == 2
+
+  #if defined(__CLZ)
+    #undef __CLZ
+  #endif
+  #if defined(__REVSH)
+    #undef __REVSH
+  #endif
+  #if defined(__RBIT)
+    #undef __RBIT
+  #endif
+  #if defined(__SSAT)
+    #undef __SSAT
+  #endif
+  #if defined(__USAT)
+    #undef __USAT
+  #endif
+
+  #include "iccarm_builtin.h"
+
+  #define __disable_fault_irq   __iar_builtin_disable_fiq
+  #define __disable_irq       __iar_builtin_disable_interrupt
+  #define __enable_fault_irq    __iar_builtin_enable_fiq
+  #define __enable_irq        __iar_builtin_enable_interrupt
+  #define __arm_rsr           __iar_builtin_rsr
+  #define __arm_wsr           __iar_builtin_wsr
+
+  #if ((defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)))
+    #define __get_FPSCR()             (__arm_rsr("FPSCR"))
+    #define __set_FPSCR(VALUE)        (__arm_wsr("FPSCR", (VALUE)))
+  #else
+    #define __get_FPSCR()             ( 0 )
+    #define __set_FPSCR(VALUE)        ((void)VALUE)
+  #endif
+
+  #define __get_CPSR()                (__arm_rsr("CPSR"))
+  #define __get_mode()                (__get_CPSR() & 0x1FU)
+
+  #define __set_CPSR(VALUE)           (__arm_wsr("CPSR", (VALUE)))
+  #define __set_mode(VALUE)           (__arm_wsr("CPSR_c", (VALUE)))
+
+
+  #define __get_FPEXC()       (__arm_rsr("FPEXC"))
+  #define __set_FPEXC(VALUE)    (__arm_wsr("FPEXC", VALUE))
+
+  #define __get_CP(cp, op1, RT, CRn, CRm, op2) \
+    ((RT) = __arm_rsr("p" # cp ":" # op1 ":c" # CRn ":c" # CRm ":" # op2))
+
+  #define __set_CP(cp, op1, RT, CRn, CRm, op2) \
+    (__arm_wsr("p" # cp ":" # op1 ":c" # CRn ":c" # CRm ":" # op2, (RT)))
+
+  #define __get_CP64(cp, op1, Rt, CRm) \
+    __ASM volatile("MRRC p" # cp ", " # op1 ", %Q0, %R0, c" # CRm  : "=r" (Rt) : : "memory" )
+
+  #define __set_CP64(cp, op1, Rt, CRm) \
+    __ASM volatile("MCRR p" # cp ", " # op1 ", %Q0, %R0, c" # CRm  : : "r" (Rt) : "memory" )
+
+  #include "cmsis_cp15.h"
+
+  #define __NOP     __iar_builtin_no_operation
+
+  #define __CLZ     __iar_builtin_CLZ
+  #define __CLREX   __iar_builtin_CLREX
+
+  #define __DMB     __iar_builtin_DMB
+  #define __DSB     __iar_builtin_DSB
+  #define __ISB     __iar_builtin_ISB
+
+  #define __LDREXB  __iar_builtin_LDREXB
+  #define __LDREXH  __iar_builtin_LDREXH
+  #define __LDREXW  __iar_builtin_LDREX
+
+  #define __RBIT    __iar_builtin_RBIT
+  #define __REV     __iar_builtin_REV
+  #define __REV16   __iar_builtin_REV16
+
+  __IAR_FT int16_t __REVSH(int16_t val)
+  {
+    return (int16_t) __iar_builtin_REVSH(val);
+  }
+
+  #define __ROR     __iar_builtin_ROR
+  #define __RRX     __iar_builtin_RRX
+
+  #define __SEV     __iar_builtin_SEV
+
+  #define __SSAT    __iar_builtin_SSAT
+
+  #define __STREXB  __iar_builtin_STREXB
+  #define __STREXH  __iar_builtin_STREXH
+  #define __STREXW  __iar_builtin_STREX
+
+  #define __USAT    __iar_builtin_USAT
+
+  #define __WFE     __iar_builtin_WFE
+  #define __WFI     __iar_builtin_WFI
+
+  #define __SADD8   __iar_builtin_SADD8
+  #define __QADD8   __iar_builtin_QADD8
+  #define __SHADD8  __iar_builtin_SHADD8
+  #define __UADD8   __iar_builtin_UADD8
+  #define __UQADD8  __iar_builtin_UQADD8
+  #define __UHADD8  __iar_builtin_UHADD8
+  #define __SSUB8   __iar_builtin_SSUB8
+  #define __QSUB8   __iar_builtin_QSUB8
+  #define __SHSUB8  __iar_builtin_SHSUB8
+  #define __USUB8   __iar_builtin_USUB8
+  #define __UQSUB8  __iar_builtin_UQSUB8
+  #define __UHSUB8  __iar_builtin_UHSUB8
+  #define __SADD16  __iar_builtin_SADD16
+  #define __QADD16  __iar_builtin_QADD16
+  #define __SHADD16 __iar_builtin_SHADD16
+  #define __UADD16  __iar_builtin_UADD16
+  #define __UQADD16 __iar_builtin_UQADD16
+  #define __UHADD16 __iar_builtin_UHADD16
+  #define __SSUB16  __iar_builtin_SSUB16
+  #define __QSUB16  __iar_builtin_QSUB16
+  #define __SHSUB16 __iar_builtin_SHSUB16
+  #define __USUB16  __iar_builtin_USUB16
+  #define __UQSUB16 __iar_builtin_UQSUB16
+  #define __UHSUB16 __iar_builtin_UHSUB16
+  #define __SASX    __iar_builtin_SASX
+  #define __QASX    __iar_builtin_QASX
+  #define __SHASX   __iar_builtin_SHASX
+  #define __UASX    __iar_builtin_UASX
+  #define __UQASX   __iar_builtin_UQASX
+  #define __UHASX   __iar_builtin_UHASX
+  #define __SSAX    __iar_builtin_SSAX
+  #define __QSAX    __iar_builtin_QSAX
+  #define __SHSAX   __iar_builtin_SHSAX
+  #define __USAX    __iar_builtin_USAX
+  #define __UQSAX   __iar_builtin_UQSAX
+  #define __UHSAX   __iar_builtin_UHSAX
+  #define __USAD8   __iar_builtin_USAD8
+  #define __USADA8  __iar_builtin_USADA8
+  #define __SSAT16  __iar_builtin_SSAT16
+  #define __USAT16  __iar_builtin_USAT16
+  #define __UXTB16  __iar_builtin_UXTB16
+  #define __UXTAB16 __iar_builtin_UXTAB16
+  #define __SXTB16  __iar_builtin_SXTB16
+  #define __SXTAB16 __iar_builtin_SXTAB16
+  #define __SMUAD   __iar_builtin_SMUAD
+  #define __SMUADX  __iar_builtin_SMUADX
+  #define __SMMLA   __iar_builtin_SMMLA
+  #define __SMLAD   __iar_builtin_SMLAD
+  #define __SMLADX  __iar_builtin_SMLADX
+  #define __SMLALD  __iar_builtin_SMLALD
+  #define __SMLALDX __iar_builtin_SMLALDX
+  #define __SMUSD   __iar_builtin_SMUSD
+  #define __SMUSDX  __iar_builtin_SMUSDX
+  #define __SMLSD   __iar_builtin_SMLSD
+  #define __SMLSDX  __iar_builtin_SMLSDX
+  #define __SMLSLD  __iar_builtin_SMLSLD
+  #define __SMLSLDX __iar_builtin_SMLSLDX
+  #define __SEL     __iar_builtin_SEL
+  #define __QADD    __iar_builtin_QADD
+  #define __QSUB    __iar_builtin_QSUB
+  #define __PKHBT   __iar_builtin_PKHBT
+  #define __PKHTB   __iar_builtin_PKHTB
+
+#else /* __ICCARM_INTRINSICS_VERSION__ == 2 */
+
+  #if !((defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)))
+    #define __get_FPSCR __cmsis_iar_get_FPSR_not_active
+  #endif
+
+  #ifdef __INTRINSICS_INCLUDED
+  #error intrinsics.h is already included previously!
+  #endif
+
+  #include <intrinsics.h>
+
+  #if !((defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)))
+    #define __get_FPSCR() (0)
+  #endif
+
+  #pragma diag_suppress=Pe940
+  #pragma diag_suppress=Pe177
+
+  #define __enable_irq        __enable_interrupt
+  #define __disable_irq       __disable_interrupt
+  #define __enable_fault_irq    __enable_fiq
+  #define __disable_fault_irq   __disable_fiq
+  #define __NOP               __no_operation
+
+  #define __get_xPSR          __get_PSR
+
+  __IAR_FT void __set_mode(uint32_t mode)
+  {
+    __ASM volatile("MSR  cpsr_c, %0" : : "r" (mode) : "memory");
+  }
+
+  __IAR_FT uint32_t __LDREXW(uint32_t volatile *ptr)
+  {
+    return __LDREX((unsigned long *)ptr);
+  }
+
+  __IAR_FT uint32_t __STREXW(uint32_t value, uint32_t volatile *ptr)
+  {
+    return __STREX(value, (unsigned long *)ptr);
+  }
+
+
+  __IAR_FT uint32_t __RRX(uint32_t value)
+  {
+    uint32_t result;
+    __ASM("RRX      %0, %1" : "=r"(result) : "r" (value) : "cc");
+    return(result);
+  }
+
+
+  __IAR_FT uint32_t __ROR(uint32_t op1, uint32_t op2)
+  {
+    return (op1 >> op2) | (op1 << ((sizeof(op1)*8)-op2));
+  }
+
+  __IAR_FT uint32_t __get_FPEXC(void)
+  {
+  #if ((defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)))
+    uint32_t result;
+    __ASM volatile("VMRS %0, fpexc" : "=r" (result) : : "memory");
+    return(result);
+  #else
+    return(0);
+  #endif
+  }
+
+  __IAR_FT void __set_FPEXC(uint32_t fpexc)
+  {
+  #if ((defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)))
+    __ASM volatile ("VMSR fpexc, %0" : : "r" (fpexc) : "memory");
+  #endif
+  }
+
+
+  #define __get_CP(cp, op1, Rt, CRn, CRm, op2) \
+    __ASM volatile("MRC p" # cp ", " # op1 ", %0, c" # CRn ", c" # CRm ", " # op2 : "=r" (Rt) : : "memory" )
+  #define __set_CP(cp, op1, Rt, CRn, CRm, op2) \
+    __ASM volatile("MCR p" # cp ", " # op1 ", %0, c" # CRn ", c" # CRm ", " # op2 : : "r" (Rt) : "memory" )
+  #define __get_CP64(cp, op1, Rt, CRm) \
+    __ASM volatile("MRRC p" # cp ", " # op1 ", %Q0, %R0, c" # CRm  : "=r" (Rt) : : "memory" )
+  #define __set_CP64(cp, op1, Rt, CRm) \
+    __ASM volatile("MCRR p" # cp ", " # op1 ", %Q0, %R0, c" # CRm  : : "r" (Rt) : "memory" )
+
+  #include "cmsis_cp15.h"
+
+#endif   /* __ICCARM_INTRINSICS_VERSION__ == 2 */
+
+#define __BKPT(value)    __asm volatile ("BKPT     %0" : : "i"(value))
+
+
+__IAR_FT uint32_t __get_SP_usr(void)
+{
+  uint32_t cpsr;
+  uint32_t result;
+  __ASM volatile(
+    "MRS     %0, cpsr   \n"
+    "CPS     #0x1F      \n" // no effect in USR mode
+    "MOV     %1, sp     \n"
+    "MSR     cpsr_c, %2 \n" // no effect in USR mode
+    "ISB" :  "=r"(cpsr), "=r"(result) : "r"(cpsr) : "memory"
+   );
+  return result;
+}
+
+__IAR_FT void __set_SP_usr(uint32_t topOfProcStack)
+{
+  uint32_t cpsr;
+  __ASM volatile(
+    "MRS     %0, cpsr   \n"
+    "CPS     #0x1F      \n" // no effect in USR mode
+    "MOV     sp, %1     \n"
+    "MSR     cpsr_c, %2 \n" // no effect in USR mode
+    "ISB" : "=r"(cpsr) : "r" (topOfProcStack), "r"(cpsr) : "memory"
+   );
+}
+
+#define __get_mode()                (__get_CPSR() & 0x1FU)
+
+__STATIC_INLINE
+void __FPU_Enable(void)
+{
+  __ASM volatile(
+    //Permit access to VFP/NEON, registers by modifying CPACR
+    "        MRC     p15,0,R1,c1,c0,2  \n"
+    "        ORR     R1,R1,#0x00F00000 \n"
+    "        MCR     p15,0,R1,c1,c0,2  \n"
+
+    //Ensure that subsequent instructions occur in the context of VFP/NEON access permitted
+    "        ISB                       \n"
+
+    //Enable VFP/NEON
+    "        VMRS    R1,FPEXC          \n"
+    "        ORR     R1,R1,#0x40000000 \n"
+    "        VMSR    FPEXC,R1          \n"
+
+    //Initialise VFP/NEON registers to 0
+    "        MOV     R2,#0             \n"
+
+    //Initialise D16 registers to 0
+    "        VMOV    D0, R2,R2         \n"
+    "        VMOV    D1, R2,R2         \n"
+    "        VMOV    D2, R2,R2         \n"
+    "        VMOV    D3, R2,R2         \n"
+    "        VMOV    D4, R2,R2         \n"
+    "        VMOV    D5, R2,R2         \n"
+    "        VMOV    D6, R2,R2         \n"
+    "        VMOV    D7, R2,R2         \n"
+    "        VMOV    D8, R2,R2         \n"
+    "        VMOV    D9, R2,R2         \n"
+    "        VMOV    D10,R2,R2         \n"
+    "        VMOV    D11,R2,R2         \n"
+    "        VMOV    D12,R2,R2         \n"
+    "        VMOV    D13,R2,R2         \n"
+    "        VMOV    D14,R2,R2         \n"
+    "        VMOV    D15,R2,R2         \n"
+
+#ifdef __ARM_ADVANCED_SIMD__
+    //Initialise D32 registers to 0
+    "        VMOV    D16,R2,R2         \n"
+    "        VMOV    D17,R2,R2         \n"
+    "        VMOV    D18,R2,R2         \n"
+    "        VMOV    D19,R2,R2         \n"
+    "        VMOV    D20,R2,R2         \n"
+    "        VMOV    D21,R2,R2         \n"
+    "        VMOV    D22,R2,R2         \n"
+    "        VMOV    D23,R2,R2         \n"
+    "        VMOV    D24,R2,R2         \n"
+    "        VMOV    D25,R2,R2         \n"
+    "        VMOV    D26,R2,R2         \n"
+    "        VMOV    D27,R2,R2         \n"
+    "        VMOV    D28,R2,R2         \n"
+    "        VMOV    D29,R2,R2         \n"
+    "        VMOV    D30,R2,R2         \n"
+    "        VMOV    D31,R2,R2         \n"
+#endif
+
+    //Initialise FPSCR to a known state
+    "        VMRS    R1,FPSCR          \n"
+    "        MOV32   R2,#0x00086060    \n" //Mask off all bits that do not have to be preserved. Non-preserved bits can/should be zero.
+    "        AND     R1,R1,R2          \n"
+    "        VMSR    FPSCR,R1          \n"
+    : : : "cc", "r1", "r2"
+  );
+}
+
+
+
+#undef __IAR_FT
+#undef __ICCARM_V8
+
+#pragma diag_default=Pe940
+#pragma diag_default=Pe177
+
+#endif /* __CMSIS_ICCARM_A_H__ */

--- a/platform/ext/cmsis/CMSIS/Core/Include/a-profile/irq_ctrl.h
+++ b/platform/ext/cmsis/CMSIS/Core/Include/a-profile/irq_ctrl.h
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2017-2020 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS-Core(A) Interrupt Controller API Header File
+ */
+
+#ifndef IRQ_CTRL_H_
+#define IRQ_CTRL_H_
+
+#if   defined ( __ICCARM__ )
+  #pragma system_include         /* treat file as system include file for MISRA check */
+#elif defined (__clang__)
+  #pragma clang system_header    /* treat file as system include file */
+#endif
+
+#include <stdint.h>
+
+#ifndef IRQHANDLER_T
+#define IRQHANDLER_T
+/// Interrupt handler data type
+typedef void (*IRQHandler_t) (void);
+#endif
+
+#ifndef IRQN_ID_T
+#define IRQN_ID_T
+/// Interrupt ID number data type
+typedef int32_t IRQn_ID_t;
+#endif
+
+/* Interrupt mode bit-masks */
+#define IRQ_MODE_TRIG_Pos           (0U)
+#define IRQ_MODE_TRIG_Msk           (0x07UL /*<< IRQ_MODE_TRIG_Pos*/)
+#define IRQ_MODE_TRIG_LEVEL         (0x00UL /*<< IRQ_MODE_TRIG_Pos*/) ///< Trigger: level triggered interrupt
+#define IRQ_MODE_TRIG_LEVEL_LOW     (0x01UL /*<< IRQ_MODE_TRIG_Pos*/) ///< Trigger: low level triggered interrupt
+#define IRQ_MODE_TRIG_LEVEL_HIGH    (0x02UL /*<< IRQ_MODE_TRIG_Pos*/) ///< Trigger: high level triggered interrupt
+#define IRQ_MODE_TRIG_EDGE          (0x04UL /*<< IRQ_MODE_TRIG_Pos*/) ///< Trigger: edge triggered interrupt
+#define IRQ_MODE_TRIG_EDGE_RISING   (0x05UL /*<< IRQ_MODE_TRIG_Pos*/) ///< Trigger: rising edge triggered interrupt
+#define IRQ_MODE_TRIG_EDGE_FALLING  (0x06UL /*<< IRQ_MODE_TRIG_Pos*/) ///< Trigger: falling edge triggered interrupt
+#define IRQ_MODE_TRIG_EDGE_BOTH     (0x07UL /*<< IRQ_MODE_TRIG_Pos*/) ///< Trigger: rising and falling edge triggered interrupt
+
+#define IRQ_MODE_TYPE_Pos           (3U)
+#define IRQ_MODE_TYPE_Msk           (0x01UL << IRQ_MODE_TYPE_Pos)
+#define IRQ_MODE_TYPE_IRQ           (0x00UL << IRQ_MODE_TYPE_Pos)     ///< Type: interrupt source triggers CPU IRQ line
+#define IRQ_MODE_TYPE_FIQ           (0x01UL << IRQ_MODE_TYPE_Pos)     ///< Type: interrupt source triggers CPU FIQ line
+
+#define IRQ_MODE_DOMAIN_Pos         (4U)
+#define IRQ_MODE_DOMAIN_Msk         (0x01UL << IRQ_MODE_DOMAIN_Pos)
+#define IRQ_MODE_DOMAIN_NONSECURE   (0x00UL << IRQ_MODE_DOMAIN_Pos)   ///< Domain: interrupt is targeting non-secure domain
+#define IRQ_MODE_DOMAIN_SECURE      (0x01UL << IRQ_MODE_DOMAIN_Pos)   ///< Domain: interrupt is targeting secure domain
+
+#define IRQ_MODE_CPU_Pos            (5U)
+#define IRQ_MODE_CPU_Msk            (0xFFUL << IRQ_MODE_CPU_Pos)
+#define IRQ_MODE_CPU_ALL            (0x00UL << IRQ_MODE_CPU_Pos)      ///< CPU: interrupt targets all CPUs
+#define IRQ_MODE_CPU_0              (0x01UL << IRQ_MODE_CPU_Pos)      ///< CPU: interrupt targets CPU 0
+#define IRQ_MODE_CPU_1              (0x02UL << IRQ_MODE_CPU_Pos)      ///< CPU: interrupt targets CPU 1
+#define IRQ_MODE_CPU_2              (0x04UL << IRQ_MODE_CPU_Pos)      ///< CPU: interrupt targets CPU 2
+#define IRQ_MODE_CPU_3              (0x08UL << IRQ_MODE_CPU_Pos)      ///< CPU: interrupt targets CPU 3
+#define IRQ_MODE_CPU_4              (0x10UL << IRQ_MODE_CPU_Pos)      ///< CPU: interrupt targets CPU 4
+#define IRQ_MODE_CPU_5              (0x20UL << IRQ_MODE_CPU_Pos)      ///< CPU: interrupt targets CPU 5
+#define IRQ_MODE_CPU_6              (0x40UL << IRQ_MODE_CPU_Pos)      ///< CPU: interrupt targets CPU 6
+#define IRQ_MODE_CPU_7              (0x80UL << IRQ_MODE_CPU_Pos)      ///< CPU: interrupt targets CPU 7
+
+// Encoding in some early GIC implementations
+#define IRQ_MODE_MODEL_Pos          (13U)
+#define IRQ_MODE_MODEL_Msk          (0x1UL << IRQ_MODE_MODEL_Pos)
+#define IRQ_MODE_MODEL_NN           (0x0UL << IRQ_MODE_MODEL_Pos)     ///< Corresponding interrupt is handled using the N-N model
+#define IRQ_MODE_MODEL_1N           (0x1UL << IRQ_MODE_MODEL_Pos)     ///< Corresponding interrupt is handled using the 1-N model
+
+#define IRQ_MODE_ERROR              (0x80000000UL)                    ///< Bit indicating mode value error
+
+/* Interrupt priority bit-masks */
+#define IRQ_PRIORITY_Msk            (0x0000FFFFUL)                    ///< Interrupt priority value bit-mask
+#define IRQ_PRIORITY_ERROR          (0x80000000UL)                    ///< Bit indicating priority value error
+
+/// Initialize interrupt controller.
+/// \return 0 on success, -1 on error.
+int32_t IRQ_Initialize (void);
+
+/// Register interrupt handler.
+/// \param[in]     irqn          interrupt ID number
+/// \param[in]     handler       interrupt handler function address
+/// \return 0 on success, -1 on error.
+int32_t IRQ_SetHandler (IRQn_ID_t irqn, IRQHandler_t handler);
+
+/// Get the registered interrupt handler.
+/// \param[in]     irqn          interrupt ID number
+/// \return registered interrupt handler function address.
+IRQHandler_t IRQ_GetHandler (IRQn_ID_t irqn);
+
+/// Enable interrupt.
+/// \param[in]     irqn          interrupt ID number
+/// \return 0 on success, -1 on error.
+int32_t IRQ_Enable (IRQn_ID_t irqn);
+
+/// Disable interrupt.
+/// \param[in]     irqn          interrupt ID number
+/// \return 0 on success, -1 on error.
+int32_t IRQ_Disable (IRQn_ID_t irqn);
+
+/// Get interrupt enable state.
+/// \param[in]     irqn          interrupt ID number
+/// \return 0 - interrupt is disabled, 1 - interrupt is enabled.
+uint32_t IRQ_GetEnableState (IRQn_ID_t irqn);
+
+/// Configure interrupt request mode.
+/// \param[in]     irqn          interrupt ID number
+/// \param[in]     mode          mode configuration
+/// \return 0 on success, -1 on error.
+int32_t IRQ_SetMode (IRQn_ID_t irqn, uint32_t mode);
+
+/// Get interrupt mode configuration.
+/// \param[in]     irqn          interrupt ID number
+/// \return current interrupt mode configuration with optional IRQ_MODE_ERROR bit set.
+uint32_t IRQ_GetMode (IRQn_ID_t irqn);
+
+/// Get ID number of current interrupt request (IRQ).
+/// \return interrupt ID number.
+IRQn_ID_t IRQ_GetActiveIRQ (void);
+
+/// Get ID number of current fast interrupt request (FIQ).
+/// \return interrupt ID number.
+IRQn_ID_t IRQ_GetActiveFIQ (void);
+
+/// Signal end of interrupt processing.
+/// \param[in]     irqn          interrupt ID number
+/// \return 0 on success, -1 on error.
+int32_t IRQ_EndOfInterrupt (IRQn_ID_t irqn);
+
+/// Set interrupt pending flag.
+/// \param[in]     irqn          interrupt ID number
+/// \return 0 on success, -1 on error.
+int32_t IRQ_SetPending (IRQn_ID_t irqn);
+
+/// Get interrupt pending flag.
+/// \param[in]     irqn          interrupt ID number
+/// \return 0 - interrupt is not pending, 1 - interrupt is pending.
+uint32_t IRQ_GetPending (IRQn_ID_t irqn);
+
+/// Clear interrupt pending flag.
+/// \param[in]     irqn          interrupt ID number
+/// \return 0 on success, -1 on error.
+int32_t IRQ_ClearPending (IRQn_ID_t irqn);
+
+/// Set interrupt priority value.
+/// \param[in]     irqn          interrupt ID number
+/// \param[in]     priority      interrupt priority value
+/// \return 0 on success, -1 on error.
+int32_t IRQ_SetPriority (IRQn_ID_t irqn, uint32_t priority);
+
+/// Get interrupt priority.
+/// \param[in]     irqn          interrupt ID number
+/// \return current interrupt priority value with optional IRQ_PRIORITY_ERROR bit set.
+uint32_t IRQ_GetPriority (IRQn_ID_t irqn);
+
+/// Set priority masking threshold.
+/// \param[in]     priority      priority masking threshold value
+/// \return 0 on success, -1 on error.
+int32_t IRQ_SetPriorityMask (uint32_t priority);
+
+/// Get priority masking threshold
+/// \return current priority masking threshold value with optional IRQ_PRIORITY_ERROR bit set.
+uint32_t IRQ_GetPriorityMask (void);
+
+/// Set priority grouping field split point
+/// \param[in]     bits          number of MSB bits included in the group priority field comparison
+/// \return 0 on success, -1 on error.
+int32_t IRQ_SetPriorityGroupBits (uint32_t bits);
+
+/// Get priority grouping field split point
+/// \return current number of MSB bits included in the group priority field comparison with
+///         optional IRQ_PRIORITY_ERROR bit set.
+uint32_t IRQ_GetPriorityGroupBits (void);
+
+#endif  // IRQ_CTRL_H_

--- a/platform/ext/cmsis/CMSIS/Core/Include/cmsis_compiler.h
+++ b/platform/ext/cmsis/CMSIS/Core/Include/cmsis_compiler.h
@@ -1,0 +1,324 @@
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS Compiler Generic Header File
+ */
+
+#ifndef __CMSIS_COMPILER_H
+#define __CMSIS_COMPILER_H
+
+#include <stdint.h>
+
+/*
+ * Arm Compiler above 6.10.1 (armclang)
+ */
+#if defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6100100)
+  #if __ARM_ARCH_PROFILE == 'A'
+    #include "./a-profile/cmsis_armclang_a.h"
+  #elif __ARM_ARCH_PROFILE == 'R'
+    #include "./r-profile/cmsis_armclang_r.h"
+  #elif __ARM_ARCH_PROFILE == 'M'
+    #include "./m-profile/cmsis_armclang_m.h"
+  #else
+    #error "Unknown Arm architecture profile"
+  #endif
+
+/*
+ * TI Arm Clang Compiler (tiarmclang)
+ */
+#elif defined (__ti__)
+  #if __ARM_ARCH_PROFILE == 'A'
+    #error "Core-A is not supported for this compiler"
+  #elif __ARM_ARCH_PROFILE == 'R'
+    #error "Core-R is not supported for this compiler"
+  #elif __ARM_ARCH_PROFILE == 'M'
+    #include "m-profile/cmsis_tiarmclang_m.h"
+  #else
+    #error "Unknown Arm architecture profile"
+  #endif
+
+
+/*
+ * LLVM/Clang Compiler
+ */
+#elif defined ( __clang__ )
+  #if __ARM_ARCH_PROFILE == 'A'
+    #include "a-profile/cmsis_clang_a.h"
+  #elif __ARM_ARCH_PROFILE == 'R'
+    #include "r-profile/cmsis_clang_r.h"
+  #elif __ARM_ARCH_PROFILE == 'M'
+    #include "m-profile/cmsis_clang_m.h"
+  #else
+    #error "Unknown Arm architecture profile"
+  #endif
+
+
+/*
+ * GNU Compiler
+ */
+#elif defined ( __GNUC__ )
+  #if __ARM_ARCH_PROFILE == 'A'
+    #include "a-profile/cmsis_gcc_a.h"
+  #elif __ARM_ARCH_PROFILE == 'R'
+    #include "r-profile/cmsis_gcc_r.h"
+  #elif __ARM_ARCH_PROFILE == 'M'
+    #include "m-profile/cmsis_gcc_m.h"
+  #else
+    #error "Unknown Arm architecture profile"
+  #endif
+
+
+/*
+ * IAR Compiler
+ */
+#elif defined ( __ICCARM__ )
+  #if __ARM_ARCH_PROFILE == 'A'
+    #include "a-profile/cmsis_iccarm_a.h"
+  #elif __ARM_ARCH_PROFILE == 'R'
+    #include "r-profile/cmsis_iccarm_r.h"
+  #elif __ARM_ARCH_PROFILE == 'M'
+    #include "m-profile/cmsis_iccarm_m.h"
+  #else
+    #error "Unknown Arm architecture profile"
+  #endif
+
+
+/*
+ * TI Arm Compiler (armcl)
+ */
+#elif defined ( __TI_ARM__ )
+  #include <cmsis_ccs.h>
+
+  #ifndef   __ASM
+    #define __ASM                                  __asm
+  #endif
+  #ifndef   __INLINE
+    #define __INLINE                               inline
+  #endif
+  #ifndef   __STATIC_INLINE
+    #define __STATIC_INLINE                        static inline
+  #endif
+  #ifndef   __STATIC_FORCEINLINE
+    #define __STATIC_FORCEINLINE                   __STATIC_INLINE
+  #endif
+  #ifndef   __NO_RETURN
+    #define __NO_RETURN                            __attribute__((noreturn))
+  #endif
+  #ifndef   __USED
+    #define __USED                                 __attribute__((used))
+  #endif
+  #ifndef   __WEAK
+    #define __WEAK                                 __attribute__((weak))
+  #endif
+  #ifndef   __PACKED
+    #define __PACKED                               __attribute__((packed))
+  #endif
+  #ifndef   __PACKED_STRUCT
+    #define __PACKED_STRUCT                        struct __attribute__((packed))
+  #endif
+  #ifndef   __PACKED_UNION
+    #define __PACKED_UNION                         union __attribute__((packed))
+  #endif
+  #ifndef   __UNALIGNED_UINT16_WRITE
+    __PACKED_STRUCT T_UINT16_WRITE { uint16_t v; };
+    #define __UNALIGNED_UINT16_WRITE(addr, val)    (void)((((struct T_UINT16_WRITE *)(void*)(addr))->v) = (val))
+  #endif
+  #ifndef   __UNALIGNED_UINT16_READ
+    __PACKED_STRUCT T_UINT16_READ { uint16_t v; };
+    #define __UNALIGNED_UINT16_READ(addr)          (((const struct T_UINT16_READ *)(const void *)(addr))->v)
+  #endif
+  #ifndef   __UNALIGNED_UINT32_WRITE
+    __PACKED_STRUCT T_UINT32_WRITE { uint32_t v; };
+    #define __UNALIGNED_UINT32_WRITE(addr, val)    (void)((((struct T_UINT32_WRITE *)(void *)(addr))->v) = (val))
+  #endif
+  #ifndef   __UNALIGNED_UINT32_READ
+    __PACKED_STRUCT T_UINT32_READ { uint32_t v; };
+    #define __UNALIGNED_UINT32_READ(addr)          (((const struct T_UINT32_READ *)(const void *)(addr))->v)
+  #endif
+  #ifndef   __ALIGNED
+    #define __ALIGNED(x)                           __attribute__((aligned(x)))
+  #endif
+  #ifndef   __RESTRICT
+    #define __RESTRICT                             __restrict
+  #endif
+  #ifndef   __COMPILER_BARRIER
+    #warning No compiler specific solution for __COMPILER_BARRIER. __COMPILER_BARRIER is ignored.
+    #define __COMPILER_BARRIER()                   (void)0
+  #endif
+  #ifndef __NO_INIT
+    #define __NO_INIT                              __attribute__ ((section (".noinit")))
+  #endif
+  #ifndef __ALIAS
+    #define __ALIAS(x)                             __attribute__ ((alias(x)))
+  #endif
+
+/*
+ * TASKING Compiler
+ */
+#elif defined ( __TASKING__ )
+  /*
+   * The CMSIS functions have been implemented as intrinsics in the compiler.
+   * Please use "carm -?i" to get an up to date list of all intrinsics,
+   * Including the CMSIS ones.
+   */
+
+  #ifndef   __ASM
+    #define __ASM                                  __asm
+  #endif
+  #ifndef   __INLINE
+    #define __INLINE                               inline
+  #endif
+  #ifndef   __STATIC_INLINE
+    #define __STATIC_INLINE                        static inline
+  #endif
+  #ifndef   __STATIC_FORCEINLINE
+    #define __STATIC_FORCEINLINE                   __STATIC_INLINE
+  #endif
+  #ifndef   __NO_RETURN
+    #define __NO_RETURN                            __attribute__((noreturn))
+  #endif
+  #ifndef   __USED
+    #define __USED                                 __attribute__((used))
+  #endif
+  #ifndef   __WEAK
+    #define __WEAK                                 __attribute__((weak))
+  #endif
+  #ifndef   __PACKED
+    #define __PACKED                               __packed__
+  #endif
+  #ifndef   __PACKED_STRUCT
+    #define __PACKED_STRUCT                        struct __packed__
+  #endif
+  #ifndef   __PACKED_UNION
+    #define __PACKED_UNION                         union __packed__
+  #endif
+  #ifndef   __UNALIGNED_UINT16_WRITE
+    __PACKED_STRUCT T_UINT16_WRITE { uint16_t v; };
+    #define __UNALIGNED_UINT16_WRITE(addr, val)    (void)((((struct T_UINT16_WRITE *)(void *)(addr))->v) = (val))
+  #endif
+  #ifndef   __UNALIGNED_UINT16_READ
+    __PACKED_STRUCT T_UINT16_READ { uint16_t v; };
+    #define __UNALIGNED_UINT16_READ(addr)          (((const struct T_UINT16_READ *)(const void *)(addr))->v)
+  #endif
+  #ifndef   __UNALIGNED_UINT32_WRITE
+    __PACKED_STRUCT T_UINT32_WRITE { uint32_t v; };
+    #define __UNALIGNED_UINT32_WRITE(addr, val)    (void)((((struct T_UINT32_WRITE *)(void *)(addr))->v) = (val))
+  #endif
+  #ifndef   __UNALIGNED_UINT32_READ
+    __PACKED_STRUCT T_UINT32_READ { uint32_t v; };
+    #define __UNALIGNED_UINT32_READ(addr)          (((const struct T_UINT32_READ *)(const void *)(addr))->v)
+  #endif
+  #ifndef   __ALIGNED
+    #define __ALIGNED(x)                           __align(x)
+  #endif
+  #ifndef   __RESTRICT
+    #warning No compiler specific solution for __RESTRICT. __RESTRICT is ignored.
+    #define __RESTRICT
+  #endif
+  #ifndef   __COMPILER_BARRIER
+    #warning No compiler specific solution for __COMPILER_BARRIER. __COMPILER_BARRIER is ignored.
+    #define __COMPILER_BARRIER()                   (void)0
+  #endif
+  #ifndef __NO_INIT
+    #define __NO_INIT                              __attribute__ ((section (".noinit")))
+  #endif
+  #ifndef __ALIAS
+    #define __ALIAS(x)                             __attribute__ ((alias(x)))
+  #endif
+
+/*
+ * COSMIC Compiler
+ */
+#elif defined ( __CSMC__ )
+   #include <cmsis_csm.h>
+
+ #ifndef   __ASM
+    #define __ASM                                  _asm
+  #endif
+  #ifndef   __INLINE
+    #define __INLINE                               inline
+  #endif
+  #ifndef   __STATIC_INLINE
+    #define __STATIC_INLINE                        static inline
+  #endif
+  #ifndef   __STATIC_FORCEINLINE
+    #define __STATIC_FORCEINLINE                   __STATIC_INLINE
+  #endif
+  #ifndef   __NO_RETURN
+    // NO RETURN is automatically detected hence no warning here
+    #define __NO_RETURN
+  #endif
+  #ifndef   __USED
+    #warning No compiler specific solution for __USED. __USED is ignored.
+    #define __USED
+  #endif
+  #ifndef   __WEAK
+    #define __WEAK                                 __weak
+  #endif
+  #ifndef   __PACKED
+    #define __PACKED                               @packed
+  #endif
+  #ifndef   __PACKED_STRUCT
+    #define __PACKED_STRUCT                        @packed struct
+  #endif
+  #ifndef   __PACKED_UNION
+    #define __PACKED_UNION                         @packed union
+  #endif
+  #ifndef   __UNALIGNED_UINT16_WRITE
+    __PACKED_STRUCT T_UINT16_WRITE { uint16_t v; };
+    #define __UNALIGNED_UINT16_WRITE(addr, val)    (void)((((struct T_UINT16_WRITE *)(void *)(addr))->v) = (val))
+  #endif
+  #ifndef   __UNALIGNED_UINT16_READ
+    __PACKED_STRUCT T_UINT16_READ { uint16_t v; };
+    #define __UNALIGNED_UINT16_READ(addr)          (((const struct T_UINT16_READ *)(const void *)(addr))->v)
+  #endif
+  #ifndef   __UNALIGNED_UINT32_WRITE
+    __PACKED_STRUCT T_UINT32_WRITE { uint32_t v; };
+    #define __UNALIGNED_UINT32_WRITE(addr, val)    (void)((((struct T_UINT32_WRITE *)(void *)(addr))->v) = (val))
+  #endif
+  #ifndef   __UNALIGNED_UINT32_READ
+    __PACKED_STRUCT T_UINT32_READ { uint32_t v; };
+    #define __UNALIGNED_UINT32_READ(addr)          (((const struct T_UINT32_READ *)(const void *)(addr))->v)
+  #endif
+  #ifndef   __ALIGNED
+    #warning No compiler specific solution for __ALIGNED. __ALIGNED is ignored.
+    #define __ALIGNED(x)
+  #endif
+  #ifndef   __RESTRICT
+    #warning No compiler specific solution for __RESTRICT. __RESTRICT is ignored.
+    #define __RESTRICT
+  #endif
+  #ifndef   __COMPILER_BARRIER
+    #warning No compiler specific solution for __COMPILER_BARRIER. __COMPILER_BARRIER is ignored.
+    #define __COMPILER_BARRIER()                   (void)0
+  #endif
+  #ifndef __NO_INIT
+    #define __NO_INIT                              __attribute__ ((section (".noinit")))
+  #endif
+  #ifndef __ALIAS
+    #define __ALIAS(x)                             __attribute__ ((alias(x)))
+  #endif
+
+#else
+  #error Unknown compiler.
+#endif
+
+
+#endif /* __CMSIS_COMPILER_H */
+

--- a/platform/ext/cmsis/CMSIS/Core/Include/cmsis_version.h
+++ b/platform/ext/cmsis/CMSIS/Core/Include/cmsis_version.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2009-2023 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS Core Version Definitions
+ */
+
+#if   defined ( __ICCARM__ )
+  #pragma system_include         /* treat file as system include file for MISRA check */
+#elif defined (__clang__)
+  #pragma clang system_header   /* treat file as system include file */
+#endif
+
+#ifndef __CMSIS_VERSION_H
+#define __CMSIS_VERSION_H
+
+/*  CMSIS-Core(M) Version definitions */
+#define __CM_CMSIS_VERSION_MAIN  ( 6U)                                    /*!< \brief [31:16] CMSIS-Core(M) main version */
+#define __CM_CMSIS_VERSION_SUB   ( 0U)                                    /*!< \brief [15:0]  CMSIS-Core(M) sub version */
+#define __CM_CMSIS_VERSION       ((__CM_CMSIS_VERSION_MAIN << 16U) | \
+                                   __CM_CMSIS_VERSION_SUB           )     /*!< \brief CMSIS Core(M) version number */
+
+/*  CMSIS-Core(A) Version definitions */
+#define __CA_CMSIS_VERSION_MAIN  ( 6U)                                    /*!< \brief [31:16] CMSIS-Core(A) main version */
+#define __CA_CMSIS_VERSION_SUB   ( 0U)                                    /*!< \brief [15:0]  CMSIS-Core(A) sub version */
+#define __CA_CMSIS_VERSION       ((__CA_CMSIS_VERSION_MAIN << 16U) | \
+                                   __CA_CMSIS_VERSION_SUB          )      /*!< \brief CMSIS-Core(A) version number */
+
+#endif

--- a/platform/ext/cmsis/CMSIS/Core/Include/core_ca.h
+++ b/platform/ext/cmsis/CMSIS/Core/Include/core_ca.h
@@ -1,0 +1,3000 @@
+/*
+ * Copyright (c) 2009-2023 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS Cortex-A Core Peripheral Access Layer Header File
+ */
+
+#ifndef __CORE_CA_H_GENERIC
+#define __CORE_CA_H_GENERIC
+
+#if   defined ( __ICCARM__ )
+  #pragma system_include         /* treat file as system include file for MISRA check */
+#elif defined (__clang__)
+  #pragma clang system_header   /* treat file as system include file */
+#endif
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/*******************************************************************************
+ *                 CMSIS definitions
+ ******************************************************************************/
+
+#include "cmsis_version.h"
+
+/*  CMSIS CA definitions */
+
+#if defined ( __CC_ARM )
+  #if defined (__TARGET_FPU_VFP)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #if defined (__ARM_FP)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#elif defined ( __ICCARM__ )
+  #if defined (__ARMVFP__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#elif defined ( __TMS470__ )
+  #if defined __TI_VFP_SUPPORT__
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#elif defined ( __GNUC__ )
+  #if defined (__VFP_FP__) && !defined(__SOFTFP__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#elif defined ( __TASKING__ )
+  #if defined (__FPU_VFP__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+#endif
+
+#include "cmsis_compiler.h"               /* CMSIS compiler specific defines */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_CA_H_GENERIC */
+
+#ifndef __CMSIS_GENERIC
+
+#ifndef __CORE_CA_H_DEPENDANT
+#define __CORE_CA_H_DEPENDANT
+
+#if   defined ( __ICCARM__ )
+  #pragma system_include         /* treat file as system include file for MISRA check */
+#elif defined (__clang__)
+  #pragma clang system_header   /* treat file as system include file */
+#endif
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+ /* check device defines and use defaults */
+#if defined __CHECK_DEVICE_DEFINES
+  #ifndef __CA_REV
+    #define __CA_REV              0x0000U /*!< \brief Contains the core revision for a Cortex-A class device */
+    #warning "__CA_REV not defined in device header file; using default!"
+  #endif
+
+  #ifndef __FPU_PRESENT
+    #define __FPU_PRESENT             0U
+    #warning "__FPU_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __GIC_PRESENT
+    #define __GIC_PRESENT             1U
+    #warning "__GIC_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __TIM_PRESENT
+    #define __TIM_PRESENT             1U
+    #warning "__TIM_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __L2C_PRESENT
+    #define __L2C_PRESENT             0U
+    #warning "__L2C_PRESENT not defined in device header file; using default!"
+  #endif
+#endif
+
+/* IO definitions (access restrictions to peripheral registers) */
+#ifdef __cplusplus
+  #define   __I     volatile             /*!< \brief Defines 'read only' permissions */
+#else
+  #define   __I     volatile const       /*!< \brief Defines 'read only' permissions */
+#endif
+#define     __O     volatile             /*!< \brief Defines 'write only' permissions */
+#define     __IO    volatile             /*!< \brief Defines 'read / write' permissions */
+
+/* following defines should be used for structure members */
+#define     __IM     volatile const      /*!< \brief Defines 'read only' structure member permissions */
+#define     __OM     volatile            /*!< \brief Defines 'write only' structure member permissions */
+#define     __IOM    volatile            /*!< \brief Defines 'read / write' structure member permissions */
+#define RESERVED(N, T) T RESERVED##N;    // placeholder struct members used for "reserved" areas
+
+ /*******************************************************************************
+  *                 Register Abstraction
+   Core Register contain:
+   - CPSR
+   - CP15 Registers
+   - L2C-310 Cache Controller
+   - Generic Interrupt Controller Distributor
+   - Generic Interrupt Controller Interface
+  ******************************************************************************/
+
+/* Core Register CPSR */
+typedef union
+{
+  struct
+  {
+    uint32_t M:5;                        /*!< \brief bit:  0.. 4  Mode field */
+    uint32_t T:1;                        /*!< \brief bit:      5  Thumb execution state bit */
+    uint32_t F:1;                        /*!< \brief bit:      6  FIQ mask bit */
+    uint32_t I:1;                        /*!< \brief bit:      7  IRQ mask bit */
+    uint32_t A:1;                        /*!< \brief bit:      8  Asynchronous abort mask bit */
+    uint32_t E:1;                        /*!< \brief bit:      9  Endianness execution state bit */
+    uint32_t IT1:6;                      /*!< \brief bit: 10..15  If-Then execution state bits 2-7 */
+    uint32_t GE:4;                       /*!< \brief bit: 16..19  Greater than or Equal flags */
+    RESERVED(0:4, uint32_t)
+    uint32_t J:1;                        /*!< \brief bit:     24  Jazelle bit */
+    uint32_t IT0:2;                      /*!< \brief bit: 25..26  If-Then execution state bits 0-1 */
+    uint32_t Q:1;                        /*!< \brief bit:     27  Saturation condition flag */
+    uint32_t V:1;                        /*!< \brief bit:     28  Overflow condition code flag */
+    uint32_t C:1;                        /*!< \brief bit:     29  Carry condition code flag */
+    uint32_t Z:1;                        /*!< \brief bit:     30  Zero condition code flag */
+    uint32_t N:1;                        /*!< \brief bit:     31  Negative condition code flag */
+  } b;                                   /*!< \brief Structure used for bit  access */
+  uint32_t w;                            /*!< \brief Type      used for word access */
+} CPSR_Type;
+
+
+
+/* CPSR Register Definitions */
+#define CPSR_N_Pos                       31U                                    /*!< \brief CPSR: N Position */
+#define CPSR_N_Msk                       (1UL << CPSR_N_Pos)                    /*!< \brief CPSR: N Mask */
+
+#define CPSR_Z_Pos                       30U                                    /*!< \brief CPSR: Z Position */
+#define CPSR_Z_Msk                       (1UL << CPSR_Z_Pos)                    /*!< \brief CPSR: Z Mask */
+
+#define CPSR_C_Pos                       29U                                    /*!< \brief CPSR: C Position */
+#define CPSR_C_Msk                       (1UL << CPSR_C_Pos)                    /*!< \brief CPSR: C Mask */
+
+#define CPSR_V_Pos                       28U                                    /*!< \brief CPSR: V Position */
+#define CPSR_V_Msk                       (1UL << CPSR_V_Pos)                    /*!< \brief CPSR: V Mask */
+
+#define CPSR_Q_Pos                       27U                                    /*!< \brief CPSR: Q Position */
+#define CPSR_Q_Msk                       (1UL << CPSR_Q_Pos)                    /*!< \brief CPSR: Q Mask */
+
+#define CPSR_IT0_Pos                     25U                                    /*!< \brief CPSR: IT0 Position */
+#define CPSR_IT0_Msk                     (3UL << CPSR_IT0_Pos)                  /*!< \brief CPSR: IT0 Mask */
+
+#define CPSR_J_Pos                       24U                                    /*!< \brief CPSR: J Position */
+#define CPSR_J_Msk                       (1UL << CPSR_J_Pos)                    /*!< \brief CPSR: J Mask */
+
+#define CPSR_GE_Pos                      16U                                    /*!< \brief CPSR: GE Position */
+#define CPSR_GE_Msk                      (0xFUL << CPSR_GE_Pos)                 /*!< \brief CPSR: GE Mask */
+
+#define CPSR_IT1_Pos                     10U                                    /*!< \brief CPSR: IT1 Position */
+#define CPSR_IT1_Msk                     (0x3FUL << CPSR_IT1_Pos)               /*!< \brief CPSR: IT1 Mask */
+
+#define CPSR_E_Pos                       9U                                     /*!< \brief CPSR: E Position */
+#define CPSR_E_Msk                       (1UL << CPSR_E_Pos)                    /*!< \brief CPSR: E Mask */
+
+#define CPSR_A_Pos                       8U                                     /*!< \brief CPSR: A Position */
+#define CPSR_A_Msk                       (1UL << CPSR_A_Pos)                    /*!< \brief CPSR: A Mask */
+
+#define CPSR_I_Pos                       7U                                     /*!< \brief CPSR: I Position */
+#define CPSR_I_Msk                       (1UL << CPSR_I_Pos)                    /*!< \brief CPSR: I Mask */
+
+#define CPSR_F_Pos                       6U                                     /*!< \brief CPSR: F Position */
+#define CPSR_F_Msk                       (1UL << CPSR_F_Pos)                    /*!< \brief CPSR: F Mask */
+
+#define CPSR_T_Pos                       5U                                     /*!< \brief CPSR: T Position */
+#define CPSR_T_Msk                       (1UL << CPSR_T_Pos)                    /*!< \brief CPSR: T Mask */
+
+#define CPSR_M_Pos                       0U                                     /*!< \brief CPSR: M Position */
+#define CPSR_M_Msk                       (0x1FUL << CPSR_M_Pos)                 /*!< \brief CPSR: M Mask */
+
+#define CPSR_M_USR                       0x10U                                  /*!< \brief CPSR: M User mode (PL0) */
+#define CPSR_M_FIQ                       0x11U                                  /*!< \brief CPSR: M Fast Interrupt mode (PL1) */
+#define CPSR_M_IRQ                       0x12U                                  /*!< \brief CPSR: M Interrupt mode (PL1) */
+#define CPSR_M_SVC                       0x13U                                  /*!< \brief CPSR: M Supervisor mode (PL1) */
+#define CPSR_M_MON                       0x16U                                  /*!< \brief CPSR: M Monitor mode (PL1) */
+#define CPSR_M_ABT                       0x17U                                  /*!< \brief CPSR: M Abort mode (PL1) */
+#define CPSR_M_HYP                       0x1AU                                  /*!< \brief CPSR: M Hypervisor mode (PL2) */
+#define CPSR_M_UND                       0x1BU                                  /*!< \brief CPSR: M Undefined mode (PL1) */
+#define CPSR_M_SYS                       0x1FU                                  /*!< \brief CPSR: M System mode (PL1) */
+
+/* CP15 Register SCTLR */
+typedef union
+{
+  struct
+  {
+    uint32_t M:1;                        /*!< \brief bit:     0  MMU enable */
+    uint32_t A:1;                        /*!< \brief bit:     1  Alignment check enable */
+    uint32_t C:1;                        /*!< \brief bit:     2  Cache enable */
+    RESERVED(0:2, uint32_t)
+    uint32_t CP15BEN:1;                  /*!< \brief bit:     5  CP15 barrier enable */
+    RESERVED(1:1, uint32_t)
+    uint32_t B:1;                        /*!< \brief bit:     7  Endianness model */
+    RESERVED(2:2, uint32_t)
+    uint32_t SW:1;                       /*!< \brief bit:    10  SWP and SWPB enable */
+    uint32_t Z:1;                        /*!< \brief bit:    11  Branch prediction enable */
+    uint32_t I:1;                        /*!< \brief bit:    12  Instruction cache enable */
+    uint32_t V:1;                        /*!< \brief bit:    13  Vectors bit */
+    uint32_t RR:1;                       /*!< \brief bit:    14  Round Robin select */
+    RESERVED(3:2, uint32_t)
+    uint32_t HA:1;                       /*!< \brief bit:    17  Hardware Access flag enable */
+    RESERVED(4:1, uint32_t)
+    uint32_t WXN:1;                      /*!< \brief bit:    19  Write permission implies XN */
+    uint32_t UWXN:1;                     /*!< \brief bit:    20  Unprivileged write permission implies PL1 XN */
+    uint32_t FI:1;                       /*!< \brief bit:    21  Fast interrupts configuration enable */
+    uint32_t U:1;                        /*!< \brief bit:    22  Alignment model */
+    RESERVED(5:1, uint32_t)
+    uint32_t VE:1;                       /*!< \brief bit:    24  Interrupt Vectors Enable */
+    uint32_t EE:1;                       /*!< \brief bit:    25  Exception Endianness */
+    RESERVED(6:1, uint32_t)
+    uint32_t NMFI:1;                     /*!< \brief bit:    27  Non-maskable FIQ (NMFI) support */
+    uint32_t TRE:1;                      /*!< \brief bit:    28  TEX remap enable. */
+    uint32_t AFE:1;                      /*!< \brief bit:    29  Access flag enable */
+    uint32_t TE:1;                       /*!< \brief bit:    30  Thumb Exception enable */
+    RESERVED(7:1, uint32_t)
+  } b;                                   /*!< \brief Structure used for bit  access */
+  uint32_t w;                            /*!< \brief Type      used for word access */
+} SCTLR_Type;
+
+#define SCTLR_TE_Pos                     30U                                    /*!< \brief SCTLR: TE Position */
+#define SCTLR_TE_Msk                     (1UL << SCTLR_TE_Pos)                  /*!< \brief SCTLR: TE Mask */
+
+#define SCTLR_AFE_Pos                    29U                                    /*!< \brief SCTLR: AFE Position */
+#define SCTLR_AFE_Msk                    (1UL << SCTLR_AFE_Pos)                 /*!< \brief SCTLR: AFE Mask */
+
+#define SCTLR_TRE_Pos                    28U                                    /*!< \brief SCTLR: TRE Position */
+#define SCTLR_TRE_Msk                    (1UL << SCTLR_TRE_Pos)                 /*!< \brief SCTLR: TRE Mask */
+
+#define SCTLR_NMFI_Pos                   27U                                    /*!< \brief SCTLR: NMFI Position */
+#define SCTLR_NMFI_Msk                   (1UL << SCTLR_NMFI_Pos)                /*!< \brief SCTLR: NMFI Mask */
+
+#define SCTLR_EE_Pos                     25U                                    /*!< \brief SCTLR: EE Position */
+#define SCTLR_EE_Msk                     (1UL << SCTLR_EE_Pos)                  /*!< \brief SCTLR: EE Mask */
+
+#define SCTLR_VE_Pos                     24U                                    /*!< \brief SCTLR: VE Position */
+#define SCTLR_VE_Msk                     (1UL << SCTLR_VE_Pos)                  /*!< \brief SCTLR: VE Mask */
+
+#define SCTLR_U_Pos                      22U                                    /*!< \brief SCTLR: U Position */
+#define SCTLR_U_Msk                      (1UL << SCTLR_U_Pos)                   /*!< \brief SCTLR: U Mask */
+
+#define SCTLR_FI_Pos                     21U                                    /*!< \brief SCTLR: FI Position */
+#define SCTLR_FI_Msk                     (1UL << SCTLR_FI_Pos)                  /*!< \brief SCTLR: FI Mask */
+
+#define SCTLR_UWXN_Pos                   20U                                    /*!< \brief SCTLR: UWXN Position */
+#define SCTLR_UWXN_Msk                   (1UL << SCTLR_UWXN_Pos)                /*!< \brief SCTLR: UWXN Mask */
+
+#define SCTLR_WXN_Pos                    19U                                    /*!< \brief SCTLR: WXN Position */
+#define SCTLR_WXN_Msk                    (1UL << SCTLR_WXN_Pos)                 /*!< \brief SCTLR: WXN Mask */
+
+#define SCTLR_HA_Pos                     17U                                    /*!< \brief SCTLR: HA Position */
+#define SCTLR_HA_Msk                     (1UL << SCTLR_HA_Pos)                  /*!< \brief SCTLR: HA Mask */
+
+#define SCTLR_RR_Pos                     14U                                    /*!< \brief SCTLR: RR Position */
+#define SCTLR_RR_Msk                     (1UL << SCTLR_RR_Pos)                  /*!< \brief SCTLR: RR Mask */
+
+#define SCTLR_V_Pos                      13U                                    /*!< \brief SCTLR: V Position */
+#define SCTLR_V_Msk                      (1UL << SCTLR_V_Pos)                   /*!< \brief SCTLR: V Mask */
+
+#define SCTLR_I_Pos                      12U                                    /*!< \brief SCTLR: I Position */
+#define SCTLR_I_Msk                      (1UL << SCTLR_I_Pos)                   /*!< \brief SCTLR: I Mask */
+
+#define SCTLR_Z_Pos                      11U                                    /*!< \brief SCTLR: Z Position */
+#define SCTLR_Z_Msk                      (1UL << SCTLR_Z_Pos)                   /*!< \brief SCTLR: Z Mask */
+
+#define SCTLR_SW_Pos                     10U                                    /*!< \brief SCTLR: SW Position */
+#define SCTLR_SW_Msk                     (1UL << SCTLR_SW_Pos)                  /*!< \brief SCTLR: SW Mask */
+
+#define SCTLR_B_Pos                      7U                                     /*!< \brief SCTLR: B Position */
+#define SCTLR_B_Msk                      (1UL << SCTLR_B_Pos)                   /*!< \brief SCTLR: B Mask */
+
+#define SCTLR_CP15BEN_Pos                5U                                     /*!< \brief SCTLR: CP15BEN Position */
+#define SCTLR_CP15BEN_Msk                (1UL << SCTLR_CP15BEN_Pos)             /*!< \brief SCTLR: CP15BEN Mask */
+
+#define SCTLR_C_Pos                      2U                                     /*!< \brief SCTLR: C Position */
+#define SCTLR_C_Msk                      (1UL << SCTLR_C_Pos)                   /*!< \brief SCTLR: C Mask */
+
+#define SCTLR_A_Pos                      1U                                     /*!< \brief SCTLR: A Position */
+#define SCTLR_A_Msk                      (1UL << SCTLR_A_Pos)                   /*!< \brief SCTLR: A Mask */
+
+#define SCTLR_M_Pos                      0U                                     /*!< \brief SCTLR: M Position */
+#define SCTLR_M_Msk                      (1UL << SCTLR_M_Pos)                   /*!< \brief SCTLR: M Mask */
+
+/* CP15 Register ACTLR */
+typedef union
+{
+#if __CORTEX_A == 5 || defined(DOXYGEN)
+  /** \brief Structure used for bit access on Cortex-A5 */
+  struct
+  {
+    uint32_t FW:1;                      /*!< \brief bit:      0  Cache and TLB maintenance broadcast */
+    RESERVED(0:5, uint32_t)
+    uint32_t SMP:1;                      /*!< \brief bit:     6  Enables coherent requests to the processor */
+    uint32_t EXCL:1;                     /*!< \brief bit:     7  Exclusive L1/L2 cache control */
+    RESERVED(1:2, uint32_t)
+    uint32_t DODMBS:1;                   /*!< \brief bit:    10  Disable optimized data memory barrier behavior */
+    uint32_t DWBST:1;                    /*!< \brief bit:    11  AXI data write bursts to Normal memory */
+    uint32_t RADIS:1;                    /*!< \brief bit:    12  L1 Data Cache read-allocate mode disable */
+    uint32_t L1PCTL:2;                   /*!< \brief bit:13..14  L1 Data prefetch control */
+    uint32_t BP:2;                       /*!< \brief bit:16..15  Branch prediction policy */
+    uint32_t RSDIS:1;                    /*!< \brief bit:    17  Disable return stack operation */
+    uint32_t BTDIS:1;                    /*!< \brief bit:    18  Disable indirect Branch Target Address Cache (BTAC) */
+    RESERVED(3:9, uint32_t)
+    uint32_t DBDI:1;                     /*!< \brief bit:    28  Disable branch dual issue */
+    RESERVED(7:3, uint32_t)
+ } b;
+#endif
+#if __CORTEX_A == 7 || defined(DOXYGEN)
+  /** \brief Structure used for bit access on Cortex-A7 */
+  struct
+  {
+    RESERVED(0:6, uint32_t)
+    uint32_t SMP:1;                      /*!< \brief bit:     6  Enables coherent requests to the processor */
+    RESERVED(1:3, uint32_t)
+    uint32_t DODMBS:1;                   /*!< \brief bit:    10  Disable optimized data memory barrier behavior */
+    uint32_t L2RADIS:1;                  /*!< \brief bit:    11  L2 Data Cache read-allocate mode disable */
+    uint32_t L1RADIS:1;                  /*!< \brief bit:    12  L1 Data Cache read-allocate mode disable */
+    uint32_t L1PCTL:2;                   /*!< \brief bit:13..14  L1 Data prefetch control */
+    uint32_t DDVM:1;                     /*!< \brief bit:    15  Disable Distributed Virtual Memory (DVM) transactions */
+    RESERVED(3:12, uint32_t)
+    uint32_t DDI:1;                      /*!< \brief bit:    28  Disable dual issue */
+    RESERVED(7:3, uint32_t)
+  } b;
+#endif
+#if __CORTEX_A == 9 || defined(DOXYGEN)
+  /** \brief Structure used for bit access on Cortex-A9 */
+  struct
+  {
+    uint32_t FW:1;                       /*!< \brief bit:     0  Cache and TLB maintenance broadcast */
+    RESERVED(0:1, uint32_t)
+    uint32_t L1PE:1;                     /*!< \brief bit:     2  Dside prefetch */
+    uint32_t WFLZM:1;                    /*!< \brief bit:     3  Cache and TLB maintenance broadcast */
+    RESERVED(1:2, uint32_t)
+    uint32_t SMP:1;                      /*!< \brief bit:     6  Enables coherent requests to the processor */
+    uint32_t EXCL:1;                     /*!< \brief bit:     7  Exclusive L1/L2 cache control */
+    uint32_t AOW:1;                      /*!< \brief bit:     8  Enable allocation in one cache way only */
+    uint32_t PARITY:1;                   /*!< \brief bit:     9  Support for parity checking, if implemented */
+    RESERVED(7:22, uint32_t)
+  } b;
+#endif
+  uint32_t w;                            /*!< \brief Type      used for word access */
+} ACTLR_Type;
+
+#define ACTLR_DDI_Pos                    28U                                     /*!< \brief ACTLR: DDI Position */
+#define ACTLR_DDI_Msk                    (1UL << ACTLR_DDI_Pos)                  /*!< \brief ACTLR: DDI Mask */
+
+#define ACTLR_DBDI_Pos                   28U                                     /*!< \brief ACTLR: DBDI Position */
+#define ACTLR_DBDI_Msk                   (1UL << ACTLR_DBDI_Pos)                 /*!< \brief ACTLR: DBDI Mask */
+
+#define ACTLR_BTDIS_Pos                  18U                                     /*!< \brief ACTLR: BTDIS Position */
+#define ACTLR_BTDIS_Msk                  (1UL << ACTLR_BTDIS_Pos)                /*!< \brief ACTLR: BTDIS Mask */
+
+#define ACTLR_RSDIS_Pos                  17U                                     /*!< \brief ACTLR: RSDIS Position */
+#define ACTLR_RSDIS_Msk                  (1UL << ACTLR_RSDIS_Pos)                /*!< \brief ACTLR: RSDIS Mask */
+
+#define ACTLR_BP_Pos                     15U                                     /*!< \brief ACTLR: BP Position */
+#define ACTLR_BP_Msk                     (3UL << ACTLR_BP_Pos)                   /*!< \brief ACTLR: BP Mask */
+
+#define ACTLR_DDVM_Pos                   15U                                     /*!< \brief ACTLR: DDVM Position */
+#define ACTLR_DDVM_Msk                   (1UL << ACTLR_DDVM_Pos)                 /*!< \brief ACTLR: DDVM Mask */
+
+#define ACTLR_L1PCTL_Pos                 13U                                     /*!< \brief ACTLR: L1PCTL Position */
+#define ACTLR_L1PCTL_Msk                 (3UL << ACTLR_L1PCTL_Pos)               /*!< \brief ACTLR: L1PCTL Mask */
+
+#define ACTLR_RADIS_Pos                  12U                                     /*!< \brief ACTLR: RADIS Position */
+#define ACTLR_RADIS_Msk                  (1UL << ACTLR_RADIS_Pos)                /*!< \brief ACTLR: RADIS Mask */
+
+#define ACTLR_L1RADIS_Pos                12U                                     /*!< \brief ACTLR: L1RADIS Position */
+#define ACTLR_L1RADIS_Msk                (1UL << ACTLR_L1RADIS_Pos)              /*!< \brief ACTLR: L1RADIS Mask */
+
+#define ACTLR_DWBST_Pos                  11U                                     /*!< \brief ACTLR: DWBST Position */
+#define ACTLR_DWBST_Msk                  (1UL << ACTLR_DWBST_Pos)                /*!< \brief ACTLR: DWBST Mask */
+
+#define ACTLR_L2RADIS_Pos                11U                                     /*!< \brief ACTLR: L2RADIS Position */
+#define ACTLR_L2RADIS_Msk                (1UL << ACTLR_L2RADIS_Pos)              /*!< \brief ACTLR: L2RADIS Mask */
+
+#define ACTLR_DODMBS_Pos                 10U                                     /*!< \brief ACTLR: DODMBS Position */
+#define ACTLR_DODMBS_Msk                 (1UL << ACTLR_DODMBS_Pos)               /*!< \brief ACTLR: DODMBS Mask */
+
+#define ACTLR_PARITY_Pos                 9U                                      /*!< \brief ACTLR: PARITY Position */
+#define ACTLR_PARITY_Msk                 (1UL << ACTLR_PARITY_Pos)               /*!< \brief ACTLR: PARITY Mask */
+
+#define ACTLR_AOW_Pos                    8U                                      /*!< \brief ACTLR: AOW Position */
+#define ACTLR_AOW_Msk                    (1UL << ACTLR_AOW_Pos)                  /*!< \brief ACTLR: AOW Mask */
+
+#define ACTLR_EXCL_Pos                   7U                                      /*!< \brief ACTLR: EXCL Position */
+#define ACTLR_EXCL_Msk                   (1UL << ACTLR_EXCL_Pos)                 /*!< \brief ACTLR: EXCL Mask */
+
+#define ACTLR_SMP_Pos                    6U                                      /*!< \brief ACTLR: SMP Position */
+#define ACTLR_SMP_Msk                    (1UL << ACTLR_SMP_Pos)                  /*!< \brief ACTLR: SMP Mask */
+
+#define ACTLR_WFLZM_Pos                  3U                                      /*!< \brief ACTLR: WFLZM Position */
+#define ACTLR_WFLZM_Msk                  (1UL << ACTLR_WFLZM_Pos)                /*!< \brief ACTLR: WFLZM Mask */
+
+#define ACTLR_L1PE_Pos                   2U                                      /*!< \brief ACTLR: L1PE Position */
+#define ACTLR_L1PE_Msk                   (1UL << ACTLR_L1PE_Pos)                 /*!< \brief ACTLR: L1PE Mask */
+
+#define ACTLR_FW_Pos                     0U                                      /*!< \brief ACTLR: FW Position */
+#define ACTLR_FW_Msk                     (1UL << ACTLR_FW_Pos)                   /*!< \brief ACTLR: FW Mask */
+
+/* CP15 Register CPACR */
+typedef union
+{
+  struct
+  {
+    uint32_t CP0:2;                      /*!< \brief bit:  0..1  Access rights for coprocessor 0 */
+    uint32_t CP1:2;                      /*!< \brief bit:  2..3  Access rights for coprocessor 1 */
+    uint32_t CP2:2;                      /*!< \brief bit:  4..5  Access rights for coprocessor 2 */
+    uint32_t CP3:2;                      /*!< \brief bit:  6..7  Access rights for coprocessor 3 */
+    uint32_t CP4:2;                      /*!< \brief bit:  8..9  Access rights for coprocessor 4 */
+    uint32_t CP5:2;                      /*!< \brief bit:10..11  Access rights for coprocessor 5 */
+    uint32_t CP6:2;                      /*!< \brief bit:12..13  Access rights for coprocessor 6 */
+    uint32_t CP7:2;                      /*!< \brief bit:14..15  Access rights for coprocessor 7 */
+    uint32_t CP8:2;                      /*!< \brief bit:16..17  Access rights for coprocessor 8 */
+    uint32_t CP9:2;                      /*!< \brief bit:18..19  Access rights for coprocessor 9 */
+    uint32_t CP10:2;                     /*!< \brief bit:20..21  Access rights for coprocessor 10 */
+    uint32_t CP11:2;                     /*!< \brief bit:22..23  Access rights for coprocessor 11 */
+    uint32_t CP12:2;                     /*!< \brief bit:24..25  Access rights for coprocessor 11 */
+    uint32_t CP13:2;                     /*!< \brief bit:26..27  Access rights for coprocessor 11 */
+    uint32_t TRCDIS:1;                   /*!< \brief bit:    28  Disable CP14 access to trace registers */
+    RESERVED(0:1, uint32_t)
+    uint32_t D32DIS:1;                   /*!< \brief bit:    30  Disable use of registers D16-D31 of the VFP register file */
+    uint32_t ASEDIS:1;                   /*!< \brief bit:    31  Disable Advanced SIMD Functionality */
+  } b;                                   /*!< \brief Structure used for bit  access */
+  uint32_t w;                            /*!< \brief Type      used for word access */
+} CPACR_Type;
+
+#define CPACR_ASEDIS_Pos                 31U                                    /*!< \brief CPACR: ASEDIS Position */
+#define CPACR_ASEDIS_Msk                 (1UL << CPACR_ASEDIS_Pos)              /*!< \brief CPACR: ASEDIS Mask */
+
+#define CPACR_D32DIS_Pos                 30U                                    /*!< \brief CPACR: D32DIS Position */
+#define CPACR_D32DIS_Msk                 (1UL << CPACR_D32DIS_Pos)              /*!< \brief CPACR: D32DIS Mask */
+
+#define CPACR_TRCDIS_Pos                 28U                                    /*!< \brief CPACR: D32DIS Position */
+#define CPACR_TRCDIS_Msk                 (1UL << CPACR_D32DIS_Pos)              /*!< \brief CPACR: D32DIS Mask */
+
+#define CPACR_CP_Pos_(n)                 (n*2U)                                 /*!< \brief CPACR: CPn Position */
+#define CPACR_CP_Msk_(n)                 (3UL << CPACR_CP_Pos_(n))              /*!< \brief CPACR: CPn Mask */
+
+#define CPACR_CP_NA                      0U                                     /*!< \brief CPACR CPn field: Access denied. */
+#define CPACR_CP_PL1                     1U                                     /*!< \brief CPACR CPn field: Accessible from PL1 only. */
+#define CPACR_CP_FA                      3U                                     /*!< \brief CPACR CPn field: Full access. */
+
+/* CP15 Register DFSR */
+typedef union
+{
+  struct
+  {
+    uint32_t FS0:4;                      /*!< \brief bit: 0.. 3  Fault Status bits bit 0-3 */
+    uint32_t Domain:4;                   /*!< \brief bit: 4.. 7  Fault on which domain */
+    RESERVED(0:1, uint32_t)
+    uint32_t LPAE:1;                     /*!< \brief bit:     9  Large Physical Address Extension */
+    uint32_t FS1:1;                      /*!< \brief bit:    10  Fault Status bits bit 4 */
+    uint32_t WnR:1;                      /*!< \brief bit:    11  Write not Read bit */
+    uint32_t ExT:1;                      /*!< \brief bit:    12  External abort type */
+    uint32_t CM:1;                       /*!< \brief bit:    13  Cache maintenance fault */
+    RESERVED(1:18, uint32_t)
+  } s;                                   /*!< \brief Structure used for bit  access in short format */
+  struct
+  {
+    uint32_t STATUS:5;                   /*!< \brief bit: 0.. 5  Fault Status bits */
+    RESERVED(0:3, uint32_t)
+    uint32_t LPAE:1;                     /*!< \brief bit:     9  Large Physical Address Extension */
+    RESERVED(1:1, uint32_t)
+    uint32_t WnR:1;                      /*!< \brief bit:    11  Write not Read bit */
+    uint32_t ExT:1;                      /*!< \brief bit:    12  External abort type */
+    uint32_t CM:1;                       /*!< \brief bit:    13  Cache maintenance fault */
+    RESERVED(2:18, uint32_t)
+  } l;                                   /*!< \brief Structure used for bit  access in long format */
+  uint32_t w;                            /*!< \brief Type      used for word access */
+} DFSR_Type;
+
+#define DFSR_CM_Pos                      13U                                    /*!< \brief DFSR: CM Position */
+#define DFSR_CM_Msk                      (1UL << DFSR_CM_Pos)                   /*!< \brief DFSR: CM Mask */
+
+#define DFSR_Ext_Pos                     12U                                    /*!< \brief DFSR: Ext Position */
+#define DFSR_Ext_Msk                     (1UL << DFSR_Ext_Pos)                  /*!< \brief DFSR: Ext Mask */
+
+#define DFSR_WnR_Pos                     11U                                    /*!< \brief DFSR: WnR Position */
+#define DFSR_WnR_Msk                     (1UL << DFSR_WnR_Pos)                  /*!< \brief DFSR: WnR Mask */
+
+#define DFSR_FS1_Pos                     10U                                    /*!< \brief DFSR: FS1 Position */
+#define DFSR_FS1_Msk                     (1UL << DFSR_FS1_Pos)                  /*!< \brief DFSR: FS1 Mask */
+
+#define DFSR_LPAE_Pos                    9U                                    /*!< \brief DFSR: LPAE Position */
+#define DFSR_LPAE_Msk                    (1UL << DFSR_LPAE_Pos)                /*!< \brief DFSR: LPAE Mask */
+
+#define DFSR_Domain_Pos                  4U                                     /*!< \brief DFSR: Domain Position */
+#define DFSR_Domain_Msk                  (0xFUL << DFSR_Domain_Pos)             /*!< \brief DFSR: Domain Mask */
+
+#define DFSR_FS0_Pos                     0U                                     /*!< \brief DFSR: FS0 Position */
+#define DFSR_FS0_Msk                     (0xFUL << DFSR_FS0_Pos)                /*!< \brief DFSR: FS0 Mask */
+
+#define DFSR_STATUS_Pos                  0U                                     /*!< \brief DFSR: STATUS Position */
+#define DFSR_STATUS_Msk                  (0x3FUL << DFSR_STATUS_Pos)            /*!< \brief DFSR: STATUS Mask */
+
+/* CP15 Register IFSR */
+typedef union
+{
+  struct
+  {
+    uint32_t FS0:4;                      /*!< \brief bit: 0.. 3  Fault Status bits bit 0-3 */
+    RESERVED(0:5, uint32_t)
+    uint32_t LPAE:1;                     /*!< \brief bit:     9  Large Physical Address Extension */
+    uint32_t FS1:1;                      /*!< \brief bit:    10  Fault Status bits bit 4 */
+    RESERVED(1:1, uint32_t)
+    uint32_t ExT:1;                      /*!< \brief bit:    12  External abort type */
+    RESERVED(2:19, uint32_t)
+  } s;                                   /*!< \brief Structure used for bit access in short format */
+  struct
+  {
+    uint32_t STATUS:6;                   /*!< \brief bit: 0.. 5  Fault Status bits */
+    RESERVED(0:3, uint32_t)
+    uint32_t LPAE:1;                     /*!< \brief bit:     9  Large Physical Address Extension */
+    RESERVED(1:2, uint32_t)
+    uint32_t ExT:1;                      /*!< \brief bit:    12  External abort type */
+    RESERVED(2:19, uint32_t)
+  } l;                                   /*!< \brief Structure used for bit access in long format */
+  uint32_t w;                            /*!< \brief Type      used for word access */
+} IFSR_Type;
+
+#define IFSR_ExT_Pos                     12U                                    /*!< \brief IFSR: ExT Position */
+#define IFSR_ExT_Msk                     (1UL << IFSR_ExT_Pos)                  /*!< \brief IFSR: ExT Mask */
+
+#define IFSR_FS1_Pos                     10U                                    /*!< \brief IFSR: FS1 Position */
+#define IFSR_FS1_Msk                     (1UL << IFSR_FS1_Pos)                  /*!< \brief IFSR: FS1 Mask */
+
+#define IFSR_LPAE_Pos                    9U                                     /*!< \brief IFSR: LPAE Position */
+#define IFSR_LPAE_Msk                    (0x1UL << IFSR_LPAE_Pos)               /*!< \brief IFSR: LPAE Mask */
+
+#define IFSR_FS0_Pos                     0U                                     /*!< \brief IFSR: FS0 Position */
+#define IFSR_FS0_Msk                     (0xFUL << IFSR_FS0_Pos)                /*!< \brief IFSR: FS0 Mask */
+
+#define IFSR_STATUS_Pos                  0U                                     /*!< \brief IFSR: STATUS Position */
+#define IFSR_STATUS_Msk                  (0x3FUL << IFSR_STATUS_Pos)            /*!< \brief IFSR: STATUS Mask */
+
+/* CP15 Register ISR */
+typedef union
+{
+  struct
+  {
+    RESERVED(0:6, uint32_t)
+    uint32_t F:1;                        /*!< \brief bit:     6  FIQ pending bit */
+    uint32_t I:1;                        /*!< \brief bit:     7  IRQ pending bit */
+    uint32_t A:1;                        /*!< \brief bit:     8  External abort pending bit */
+    RESERVED(1:23, uint32_t)
+  } b;                                   /*!< \brief Structure used for bit  access */
+  uint32_t w;                            /*!< \brief Type      used for word access */
+} ISR_Type;
+
+#define ISR_A_Pos                        13U                                    /*!< \brief ISR: A Position */
+#define ISR_A_Msk                        (1UL << ISR_A_Pos)                     /*!< \brief ISR: A Mask */
+
+#define ISR_I_Pos                        12U                                    /*!< \brief ISR: I Position */
+#define ISR_I_Msk                        (1UL << ISR_I_Pos)                     /*!< \brief ISR: I Mask */
+
+#define ISR_F_Pos                        11U                                    /*!< \brief ISR: F Position */
+#define ISR_F_Msk                        (1UL << ISR_F_Pos)                     /*!< \brief ISR: F Mask */
+
+/* DACR Register */
+#define DACR_D_Pos_(n)                   (2U*n)                                 /*!< \brief DACR: Dn Position */
+#define DACR_D_Msk_(n)                   (3UL << DACR_D_Pos_(n))                /*!< \brief DACR: Dn Mask */
+#define DACR_Dn_NOACCESS                 0U                                     /*!< \brief DACR Dn field: No access */
+#define DACR_Dn_CLIENT                   1U                                     /*!< \brief DACR Dn field: Client */
+#define DACR_Dn_MANAGER                  3U                                     /*!< \brief DACR Dn field: Manager */
+
+/**
+  \brief     Mask and shift a bit field value for use in a register bit range.
+  \param [in] field  Name of the register bit field.
+  \param [in] value  Value of the bit field. This parameter is interpreted as an uint32_t type.
+  \return           Masked and shifted value.
+*/
+#define _VAL2FLD(field, value)    (((uint32_t)(value) << field ## _Pos) & field ## _Msk)
+
+/**
+  \brief     Mask and shift a register value to extract a bit filed value.
+  \param [in] field  Name of the register bit field.
+  \param [in] value  Value of register. This parameter is interpreted as an uint32_t type.
+  \return           Masked and shifted bit field value.
+*/
+#define _FLD2VAL(field, value)    (((uint32_t)(value) & field ## _Msk) >> field ## _Pos)
+
+
+/**
+ \brief  Union type to access the L2C_310 Cache Controller.
+*/
+#if (defined(__L2C_PRESENT) && (__L2C_PRESENT == 1U)) || \
+     defined(DOXYGEN)
+typedef struct
+{
+  __IM  uint32_t CACHE_ID;                   /*!< \brief Offset: 0x0000 (R/ ) Cache ID Register               */
+  __IM  uint32_t CACHE_TYPE;                 /*!< \brief Offset: 0x0004 (R/ ) Cache Type Register             */
+        RESERVED(0[0x3e], uint32_t)
+  __IOM uint32_t CONTROL;                    /*!< \brief Offset: 0x0100 (R/W) Control Register                */
+  __IOM uint32_t AUX_CNT;                    /*!< \brief Offset: 0x0104 (R/W) Auxiliary Control               */
+        RESERVED(1[0x3e], uint32_t)
+  __IOM uint32_t EVENT_CONTROL;              /*!< \brief Offset: 0x0200 (R/W) Event Counter Control           */
+  __IOM uint32_t EVENT_COUNTER1_CONF;        /*!< \brief Offset: 0x0204 (R/W) Event Counter 1 Configuration   */
+  __IOM uint32_t EVENT_COUNTER0_CONF;        /*!< \brief Offset: 0x0208 (R/W) Event Counter 1 Configuration   */
+        RESERVED(2[0x2], uint32_t)
+  __IOM uint32_t INTERRUPT_MASK;             /*!< \brief Offset: 0x0214 (R/W) Interrupt Mask                  */
+  __IM  uint32_t MASKED_INT_STATUS;          /*!< \brief Offset: 0x0218 (R/ ) Masked Interrupt Status         */
+  __IM  uint32_t RAW_INT_STATUS;             /*!< \brief Offset: 0x021c (R/ ) Raw Interrupt Status            */
+  __OM  uint32_t INTERRUPT_CLEAR;            /*!< \brief Offset: 0x0220 ( /W) Interrupt Clear                 */
+        RESERVED(3[0x143], uint32_t)
+  __IOM uint32_t CACHE_SYNC;                 /*!< \brief Offset: 0x0730 (R/W) Cache Sync                      */
+        RESERVED(4[0xf], uint32_t)
+  __IOM uint32_t INV_LINE_PA;                /*!< \brief Offset: 0x0770 (R/W) Invalidate Line By PA           */
+        RESERVED(6[2], uint32_t)
+  __IOM uint32_t INV_WAY;                    /*!< \brief Offset: 0x077c (R/W) Invalidate by Way               */
+        RESERVED(5[0xc], uint32_t)
+  __IOM uint32_t CLEAN_LINE_PA;              /*!< \brief Offset: 0x07b0 (R/W) Clean Line by PA                */
+        RESERVED(7[1], uint32_t)
+  __IOM uint32_t CLEAN_LINE_INDEX_WAY;       /*!< \brief Offset: 0x07b8 (R/W) Clean Line by Index/Way         */
+  __IOM uint32_t CLEAN_WAY;                  /*!< \brief Offset: 0x07bc (R/W) Clean by Way                    */
+        RESERVED(8[0xc], uint32_t)
+  __IOM uint32_t CLEAN_INV_LINE_PA;          /*!< \brief Offset: 0x07f0 (R/W) Clean and Invalidate Line by PA  */
+        RESERVED(9[1], uint32_t)
+  __IOM uint32_t CLEAN_INV_LINE_INDEX_WAY;   /*!< \brief Offset: 0x07f8 (R/W) Clean and Invalidate Line by Index/Way  */
+  __IOM uint32_t CLEAN_INV_WAY;              /*!< \brief Offset: 0x07fc (R/W) Clean and Invalidate by Way     */
+        RESERVED(10[0x40], uint32_t)
+  __IOM uint32_t DATA_LOCK_0_WAY;            /*!< \brief Offset: 0x0900 (R/W) Data Lockdown 0 by Way          */
+  __IOM uint32_t INST_LOCK_0_WAY;            /*!< \brief Offset: 0x0904 (R/W) Instruction Lockdown 0 by Way   */
+  __IOM uint32_t DATA_LOCK_1_WAY;            /*!< \brief Offset: 0x0908 (R/W) Data Lockdown 1 by Way          */
+  __IOM uint32_t INST_LOCK_1_WAY;            /*!< \brief Offset: 0x090c (R/W) Instruction Lockdown 1 by Way   */
+  __IOM uint32_t DATA_LOCK_2_WAY;            /*!< \brief Offset: 0x0910 (R/W) Data Lockdown 2 by Way          */
+  __IOM uint32_t INST_LOCK_2_WAY;            /*!< \brief Offset: 0x0914 (R/W) Instruction Lockdown 2 by Way   */
+  __IOM uint32_t DATA_LOCK_3_WAY;            /*!< \brief Offset: 0x0918 (R/W) Data Lockdown 3 by Way          */
+  __IOM uint32_t INST_LOCK_3_WAY;            /*!< \brief Offset: 0x091c (R/W) Instruction Lockdown 3 by Way   */
+  __IOM uint32_t DATA_LOCK_4_WAY;            /*!< \brief Offset: 0x0920 (R/W) Data Lockdown 4 by Way          */
+  __IOM uint32_t INST_LOCK_4_WAY;            /*!< \brief Offset: 0x0924 (R/W) Instruction Lockdown 4 by Way   */
+  __IOM uint32_t DATA_LOCK_5_WAY;            /*!< \brief Offset: 0x0928 (R/W) Data Lockdown 5 by Way          */
+  __IOM uint32_t INST_LOCK_5_WAY;            /*!< \brief Offset: 0x092c (R/W) Instruction Lockdown 5 by Way   */
+  __IOM uint32_t DATA_LOCK_6_WAY;            /*!< \brief Offset: 0x0930 (R/W) Data Lockdown 5 by Way          */
+  __IOM uint32_t INST_LOCK_6_WAY;            /*!< \brief Offset: 0x0934 (R/W) Instruction Lockdown 5 by Way   */
+  __IOM uint32_t DATA_LOCK_7_WAY;            /*!< \brief Offset: 0x0938 (R/W) Data Lockdown 6 by Way          */
+  __IOM uint32_t INST_LOCK_7_WAY;            /*!< \brief Offset: 0x093c (R/W) Instruction Lockdown 6 by Way   */
+        RESERVED(11[0x4], uint32_t)
+  __IOM uint32_t LOCK_LINE_EN;               /*!< \brief Offset: 0x0950 (R/W) Lockdown by Line Enable         */
+  __IOM uint32_t UNLOCK_ALL_BY_WAY;          /*!< \brief Offset: 0x0954 (R/W) Unlock All Lines by Way         */
+        RESERVED(12[0xaa], uint32_t)
+  __IOM uint32_t ADDRESS_FILTER_START;       /*!< \brief Offset: 0x0c00 (R/W) Address Filtering Start         */
+  __IOM uint32_t ADDRESS_FILTER_END;         /*!< \brief Offset: 0x0c04 (R/W) Address Filtering End           */
+        RESERVED(13[0xce], uint32_t)
+  __IOM uint32_t DEBUG_CONTROL;              /*!< \brief Offset: 0x0f40 (R/W) Debug Control Register          */
+} L2C_310_TypeDef;
+
+#define L2C_310           ((L2C_310_TypeDef *)L2C_310_BASE) /*!< \brief L2C_310 register set access pointer */
+#endif
+
+#if (defined(__GIC_PRESENT) && (__GIC_PRESENT == 1U)) || \
+    defined(DOXYGEN)
+
+/** \brief  Structure type to access the Generic Interrupt Controller Distributor (GICD)
+*/
+typedef struct
+{
+  __IOM uint32_t CTLR;                 /*!< \brief  Offset: 0x000 (R/W) Distributor Control Register */
+  __IM  uint32_t TYPER;                /*!< \brief  Offset: 0x004 (R/ ) Interrupt Controller Type Register */
+  __IM  uint32_t IIDR;                 /*!< \brief  Offset: 0x008 (R/ ) Distributor Implementer Identification Register */
+        RESERVED(0, uint32_t)
+  __IOM uint32_t STATUSR;              /*!< \brief  Offset: 0x010 (R/W) Error Reporting Status Register, optional */
+        RESERVED(1[11], uint32_t)
+  __OM  uint32_t SETSPI_NSR;           /*!< \brief  Offset: 0x040 ( /W) Set SPI Register */
+        RESERVED(2, uint32_t)
+  __OM  uint32_t CLRSPI_NSR;           /*!< \brief  Offset: 0x048 ( /W) Clear SPI Register */
+        RESERVED(3, uint32_t)
+  __OM  uint32_t SETSPI_SR;            /*!< \brief  Offset: 0x050 ( /W) Set SPI, Secure Register */
+        RESERVED(4, uint32_t)
+  __OM  uint32_t CLRSPI_SR;            /*!< \brief  Offset: 0x058 ( /W) Clear SPI, Secure Register */
+        RESERVED(5[9], uint32_t)
+  __IOM uint32_t IGROUPR[32];          /*!< \brief  Offset: 0x080 (R/W) Interrupt Group Registers */
+  __IOM uint32_t ISENABLER[32];        /*!< \brief  Offset: 0x100 (R/W) Interrupt Set-Enable Registers */
+  __IOM uint32_t ICENABLER[32];        /*!< \brief  Offset: 0x180 (R/W) Interrupt Clear-Enable Registers */
+  __IOM uint32_t ISPENDR[32];          /*!< \brief  Offset: 0x200 (R/W) Interrupt Set-Pending Registers */
+  __IOM uint32_t ICPENDR[32];          /*!< \brief  Offset: 0x280 (R/W) Interrupt Clear-Pending Registers */
+  __IOM uint32_t ISACTIVER[32];        /*!< \brief  Offset: 0x300 (R/W) Interrupt Set-Active Registers */
+  __IOM uint32_t ICACTIVER[32];        /*!< \brief  Offset: 0x380 (R/W) Interrupt Clear-Active Registers */
+  __IOM uint32_t IPRIORITYR[255];      /*!< \brief  Offset: 0x400 (R/W) Interrupt Priority Registers */
+        RESERVED(6, uint32_t)
+  __IOM uint32_t  ITARGETSR[255];      /*!< \brief  Offset: 0x800 (R/W) Interrupt Targets Registers */
+        RESERVED(7, uint32_t)
+  __IOM uint32_t ICFGR[64];            /*!< \brief  Offset: 0xC00 (R/W) Interrupt Configuration Registers */
+  __IOM uint32_t IGRPMODR[32];         /*!< \brief  Offset: 0xD00 (R/W) Interrupt Group Modifier Registers */
+        RESERVED(8[32], uint32_t)
+  __IOM uint32_t NSACR[64];            /*!< \brief  Offset: 0xE00 (R/W) Non-secure Access Control Registers */
+  __OM  uint32_t SGIR;                 /*!< \brief  Offset: 0xF00 ( /W) Software Generated Interrupt Register */
+        RESERVED(9[3], uint32_t)
+  __IOM uint32_t CPENDSGIR[4];         /*!< \brief  Offset: 0xF10 (R/W) SGI Clear-Pending Registers */
+  __IOM uint32_t SPENDSGIR[4];         /*!< \brief  Offset: 0xF20 (R/W) SGI Set-Pending Registers */
+        RESERVED(10[5236], uint32_t)
+  __IOM uint64_t IROUTER[988];         /*!< \brief  Offset: 0x6100(R/W) Interrupt Routing Registers */
+}  GICDistributor_Type;
+
+#define GICDistributor      ((GICDistributor_Type      *)     GIC_DISTRIBUTOR_BASE ) /*!< \brief GIC Distributor register set access pointer */
+
+/* GICDistributor CTLR Register */
+#define GICDistributor_CTLR_EnableGrp0_Pos    0U                                                   /*!< GICDistributor CTLR: EnableGrp0 Position */
+#define GICDistributor_CTLR_EnableGrp0_Msk    (0x1U /*<< GICDistributor_CTLR_EnableGrp0_Pos*/)     /*!< GICDistributor CTLR: EnableGrp0 Mask */
+#define GICDistributor_CTLR_EnableGrp0(x)     (((uint32_t)(((uint32_t)(x)) /*<< GICDistributor_CTLR_EnableGrp0_Pos*/)) & GICDistributor_CTLR_EnableGrp0_Msk)
+
+#define GICDistributor_CTLR_EnableGrp1_Pos    1U                                                   /*!< GICDistributor CTLR: EnableGrp1 Position */
+#define GICDistributor_CTLR_EnableGrp1_Msk    (0x1U << GICDistributor_CTLR_EnableGrp1_Pos)         /*!< GICDistributor CTLR: EnableGrp1 Mask */
+#define GICDistributor_CTLR_EnableGrp1(x)     (((uint32_t)(((uint32_t)(x)) << GICDistributor_CTLR_EnableGrp1_Pos)) & GICDistributor_CTLR_EnableGrp1_Msk)
+
+#define GICDistributor_CTLR_ARE_Pos           4U                                                   /*!< GICDistributor CTLR: ARE Position */
+#define GICDistributor_CTLR_ARE_Msk           (0x1U << GICDistributor_CTLR_ARE_Pos)                /*!< GICDistributor CTLR: ARE Mask */
+#define GICDistributor_CTLR_ARE(x)            (((uint32_t)(((uint32_t)(x)) << GICDistributor_CTLR_ARE_Pos)) & GICDistributor_CTLR_ARE_Msk)
+
+#define GICDistributor_CTLR_DC_Pos            6U                                                   /*!< GICDistributor CTLR: DC Position */
+#define GICDistributor_CTLR_DC_Msk            (0x1U << GICDistributor_CTLR_DC_Pos)                 /*!< GICDistributor CTLR: DC Mask */
+#define GICDistributor_CTLR_DC(x)             (((uint32_t)(((uint32_t)(x)) << GICDistributor_CTLR_DC_Pos)) & GICDistributor_CTLR_DC_Msk)
+
+#define GICDistributor_CTLR_EINWF_Pos         7U                                                   /*!< GICDistributor CTLR: EINWF Position */
+#define GICDistributor_CTLR_EINWF_Msk         (0x1U << GICDistributor_CTLR_EINWF_Pos)              /*!< GICDistributor CTLR: EINWF Mask */
+#define GICDistributor_CTLR_EINWF(x)          (((uint32_t)(((uint32_t)(x)) << GICDistributor_CTLR_EINWF_Pos)) & GICDistributor_CTLR_EINWF_Msk)
+
+#define GICDistributor_CTLR_RWP_Pos           31U                                                  /*!< GICDistributor CTLR: RWP Position */
+#define GICDistributor_CTLR_RWP_Msk           (0x1U << GICDistributor_CTLR_RWP_Pos)                /*!< GICDistributor CTLR: RWP Mask */
+#define GICDistributor_CTLR_RWP(x)            (((uint32_t)(((uint32_t)(x)) << GICDistributor_CTLR_RWP_Pos)) & GICDistributor_CTLR_RWP_Msk)
+
+/* GICDistributor TYPER Register */
+#define GICDistributor_TYPER_ITLinesNumber_Pos 0U                                                    /*!< GICDistributor TYPER: ITLinesNumber Position */
+#define GICDistributor_TYPER_ITLinesNumber_Msk (0x1FU /*<< GICDistributor_TYPER_ITLinesNumber_Pos*/) /*!< GICDistributor TYPER: ITLinesNumber Mask */
+#define GICDistributor_TYPER_ITLinesNumber(x)  (((uint32_t)(((uint32_t)(x)) /*<< GICDistributor_TYPER_ITLinesNumber_Pos*/)) & GICDistributor_CTLR_ITLinesNumber_Msk)
+
+#define GICDistributor_TYPER_CPUNumber_Pos    5U                                                   /*!< GICDistributor TYPER: CPUNumber Position */
+#define GICDistributor_TYPER_CPUNumber_Msk    (0x7U << GICDistributor_TYPER_CPUNumber_Pos)         /*!< GICDistributor TYPER: CPUNumber Mask */
+#define GICDistributor_TYPER_CPUNumber(x)     (((uint32_t)(((uint32_t)(x)) << GICDistributor_TYPER_CPUNumber_Pos)) & GICDistributor_TYPER_CPUNumber_Msk)
+
+#define GICDistributor_TYPER_SecurityExtn_Pos 10U                                                  /*!< GICDistributor TYPER: SecurityExtn Position */
+#define GICDistributor_TYPER_SecurityExtn_Msk (0x1U << GICDistributor_TYPER_SecurityExtn_Pos)      /*!< GICDistributor TYPER: SecurityExtn Mask */
+#define GICDistributor_TYPER_SecurityExtn(x)  (((uint32_t)(((uint32_t)(x)) << GICDistributor_TYPER_SecurityExtn_Pos)) & GICDistributor_TYPER_SecurityExtn_Msk)
+
+#define GICDistributor_TYPER_LSPI_Pos         11U                                                  /*!< GICDistributor TYPER: LSPI Position */
+#define GICDistributor_TYPER_LSPI_Msk         (0x1FU << GICDistributor_TYPER_LSPI_Pos)             /*!< GICDistributor TYPER: LSPI Mask */
+#define GICDistributor_TYPER_LSPI(x)          (((uint32_t)(((uint32_t)(x)) << GICDistributor_TYPER_LSPI_Pos)) & GICDistributor_TYPER_LSPI_Msk)
+
+/* GICDistributor IIDR Register */
+#define GICDistributor_IIDR_Implementer_Pos   0U                                                   /*!< GICDistributor IIDR: Implementer Position */
+#define GICDistributor_IIDR_Implementer_Msk   (0xFFFU /*<< GICDistributor_IIDR_Implementer_Pos*/)  /*!< GICDistributor IIDR: Implementer Mask */
+#define GICDistributor_IIDR_Implementer(x)    (((uint32_t)(((uint32_t)(x)) /*<< GICDistributor_IIDR_Implementer_Pos*/)) & GICDistributor_IIDR_Implementer_Msk)
+
+#define GICDistributor_IIDR_Revision_Pos      12U                                                  /*!< GICDistributor IIDR: Revision Position */
+#define GICDistributor_IIDR_Revision_Msk      (0xFU << GICDistributor_IIDR_Revision_Pos)           /*!< GICDistributor IIDR: Revision Mask */
+#define GICDistributor_IIDR_Revision(x)       (((uint32_t)(((uint32_t)(x)) << GICDistributor_IIDR_Revision_Pos)) & GICDistributor_IIDR_Revision_Msk)
+
+#define GICDistributor_IIDR_Variant_Pos       16U                                                  /*!< GICDistributor IIDR: Variant Position */
+#define GICDistributor_IIDR_Variant_Msk       (0xFU << GICDistributor_IIDR_Variant_Pos)            /*!< GICDistributor IIDR: Variant Mask */
+#define GICDistributor_IIDR_Variant(x)        (((uint32_t)(((uint32_t)(x)) << GICDistributor_IIDR_Variant_Pos)) & GICDistributor_IIDR_Variant_Msk)
+
+#define GICDistributor_IIDR_ProductID_Pos     24U                                                  /*!< GICDistributor IIDR: ProductID Position */
+#define GICDistributor_IIDR_ProductID_Msk     (0xFFU << GICDistributor_IIDR_ProductID_Pos)         /*!< GICDistributor IIDR: ProductID Mask */
+#define GICDistributor_IIDR_ProductID(x)      (((uint32_t)(((uint32_t)(x)) << GICDistributor_IIDR_ProductID_Pos)) & GICDistributor_IIDR_ProductID_Msk)
+
+/* GICDistributor STATUSR Register */
+#define GICDistributor_STATUSR_RRD_Pos        0U                                                   /*!< GICDistributor STATUSR: RRD Position */
+#define GICDistributor_STATUSR_RRD_Msk        (0x1U /*<< GICDistributor_STATUSR_RRD_Pos*/)         /*!< GICDistributor STATUSR: RRD Mask */
+#define GICDistributor_STATUSR_RRD(x)         (((uint32_t)(((uint32_t)(x)) /*<< GICDistributor_STATUSR_RRD_Pos*/)) & GICDistributor_STATUSR_RRD_Msk)
+
+#define GICDistributor_STATUSR_WRD_Pos        1U                                                   /*!< GICDistributor STATUSR: WRD Position */
+#define GICDistributor_STATUSR_WRD_Msk        (0x1U << GICDistributor_STATUSR_WRD_Pos)             /*!< GICDistributor STATUSR: WRD Mask */
+#define GICDistributor_STATUSR_WRD(x)         (((uint32_t)(((uint32_t)(x)) << GICDistributor_STATUSR_WRD_Pos)) & GICDistributor_STATUSR_WRD_Msk)
+
+#define GICDistributor_STATUSR_RWOD_Pos       2U                                                   /*!< GICDistributor STATUSR: RWOD Position */
+#define GICDistributor_STATUSR_RWOD_Msk       (0x1U << GICDistributor_STATUSR_RWOD_Pos)            /*!< GICDistributor STATUSR: RWOD Mask */
+#define GICDistributor_STATUSR_RWOD(x)        (((uint32_t)(((uint32_t)(x)) << GICDistributor_STATUSR_RWOD_Pos)) & GICDistributor_STATUSR_RWOD_Msk)
+
+#define GICDistributor_STATUSR_WROD_Pos       3U                                                   /*!< GICDistributor STATUSR: WROD Position */
+#define GICDistributor_STATUSR_WROD_Msk       (0x1U << GICDistributor_STATUSR_WROD_Pos)            /*!< GICDistributor STATUSR: WROD Mask */
+#define GICDistributor_STATUSR_WROD(x)        (((uint32_t)(((uint32_t)(x)) << GICDistributor_STATUSR_WROD_Pos)) & GICDistributor_STATUSR_WROD_Msk)
+
+/* GICDistributor SETSPI_NSR Register */
+#define GICDistributor_SETSPI_NSR_INTID_Pos   0U                                                   /*!< GICDistributor SETSPI_NSR: INTID Position */
+#define GICDistributor_SETSPI_NSR_INTID_Msk   (0x3FFU /*<< GICDistributor_SETSPI_NSR_INTID_Pos*/)  /*!< GICDistributor SETSPI_NSR: INTID Mask */
+#define GICDistributor_SETSPI_NSR_INTID(x)    (((uint32_t)(((uint32_t)(x)) /*<< GICDistributor_SETSPI_NSR_INTID_Pos*/)) & GICDistributor_SETSPI_NSR_INTID_Msk)
+
+/* GICDistributor CLRSPI_NSR Register */
+#define GICDistributor_CLRSPI_NSR_INTID_Pos   0U                                                   /*!< GICDistributor CLRSPI_NSR: INTID Position */
+#define GICDistributor_CLRSPI_NSR_INTID_Msk   (0x3FFU /*<< GICDistributor_CLRSPI_NSR_INTID_Pos*/)  /*!< GICDistributor CLRSPI_NSR: INTID Mask */
+#define GICDistributor_CLRSPI_NSR_INTID(x)    (((uint32_t)(((uint32_t)(x)) /*<< GICDistributor_CLRSPI_NSR_INTID_Pos*/)) & GICDistributor_CLRSPI_NSR_INTID_Msk)
+
+/* GICDistributor SETSPI_SR Register */
+#define GICDistributor_SETSPI_SR_INTID_Pos    0U                                                  /*!< GICDistributor SETSPI_SR: INTID Position */
+#define GICDistributor_SETSPI_SR_INTID_Msk    (0x3FFU /*<< GICDistributor_SETSPI_SR_INTID_Pos*/)  /*!< GICDistributor SETSPI_SR: INTID Mask */
+#define GICDistributor_SETSPI_SR_INTID(x)     (((uint32_t)(((uint32_t)(x)) /*<< GICDistributor_SETSPI_SR_INTID_Pos*/)) & GICDistributor_SETSPI_SR_INTID_Msk)
+
+/* GICDistributor CLRSPI_SR Register */
+#define GICDistributor_CLRSPI_SR_INTID_Pos    0U                                                  /*!< GICDistributor CLRSPI_SR: INTID Position */
+#define GICDistributor_CLRSPI_SR_INTID_Msk    (0x3FFU /*<< GICDistributor_CLRSPI_SR_INTID_Pos*/)  /*!< GICDistributor CLRSPI_SR: INTID Mask */
+#define GICDistributor_CLRSPI_SR_INTID(x)     (((uint32_t)(((uint32_t)(x)) /*<< GICDistributor_CLRSPI_SR_INTID_Pos*/)) & GICDistributor_CLRSPI_SR_INTID_Msk)
+
+/* GICDistributor ITARGETSR Register */
+#define GICDistributor_ITARGETSR_CPU0_Pos     0U                                                   /*!< GICDistributor ITARGETSR: CPU0 Position */
+#define GICDistributor_ITARGETSR_CPU0_Msk     (0x1U /*<< GICDistributor_ITARGETSR_CPU0_Pos*/)      /*!< GICDistributor ITARGETSR: CPU0 Mask */
+#define GICDistributor_ITARGETSR_CPU0(x)      (((uint8_t)(((uint8_t)(x)) /*<< GICDistributor_ITARGETSR_CPU0_Pos*/)) & GICDistributor_ITARGETSR_CPU0_Msk)
+
+#define GICDistributor_ITARGETSR_CPU1_Pos     1U                                                   /*!< GICDistributor ITARGETSR: CPU1 Position */
+#define GICDistributor_ITARGETSR_CPU1_Msk     (0x1U << GICDistributor_ITARGETSR_CPU1_Pos)          /*!< GICDistributor ITARGETSR: CPU1 Mask */
+#define GICDistributor_ITARGETSR_CPU1(x)      (((uint8_t)(((uint8_t)(x)) << GICDistributor_ITARGETSR_CPU1_Pos)) & GICDistributor_ITARGETSR_CPU1_Msk)
+
+#define GICDistributor_ITARGETSR_CPU2_Pos     2U                                                   /*!< GICDistributor ITARGETSR: CPU2 Position */
+#define GICDistributor_ITARGETSR_CPU2_Msk     (0x1U << GICDistributor_ITARGETSR_CPU2_Pos)          /*!< GICDistributor ITARGETSR: CPU2 Mask */
+#define GICDistributor_ITARGETSR_CPU2(x)      (((uint8_t)(((uint8_t)(x)) << GICDistributor_ITARGETSR_CPU2_Pos)) & GICDistributor_ITARGETSR_CPU2_Msk)
+
+#define GICDistributor_ITARGETSR_CPU3_Pos     3U                                                   /*!< GICDistributor ITARGETSR: CPU3 Position */
+#define GICDistributor_ITARGETSR_CPU3_Msk     (0x1U << GICDistributor_ITARGETSR_CPU3_Pos)          /*!< GICDistributor ITARGETSR: CPU3 Mask */
+#define GICDistributor_ITARGETSR_CPU3(x)      (((uint8_t)(((uint8_t)(x)) << GICDistributor_ITARGETSR_CPU3_Pos)) & GICDistributor_ITARGETSR_CPU3_Msk)
+
+#define GICDistributor_ITARGETSR_CPU4_Pos     4U                                                   /*!< GICDistributor ITARGETSR: CPU4 Position */
+#define GICDistributor_ITARGETSR_CPU4_Msk     (0x1U << GICDistributor_ITARGETSR_CPU4_Pos)          /*!< GICDistributor ITARGETSR: CPU4 Mask */
+#define GICDistributor_ITARGETSR_CPU4(x)      (((uint8_t)(((uint8_t)(x)) << GICDistributor_ITARGETSR_CPU4_Pos)) & GICDistributor_ITARGETSR_CPU4_Msk)
+
+#define GICDistributor_ITARGETSR_CPU5_Pos     5U                                                   /*!< GICDistributor ITARGETSR: CPU5 Position */
+#define GICDistributor_ITARGETSR_CPU5_Msk     (0x1U << GICDistributor_ITARGETSR_CPU5_Pos)          /*!< GICDistributor ITARGETSR: CPU5 Mask */
+#define GICDistributor_ITARGETSR_CPU5(x)      (((uint8_t)(((uint8_t)(x)) << GICDistributor_ITARGETSR_CPU5_Pos)) & GICDistributor_ITARGETSR_CPU5_Msk)
+
+#define GICDistributor_ITARGETSR_CPU6_Pos     6U                                                   /*!< GICDistributor ITARGETSR: CPU6 Position */
+#define GICDistributor_ITARGETSR_CPU6_Msk     (0x1U << GICDistributor_ITARGETSR_CPU6_Pos)          /*!< GICDistributor ITARGETSR: CPU6 Mask */
+#define GICDistributor_ITARGETSR_CPU6(x)      (((uint8_t)(((uint8_t)(x)) << GICDistributor_ITARGETSR_CPU6_Pos)) & GICDistributor_ITARGETSR_CPU6_Msk)
+
+#define GICDistributor_ITARGETSR_CPU7_Pos     7U                                                   /*!< GICDistributor ITARGETSR: CPU7 Position */
+#define GICDistributor_ITARGETSR_CPU7_Msk     (0x1U << GICDistributor_ITARGETSR_CPU7_Pos)          /*!< GICDistributor ITARGETSR: CPU7 Mask */
+#define GICDistributor_ITARGETSR_CPU7(x)      (((uint8_t)(((uint8_t)(x)) << GICDistributor_ITARGETSR_CPU7_Pos)) & GICDistributor_ITARGETSR_CPU7_Msk)
+
+/* GICDistributor SGIR Register */
+#define GICDistributor_SGIR_INTID_Pos         0U                                                   /*!< GICDistributor SGIR: INTID Position */
+#define GICDistributor_SGIR_INTID_Msk         (0x7U /*<< GICDistributor_SGIR_INTID_Pos*/)          /*!< GICDistributor SGIR: INTID Mask */
+#define GICDistributor_SGIR_INTID(x)          (((uint32_t)(((uint32_t)(x)) /*<< GICDistributor_SGIR_INTID_Pos*/)) & GICDistributor_SGIR_INTID_Msk)
+
+#define GICDistributor_SGIR_NSATT_Pos         15U                                                  /*!< GICDistributor SGIR: NSATT Position */
+#define GICDistributor_SGIR_NSATT_Msk         (0x1U << GICDistributor_SGIR_NSATT_Pos)              /*!< GICDistributor SGIR: NSATT Mask */
+#define GICDistributor_SGIR_NSATT(x)          (((uint32_t)(((uint32_t)(x)) << GICDistributor_SGIR_NSATT_Pos)) & GICDistributor_SGIR_NSATT_Msk)
+
+#define GICDistributor_SGIR_CPUTargetList_Pos 16U                                                  /*!< GICDistributor SGIR: CPUTargetList  Position */
+#define GICDistributor_SGIR_CPUTargetList_Msk (0xFFU << GICDistributor_SGIR_CPUTargetList_Pos)     /*!< GICDistributor SGIR: CPUTargetList  Mask */
+#define GICDistributor_SGIR_CPUTargetList(x)  (((uint32_t)(((uint32_t)(x)) << GICDistributor_SGIR_CPUTargetList_Pos)) & GICDistributor_SGIR_CPUTargetList_Msk)
+
+#define GICDistributor_SGIR_TargetFilterList_Pos 24U                                                /*!< GICDistributor SGIR: TargetFilterList Position */
+#define GICDistributor_SGIR_TargetFilterList_Msk (0x3U << GICDistributor_SGIR_TargetFilterList_Pos) /*!< GICDistributor SGIR: TargetFilterList Mask */
+#define GICDistributor_SGIR_TargetFilterList(x)  (((uint32_t)(((uint32_t)(x)) << GICDistributor_SGIR_TargetFilterList_Pos)) & GICDistributor_SGIR_TargetFilterList_Msk)
+
+/* GICDistributor IROUTER Register */
+#define GICDistributor_IROUTER_Aff0_Pos       0UL                                                  /*!< GICDistributor IROUTER: Aff0 Position */
+#define GICDistributor_IROUTER_Aff0_Msk       (0xFFUL /*<< GICDistributor_IROUTER_Aff0_Pos*/)      /*!< GICDistributor IROUTER: Aff0 Mask */
+#define GICDistributor_IROUTER_Aff0(x)        (((uint64_t)(((uint64_t)(x)) /*<< GICDistributor_IROUTER_Aff0_Pos*/)) & GICDistributor_IROUTER_Aff0_Msk)
+
+#define GICDistributor_IROUTER_Aff1_Pos       8UL                                                  /*!< GICDistributor IROUTER: Aff1 Position */
+#define GICDistributor_IROUTER_Aff1_Msk       (0xFFUL << GICDistributor_IROUTER_Aff1_Pos)          /*!< GICDistributor IROUTER: Aff1 Mask */
+#define GICDistributor_IROUTER_Aff1(x)        (((uint64_t)(((uint64_t)(x)) << GICDistributor_IROUTER_Aff1_Pos)) & GICDistributor_IROUTER_Aff1_Msk)
+
+#define GICDistributor_IROUTER_Aff2_Pos       16UL                                                 /*!< GICDistributor IROUTER: Aff2 Position */
+#define GICDistributor_IROUTER_Aff2_Msk       (0xFFUL << GICDistributor_IROUTER_Aff2_Pos)          /*!< GICDistributor IROUTER: Aff2 Mask */
+#define GICDistributor_IROUTER_Aff2(x)        (((uint64_t)(((uint64_t)(x)) << GICDistributor_IROUTER_Aff2_Pos)) & GICDistributor_IROUTER_Aff2_Msk)
+
+#define GICDistributor_IROUTER_IRM_Pos        31UL                                                 /*!< GICDistributor IROUTER: IRM Position */
+#define GICDistributor_IROUTER_IRM_Msk        (0xFFUL << GICDistributor_IROUTER_IRM_Pos)           /*!< GICDistributor IROUTER: IRM Mask */
+#define GICDistributor_IROUTER_IRM(x)         (((uint64_t)(((uint64_t)(x)) << GICDistributor_IROUTER_IRM_Pos)) & GICDistributor_IROUTER_IRM_Msk)
+
+#define GICDistributor_IROUTER_Aff3_Pos       32UL                                                 /*!< GICDistributor IROUTER: Aff3 Position */
+#define GICDistributor_IROUTER_Aff3_Msk       (0xFFUL << GICDistributor_IROUTER_Aff3_Pos)          /*!< GICDistributor IROUTER: Aff3 Mask */
+#define GICDistributor_IROUTER_Aff3(x)        (((uint64_t)(((uint64_t)(x)) << GICDistributor_IROUTER_Aff3_Pos)) & GICDistributor_IROUTER_Aff3_Msk)
+
+
+
+/** \brief  Structure type to access the Generic Interrupt Controller Interface (GICC)
+*/
+typedef struct
+{
+  __IOM uint32_t CTLR;                 /*!< \brief  Offset: 0x000 (R/W) CPU Interface Control Register */
+  __IOM uint32_t PMR;                  /*!< \brief  Offset: 0x004 (R/W) Interrupt Priority Mask Register */
+  __IOM uint32_t BPR;                  /*!< \brief  Offset: 0x008 (R/W) Binary Point Register */
+  __IM  uint32_t IAR;                  /*!< \brief  Offset: 0x00C (R/ ) Interrupt Acknowledge Register */
+  __OM  uint32_t EOIR;                 /*!< \brief  Offset: 0x010 ( /W) End Of Interrupt Register */
+  __IM  uint32_t RPR;                  /*!< \brief  Offset: 0x014 (R/ ) Running Priority Register */
+  __IM  uint32_t HPPIR;                /*!< \brief  Offset: 0x018 (R/ ) Highest Priority Pending Interrupt Register */
+  __IOM uint32_t ABPR;                 /*!< \brief  Offset: 0x01C (R/W) Aliased Binary Point Register */
+  __IM  uint32_t AIAR;                 /*!< \brief  Offset: 0x020 (R/ ) Aliased Interrupt Acknowledge Register */
+  __OM  uint32_t AEOIR;                /*!< \brief  Offset: 0x024 ( /W) Aliased End Of Interrupt Register */
+  __IM  uint32_t AHPPIR;               /*!< \brief  Offset: 0x028 (R/ ) Aliased Highest Priority Pending Interrupt Register */
+  __IOM uint32_t STATUSR;              /*!< \brief  Offset: 0x02C (R/W) Error Reporting Status Register, optional */
+        RESERVED(1[40], uint32_t)
+  __IOM uint32_t APR[4];               /*!< \brief  Offset: 0x0D0 (R/W) Active Priority Register */
+  __IOM uint32_t NSAPR[4];             /*!< \brief  Offset: 0x0E0 (R/W) Non-secure Active Priority Register */
+        RESERVED(2[3], uint32_t)
+  __IM  uint32_t IIDR;                 /*!< \brief  Offset: 0x0FC (R/ ) CPU Interface Identification Register */
+        RESERVED(3[960], uint32_t)
+  __OM  uint32_t DIR;                  /*!< \brief  Offset: 0x1000( /W) Deactivate Interrupt Register */
+}  GICInterface_Type;
+
+#define GICInterface        ((GICInterface_Type        *)     GIC_INTERFACE_BASE )   /*!< \brief GIC Interface register set access pointer */
+
+/* GICInterface CTLR Register */
+#define GICInterface_CTLR_Enable_Pos        0U                                              /*!< PTIM CTLR: Enable Position */
+#define GICInterface_CTLR_Enable_Msk        (0x1U /*<< GICInterface_CTLR_Enable_Pos*/)      /*!< PTIM CTLR: Enable Mask */
+#define GICInterface_CTLR_Enable(x)         (((uint32_t)(((uint32_t)(x)) /*<< GICInterface_CTLR_Enable_Pos*/)) & GICInterface_CTLR_Enable_Msk)
+
+/* GICInterface PMR Register */
+#define GICInterface_PMR_Priority_Pos       0U                                              /*!< PTIM PMR: Priority Position */
+#define GICInterface_PMR_Priority_Msk       (0xFFU /*<< GICInterface_PMR_Priority_Pos*/)    /*!< PTIM PMR: Priority Mask */
+#define GICInterface_PMR_Priority(x)        (((uint32_t)(((uint32_t)(x)) /*<< GICInterface_PMR_Priority_Pos*/)) & GICInterface_PMR_Priority_Msk)
+
+/* GICInterface BPR Register */
+#define GICInterface_BPR_Binary_Point_Pos   0U                                              /*!< PTIM BPR: Binary_Point Position */
+#define GICInterface_BPR_Binary_Point_Msk   (0x7U /*<< GICInterface_BPR_Binary_Point_Pos*/) /*!< PTIM BPR: Binary_Point Mask */
+#define GICInterface_BPR_Binary_Point(x)    (((uint32_t)(((uint32_t)(x)) /*<< GICInterface_BPR_Binary_Point_Pos*/)) & GICInterface_BPR_Binary_Point_Msk)
+
+/* GICInterface IAR Register */
+#define GICInterface_IAR_INTID_Pos          0U                                              /*!< PTIM IAR: INTID Position */
+#define GICInterface_IAR_INTID_Msk          (0xFFFFFFU /*<< GICInterface_IAR_INTID_Pos*/)   /*!< PTIM IAR: INTID Mask */
+#define GICInterface_IAR_INTID(x)           (((uint32_t)(((uint32_t)(x)) /*<< GICInterface_IAR_INTID_Pos*/)) & GICInterface_IAR_INTID_Msk)
+
+/* GICInterface EOIR Register */
+#define GICInterface_EOIR_INTID_Pos         0U                                              /*!< PTIM EOIR: INTID Position */
+#define GICInterface_EOIR_INTID_Msk         (0xFFFFFFU /*<< GICInterface_EOIR_INTID_Pos*/)  /*!< PTIM EOIR: INTID Mask */
+#define GICInterface_EOIR_INTID(x)          (((uint32_t)(((uint32_t)(x)) /*<< GICInterface_EOIR_INTID_Pos*/)) & GICInterface_EOIR_INTID_Msk)
+
+/* GICInterface RPR Register */
+#define GICInterface_RPR_INTID_Pos          0U                                              /*!< PTIM RPR: INTID Position */
+#define GICInterface_RPR_INTID_Msk          (0xFFU /*<< GICInterface_RPR_INTID_Pos*/)       /*!< PTIM RPR: INTID Mask */
+#define GICInterface_RPR_INTID(x)           (((uint32_t)(((uint32_t)(x)) /*<< GICInterface_RPR_INTID_Pos*/)) & GICInterface_RPR_INTID_Msk)
+
+/* GICInterface HPPIR Register */
+#define GICInterface_HPPIR_INTID_Pos        0U                                               /*!< PTIM HPPIR: INTID Position */
+#define GICInterface_HPPIR_INTID_Msk        (0xFFFFFFU /*<< GICInterface_HPPIR_INTID_Pos*/)  /*!< PTIM HPPIR: INTID Mask */
+#define GICInterface_HPPIR_INTID(x)         (((uint32_t)(((uint32_t)(x)) /*<< GICInterface_HPPIR_INTID_Pos*/)) & GICInterface_HPPIR_INTID_Msk)
+
+/* GICInterface ABPR Register */
+#define GICInterface_ABPR_Binary_Point_Pos  0U                                               /*!< PTIM ABPR: Binary_Point Position */
+#define GICInterface_ABPR_Binary_Point_Msk  (0x7U /*<< GICInterface_ABPR_Binary_Point_Pos*/) /*!< PTIM ABPR: Binary_Point Mask */
+#define GICInterface_ABPR_Binary_Point(x)   (((uint32_t)(((uint32_t)(x)) /*<< GICInterface_ABPR_Binary_Point_Pos*/)) & GICInterface_ABPR_Binary_Point_Msk)
+
+/* GICInterface AIAR Register */
+#define GICInterface_AIAR_INTID_Pos         0U                                              /*!< PTIM AIAR: INTID Position */
+#define GICInterface_AIAR_INTID_Msk         (0xFFFFFFU /*<< GICInterface_AIAR_INTID_Pos*/)  /*!< PTIM AIAR: INTID Mask */
+#define GICInterface_AIAR_INTID(x)          (((uint32_t)(((uint32_t)(x)) /*<< GICInterface_AIAR_INTID_Pos*/)) & GICInterface_AIAR_INTID_Msk)
+
+/* GICInterface AEOIR Register */
+#define GICInterface_AEOIR_INTID_Pos        0U                                              /*!< PTIM AEOIR: INTID Position */
+#define GICInterface_AEOIR_INTID_Msk        (0xFFFFFFU /*<< GICInterface_AEOIR_INTID_Pos*/) /*!< PTIM AEOIR: INTID Mask */
+#define GICInterface_AEOIR_INTID(x)         (((uint32_t)(((uint32_t)(x)) /*<< GICInterface_AEOIR_INTID_Pos*/)) & GICInterface_AEOIR_INTID_Msk)
+
+/* GICInterface AHPPIR Register */
+#define GICInterface_AHPPIR_INTID_Pos       0U                                               /*!< PTIM AHPPIR: INTID Position */
+#define GICInterface_AHPPIR_INTID_Msk       (0xFFFFFFU /*<< GICInterface_AHPPIR_INTID_Pos*/) /*!< PTIM AHPPIR: INTID Mask */
+#define GICInterface_AHPPIR_INTID(x)        (((uint32_t)(((uint32_t)(x)) /*<< GICInterface_AHPPIR_INTID_Pos*/)) & GICInterface_AHPPIR_INTID_Msk)
+
+/* GICInterface STATUSR Register */
+#define GICInterface_STATUSR_RRD_Pos        0U                                              /*!< GICInterface STATUSR: RRD Position */
+#define GICInterface_STATUSR_RRD_Msk        (0x1U /*<< GICInterface_STATUSR_RRD_Pos*/)      /*!< GICInterface STATUSR: RRD Mask */
+#define GICInterface_STATUSR_RRD(x)         (((uint32_t)(((uint32_t)(x)) /*<< GICInterface_STATUSR_RRD_Pos*/)) & GICInterface_STATUSR_RRD_Msk)
+
+#define GICInterface_STATUSR_WRD_Pos        1U                                              /*!< GICInterface STATUSR: WRD Position */
+#define GICInterface_STATUSR_WRD_Msk        (0x1U << GICInterface_STATUSR_WRD_Pos)          /*!< GICInterface STATUSR: WRD Mask */
+#define GICInterface_STATUSR_WRD(x)         (((uint32_t)(((uint32_t)(x)) << GICInterface_STATUSR_WRD_Pos)) & GICInterface_STATUSR_WRD_Msk)
+
+#define GICInterface_STATUSR_RWOD_Pos       2U                                              /*!< GICInterface STATUSR: RWOD Position */
+#define GICInterface_STATUSR_RWOD_Msk       (0x1U << GICInterface_STATUSR_RWOD_Pos)         /*!< GICInterface STATUSR: RWOD Mask */
+#define GICInterface_STATUSR_RWOD(x)        (((uint32_t)(((uint32_t)(x)) << GICInterface_STATUSR_RWOD_Pos)) & GICInterface_STATUSR_RWOD_Msk)
+
+#define GICInterface_STATUSR_WROD_Pos       3U                                              /*!< GICInterface STATUSR: WROD Position */
+#define GICInterface_STATUSR_WROD_Msk       (0x1U << GICInterface_STATUSR_WROD_Pos)         /*!< GICInterface STATUSR: WROD Mask */
+#define GICInterface_STATUSR_WROD(x)        (((uint32_t)(((uint32_t)(x)) << GICInterface_STATUSR_WROD_Pos)) & GICInterface_STATUSR_WROD_Msk)
+
+#define GICInterface_STATUSR_ASV_Pos        4U                                              /*!< GICInterface STATUSR: ASV Position */
+#define GICInterface_STATUSR_ASV_Msk        (0x1U << GICInterface_STATUSR_ASV_Pos)          /*!< GICInterface STATUSR: ASV Mask */
+#define GICInterface_STATUSR_ASV(x)         (((uint32_t)(((uint32_t)(x)) << GICInterface_STATUSR_ASV_Pos)) & GICInterface_STATUSR_ASV_Msk)
+
+/* GICInterface IIDR Register */
+#define GICInterface_IIDR_Implementer_Pos   0U                                                 /*!< GICInterface IIDR: Implementer Position */
+#define GICInterface_IIDR_Implementer_Msk   (0xFFFU /*<< GICInterface_IIDR_Implementer_Pos*/)  /*!< GICInterface IIDR: Implementer Mask */
+#define GICInterface_IIDR_Implementer(x)    (((uint32_t)(((uint32_t)(x)) /*<< GICInterface_IIDR_Implementer_Pos*/)) & GICInterface_IIDR_Implementer_Msk)
+
+#define GICInterface_IIDR_Revision_Pos      12U                                             /*!< GICInterface IIDR: Revision Position */
+#define GICInterface_IIDR_Revision_Msk      (0xFU << GICInterface_IIDR_Revision_Pos)        /*!< GICInterface IIDR: Revision Mask */
+#define GICInterface_IIDR_Revision(x)       (((uint32_t)(((uint32_t)(x)) << GICInterface_IIDR_Revision_Pos)) & GICInterface_IIDR_Revision_Msk)
+
+#define GICInterface_IIDR_Arch_version_Pos  16U                                             /*!< GICInterface IIDR: Arch_version Position */
+#define GICInterface_IIDR_Arch_version_Msk  (0xFU << GICInterface_IIDR_Arch_version_Pos)    /*!< GICInterface IIDR: Arch_version Mask */
+#define GICInterface_IIDR_Arch_version(x)   (((uint32_t)(((uint32_t)(x)) << GICInterface_IIDR_Arch_version_Pos)) & GICInterface_IIDR_Arch_version_Msk)
+
+#define GICInterface_IIDR_ProductID_Pos     20U                                             /*!< GICInterface IIDR: ProductID Position */
+#define GICInterface_IIDR_ProductID_Msk     (0xFFFU << GICInterface_IIDR_ProductID_Pos)     /*!< GICInterface IIDR: ProductID Mask */
+#define GICInterface_IIDR_ProductID(x)      (((uint32_t)(((uint32_t)(x)) << GICInterface_IIDR_ProductID_Pos)) & GICInterface_IIDR_ProductID_Msk)
+
+/* GICInterface DIR Register */
+#define GICInterface_DIR_INTID_Pos          0U                                              /*!< PTIM DIR: INTID Position */
+#define GICInterface_DIR_INTID_Msk          (0xFFFFFFU /*<< GICInterface_DIR_INTID_Pos*/)   /*!< PTIM DIR: INTID Mask */
+#define GICInterface_DIR_INTID(x)           (((uint32_t)(((uint32_t)(x)) /*<< GICInterface_DIR_INTID_Pos*/)) & GICInterface_DIR_INTID_Msk)
+#endif /*  (__GIC_PRESENT == 1U) || defined(DOXYGEN) */
+
+#if (defined(__TIM_PRESENT) && (__TIM_PRESENT == 1U)) || \
+     defined(DOXYGEN)
+#if ((__CORTEX_A == 5U) || (__CORTEX_A == 9U)) || defined(DOXYGEN)
+/** \brief Structure type to access the Private Timer
+*/
+typedef struct
+{
+  __IOM uint32_t LOAD;            //!< \brief  Offset: 0x000 (R/W) Private Timer Load Register
+  __IOM uint32_t COUNTER;         //!< \brief  Offset: 0x004 (R/W) Private Timer Counter Register
+  __IOM uint32_t CONTROL;         //!< \brief  Offset: 0x008 (R/W) Private Timer Control Register
+  __IOM uint32_t ISR;             //!< \brief  Offset: 0x00C (R/W) Private Timer Interrupt Status Register
+        RESERVED(0[4], uint32_t)
+  __IOM uint32_t WLOAD;           //!< \brief  Offset: 0x020 (R/W) Watchdog Load Register
+  __IOM uint32_t WCOUNTER;        //!< \brief  Offset: 0x024 (R/W) Watchdog Counter Register
+  __IOM uint32_t WCONTROL;        //!< \brief  Offset: 0x028 (R/W) Watchdog Control Register
+  __IOM uint32_t WISR;            //!< \brief  Offset: 0x02C (R/W) Watchdog Interrupt Status Register
+  __IOM uint32_t WRESET;          //!< \brief  Offset: 0x030 (R/W) Watchdog Reset Status Register
+  __OM  uint32_t WDISABLE;        //!< \brief  Offset: 0x034 ( /W) Watchdog Disable Register
+} Timer_Type;
+#define PTIM ((Timer_Type *) TIMER_BASE )   /*!< \brief Timer register struct */
+
+/* PTIM Control Register */
+#define PTIM_CONTROL_Enable_Pos             0U                                         /*!< PTIM CONTROL: Enable Position */
+#define PTIM_CONTROL_Enable_Msk             (0x1U /*<< PTIM_CONTROL_Enable_Pos*/)      /*!< PTIM CONTROL: Enable Mask */
+#define PTIM_CONTROL_Enable(x)              (((uint32_t)(((uint32_t)(x)) /*<< PTIM_CONTROL_Enable_Pos*/)) & PTIM_CONTROL_Enable_Msk)
+
+#define PTIM_CONTROL_AutoReload_Pos         1U                                         /*!< PTIM CONTROL: Auto Reload Position */
+#define PTIM_CONTROL_AutoReload_Msk         (0x1U << PTIM_CONTROL_AutoReload_Pos)      /*!< PTIM CONTROL: Auto Reload Mask */
+#define PTIM_CONTROL_AutoReload(x)          (((uint32_t)(((uint32_t)(x)) << PTIM_CONTROL_AutoReload_Pos)) & PTIM_CONTROL_AutoReload_Msk)
+
+#define PTIM_CONTROL_IRQenable_Pos          2U                                         /*!< PTIM CONTROL: IRQ Enabel Position */
+#define PTIM_CONTROL_IRQenable_Msk          (0x1U << PTIM_CONTROL_IRQenable_Pos)       /*!< PTIM CONTROL: IRQ Enabel Mask */
+#define PTIM_CONTROL_IRQenable(x)           (((uint32_t)(((uint32_t)(x)) << PTIM_CONTROL_IRQenable_Pos)) & PTIM_CONTROL_IRQenable_Msk)
+
+#define PTIM_CONTROL_Prescaler_Pos          8U                                         /*!< PTIM CONTROL: Prescaler Position */
+#define PTIM_CONTROL_Prescaler_Msk          (0xFFU << PTIM_CONTROL_Prescaler_Pos)      /*!< PTIM CONTROL: Prescaler Mask */
+#define PTIM_CONTROL_Prescaler(x)           (((uint32_t)(((uint32_t)(x)) << PTIM_CONTROL_Prescaler_Pos)) & PTIM_CONTROL_Prescaler_Msk)
+
+/* WCONTROL Watchdog Control Register */
+#define PTIM_WCONTROL_Enable_Pos            0U                                         /*!< PTIM WCONTROL: Enable Position */
+#define PTIM_WCONTROL_Enable_Msk            (0x1U /*<< PTIM_WCONTROL_Enable_Pos*/)     /*!< PTIM WCONTROL: Enable Mask */
+#define PTIM_WCONTROL_Enable(x)             (((uint32_t)(((uint32_t)(x)) /*<< PTIM_WCONTROL_Enable_Pos*/)) & PTIM_WCONTROL_Enable_Msk)
+
+#define PTIM_WCONTROL_AutoReload_Pos        1U                                         /*!< PTIM WCONTROL: Auto Reload Position */
+#define PTIM_WCONTROL_AutoReload_Msk        (0x1U << PTIM_WCONTROL_AutoReload_Pos)     /*!< PTIM WCONTROL: Auto Reload Mask */
+#define PTIM_WCONTROL_AutoReload(x)         (((uint32_t)(((uint32_t)(x)) << PTIM_WCONTROL_AutoReload_Pos)) & PTIM_WCONTROL_AutoReload_Msk)
+
+#define PTIM_WCONTROL_IRQenable_Pos         2U                                         /*!< PTIM WCONTROL: IRQ Enable Position */
+#define PTIM_WCONTROL_IRQenable_Msk         (0x1U << PTIM_WCONTROL_IRQenable_Pos)      /*!< PTIM WCONTROL: IRQ Enable Mask */
+#define PTIM_WCONTROL_IRQenable(x)          (((uint32_t)(((uint32_t)(x)) << PTIM_WCONTROL_IRQenable_Pos)) & PTIM_WCONTROL_IRQenable_Msk)
+
+#define PTIM_WCONTROL_Mode_Pos              3U                                         /*!< PTIM WCONTROL: Watchdog Mode Position */
+#define PTIM_WCONTROL_Mode_Msk              (0x1U << PTIM_WCONTROL_Mode_Pos)           /*!< PTIM WCONTROL: Watchdog Mode Mask */
+#define PTIM_WCONTROL_Mode(x)               (((uint32_t)(((uint32_t)(x)) << PTIM_WCONTROL_Mode_Pos)) & PTIM_WCONTROL_Mode_Msk)
+
+#define PTIM_WCONTROL_Presacler_Pos         8U                                         /*!< PTIM WCONTROL: Prescaler Position */
+#define PTIM_WCONTROL_Presacler_Msk         (0xFFU << PTIM_WCONTROL_Presacler_Pos)     /*!< PTIM WCONTROL: Prescaler Mask */
+#define PTIM_WCONTROL_Presacler(x)          (((uint32_t)(((uint32_t)(x)) << PTIM_WCONTROL_Presacler_Pos)) & PTIM_WCONTROL_Presacler_Msk)
+
+/* WISR Watchdog Interrupt Status Register */
+#define PTIM_WISR_EventFlag_Pos             0U                                         /*!< PTIM WISR: Event Flag Position */
+#define PTIM_WISR_EventFlag_Msk             (0x1U /*<< PTIM_WISR_EventFlag_Pos*/)      /*!< PTIM WISR: Event Flag Mask */
+#define PTIM_WISR_EventFlag(x)              (((uint32_t)(((uint32_t)(x)) /*<< PTIM_WISR_EventFlag_Pos*/)) & PTIM_WISR_EventFlag_Msk)
+
+/* WRESET Watchdog Reset Status */
+#define PTIM_WRESET_ResetFlag_Pos           0U                                         /*!< PTIM WRESET: Reset Flag Position */
+#define PTIM_WRESET_ResetFlag_Msk           (0x1U /*<< PTIM_WRESET_ResetFlag_Pos*/)    /*!< PTIM WRESET: Reset Flag Mask */
+#define PTIM_WRESET_ResetFlag(x)            (((uint32_t)(((uint32_t)(x)) /*<< PTIM_WRESET_ResetFlag_Pos*/)) & PTIM_WRESET_ResetFlag_Msk)
+
+#endif /* ((__CORTEX_A == 5U) || (__CORTEX_A == 9U)) || defined(DOXYGEN) */
+#endif /* (__TIM_PRESENT == 1U) || defined(DOXYGEN) */
+
+ /*******************************************************************************
+  *                Hardware Abstraction Layer
+   Core Function Interface contains:
+   - L1 Cache Functions
+   - L2C-310 Cache Controller Functions
+   - PL1 Timer Functions
+   - GIC Functions
+   - MMU Functions
+  ******************************************************************************/
+
+/* ##########################  L1 Cache functions  ################################# */
+
+/** \brief Enable Caches by setting I and C bits in SCTLR register.
+*/
+__STATIC_FORCEINLINE void L1C_EnableCaches(void) {
+  __set_SCTLR( __get_SCTLR() | SCTLR_I_Msk | SCTLR_C_Msk);
+  __ISB();
+}
+
+/** \brief Disable Caches by clearing I and C bits in SCTLR register.
+*/
+__STATIC_FORCEINLINE void L1C_DisableCaches(void) {
+  __set_SCTLR( __get_SCTLR() & (~SCTLR_I_Msk) & (~SCTLR_C_Msk));
+  __ISB();
+}
+
+/** \brief  Enable Branch Prediction by setting Z bit in SCTLR register.
+*/
+__STATIC_FORCEINLINE void L1C_EnableBTAC(void) {
+  __set_SCTLR( __get_SCTLR() | SCTLR_Z_Msk);
+  __ISB();
+}
+
+/** \brief  Disable Branch Prediction by clearing Z bit in SCTLR register.
+*/
+__STATIC_FORCEINLINE void L1C_DisableBTAC(void) {
+  __set_SCTLR( __get_SCTLR() & (~SCTLR_Z_Msk));
+  __ISB();
+}
+
+/** \brief  Invalidate entire branch predictor array
+*/
+__STATIC_FORCEINLINE void L1C_InvalidateBTAC(void) {
+  __set_BPIALL(0);
+  __DSB();     //ensure completion of the invalidation
+  __ISB();     //ensure instruction fetch path sees new state
+}
+
+/** \brief  Clean instruction cache line by address.
+* \param [in] va Pointer to instructions to clear the cache for.
+*/
+__STATIC_FORCEINLINE void L1C_InvalidateICacheMVA(void *va) {
+  __set_ICIMVAC((uint32_t)va);
+  __DSB();     //ensure completion of the invalidation
+  __ISB();     //ensure instruction fetch path sees new I cache state
+}
+
+/** \brief  Invalidate the whole instruction cache
+*/
+__STATIC_FORCEINLINE void L1C_InvalidateICacheAll(void) {
+  __set_ICIALLU(0);
+  __DSB();     //ensure completion of the invalidation
+  __ISB();     //ensure instruction fetch path sees new I cache state
+}
+
+/** \brief  Clean data cache line by address.
+* \param [in] va Pointer to data to clear the cache for.
+*/
+__STATIC_FORCEINLINE void L1C_CleanDCacheMVA(void *va) {
+  __set_DCCMVAC((uint32_t)va);
+  __DMB();     //ensure the ordering of data cache maintenance operations and their effects
+}
+
+/** \brief  Invalidate data cache line by address.
+* \param [in] va Pointer to data to invalidate the cache for.
+*/
+__STATIC_FORCEINLINE void L1C_InvalidateDCacheMVA(void *va) {
+  __set_DCIMVAC((uint32_t)va);
+  __DMB();     //ensure the ordering of data cache maintenance operations and their effects
+}
+
+/** \brief  Clean and Invalidate data cache by address.
+* \param [in] va Pointer to data to invalidate the cache for.
+*/
+__STATIC_FORCEINLINE void L1C_CleanInvalidateDCacheMVA(void *va) {
+  __set_DCCIMVAC((uint32_t)va);
+  __DMB();     //ensure the ordering of data cache maintenance operations and their effects
+}
+
+/** \brief Calculate log2 rounded up
+*  - log(0)  => 0
+*  - log(1)  => 0
+*  - log(2)  => 1
+*  - log(3)  => 2
+*  - log(4)  => 2
+*  - log(5)  => 3
+*        :      :
+*  - log(16) => 4
+*  - log(32) => 5
+*        :      :
+* \param [in] n input value parameter
+* \return log2(n)
+*/
+__STATIC_FORCEINLINE uint8_t __log2_up(uint32_t n)
+{
+  if (n < 2U) {
+    return 0U;
+  }
+  uint8_t log = 0U;
+  uint32_t t = n;
+  while(t > 1U)
+  {
+    log++;
+    t >>= 1U;
+  }
+  if (n & 1U) { log++; }
+  return log;
+}
+
+/** \brief  Apply cache maintenance to given cache level.
+* \param [in] level cache level to be maintained
+* \param [in] maint 0 - invalidate, 1 - clean, otherwise - invalidate and clean
+*/
+__STATIC_FORCEINLINE void __L1C_MaintainDCacheSetWay(uint32_t level, uint32_t maint)
+{
+  uint32_t Dummy;
+  uint32_t ccsidr;
+  uint32_t num_sets;
+  uint32_t num_ways;
+  uint32_t shift_way;
+  uint32_t log2_linesize;
+   uint8_t log2_num_ways;
+
+  Dummy = level << 1U;
+  /* set csselr, select ccsidr register */
+  __set_CSSELR(Dummy);
+  /* get current ccsidr register */
+  ccsidr = __get_CCSIDR();
+  num_sets = ((ccsidr & 0x0FFFE000U) >> 13U) + 1U;
+  num_ways = ((ccsidr & 0x00001FF8U) >> 3U) + 1U;
+  log2_linesize = (ccsidr & 0x00000007U) + 2U + 2U;
+  log2_num_ways = __log2_up(num_ways);
+  if (log2_num_ways > 32U) {
+    return; // FATAL ERROR
+  }
+  shift_way = 32U - log2_num_ways;
+  for(int32_t way = num_ways-1; way >= 0; way--)
+  {
+    for(int32_t set = num_sets-1; set >= 0; set--)
+    {
+      Dummy = (level << 1U) | (((uint32_t)set) << log2_linesize) | (((uint32_t)way) << shift_way);
+      switch (maint)
+      {
+        case 0U: __set_DCISW(Dummy);  break;
+        case 1U: __set_DCCSW(Dummy);  break;
+        default: __set_DCCISW(Dummy); break;
+      }
+    }
+  }
+  __DMB();
+}
+
+/** \brief  Clean and Invalidate the entire data or unified cache
+* \param [in] op 0 - invalidate, 1 - clean, otherwise - invalidate and clean
+*/
+__STATIC_FORCEINLINE void L1C_CleanInvalidateCache(uint32_t op) {
+  uint32_t clidr;
+  uint32_t cache_type;
+  clidr =  __get_CLIDR();
+  for(uint32_t i = 0U; i<7U; i++)
+  {
+    cache_type = (clidr >> i*3U) & 0x7UL;
+    if ((cache_type >= 2U) && (cache_type <= 4U))
+    {
+      __L1C_MaintainDCacheSetWay(i, op);
+    }
+  }
+}
+
+/** \brief  Invalidate the whole data cache.
+*/
+__STATIC_FORCEINLINE void L1C_InvalidateDCacheAll(void) {
+  L1C_CleanInvalidateCache(0);
+}
+
+/** \brief  Clean the whole data cache.
+ */
+__STATIC_FORCEINLINE void L1C_CleanDCacheAll(void) {
+  L1C_CleanInvalidateCache(1);
+}
+
+/** \brief  Clean and invalidate the whole data cache.
+ */
+__STATIC_FORCEINLINE void L1C_CleanInvalidateDCacheAll(void) {
+  L1C_CleanInvalidateCache(2);
+}
+
+/* ##########################  L2 Cache functions  ################################# */
+#if (defined(__L2C_PRESENT) && (__L2C_PRESENT == 1U)) || \
+     defined(DOXYGEN)
+/** \brief Cache Sync operation by writing CACHE_SYNC register.
+*/
+__STATIC_INLINE void L2C_Sync(void)
+{
+  L2C_310->CACHE_SYNC = 0x0;
+}
+
+/** \brief Read cache controller cache ID from CACHE_ID register.
+ * \return L2C_310_TypeDef::CACHE_ID
+ */
+__STATIC_INLINE int L2C_GetID (void)
+{
+  return L2C_310->CACHE_ID;
+}
+
+/** \brief Read cache controller cache type from CACHE_TYPE register.
+*  \return L2C_310_TypeDef::CACHE_TYPE
+*/
+__STATIC_INLINE int L2C_GetType (void)
+{
+  return L2C_310->CACHE_TYPE;
+}
+
+/** \brief Invalidate all cache by way
+*/
+__STATIC_INLINE void L2C_InvAllByWay (void)
+{
+  unsigned int assoc;
+
+  if (L2C_310->AUX_CNT & (1U << 16U)) {
+    assoc = 16U;
+  } else {
+    assoc =  8U;
+  }
+
+  L2C_310->INV_WAY = (1U << assoc) - 1U;
+  while(L2C_310->INV_WAY & ((1U << assoc) - 1U)); //poll invalidate
+
+  L2C_Sync();
+}
+
+/** \brief Clean and Invalidate all cache by way
+*/
+__STATIC_INLINE void L2C_CleanInvAllByWay (void)
+{
+  unsigned int assoc;
+
+  if (L2C_310->AUX_CNT & (1U << 16U)) {
+    assoc = 16U;
+  } else {
+    assoc =  8U;
+  }
+
+  L2C_310->CLEAN_INV_WAY = (1U << assoc) - 1U;
+  while(L2C_310->CLEAN_INV_WAY & ((1U << assoc) - 1U)); //poll invalidate
+
+  L2C_Sync();
+}
+
+/** \brief Enable Level 2 Cache
+*/
+__STATIC_INLINE void L2C_Enable(void)
+{
+  L2C_310->CONTROL = 0;
+  L2C_310->INTERRUPT_CLEAR = 0x000001FFuL;
+  L2C_310->DEBUG_CONTROL = 0;
+  L2C_310->DATA_LOCK_0_WAY = 0;
+  L2C_310->CACHE_SYNC = 0;
+  L2C_310->CONTROL = 0x01;
+  L2C_Sync();
+}
+
+/** \brief Disable Level 2 Cache
+*/
+__STATIC_INLINE void L2C_Disable(void)
+{
+  L2C_310->CONTROL = 0x00;
+  L2C_Sync();
+}
+
+/** \brief Invalidate cache by physical address
+* \param [in] pa Pointer to data to invalidate cache for.
+*/
+__STATIC_INLINE void L2C_InvPa (void *pa)
+{
+  L2C_310->INV_LINE_PA = (unsigned int)pa;
+  L2C_Sync();
+}
+
+/** \brief Clean cache by physical address
+* \param [in] pa Pointer to data to invalidate cache for.
+*/
+__STATIC_INLINE void L2C_CleanPa (void *pa)
+{
+  L2C_310->CLEAN_LINE_PA = (unsigned int)pa;
+  L2C_Sync();
+}
+
+/** \brief Clean and invalidate cache by physical address
+* \param [in] pa Pointer to data to invalidate cache for.
+*/
+__STATIC_INLINE void L2C_CleanInvPa (void *pa)
+{
+  L2C_310->CLEAN_INV_LINE_PA = (unsigned int)pa;
+  L2C_Sync();
+}
+#endif
+
+/* ##########################  GIC functions  ###################################### */
+#if (defined(__GIC_PRESENT) && (__GIC_PRESENT == 1U)) || \
+     defined(DOXYGEN)
+
+/** \brief  Enable the interrupt distributor using the GIC's CTLR register.
+*/
+__STATIC_INLINE void GIC_EnableDistributor(void)
+{
+  GICDistributor->CTLR |= 1U;
+}
+
+/** \brief Disable the interrupt distributor using the GIC's CTLR register.
+*/
+__STATIC_INLINE void GIC_DisableDistributor(void)
+{
+  GICDistributor->CTLR &=~1U;
+}
+
+/** \brief Read the GIC's TYPER register.
+* \return GICDistributor_Type::TYPER
+*/
+__STATIC_INLINE uint32_t GIC_DistributorInfo(void)
+{
+  return (GICDistributor->TYPER);
+}
+
+/** \brief Reads the GIC's IIDR register.
+* \return GICDistributor_Type::IIDR
+*/
+__STATIC_INLINE uint32_t GIC_DistributorImplementer(void)
+{
+  return (GICDistributor->IIDR);
+}
+
+/** \brief Sets the GIC's ITARGETSR register for the given interrupt.
+* \param [in] IRQn Interrupt to be configured.
+* \param [in] cpu_target CPU interfaces to assign this interrupt to.
+*/
+__STATIC_INLINE void GIC_SetTarget(IRQn_Type IRQn, uint32_t cpu_target)
+{
+  uint32_t mask = GICDistributor->ITARGETSR[IRQn / 4U] & ~(0xFFUL << ((IRQn % 4U) * 8U));
+  GICDistributor->ITARGETSR[IRQn / 4U] = mask | ((cpu_target & 0xFFUL) << ((IRQn % 4U) * 8U));
+}
+
+/** \brief Read the GIC's ITARGETSR register.
+* \param [in] IRQn Interrupt to acquire the configuration for.
+* \return GICDistributor_Type::ITARGETSR
+*/
+__STATIC_INLINE uint32_t GIC_GetTarget(IRQn_Type IRQn)
+{
+  return (GICDistributor->ITARGETSR[IRQn / 4U] >> ((IRQn % 4U) * 8U)) & 0xFFUL;
+}
+
+/** \brief Enable the CPU's interrupt interface.
+*/
+__STATIC_INLINE void GIC_EnableInterface(void)
+{
+  GICInterface->CTLR |= 1U; //enable interface
+}
+
+/** \brief Disable the CPU's interrupt interface.
+*/
+__STATIC_INLINE void GIC_DisableInterface(void)
+{
+  GICInterface->CTLR &=~1U; //disable distributor
+}
+
+/** \brief Read the CPU's IAR register.
+* \return GICInterface_Type::IAR
+*/
+__STATIC_INLINE IRQn_Type GIC_AcknowledgePending(void)
+{
+  return (IRQn_Type)(GICInterface->IAR);
+}
+
+/** \brief Writes the given interrupt number to the CPU's EOIR register.
+* \param [in] IRQn The interrupt to be signaled as finished.
+*/
+__STATIC_INLINE void GIC_EndInterrupt(IRQn_Type IRQn)
+{
+  GICInterface->EOIR = IRQn;
+}
+
+/** \brief Enables the given interrupt using GIC's ISENABLER register.
+* \param [in] IRQn The interrupt to be enabled.
+*/
+__STATIC_INLINE void GIC_EnableIRQ(IRQn_Type IRQn)
+{
+  GICDistributor->ISENABLER[IRQn / 32U] = 1U << (IRQn % 32U);
+}
+
+/** \brief Get interrupt enable status using GIC's ISENABLER register.
+* \param [in] IRQn The interrupt to be queried.
+* \return 0 - interrupt is not enabled, 1 - interrupt is enabled.
+*/
+__STATIC_INLINE uint32_t GIC_GetEnableIRQ(IRQn_Type IRQn)
+{
+  return (GICDistributor->ISENABLER[IRQn / 32U] >> (IRQn % 32U)) & 1UL;
+}
+
+/** \brief Disables the given interrupt using GIC's ICENABLER register.
+* \param [in] IRQn The interrupt to be disabled.
+*/
+__STATIC_INLINE void GIC_DisableIRQ(IRQn_Type IRQn)
+{
+  GICDistributor->ICENABLER[IRQn / 32U] = 1U << (IRQn % 32U);
+}
+
+/** \brief Get interrupt pending status from GIC's ISPENDR register.
+* \param [in] IRQn The interrupt to be queried.
+* \return 0 - interrupt is not pending, 1 - interrupt is pendig.
+*/
+__STATIC_INLINE uint32_t GIC_GetPendingIRQ(IRQn_Type IRQn)
+{
+  uint32_t pend;
+
+  if (IRQn >= 16U) {
+    pend = (GICDistributor->ISPENDR[IRQn / 32U] >> (IRQn % 32U)) & 1UL;
+  } else {
+    // INTID 0-15 Software Generated Interrupt
+    pend = (GICDistributor->SPENDSGIR[IRQn / 4U] >> ((IRQn % 4U) * 8U)) & 0xFFUL;
+    // No CPU identification offered
+    if (pend != 0U) {
+      pend = 1U;
+    } else {
+      pend = 0U;
+    }
+  }
+
+  return (pend);
+}
+
+/** \brief Sets the given interrupt as pending using GIC's ISPENDR register.
+* \param [in] IRQn The interrupt to be enabled.
+*/
+__STATIC_INLINE void GIC_SetPendingIRQ(IRQn_Type IRQn)
+{
+  if (IRQn >= 16U) {
+    GICDistributor->ISPENDR[IRQn / 32U] = 1U << (IRQn % 32U);
+  } else {
+    // INTID 0-15 Software Generated Interrupt
+    // Forward the interrupt to the CPU interface that requested it
+    GICDistributor->SGIR = (IRQn | 0x02000000U);
+  }
+}
+
+/** \brief Clears the given interrupt from being pending using GIC's ICPENDR register.
+* \param [in] IRQn The interrupt to be enabled.
+*/
+__STATIC_INLINE void GIC_ClearPendingIRQ(IRQn_Type IRQn)
+{
+  if (IRQn >= 16U) {
+    GICDistributor->ICPENDR[IRQn / 32U] = 1U << (IRQn % 32U);
+  } else {
+    // INTID 0-15 Software Generated Interrupt
+    GICDistributor->CPENDSGIR[IRQn / 4U] = 1U << ((IRQn % 4U) * 8U);
+  }
+}
+
+/** \brief Sets the interrupt configuration using GIC's ICFGR register.
+* \param [in] IRQn The interrupt to be configured.
+* \param [in] int_config Int_config field value. Bit 0: Reserved (0 - N-N model, 1 - 1-N model for some GIC before v1)
+*                                           Bit 1: 0 - level sensitive, 1 - edge triggered
+*/
+__STATIC_INLINE void GIC_SetConfiguration(IRQn_Type IRQn, uint32_t int_config)
+{
+  uint32_t icfgr = GICDistributor->ICFGR[IRQn / 16U];  /* read current register content */
+  uint32_t shift = (IRQn % 16U) << 1U;                 /* calculate shift value */
+
+  int_config &= 3U;                                    /* only 2 bits are valid */
+  icfgr &= (~(3U         << shift));                   /* clear bits to change */
+  icfgr |= (  int_config << shift);                    /* set new configuration */
+
+  GICDistributor->ICFGR[IRQn / 16U] = icfgr;           /* write new register content */
+}
+
+/** \brief Get the interrupt configuration from the GIC's ICFGR register.
+* \param [in] IRQn Interrupt to acquire the configuration for.
+* \return Int_config field value. Bit 0: Reserved (0 - N-N model, 1 - 1-N model for some GIC before v1)
+*                                 Bit 1: 0 - level sensitive, 1 - edge triggered
+*/
+__STATIC_INLINE uint32_t GIC_GetConfiguration(IRQn_Type IRQn)
+{
+  return (GICDistributor->ICFGR[IRQn / 16U] >> ((IRQn % 16U) >> 1U));
+}
+
+/** \brief Set the priority for the given interrupt in the GIC's IPRIORITYR register.
+* \param [in] IRQn The interrupt to be configured.
+* \param [in] priority The priority for the interrupt, lower values denote higher priorities.
+*/
+__STATIC_INLINE void GIC_SetPriority(IRQn_Type IRQn, uint32_t priority)
+{
+  uint32_t mask = GICDistributor->IPRIORITYR[IRQn / 4U] & ~(0xFFUL << ((IRQn % 4U) * 8U));
+  GICDistributor->IPRIORITYR[IRQn / 4U] = mask | ((priority & 0xFFUL) << ((IRQn % 4U) * 8U));
+}
+
+/** \brief Read the current interrupt priority from GIC's IPRIORITYR register.
+* \param [in] IRQn The interrupt to be queried.
+*/
+__STATIC_INLINE uint32_t GIC_GetPriority(IRQn_Type IRQn)
+{
+  return (GICDistributor->IPRIORITYR[IRQn / 4U] >> ((IRQn % 4U) * 8U)) & 0xFFUL;
+}
+
+/** \brief Set the interrupt priority mask using CPU's PMR register.
+* \param [in] priority Priority mask to be set.
+*/
+__STATIC_INLINE void GIC_SetInterfacePriorityMask(uint32_t priority)
+{
+  GICInterface->PMR = priority & 0xFFUL; //set priority mask
+}
+
+/** \brief Read the current interrupt priority mask from CPU's PMR register.
+* \result GICInterface_Type::PMR
+*/
+__STATIC_INLINE uint32_t GIC_GetInterfacePriorityMask(void)
+{
+  return GICInterface->PMR;
+}
+
+/** \brief Configures the group priority and subpriority split point using CPU's BPR register.
+* \param [in] binary_point Amount of bits used as subpriority.
+*/
+__STATIC_INLINE void GIC_SetBinaryPoint(uint32_t binary_point)
+{
+  GICInterface->BPR = binary_point & 7U; //set binary point
+}
+
+/** \brief Read the current group priority and subpriority split point from CPU's BPR register.
+* \return GICInterface_Type::BPR
+*/
+__STATIC_INLINE uint32_t GIC_GetBinaryPoint(void)
+{
+  return GICInterface->BPR;
+}
+
+/** \brief Get the status for a given interrupt.
+* \param [in] IRQn The interrupt to get status for.
+* \return 0 - not pending/active, 1 - pending, 2 - active, 3 - pending and active
+*/
+__STATIC_INLINE uint32_t GIC_GetIRQStatus(IRQn_Type IRQn)
+{
+  uint32_t pending, active;
+
+  active = ((GICDistributor->ISACTIVER[IRQn / 32U])  >> (IRQn % 32U)) & 1UL;
+  pending = ((GICDistributor->ISPENDR[IRQn / 32U]) >> (IRQn % 32U)) & 1UL;
+
+  return ((active<<1U) | pending);
+}
+
+/** \brief Generate a software interrupt using GIC's SGIR register.
+* \param [in] IRQn Software interrupt to be generated.
+* \param [in] target_list List of CPUs the software interrupt should be forwarded to.
+* \param [in] filter_list Filter to be applied to determine interrupt receivers.
+*/
+__STATIC_INLINE void GIC_SendSGI(IRQn_Type IRQn, uint32_t target_list, uint32_t filter_list)
+{
+  GICDistributor->SGIR = ((filter_list & 3U) << 24U) | ((target_list & 0xFFUL) << 16U) | (IRQn & 0x0FUL);
+}
+
+/** \brief Get the interrupt number of the highest interrupt pending from CPU's HPPIR register.
+* \return GICInterface_Type::HPPIR
+*/
+__STATIC_INLINE uint32_t GIC_GetHighPendingIRQ(void)
+{
+  return GICInterface->HPPIR;
+}
+
+/** \brief Provides information about the implementer and revision of the CPU interface.
+* \return GICInterface_Type::IIDR
+*/
+__STATIC_INLINE uint32_t GIC_GetInterfaceId(void)
+{
+  return GICInterface->IIDR;
+}
+
+/** \brief Set the interrupt group from the GIC's IGROUPR register.
+* \param [in] IRQn The interrupt to be queried.
+* \param [in] group Interrupt group number: 0 - Group 0, 1 - Group 1
+*/
+__STATIC_INLINE void GIC_SetGroup(IRQn_Type IRQn, uint32_t group)
+{
+  uint32_t igroupr = GICDistributor->IGROUPR[IRQn / 32U];
+  uint32_t shift   = (IRQn % 32U);
+
+  igroupr &= (~(1U          << shift));
+  igroupr |= ( (group & 1U) << shift);
+
+  GICDistributor->IGROUPR[IRQn / 32U] = igroupr;
+}
+#define GIC_SetSecurity         GIC_SetGroup
+
+/** \brief Get the interrupt group from the GIC's IGROUPR register.
+* \param [in] IRQn The interrupt to be queried.
+* \return 0 - Group 0, 1 - Group 1
+*/
+__STATIC_INLINE uint32_t GIC_GetGroup(IRQn_Type IRQn)
+{
+  return (GICDistributor->IGROUPR[IRQn / 32U] >> (IRQn % 32U)) & 1UL;
+}
+#define GIC_GetSecurity         GIC_GetGroup
+
+/** \brief Initialize the interrupt distributor.
+*/
+__STATIC_INLINE void GIC_DistInit(void)
+{
+  uint32_t i;
+  uint32_t num_irq = 0U;
+  uint32_t priority_field;
+
+  //A reset sets all bits in the IGROUPRs corresponding to the SPIs to 0,
+  //configuring all of the interrupts as Secure.
+
+  //Disable interrupt forwarding
+  GIC_DisableDistributor();
+  //Get the maximum number of interrupts that the GIC supports
+  num_irq = 32U * ((GIC_DistributorInfo() & 0x1FU) + 1U);
+
+  /* Priority level is implementation defined.
+   To determine the number of priority bits implemented write 0xFF to an IPRIORITYR
+   priority field and read back the value stored.*/
+  GIC_SetPriority((IRQn_Type)0U, 0xFFU);
+  priority_field = GIC_GetPriority((IRQn_Type)0U);
+
+  for (i = 32U; i < num_irq; i++)
+  {
+      //Disable the SPI interrupt
+      GIC_DisableIRQ((IRQn_Type)i);
+      //Set level-sensitive (and N-N model)
+      GIC_SetConfiguration((IRQn_Type)i, 0U);
+      //Set priority
+      GIC_SetPriority((IRQn_Type)i, priority_field/2U);
+      //Set target list to CPU0
+      GIC_SetTarget((IRQn_Type)i, 1U);
+  }
+  //Enable distributor
+  GIC_EnableDistributor();
+}
+
+/** \brief Initialize the CPU's interrupt interface
+*/
+__STATIC_INLINE void GIC_CPUInterfaceInit(void)
+{
+  uint32_t i;
+  uint32_t priority_field;
+
+  //A reset sets all bits in the IGROUPRs corresponding to the SPIs to 0,
+  //configuring all of the interrupts as Secure.
+
+  //Disable interrupt forwarding
+  GIC_DisableInterface();
+
+  /* Priority level is implementation defined.
+   To determine the number of priority bits implemented write 0xFF to an IPRIORITYR
+   priority field and read back the value stored.*/
+  GIC_SetPriority((IRQn_Type)0U, 0xFFU);
+  priority_field = GIC_GetPriority((IRQn_Type)0U);
+
+  //SGI and PPI
+  for (i = 0U; i < 32U; i++)
+  {
+    if(i > 15U) {
+      //Set level-sensitive (and N-N model) for PPI
+      GIC_SetConfiguration((IRQn_Type)i, 0U);
+    }
+    //Disable SGI and PPI interrupts
+    GIC_DisableIRQ((IRQn_Type)i);
+    //Set priority
+    GIC_SetPriority((IRQn_Type)i, priority_field/2U);
+  }
+  //Enable interface
+  GIC_EnableInterface();
+  //Set binary point to 0
+  GIC_SetBinaryPoint(0U);
+  //Set priority mask
+  GIC_SetInterfacePriorityMask(0xFFU);
+}
+
+/** \brief Initialize and enable the GIC
+*/
+__STATIC_INLINE void GIC_Enable(void)
+{
+  GIC_DistInit();
+  GIC_CPUInterfaceInit(); //per CPU
+}
+#endif
+
+/* ##########################  Generic Timer functions  ############################ */
+#if (defined(__TIM_PRESENT) && (__TIM_PRESENT == 1U)) || \
+    defined(DOXYGEN)
+
+/* PL1 Physical Timer */
+#if (__CORTEX_A == 7U) || defined(DOXYGEN)
+
+/** \brief Physical Timer Control register */
+typedef union
+{
+  struct
+  {
+    uint32_t ENABLE:1;      /*!< \brief bit: 0      Enables the timer. */
+    uint32_t IMASK:1;       /*!< \brief bit: 1      Timer output signal mask bit. */
+    uint32_t ISTATUS:1;     /*!< \brief bit: 2      The status of the timer. */
+    RESERVED(0:29, uint32_t)
+  } b;                      /*!< \brief Structure used for bit  access */
+  uint32_t w;               /*!< \brief Type      used for word access */
+} CNTP_CTL_Type;
+
+/** \brief Configures the frequency the timer shall run at.
+* \param [in] value The timer frequency in Hz.
+*/
+__STATIC_INLINE void PL1_SetCounterFrequency(uint32_t value)
+{
+  __set_CNTFRQ(value);
+  __ISB();
+}
+
+/** \brief Sets the reset value of the timer.
+* \param [in] value The value the timer is loaded with.
+*/
+__STATIC_INLINE void PL1_SetLoadValue(uint32_t value)
+{
+  __set_CNTP_TVAL(value);
+  __ISB();
+}
+
+/** \brief Get the current counter value.
+* \return Current counter value.
+*/
+__STATIC_INLINE uint32_t PL1_GetCurrentValue(void)
+{
+  return(__get_CNTP_TVAL());
+}
+
+/** \brief Get the current physical counter value.
+* \return Current physical counter value.
+*/
+__STATIC_INLINE uint64_t PL1_GetCurrentPhysicalValue(void)
+{
+  return(__get_CNTPCT());
+}
+
+/** \brief Set the physical compare value.
+* \param [in] value New physical timer compare value.
+*/
+__STATIC_INLINE void PL1_SetPhysicalCompareValue(uint64_t value)
+{
+  __set_CNTP_CVAL(value);
+  __ISB();
+}
+
+/** \brief Get the physical compare value.
+* \return Physical compare value.
+*/
+__STATIC_INLINE uint64_t PL1_GetPhysicalCompareValue(void)
+{
+  return(__get_CNTP_CVAL());
+}
+
+/** \brief Configure the timer by setting the control value.
+* \param [in] value New timer control value.
+*/
+__STATIC_INLINE void PL1_SetControl(uint32_t value)
+{
+  __set_CNTP_CTL(value);
+  __ISB();
+}
+
+/** \brief Get the control value.
+* \return Control value.
+*/
+__STATIC_INLINE uint32_t PL1_GetControl(void)
+{
+  return(__get_CNTP_CTL());
+}
+
+/******************************* VIRTUAL TIMER *******************************/
+/** \brief Virtual Timer Control register */
+
+/** \brief Sets the reset value of the virtual timer.
+* \param [in] value The value the virtual timer is loaded with.
+*/
+__STATIC_INLINE void VL1_SetCurrentTimerValue(uint32_t value)
+{
+  __set_CNTV_TVAL(value);
+  __ISB();
+}
+
+/** \brief Get the current virtual timer value.
+* \return Current virtual timer value.
+*/
+__STATIC_INLINE uint32_t VL1_GetCurrentTimerValue(void)
+{
+  return(__get_CNTV_TVAL());
+}
+
+/** \brief Get the current virtual count value.
+* \return Current virtual count value.
+*/
+__STATIC_INLINE uint64_t VL1_GetCurrentCountValue(void)
+{
+  return(__get_CNTVCT());
+}
+
+/** \brief Set the virtual timer compare value.
+* \param [in] value New virtual timer compare value.
+*/
+__STATIC_INLINE void VL1_SetTimerCompareValue(uint64_t value)
+{
+  __set_CNTV_CVAL(value);
+  __ISB();
+}
+
+/** \brief Get the virtual timer compare value.
+* \return Virtual timer compare value.
+*/
+__STATIC_INLINE uint64_t VL1_GetTimerCompareValue(void)
+{
+  return(__get_CNTV_CVAL());
+}
+
+/** \brief Configure the virtual timer by setting the control value.
+* \param [in] value New virtual timer control value.
+*/
+__STATIC_INLINE void VL1_SetControl(uint32_t value)
+{
+  __set_CNTV_CTL(value);
+  __ISB();
+}
+
+/** \brief Get the virtual timer control value.
+* \return Virtual timer control value.
+*/
+__STATIC_INLINE uint32_t VL1_GetControl(void)
+{
+  return(__get_CNTV_CTL());
+}
+/***************************** VIRTUAL TIMER END *****************************/
+#endif
+
+/* Private Timer */
+#if ((__CORTEX_A == 5U) || (__CORTEX_A == 9U)) || defined(DOXYGEN)
+/** \brief Set the load value to timers LOAD register.
+* \param [in] value The load value to be set.
+*/
+__STATIC_INLINE void PTIM_SetLoadValue(uint32_t value)
+{
+  PTIM->LOAD = value;
+}
+
+/** \brief Get the load value from timers LOAD register.
+* \return Timer_Type::LOAD
+*/
+__STATIC_INLINE uint32_t PTIM_GetLoadValue(void)
+{
+  return(PTIM->LOAD);
+}
+
+/** \brief Set current counter value from its COUNTER register.
+*/
+__STATIC_INLINE void PTIM_SetCurrentValue(uint32_t value)
+{
+  PTIM->COUNTER = value;
+}
+
+/** \brief Get current counter value from timers COUNTER register.
+* \result Timer_Type::COUNTER
+*/
+__STATIC_INLINE uint32_t PTIM_GetCurrentValue(void)
+{
+  return(PTIM->COUNTER);
+}
+
+/** \brief Configure the timer using its CONTROL register.
+* \param [in] value The new configuration value to be set.
+*/
+__STATIC_INLINE void PTIM_SetControl(uint32_t value)
+{
+  PTIM->CONTROL = value;
+}
+
+/** ref Timer_Type::CONTROL Get the current timer configuration from its CONTROL register.
+* \return Timer_Type::CONTROL
+*/
+__STATIC_INLINE uint32_t PTIM_GetControl(void)
+{
+  return(PTIM->CONTROL);
+}
+
+/** ref Timer_Type::CONTROL Get the event flag in timers ISR register.
+* \return 0 - flag is not set, 1- flag is set
+*/
+__STATIC_INLINE uint32_t PTIM_GetEventFlag(void)
+{
+  return (PTIM->ISR & 1UL);
+}
+
+/** ref Timer_Type::CONTROL Clears the event flag in timers ISR register.
+*/
+__STATIC_INLINE void PTIM_ClearEventFlag(void)
+{
+  PTIM->ISR = 1;
+}
+#endif
+#endif
+
+/* ##########################  MMU functions  ###################################### */
+
+#define SECTION_DESCRIPTOR      (0x2)
+#define SECTION_MASK            (0xFFFFFFFC)
+
+#define SECTION_TEXCB_MASK      (0xFFFF8FF3)
+#define SECTION_B_SHIFT         (2)
+#define SECTION_C_SHIFT         (3)
+#define SECTION_TEX0_SHIFT      (12)
+#define SECTION_TEX1_SHIFT      (13)
+#define SECTION_TEX2_SHIFT      (14)
+
+#define SECTION_XN_MASK         (0xFFFFFFEF)
+#define SECTION_XN_SHIFT        (4)
+
+#define SECTION_DOMAIN_MASK     (0xFFFFFE1F)
+#define SECTION_DOMAIN_SHIFT    (5)
+
+#define SECTION_P_MASK          (0xFFFFFDFF)
+#define SECTION_P_SHIFT         (9)
+
+#define SECTION_AP_MASK         (0xFFFF73FF)
+#define SECTION_AP_SHIFT        (10)
+#define SECTION_AP2_SHIFT       (15)
+
+#define SECTION_S_MASK          (0xFFFEFFFF)
+#define SECTION_S_SHIFT         (16)
+
+#define SECTION_NG_MASK         (0xFFFDFFFF)
+#define SECTION_NG_SHIFT        (17)
+
+#define SECTION_NS_MASK         (0xFFF7FFFF)
+#define SECTION_NS_SHIFT        (19)
+
+#define PAGE_L1_DESCRIPTOR      (0x1)
+#define PAGE_L1_MASK            (0xFFFFFFFC)
+
+#define PAGE_L2_4K_DESC         (0x2)
+#define PAGE_L2_4K_MASK         (0xFFFFFFFD)
+
+#define PAGE_L2_64K_DESC        (0x1)
+#define PAGE_L2_64K_MASK        (0xFFFFFFFC)
+
+#define PAGE_4K_TEXCB_MASK      (0xFFFFFE33)
+#define PAGE_4K_B_SHIFT         (2)
+#define PAGE_4K_C_SHIFT         (3)
+#define PAGE_4K_TEX0_SHIFT      (6)
+#define PAGE_4K_TEX1_SHIFT      (7)
+#define PAGE_4K_TEX2_SHIFT      (8)
+
+#define PAGE_64K_TEXCB_MASK     (0xFFFF8FF3)
+#define PAGE_64K_B_SHIFT        (2)
+#define PAGE_64K_C_SHIFT        (3)
+#define PAGE_64K_TEX0_SHIFT     (12)
+#define PAGE_64K_TEX1_SHIFT     (13)
+#define PAGE_64K_TEX2_SHIFT     (14)
+
+#define PAGE_TEXCB_MASK         (0xFFFF8FF3)
+#define PAGE_B_SHIFT            (2)
+#define PAGE_C_SHIFT            (3)
+#define PAGE_TEX_SHIFT          (12)
+
+#define PAGE_XN_4K_MASK         (0xFFFFFFFE)
+#define PAGE_XN_4K_SHIFT        (0)
+#define PAGE_XN_64K_MASK        (0xFFFF7FFF)
+#define PAGE_XN_64K_SHIFT       (15)
+
+#define PAGE_DOMAIN_MASK        (0xFFFFFE1F)
+#define PAGE_DOMAIN_SHIFT       (5)
+
+#define PAGE_P_MASK             (0xFFFFFDFF)
+#define PAGE_P_SHIFT            (9)
+
+#define PAGE_AP_MASK            (0xFFFFFDCF)
+#define PAGE_AP_SHIFT           (4)
+#define PAGE_AP2_SHIFT          (9)
+
+#define PAGE_S_MASK             (0xFFFFFBFF)
+#define PAGE_S_SHIFT            (10)
+
+#define PAGE_NG_MASK            (0xFFFFF7FF)
+#define PAGE_NG_SHIFT           (11)
+
+#define PAGE_NS_MASK            (0xFFFFFFF7)
+#define PAGE_NS_SHIFT           (3)
+
+#define OFFSET_1M               (0x00100000)
+#define OFFSET_64K              (0x00010000)
+#define OFFSET_4K               (0x00001000)
+
+#define DESCRIPTOR_FAULT        (0x00000000)
+
+/* Attributes enumerations */
+
+/* Region size attributes */
+typedef enum
+{
+   SECTION,
+   PAGE_4k,
+   PAGE_64k,
+} mmu_region_size_Type;
+
+/* Region type attributes */
+typedef enum
+{
+   NORMAL,
+   DEVICE,
+   SHARED_DEVICE,
+   NON_SHARED_DEVICE,
+   STRONGLY_ORDERED
+} mmu_memory_Type;
+
+/* Region cacheability attributes */
+typedef enum
+{
+   NON_CACHEABLE,
+   WB_WA,
+   WT,
+   WB_NO_WA,
+} mmu_cacheability_Type;
+
+/* Region parity check attributes */
+typedef enum
+{
+   ECC_DISABLED,
+   ECC_ENABLED,
+} mmu_ecc_check_Type;
+
+/* Region execution attributes */
+typedef enum
+{
+   EXECUTE,
+   NON_EXECUTE,
+} mmu_execute_Type;
+
+/* Region global attributes */
+typedef enum
+{
+   GLOBAL,
+   NON_GLOBAL,
+} mmu_global_Type;
+
+/* Region shareability attributes */
+typedef enum
+{
+   NON_SHARED,
+   SHARED,
+} mmu_shared_Type;
+
+/* Region security attributes */
+typedef enum
+{
+   SECURE,
+   NON_SECURE,
+} mmu_secure_Type;
+
+/* Region access attributes */
+typedef enum
+{
+   NO_ACCESS,
+   RW,
+   READ,
+} mmu_access_Type;
+
+/* Memory Region definition */
+typedef struct RegionStruct {
+    mmu_region_size_Type rg_t;
+    mmu_memory_Type mem_t;
+    uint8_t domain;
+    mmu_cacheability_Type inner_norm_t;
+    mmu_cacheability_Type outer_norm_t;
+    mmu_ecc_check_Type e_t;
+    mmu_execute_Type xn_t;
+    mmu_global_Type g_t;
+    mmu_secure_Type sec_t;
+    mmu_access_Type priv_t;
+    mmu_access_Type user_t;
+    mmu_shared_Type sh_t;
+
+} mmu_region_attributes_Type;
+
+//Following macros define the descriptors and attributes
+//Sect_Normal. Outer & inner wb/wa, non-shareable, executable, rw, domain 0
+#define section_normal(descriptor_l1, region)     region.rg_t = SECTION; \
+                                   region.domain = 0x0; \
+                                   region.e_t = ECC_DISABLED; \
+                                   region.g_t = GLOBAL; \
+                                   region.inner_norm_t = WB_WA; \
+                                   region.outer_norm_t = WB_WA; \
+                                   region.mem_t = NORMAL; \
+                                   region.sec_t = SECURE; \
+                                   region.xn_t = EXECUTE; \
+                                   region.priv_t = RW; \
+                                   region.user_t = RW; \
+                                   region.sh_t = NON_SHARED; \
+                                   MMU_GetSectionDescriptor(&descriptor_l1, region);
+
+//Sect_Normal_NC. Outer & inner non-cacheable, non-shareable, executable, rw, domain 0
+#define section_normal_nc(descriptor_l1, region)     region.rg_t = SECTION; \
+                                   region.domain = 0x0; \
+                                   region.e_t = ECC_DISABLED; \
+                                   region.g_t = GLOBAL; \
+                                   region.inner_norm_t = NON_CACHEABLE; \
+                                   region.outer_norm_t = NON_CACHEABLE; \
+                                   region.mem_t = NORMAL; \
+                                   region.sec_t = SECURE; \
+                                   region.xn_t = EXECUTE; \
+                                   region.priv_t = RW; \
+                                   region.user_t = RW; \
+                                   region.sh_t = NON_SHARED; \
+                                   MMU_GetSectionDescriptor(&descriptor_l1, region);
+
+//Sect_Normal_Cod. Outer & inner wb/wa, non-shareable, executable, ro, domain 0
+#define section_normal_cod(descriptor_l1, region) region.rg_t = SECTION; \
+                                   region.domain = 0x0; \
+                                   region.e_t = ECC_DISABLED; \
+                                   region.g_t = GLOBAL; \
+                                   region.inner_norm_t = WB_WA; \
+                                   region.outer_norm_t = WB_WA; \
+                                   region.mem_t = NORMAL; \
+                                   region.sec_t = SECURE; \
+                                   region.xn_t = EXECUTE; \
+                                   region.priv_t = READ; \
+                                   region.user_t = READ; \
+                                   region.sh_t = NON_SHARED; \
+                                   MMU_GetSectionDescriptor(&descriptor_l1, region);
+
+//Sect_Normal_RO. Sect_Normal_Cod, but not executable
+#define section_normal_ro(descriptor_l1, region)  region.rg_t = SECTION; \
+                                   region.domain = 0x0; \
+                                   region.e_t = ECC_DISABLED; \
+                                   region.g_t = GLOBAL; \
+                                   region.inner_norm_t = WB_WA; \
+                                   region.outer_norm_t = WB_WA; \
+                                   region.mem_t = NORMAL; \
+                                   region.sec_t = SECURE; \
+                                   region.xn_t = NON_EXECUTE; \
+                                   region.priv_t = READ; \
+                                   region.user_t = READ; \
+                                   region.sh_t = NON_SHARED; \
+                                   MMU_GetSectionDescriptor(&descriptor_l1, region);
+
+//Sect_Normal_RW. Sect_Normal_Cod, but writeable and not executable
+#define section_normal_rw(descriptor_l1, region) region.rg_t = SECTION; \
+                                   region.domain = 0x0; \
+                                   region.e_t = ECC_DISABLED; \
+                                   region.g_t = GLOBAL; \
+                                   region.inner_norm_t = WB_WA; \
+                                   region.outer_norm_t = WB_WA; \
+                                   region.mem_t = NORMAL; \
+                                   region.sec_t = SECURE; \
+                                   region.xn_t = NON_EXECUTE; \
+                                   region.priv_t = RW; \
+                                   region.user_t = RW; \
+                                   region.sh_t = NON_SHARED; \
+                                   MMU_GetSectionDescriptor(&descriptor_l1, region);
+//Sect_SO. Strongly-ordered (therefore shareable), not executable, rw, domain 0, base addr 0
+#define section_so(descriptor_l1, region) region.rg_t = SECTION; \
+                                   region.domain = 0x0; \
+                                   region.e_t = ECC_DISABLED; \
+                                   region.g_t = GLOBAL; \
+                                   region.inner_norm_t = NON_CACHEABLE; \
+                                   region.outer_norm_t = NON_CACHEABLE; \
+                                   region.mem_t = STRONGLY_ORDERED; \
+                                   region.sec_t = SECURE; \
+                                   region.xn_t = NON_EXECUTE; \
+                                   region.priv_t = RW; \
+                                   region.user_t = RW; \
+                                   region.sh_t = NON_SHARED; \
+                                   MMU_GetSectionDescriptor(&descriptor_l1, region);
+
+//Sect_Device_RO. Device, non-shareable, non-executable, ro, domain 0, base addr 0
+#define section_device_ro(descriptor_l1, region) region.rg_t = SECTION; \
+                                   region.domain = 0x0; \
+                                   region.e_t = ECC_DISABLED; \
+                                   region.g_t = GLOBAL; \
+                                   region.inner_norm_t = NON_CACHEABLE; \
+                                   region.outer_norm_t = NON_CACHEABLE; \
+                                   region.mem_t = STRONGLY_ORDERED; \
+                                   region.sec_t = SECURE; \
+                                   region.xn_t = NON_EXECUTE; \
+                                   region.priv_t = READ; \
+                                   region.user_t = READ; \
+                                   region.sh_t = NON_SHARED; \
+                                   MMU_GetSectionDescriptor(&descriptor_l1, region);
+
+//Sect_Device_RW. Sect_Device_RO, but writeable
+#define section_device_rw(descriptor_l1, region) region.rg_t = SECTION; \
+                                   region.domain = 0x0; \
+                                   region.e_t = ECC_DISABLED; \
+                                   region.g_t = GLOBAL; \
+                                   region.inner_norm_t = NON_CACHEABLE; \
+                                   region.outer_norm_t = NON_CACHEABLE; \
+                                   region.mem_t = STRONGLY_ORDERED; \
+                                   region.sec_t = SECURE; \
+                                   region.xn_t = NON_EXECUTE; \
+                                   region.priv_t = RW; \
+                                   region.user_t = RW; \
+                                   region.sh_t = NON_SHARED; \
+                                   MMU_GetSectionDescriptor(&descriptor_l1, region);
+//Page_4k_Device_RW.  Shared device, not executable, rw, domain 0
+#define page4k_device_rw(descriptor_l1, descriptor_l2, region) region.rg_t = PAGE_4k; \
+                                   region.domain = 0x0; \
+                                   region.e_t = ECC_DISABLED; \
+                                   region.g_t = GLOBAL; \
+                                   region.inner_norm_t = NON_CACHEABLE; \
+                                   region.outer_norm_t = NON_CACHEABLE; \
+                                   region.mem_t = SHARED_DEVICE; \
+                                   region.sec_t = SECURE; \
+                                   region.xn_t = NON_EXECUTE; \
+                                   region.priv_t = RW; \
+                                   region.user_t = RW; \
+                                   region.sh_t = NON_SHARED; \
+                                   MMU_GetPageDescriptor(&descriptor_l1, &descriptor_l2, region);
+
+//Page_64k_Device_RW.  Shared device, not executable, rw, domain 0
+#define page64k_device_rw(descriptor_l1, descriptor_l2, region)  region.rg_t = PAGE_64k; \
+                                   region.domain = 0x0; \
+                                   region.e_t = ECC_DISABLED; \
+                                   region.g_t = GLOBAL; \
+                                   region.inner_norm_t = NON_CACHEABLE; \
+                                   region.outer_norm_t = NON_CACHEABLE; \
+                                   region.mem_t = SHARED_DEVICE; \
+                                   region.sec_t = SECURE; \
+                                   region.xn_t = NON_EXECUTE; \
+                                   region.priv_t = RW; \
+                                   region.user_t = RW; \
+                                   region.sh_t = NON_SHARED; \
+                                   MMU_GetPageDescriptor(&descriptor_l1, &descriptor_l2, region);
+
+/** \brief  Set section execution-never attribute
+
+  \param [out]    descriptor_l1  L1 descriptor.
+  \param [in]                xn  Section execution-never attribute : EXECUTE , NON_EXECUTE.
+
+  \return          0
+*/
+__STATIC_INLINE int MMU_XNSection(uint32_t *descriptor_l1, mmu_execute_Type xn)
+{
+  *descriptor_l1 &= SECTION_XN_MASK;
+  *descriptor_l1 |= ((xn & 0x1) << SECTION_XN_SHIFT);
+  return 0;
+}
+
+/** \brief  Set section domain
+
+  \param [out]    descriptor_l1  L1 descriptor.
+  \param [in]            domain  Section domain
+
+  \return          0
+*/
+__STATIC_INLINE int MMU_DomainSection(uint32_t *descriptor_l1, uint8_t domain)
+{
+  *descriptor_l1 &= SECTION_DOMAIN_MASK;
+  *descriptor_l1 |= ((domain & 0xF) << SECTION_DOMAIN_SHIFT);
+  return 0;
+}
+
+/** \brief  Set section parity check
+
+  \param [out]    descriptor_l1  L1 descriptor.
+  \param [in]              p_bit Parity check: ECC_DISABLED, ECC_ENABLED
+
+  \return          0
+*/
+__STATIC_INLINE int MMU_PSection(uint32_t *descriptor_l1, mmu_ecc_check_Type p_bit)
+{
+  *descriptor_l1 &= SECTION_P_MASK;
+  *descriptor_l1 |= ((p_bit & 0x1) << SECTION_P_SHIFT);
+  return 0;
+}
+
+/** \brief  Set section access privileges
+
+  \param [out]    descriptor_l1  L1 descriptor.
+  \param [in]              user  User Level Access: NO_ACCESS, RW, READ
+  \param [in]              priv  Privilege Level Access: NO_ACCESS, RW, READ
+  \param [in]               afe  Access flag enable
+
+  \return          0
+*/
+__STATIC_INLINE int MMU_APSection(uint32_t *descriptor_l1, mmu_access_Type user, mmu_access_Type priv, uint32_t afe)
+{
+  uint32_t ap = 0;
+
+  if (afe == 0) { //full access
+    if ((priv == NO_ACCESS) && (user == NO_ACCESS)) { ap = 0x0; }
+    else if ((priv == RW) && (user == NO_ACCESS))   { ap = 0x1; }
+    else if ((priv == RW) && (user == READ))        { ap = 0x2; }
+    else if ((priv == RW) && (user == RW))          { ap = 0x3; }
+    else if ((priv == READ) && (user == NO_ACCESS)) { ap = 0x5; }
+    else if ((priv == READ) && (user == READ))      { ap = 0x7; }
+  }
+
+  else { //Simplified access
+    if ((priv == RW) && (user == NO_ACCESS))        { ap = 0x1; }
+    else if ((priv == RW) && (user == RW))          { ap = 0x3; }
+    else if ((priv == READ) && (user == NO_ACCESS)) { ap = 0x5; }
+    else if ((priv == READ) && (user == READ))      { ap = 0x7; }
+  }
+
+  *descriptor_l1 &= SECTION_AP_MASK;
+  *descriptor_l1 |= (ap & 0x3) << SECTION_AP_SHIFT;
+  *descriptor_l1 |= ((ap & 0x4)>>2) << SECTION_AP2_SHIFT;
+
+  return 0;
+}
+
+/** \brief  Set section shareability
+
+  \param [out]    descriptor_l1  L1 descriptor.
+  \param [in]             s_bit  Section shareability: NON_SHARED, SHARED
+
+  \return          0
+*/
+__STATIC_INLINE int MMU_SharedSection(uint32_t *descriptor_l1, mmu_shared_Type s_bit)
+{
+  *descriptor_l1 &= SECTION_S_MASK;
+  *descriptor_l1 |= ((s_bit & 0x1) << SECTION_S_SHIFT);
+  return 0;
+}
+
+/** \brief  Set section Global attribute
+
+  \param [out]    descriptor_l1  L1 descriptor.
+  \param [in]             g_bit  Section attribute: GLOBAL, NON_GLOBAL
+
+  \return          0
+*/
+__STATIC_INLINE int MMU_GlobalSection(uint32_t *descriptor_l1, mmu_global_Type g_bit)
+{
+  *descriptor_l1 &= SECTION_NG_MASK;
+  *descriptor_l1 |= ((g_bit & 0x1) << SECTION_NG_SHIFT);
+  return 0;
+}
+
+/** \brief  Set section Security attribute
+
+  \param [out]    descriptor_l1  L1 descriptor.
+  \param [in]             s_bit  Section Security attribute: SECURE, NON_SECURE
+
+  \return          0
+*/
+__STATIC_INLINE int MMU_SecureSection(uint32_t *descriptor_l1, mmu_secure_Type s_bit)
+{
+  *descriptor_l1 &= SECTION_NS_MASK;
+  *descriptor_l1 |= ((s_bit & 0x1) << SECTION_NS_SHIFT);
+  return 0;
+}
+
+/* Page 4k or 64k */
+/** \brief  Set 4k/64k page execution-never attribute
+
+  \param [out]    descriptor_l2  L2 descriptor.
+  \param [in]                xn  Page execution-never attribute : EXECUTE , NON_EXECUTE.
+  \param [in]              page  Page size: PAGE_4k, PAGE_64k,
+
+  \return          0
+*/
+__STATIC_INLINE int MMU_XNPage(uint32_t *descriptor_l2, mmu_execute_Type xn, mmu_region_size_Type page)
+{
+  if (page == PAGE_4k)
+  {
+      *descriptor_l2 &= PAGE_XN_4K_MASK;
+      *descriptor_l2 |= ((xn & 0x1) << PAGE_XN_4K_SHIFT);
+  }
+  else
+  {
+      *descriptor_l2 &= PAGE_XN_64K_MASK;
+      *descriptor_l2 |= ((xn & 0x1) << PAGE_XN_64K_SHIFT);
+  }
+  return 0;
+}
+
+/** \brief  Set 4k/64k page domain
+
+  \param [out]    descriptor_l1  L1 descriptor.
+  \param [in]            domain  Page domain
+
+  \return          0
+*/
+__STATIC_INLINE int MMU_DomainPage(uint32_t *descriptor_l1, uint8_t domain)
+{
+  *descriptor_l1 &= PAGE_DOMAIN_MASK;
+  *descriptor_l1 |= ((domain & 0xf) << PAGE_DOMAIN_SHIFT);
+  return 0;
+}
+
+/** \brief  Set 4k/64k page parity check
+
+  \param [out]    descriptor_l1  L1 descriptor.
+  \param [in]              p_bit Parity check: ECC_DISABLED, ECC_ENABLED
+
+  \return          0
+*/
+__STATIC_INLINE int MMU_PPage(uint32_t *descriptor_l1, mmu_ecc_check_Type p_bit)
+{
+  *descriptor_l1 &= SECTION_P_MASK;
+  *descriptor_l1 |= ((p_bit & 0x1) << SECTION_P_SHIFT);
+  return 0;
+}
+
+/** \brief  Set 4k/64k page access privileges
+
+  \param [out]    descriptor_l2  L2 descriptor.
+  \param [in]              user  User Level Access: NO_ACCESS, RW, READ
+  \param [in]              priv  Privilege Level Access: NO_ACCESS, RW, READ
+  \param [in]               afe  Access flag enable
+
+  \return          0
+*/
+__STATIC_INLINE int MMU_APPage(uint32_t *descriptor_l2, mmu_access_Type user, mmu_access_Type priv, uint32_t afe)
+{
+  uint32_t ap = 0;
+
+  if (afe == 0) { //full access
+    if ((priv == NO_ACCESS) && (user == NO_ACCESS)) { ap = 0x0; }
+    else if ((priv == RW) && (user == NO_ACCESS))   { ap = 0x1; }
+    else if ((priv == RW) && (user == READ))        { ap = 0x2; }
+    else if ((priv == RW) && (user == RW))          { ap = 0x3; }
+    else if ((priv == READ) && (user == NO_ACCESS)) { ap = 0x5; }
+    else if ((priv == READ) && (user == READ))      { ap = 0x6; }
+  }
+
+  else { //Simplified access
+    if ((priv == RW) && (user == NO_ACCESS))        { ap = 0x1; }
+    else if ((priv == RW) && (user == RW))          { ap = 0x3; }
+    else if ((priv == READ) && (user == NO_ACCESS)) { ap = 0x5; }
+    else if ((priv == READ) && (user == READ))      { ap = 0x7; }
+  }
+
+  *descriptor_l2 &= PAGE_AP_MASK;
+  *descriptor_l2 |= (ap & 0x3) << PAGE_AP_SHIFT;
+  *descriptor_l2 |= ((ap & 0x4)>>2) << PAGE_AP2_SHIFT;
+
+  return 0;
+}
+
+/** \brief  Set 4k/64k page shareability
+
+  \param [out]    descriptor_l2  L2 descriptor.
+  \param [in]             s_bit  4k/64k page shareability: NON_SHARED, SHARED
+
+  \return          0
+*/
+__STATIC_INLINE int MMU_SharedPage(uint32_t *descriptor_l2, mmu_shared_Type s_bit)
+{
+  *descriptor_l2 &= PAGE_S_MASK;
+  *descriptor_l2 |= ((s_bit & 0x1) << PAGE_S_SHIFT);
+  return 0;
+}
+
+/** \brief  Set 4k/64k page Global attribute
+
+  \param [out]    descriptor_l2  L2 descriptor.
+  \param [in]             g_bit  4k/64k page attribute: GLOBAL, NON_GLOBAL
+
+  \return          0
+*/
+__STATIC_INLINE int MMU_GlobalPage(uint32_t *descriptor_l2, mmu_global_Type g_bit)
+{
+  *descriptor_l2 &= PAGE_NG_MASK;
+  *descriptor_l2 |= ((g_bit & 0x1) << PAGE_NG_SHIFT);
+  return 0;
+}
+
+/** \brief  Set 4k/64k page Security attribute
+
+  \param [out]    descriptor_l1  L1 descriptor.
+  \param [in]             s_bit  4k/64k page Security attribute: SECURE, NON_SECURE
+
+  \return          0
+*/
+__STATIC_INLINE int MMU_SecurePage(uint32_t *descriptor_l1, mmu_secure_Type s_bit)
+{
+  *descriptor_l1 &= PAGE_NS_MASK;
+  *descriptor_l1 |= ((s_bit & 0x1) << PAGE_NS_SHIFT);
+  return 0;
+}
+
+/** \brief  Set Section memory attributes
+
+  \param [out]    descriptor_l1  L1 descriptor.
+  \param [in]               mem  Section memory type: NORMAL, DEVICE, SHARED_DEVICE, NON_SHARED_DEVICE, STRONGLY_ORDERED
+  \param [in]             outer  Outer cacheability: NON_CACHEABLE, WB_WA, WT, WB_NO_WA,
+  \param [in]             inner  Inner cacheability: NON_CACHEABLE, WB_WA, WT, WB_NO_WA,
+
+  \return          0
+*/
+__STATIC_INLINE int MMU_MemorySection(uint32_t *descriptor_l1, mmu_memory_Type mem, mmu_cacheability_Type outer, mmu_cacheability_Type inner)
+{
+  *descriptor_l1 &= SECTION_TEXCB_MASK;
+
+  if (STRONGLY_ORDERED == mem)
+  {
+    return 0;
+  }
+  else if (SHARED_DEVICE == mem)
+  {
+    *descriptor_l1 |= (1 << SECTION_B_SHIFT);
+  }
+  else if (NON_SHARED_DEVICE == mem)
+  {
+    *descriptor_l1 |= (1 << SECTION_TEX1_SHIFT);
+  }
+  else if (NORMAL == mem)
+  {
+   *descriptor_l1 |= 1 << SECTION_TEX2_SHIFT;
+   switch(inner)
+   {
+      case NON_CACHEABLE:
+        break;
+      case WB_WA:
+        *descriptor_l1 |= (1 << SECTION_B_SHIFT);
+        break;
+      case WT:
+        *descriptor_l1 |= 1 << SECTION_C_SHIFT;
+        break;
+      case WB_NO_WA:
+        *descriptor_l1 |= (1 << SECTION_B_SHIFT) | (1 << SECTION_C_SHIFT);
+        break;
+    }
+    switch(outer)
+    {
+      case NON_CACHEABLE:
+        break;
+      case WB_WA:
+        *descriptor_l1 |= (1 << SECTION_TEX0_SHIFT);
+        break;
+      case WT:
+        *descriptor_l1 |= 1 << SECTION_TEX1_SHIFT;
+        break;
+      case WB_NO_WA:
+        *descriptor_l1 |= (1 << SECTION_TEX0_SHIFT) | (1 << SECTION_TEX0_SHIFT);
+        break;
+    }
+  }
+  return 0;
+}
+
+/** \brief  Set 4k/64k page memory attributes
+
+  \param [out]    descriptor_l2  L2 descriptor.
+  \param [in]               mem  4k/64k page memory type: NORMAL, DEVICE, SHARED_DEVICE, NON_SHARED_DEVICE, STRONGLY_ORDERED
+  \param [in]             outer  Outer cacheability: NON_CACHEABLE, WB_WA, WT, WB_NO_WA,
+  \param [in]             inner  Inner cacheability: NON_CACHEABLE, WB_WA, WT, WB_NO_WA,
+  \param [in]              page  Page size
+
+  \return          0
+*/
+__STATIC_INLINE int MMU_MemoryPage(uint32_t *descriptor_l2, mmu_memory_Type mem, mmu_cacheability_Type outer, mmu_cacheability_Type inner, mmu_region_size_Type page)
+{
+  *descriptor_l2 &= PAGE_4K_TEXCB_MASK;
+
+  if (page == PAGE_64k)
+  {
+    //same as section
+    MMU_MemorySection(descriptor_l2, mem, outer, inner);
+  }
+  else
+  {
+    if (STRONGLY_ORDERED == mem)
+    {
+      return 0;
+    }
+    else if (SHARED_DEVICE == mem)
+    {
+      *descriptor_l2 |= (1 << PAGE_4K_B_SHIFT);
+    }
+    else if (NON_SHARED_DEVICE == mem)
+    {
+      *descriptor_l2 |= (1 << PAGE_4K_TEX1_SHIFT);
+    }
+    else if (NORMAL == mem)
+    {
+      *descriptor_l2 |= 1 << PAGE_4K_TEX2_SHIFT;
+      switch(inner)
+      {
+        case NON_CACHEABLE:
+          break;
+        case WB_WA:
+          *descriptor_l2 |= (1 << PAGE_4K_B_SHIFT);
+          break;
+        case WT:
+          *descriptor_l2 |= 1 << PAGE_4K_C_SHIFT;
+          break;
+        case WB_NO_WA:
+          *descriptor_l2 |= (1 << PAGE_4K_B_SHIFT) | (1 << PAGE_4K_C_SHIFT);
+          break;
+      }
+      switch(outer)
+      {
+        case NON_CACHEABLE:
+          break;
+        case WB_WA:
+          *descriptor_l2 |= (1 << PAGE_4K_TEX0_SHIFT);
+          break;
+        case WT:
+          *descriptor_l2 |= 1 << PAGE_4K_TEX1_SHIFT;
+          break;
+        case WB_NO_WA:
+          *descriptor_l2 |= (1 << PAGE_4K_TEX0_SHIFT) | (1 << PAGE_4K_TEX0_SHIFT);
+          break;
+      }
+    }
+  }
+
+  return 0;
+}
+
+/** \brief  Create a L1 section descriptor
+
+  \param [out]     descriptor  L1 descriptor
+  \param [in]      reg  Section attributes
+
+  \return          0
+*/
+__STATIC_INLINE int MMU_GetSectionDescriptor(uint32_t *descriptor, mmu_region_attributes_Type reg)
+{
+  *descriptor  = 0;
+
+  MMU_MemorySection(descriptor, reg.mem_t, reg.outer_norm_t, reg.inner_norm_t);
+  MMU_XNSection(descriptor,reg.xn_t);
+  MMU_DomainSection(descriptor, reg.domain);
+  MMU_PSection(descriptor, reg.e_t);
+  MMU_APSection(descriptor, reg.user_t, reg.priv_t, 1);
+  MMU_SharedSection(descriptor,reg.sh_t);
+  MMU_GlobalSection(descriptor,reg.g_t);
+  MMU_SecureSection(descriptor,reg.sec_t);
+  *descriptor &= SECTION_MASK;
+  *descriptor |= SECTION_DESCRIPTOR;
+
+  return 0;
+}
+
+
+/** \brief  Create a L1 and L2 4k/64k page descriptor
+
+  \param [out]       descriptor  L1 descriptor
+  \param [out]      descriptor2  L2 descriptor
+  \param [in]               reg  4k/64k page attributes
+
+  \return          0
+*/
+__STATIC_INLINE int MMU_GetPageDescriptor(uint32_t *descriptor, uint32_t *descriptor2, mmu_region_attributes_Type reg)
+{
+  *descriptor  = 0;
+  *descriptor2 = 0;
+
+  switch (reg.rg_t)
+  {
+    case PAGE_4k:
+      MMU_MemoryPage(descriptor2, reg.mem_t, reg.outer_norm_t, reg.inner_norm_t, PAGE_4k);
+      MMU_XNPage(descriptor2, reg.xn_t, PAGE_4k);
+      MMU_DomainPage(descriptor, reg.domain);
+      MMU_PPage(descriptor, reg.e_t);
+      MMU_APPage(descriptor2, reg.user_t, reg.priv_t, 1);
+      MMU_SharedPage(descriptor2,reg.sh_t);
+      MMU_GlobalPage(descriptor2,reg.g_t);
+      MMU_SecurePage(descriptor,reg.sec_t);
+      *descriptor &= PAGE_L1_MASK;
+      *descriptor |= PAGE_L1_DESCRIPTOR;
+      *descriptor2 &= PAGE_L2_4K_MASK;
+      *descriptor2 |= PAGE_L2_4K_DESC;
+      break;
+
+    case PAGE_64k:
+      MMU_MemoryPage(descriptor2, reg.mem_t, reg.outer_norm_t, reg.inner_norm_t, PAGE_64k);
+      MMU_XNPage(descriptor2, reg.xn_t, PAGE_64k);
+      MMU_DomainPage(descriptor, reg.domain);
+      MMU_PPage(descriptor, reg.e_t);
+      MMU_APPage(descriptor2, reg.user_t, reg.priv_t, 1);
+      MMU_SharedPage(descriptor2,reg.sh_t);
+      MMU_GlobalPage(descriptor2,reg.g_t);
+      MMU_SecurePage(descriptor,reg.sec_t);
+      *descriptor &= PAGE_L1_MASK;
+      *descriptor |= PAGE_L1_DESCRIPTOR;
+      *descriptor2 &= PAGE_L2_64K_MASK;
+      *descriptor2 |= PAGE_L2_64K_DESC;
+      break;
+
+    case SECTION:
+      //error
+      break;
+  }
+
+  return 0;
+}
+
+/** \brief  Create a 1MB Section
+
+  \param [in]               ttb  Translation table base address
+  \param [in]      base_address  Section base address
+  \param [in]             count  Number of sections to create
+  \param [in]     descriptor_l1  L1 descriptor (region attributes)
+
+*/
+__STATIC_INLINE void MMU_TTSection(uint32_t *ttb, uint32_t base_address, uint32_t count, uint32_t descriptor_l1)
+{
+  uint32_t offset;
+  uint32_t entry;
+  uint32_t i;
+
+  offset = base_address >> 20;
+  entry  = (base_address & 0xFFF00000) | descriptor_l1;
+
+  //4 bytes aligned
+  ttb = ttb + offset;
+
+  for (i = 0; i < count; i++ )
+  {
+    //4 bytes aligned
+    *ttb++ = entry;
+    entry += OFFSET_1M;
+  }
+}
+
+/** \brief  Create a 4k page entry
+
+  \param [in]               ttb  L1 table base address
+  \param [in]      base_address  4k base address
+  \param [in]             count  Number of 4k pages to create
+  \param [in]     descriptor_l1  L1 descriptor (region attributes)
+  \param [in]            ttb_l2  L2 table base address
+  \param [in]     descriptor_l2  L2 descriptor (region attributes)
+
+*/
+__STATIC_INLINE void MMU_TTPage4k(uint32_t *ttb, uint32_t base_address, uint32_t count, uint32_t descriptor_l1, uint32_t *ttb_l2, uint32_t descriptor_l2 )
+{
+
+  uint32_t offset, offset2;
+  uint32_t entry, entry2;
+  uint32_t i;
+
+  offset = base_address >> 20;
+  entry  = ((int)ttb_l2 & 0xFFFFFC00) | descriptor_l1;
+
+  //4 bytes aligned
+  ttb += offset;
+  //create l1_entry
+  *ttb = entry;
+
+  offset2 = (base_address & 0xff000) >> 12;
+  ttb_l2 += offset2;
+  entry2 = (base_address & 0xFFFFF000) | descriptor_l2;
+  for (i = 0; i < count; i++ )
+  {
+    //4 bytes aligned
+    *ttb_l2++ = entry2;
+    entry2 += OFFSET_4K;
+  }
+}
+
+/** \brief  Create a 64k page entry
+
+  \param [in]               ttb  L1 table base address
+  \param [in]      base_address  64k base address
+  \param [in]             count  Number of 64k pages to create
+  \param [in]     descriptor_l1  L1 descriptor (region attributes)
+  \param [in]            ttb_l2  L2 table base address
+  \param [in]     descriptor_l2  L2 descriptor (region attributes)
+
+*/
+__STATIC_INLINE void MMU_TTPage64k(uint32_t *ttb, uint32_t base_address, uint32_t count, uint32_t descriptor_l1, uint32_t *ttb_l2, uint32_t descriptor_l2 )
+{
+  uint32_t offset, offset2;
+  uint32_t entry, entry2;
+  uint32_t i,j;
+
+
+  offset = base_address >> 20;
+  entry  = ((int)ttb_l2 & 0xFFFFFC00) | descriptor_l1;
+
+  //4 bytes aligned
+  ttb += offset;
+  //create l1_entry
+  *ttb = entry;
+
+  offset2 = (base_address & 0xff000) >> 12;
+  ttb_l2 += offset2;
+  entry2 = (base_address & 0xFFFF0000) | descriptor_l2;
+  for (i = 0; i < count; i++ )
+  {
+    //create 16 entries
+    for (j = 0; j < 16; j++)
+    {
+      //4 bytes aligned
+      *ttb_l2++ = entry2;
+    }
+    entry2 += OFFSET_64K;
+  }
+}
+
+/** \brief  Enable MMU
+*/
+__STATIC_INLINE void MMU_Enable(void)
+{
+  // Set M bit 0 to enable the MMU
+  // Set AFE bit to enable simplified access permissions model
+  // Clear TRE bit to disable TEX remap and A bit to disable strict alignment fault checking
+  __set_SCTLR( (__get_SCTLR() & ~(1 << 28) & ~(1 << 1)) | 1 | (1 << 29));
+  __ISB();
+}
+
+/** \brief  Disable MMU
+*/
+__STATIC_INLINE void MMU_Disable(void)
+{
+  // Clear M bit 0 to disable the MMU
+  __set_SCTLR( __get_SCTLR() & ~1);
+  __ISB();
+}
+
+/** \brief  Invalidate entire unified TLB
+*/
+
+__STATIC_INLINE void MMU_InvalidateTLB(void)
+{
+  __set_TLBIALL(0);
+  __DSB();     //ensure completion of the invalidation
+  __ISB();     //ensure instruction fetch path sees new state
+}
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_CA_H_DEPENDANT */
+
+#endif /* __CMSIS_GENERIC */

--- a/platform/ext/cmsis/CMSIS/Core/Include/core_cm0.h
+++ b/platform/ext/cmsis/CMSIS/Core/Include/core_cm0.h
@@ -1,0 +1,961 @@
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS Cortex-M0 Core Peripheral Access Layer Header File
+ */
+
+#if   defined ( __ICCARM__ )
+  #pragma system_include                        /* treat file as system include file for MISRA check */
+#elif defined (__clang__)
+  #pragma clang system_header                   /* treat file as system include file */
+#elif defined ( __GNUC__ )
+  #pragma GCC diagnostic ignored "-Wpedantic"   /* disable pedantic warning due to unnamed structs/unions */
+#endif
+
+#ifndef __CORE_CM0_H_GENERIC
+#define __CORE_CM0_H_GENERIC
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/**
+  \page CMSIS_MISRA_Exceptions  MISRA-C:2004 Compliance Exceptions
+  CMSIS violates the following MISRA-C:2004 rules:
+
+   \li Required Rule 8.5, object/function definition in header file.<br>
+     Function definitions in header files are used to allow 'inlining'.
+
+   \li Required Rule 18.4, declaration of union type or object of union type: '{...}'.<br>
+     Unions are used for effective representation of core registers.
+
+   \li Advisory Rule 19.7, Function-like macro defined.<br>
+     Function-like macros are used to allow more efficient code.
+ */
+
+
+/*******************************************************************************
+ *                 CMSIS definitions
+ ******************************************************************************/
+/**
+  \ingroup Cortex_M0
+  @{
+ */
+
+#include "cmsis_version.h"
+
+/* CMSIS CM0 definitions */
+
+#define __CORTEX_M                (0U)                                /*!< Cortex-M Core */
+
+/** __FPU_USED indicates whether an FPU is used or not.
+    This core does not support an FPU at all
+*/
+#define __FPU_USED       0U
+
+#if defined ( __CC_ARM )
+  #if defined (__TARGET_FPU_VFP)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #if defined (__ARM_FP)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined (__ti__)
+  #if defined (__ARM_FP)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __GNUC__ )
+  #if defined (__VFP_FP__) && !defined(__SOFTFP__)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __ICCARM__ )
+  #if defined (__ARMVFP__)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __TI_ARM__ )
+  #if defined (__TI_VFP_SUPPORT__)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __TASKING__ )
+  #if defined (__FPU_VFP__)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __CSMC__ )
+  #if ( __CSMC__ & 0x400U)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#endif
+
+#include "cmsis_compiler.h"               /* CMSIS compiler specific defines */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_CM0_H_GENERIC */
+
+#ifndef __CMSIS_GENERIC
+
+#ifndef __CORE_CM0_H_DEPENDANT
+#define __CORE_CM0_H_DEPENDANT
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* check device defines and use defaults */
+#if defined __CHECK_DEVICE_DEFINES
+  #ifndef __CM0_REV
+    #define __CM0_REV               0x0000U
+    #warning "__CM0_REV not defined in device header file; using default!"
+  #endif
+
+  #ifndef __NVIC_PRIO_BITS
+    #define __NVIC_PRIO_BITS          2U
+    #warning "__NVIC_PRIO_BITS not defined in device header file; using default!"
+  #endif
+
+  #ifndef __Vendor_SysTickConfig
+    #define __Vendor_SysTickConfig    0U
+    #warning "__Vendor_SysTickConfig not defined in device header file; using default!"
+  #endif
+#endif
+
+/* IO definitions (access restrictions to peripheral registers) */
+/**
+    \defgroup CMSIS_glob_defs CMSIS Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+*/
+#ifdef __cplusplus
+  #define   __I     volatile             /*!< Defines 'read only' permissions */
+#else
+  #define   __I     volatile const       /*!< Defines 'read only' permissions */
+#endif
+#define     __O     volatile             /*!< Defines 'write only' permissions */
+#define     __IO    volatile             /*!< Defines 'read / write' permissions */
+
+/* following defines should be used for structure members */
+#define     __IM     volatile const      /*! Defines 'read only' structure member permissions */
+#define     __OM     volatile            /*! Defines 'write only' structure member permissions */
+#define     __IOM    volatile            /*! Defines 'read / write' structure member permissions */
+
+/*@} end of group Cortex_M0 */
+
+
+
+/*******************************************************************************
+ *                 Register Abstraction
+  Core Register contain:
+  - Core Register
+  - Core NVIC Register
+  - Core SCB Register
+  - Core SysTick Register
+ ******************************************************************************/
+/**
+  \defgroup CMSIS_core_register Defines and Type Definitions
+  \brief Type definitions and defines for Cortex-M processor based devices.
+*/
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_CORE  Status and Control Registers
+  \brief      Core Register type definitions.
+  @{
+ */
+
+/**
+  \brief  Union type to access the Application Program Status Register (APSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t _reserved0:28;              /*!< bit:  0..27  Reserved */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} APSR_Type;
+
+/** \brief APSR Register Definitions */
+#define APSR_N_Pos                         31U                                            /*!< APSR: N Position */
+#define APSR_N_Msk                         (1UL << APSR_N_Pos)                            /*!< APSR: N Mask */
+
+#define APSR_Z_Pos                         30U                                            /*!< APSR: Z Position */
+#define APSR_Z_Msk                         (1UL << APSR_Z_Pos)                            /*!< APSR: Z Mask */
+
+#define APSR_C_Pos                         29U                                            /*!< APSR: C Position */
+#define APSR_C_Msk                         (1UL << APSR_C_Pos)                            /*!< APSR: C Mask */
+
+#define APSR_V_Pos                         28U                                            /*!< APSR: V Position */
+#define APSR_V_Msk                         (1UL << APSR_V_Pos)                            /*!< APSR: V Mask */
+
+
+/**
+  \brief  Union type to access the Interrupt Program Status Register (IPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number */
+    uint32_t _reserved0:23;              /*!< bit:  9..31  Reserved */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} IPSR_Type;
+
+/** \brief IPSR Register Definitions */
+#define IPSR_ISR_Pos                        0U                                            /*!< IPSR: ISR Position */
+#define IPSR_ISR_Msk                       (0x1FFUL /*<< IPSR_ISR_Pos*/)                  /*!< IPSR: ISR Mask */
+
+
+/**
+  \brief  Union type to access the Special-Purpose Program Status Registers (xPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number */
+    uint32_t _reserved0:15;              /*!< bit:  9..23  Reserved */
+    uint32_t T:1;                        /*!< bit:     24  Thumb bit        (read 0) */
+    uint32_t _reserved1:3;               /*!< bit: 25..27  Reserved */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} xPSR_Type;
+
+/** \brief xPSR Register Definitions */
+#define xPSR_N_Pos                         31U                                            /*!< xPSR: N Position */
+#define xPSR_N_Msk                         (1UL << xPSR_N_Pos)                            /*!< xPSR: N Mask */
+
+#define xPSR_Z_Pos                         30U                                            /*!< xPSR: Z Position */
+#define xPSR_Z_Msk                         (1UL << xPSR_Z_Pos)                            /*!< xPSR: Z Mask */
+
+#define xPSR_C_Pos                         29U                                            /*!< xPSR: C Position */
+#define xPSR_C_Msk                         (1UL << xPSR_C_Pos)                            /*!< xPSR: C Mask */
+
+#define xPSR_V_Pos                         28U                                            /*!< xPSR: V Position */
+#define xPSR_V_Msk                         (1UL << xPSR_V_Pos)                            /*!< xPSR: V Mask */
+
+#define xPSR_T_Pos                         24U                                            /*!< xPSR: T Position */
+#define xPSR_T_Msk                         (1UL << xPSR_T_Pos)                            /*!< xPSR: T Mask */
+
+#define xPSR_ISR_Pos                        0U                                            /*!< xPSR: ISR Position */
+#define xPSR_ISR_Msk                       (0x1FFUL /*<< xPSR_ISR_Pos*/)                  /*!< xPSR: ISR Mask */
+
+
+/**
+  \brief  Union type to access the Control Registers (CONTROL).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t _reserved0:1;               /*!< bit:      0  Reserved */
+    uint32_t SPSEL:1;                    /*!< bit:      1  Stack to be used */
+    uint32_t _reserved1:30;              /*!< bit:  2..31  Reserved */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} CONTROL_Type;
+
+/** \brief CONTROL Register Definitions */
+#define CONTROL_SPSEL_Pos                   1U                                            /*!< CONTROL: SPSEL Position */
+#define CONTROL_SPSEL_Msk                  (1UL << CONTROL_SPSEL_Pos)                     /*!< CONTROL: SPSEL Mask */
+
+/*@} end of group CMSIS_CORE */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_NVIC  Nested Vectored Interrupt Controller (NVIC)
+  \brief      Type definitions for the NVIC Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Nested Vectored Interrupt Controller (NVIC).
+ */
+typedef struct
+{
+  __IOM uint32_t ISER[1U];               /*!< Offset: 0x000 (R/W)  Interrupt Set Enable Register */
+        uint32_t RESERVED0[31U];
+  __IOM uint32_t ICER[1U];               /*!< Offset: 0x080 (R/W)  Interrupt Clear Enable Register */
+        uint32_t RESERVED1[31U];
+  __IOM uint32_t ISPR[1U];               /*!< Offset: 0x100 (R/W)  Interrupt Set Pending Register */
+        uint32_t RESERVED2[31U];
+  __IOM uint32_t ICPR[1U];               /*!< Offset: 0x180 (R/W)  Interrupt Clear Pending Register */
+        uint32_t RESERVED3[31U];
+        uint32_t RESERVED4[64U];
+  __IOM uint32_t IPR[8U];                /*!< Offset: 0x300 (R/W)  Interrupt Priority Register */
+}  NVIC_Type;
+
+/*@} end of group CMSIS_NVIC */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SCB     System Control Block (SCB)
+  \brief    Type definitions for the System Control Block Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Control Block (SCB).
+ */
+typedef struct
+{
+  __IM  uint32_t CPUID;                  /*!< Offset: 0x000 (R/ )  CPUID Base Register */
+  __IOM uint32_t ICSR;                   /*!< Offset: 0x004 (R/W)  Interrupt Control and State Register */
+        uint32_t RESERVED0;
+  __IOM uint32_t AIRCR;                  /*!< Offset: 0x00C (R/W)  Application Interrupt and Reset Control Register */
+  __IOM uint32_t SCR;                    /*!< Offset: 0x010 (R/W)  System Control Register */
+  __IOM uint32_t CCR;                    /*!< Offset: 0x014 (R/W)  Configuration Control Register */
+        uint32_t RESERVED1;
+  __IOM uint32_t SHPR[2U];               /*!< Offset: 0x01C (R/W)  System Handlers Priority Registers. [0] is RESERVED */
+  __IOM uint32_t SHCSR;                  /*!< Offset: 0x024 (R/W)  System Handler Control and State Register */
+} SCB_Type;
+
+/** \brief SCB CPUID Register Definitions */
+#define SCB_CPUID_IMPLEMENTER_Pos          24U                                            /*!< SCB CPUID: IMPLEMENTER Position */
+#define SCB_CPUID_IMPLEMENTER_Msk          (0xFFUL << SCB_CPUID_IMPLEMENTER_Pos)          /*!< SCB CPUID: IMPLEMENTER Mask */
+
+#define SCB_CPUID_VARIANT_Pos              20U                                            /*!< SCB CPUID: VARIANT Position */
+#define SCB_CPUID_VARIANT_Msk              (0xFUL << SCB_CPUID_VARIANT_Pos)               /*!< SCB CPUID: VARIANT Mask */
+
+#define SCB_CPUID_ARCHITECTURE_Pos         16U                                            /*!< SCB CPUID: ARCHITECTURE Position */
+#define SCB_CPUID_ARCHITECTURE_Msk         (0xFUL << SCB_CPUID_ARCHITECTURE_Pos)          /*!< SCB CPUID: ARCHITECTURE Mask */
+
+#define SCB_CPUID_PARTNO_Pos                4U                                            /*!< SCB CPUID: PARTNO Position */
+#define SCB_CPUID_PARTNO_Msk               (0xFFFUL << SCB_CPUID_PARTNO_Pos)              /*!< SCB CPUID: PARTNO Mask */
+
+#define SCB_CPUID_REVISION_Pos              0U                                            /*!< SCB CPUID: REVISION Position */
+#define SCB_CPUID_REVISION_Msk             (0xFUL /*<< SCB_CPUID_REVISION_Pos*/)          /*!< SCB CPUID: REVISION Mask */
+
+/** \brief SCB Interrupt Control State Register Definitions */
+#define SCB_ICSR_NMIPENDSET_Pos            31U                                            /*!< SCB ICSR: NMIPENDSET Position */
+#define SCB_ICSR_NMIPENDSET_Msk            (1UL << SCB_ICSR_NMIPENDSET_Pos)               /*!< SCB ICSR: NMIPENDSET Mask */
+
+#define SCB_ICSR_PENDSVSET_Pos             28U                                            /*!< SCB ICSR: PENDSVSET Position */
+#define SCB_ICSR_PENDSVSET_Msk             (1UL << SCB_ICSR_PENDSVSET_Pos)                /*!< SCB ICSR: PENDSVSET Mask */
+
+#define SCB_ICSR_PENDSVCLR_Pos             27U                                            /*!< SCB ICSR: PENDSVCLR Position */
+#define SCB_ICSR_PENDSVCLR_Msk             (1UL << SCB_ICSR_PENDSVCLR_Pos)                /*!< SCB ICSR: PENDSVCLR Mask */
+
+#define SCB_ICSR_PENDSTSET_Pos             26U                                            /*!< SCB ICSR: PENDSTSET Position */
+#define SCB_ICSR_PENDSTSET_Msk             (1UL << SCB_ICSR_PENDSTSET_Pos)                /*!< SCB ICSR: PENDSTSET Mask */
+
+#define SCB_ICSR_PENDSTCLR_Pos             25U                                            /*!< SCB ICSR: PENDSTCLR Position */
+#define SCB_ICSR_PENDSTCLR_Msk             (1UL << SCB_ICSR_PENDSTCLR_Pos)                /*!< SCB ICSR: PENDSTCLR Mask */
+
+#define SCB_ICSR_ISRPREEMPT_Pos            23U                                            /*!< SCB ICSR: ISRPREEMPT Position */
+#define SCB_ICSR_ISRPREEMPT_Msk            (1UL << SCB_ICSR_ISRPREEMPT_Pos)               /*!< SCB ICSR: ISRPREEMPT Mask */
+
+#define SCB_ICSR_ISRPENDING_Pos            22U                                            /*!< SCB ICSR: ISRPENDING Position */
+#define SCB_ICSR_ISRPENDING_Msk            (1UL << SCB_ICSR_ISRPENDING_Pos)               /*!< SCB ICSR: ISRPENDING Mask */
+
+#define SCB_ICSR_VECTPENDING_Pos           12U                                            /*!< SCB ICSR: VECTPENDING Position */
+#define SCB_ICSR_VECTPENDING_Msk           (0x1FFUL << SCB_ICSR_VECTPENDING_Pos)          /*!< SCB ICSR: VECTPENDING Mask */
+
+#define SCB_ICSR_VECTACTIVE_Pos             0U                                            /*!< SCB ICSR: VECTACTIVE Position */
+#define SCB_ICSR_VECTACTIVE_Msk            (0x1FFUL /*<< SCB_ICSR_VECTACTIVE_Pos*/)       /*!< SCB ICSR: VECTACTIVE Mask */
+
+/** \brief SCB Application Interrupt and Reset Control Register Definitions */
+#define SCB_AIRCR_VECTKEY_Pos              16U                                            /*!< SCB AIRCR: VECTKEY Position */
+#define SCB_AIRCR_VECTKEY_Msk              (0xFFFFUL << SCB_AIRCR_VECTKEY_Pos)            /*!< SCB AIRCR: VECTKEY Mask */
+
+#define SCB_AIRCR_VECTKEYSTAT_Pos          16U                                            /*!< SCB AIRCR: VECTKEYSTAT Position */
+#define SCB_AIRCR_VECTKEYSTAT_Msk          (0xFFFFUL << SCB_AIRCR_VECTKEYSTAT_Pos)        /*!< SCB AIRCR: VECTKEYSTAT Mask */
+
+#define SCB_AIRCR_ENDIANESS_Pos            15U                                            /*!< SCB AIRCR: ENDIANESS Position */
+#define SCB_AIRCR_ENDIANESS_Msk            (1UL << SCB_AIRCR_ENDIANESS_Pos)               /*!< SCB AIRCR: ENDIANESS Mask */
+
+#define SCB_AIRCR_SYSRESETREQ_Pos           2U                                            /*!< SCB AIRCR: SYSRESETREQ Position */
+#define SCB_AIRCR_SYSRESETREQ_Msk          (1UL << SCB_AIRCR_SYSRESETREQ_Pos)             /*!< SCB AIRCR: SYSRESETREQ Mask */
+
+#define SCB_AIRCR_VECTCLRACTIVE_Pos         1U                                            /*!< SCB AIRCR: VECTCLRACTIVE Position */
+#define SCB_AIRCR_VECTCLRACTIVE_Msk        (1UL << SCB_AIRCR_VECTCLRACTIVE_Pos)           /*!< SCB AIRCR: VECTCLRACTIVE Mask */
+
+/** \brief SCB System Control Register Definitions */
+#define SCB_SCR_SEVONPEND_Pos               4U                                            /*!< SCB SCR: SEVONPEND Position */
+#define SCB_SCR_SEVONPEND_Msk              (1UL << SCB_SCR_SEVONPEND_Pos)                 /*!< SCB SCR: SEVONPEND Mask */
+
+#define SCB_SCR_SLEEPDEEP_Pos               2U                                            /*!< SCB SCR: SLEEPDEEP Position */
+#define SCB_SCR_SLEEPDEEP_Msk              (1UL << SCB_SCR_SLEEPDEEP_Pos)                 /*!< SCB SCR: SLEEPDEEP Mask */
+
+#define SCB_SCR_SLEEPONEXIT_Pos             1U                                            /*!< SCB SCR: SLEEPONEXIT Position */
+#define SCB_SCR_SLEEPONEXIT_Msk            (1UL << SCB_SCR_SLEEPONEXIT_Pos)               /*!< SCB SCR: SLEEPONEXIT Mask */
+
+/** \brief SCB Configuration Control Register Definitions */
+#define SCB_CCR_STKALIGN_Pos                9U                                            /*!< SCB CCR: STKALIGN Position */
+#define SCB_CCR_STKALIGN_Msk               (1UL << SCB_CCR_STKALIGN_Pos)                  /*!< SCB CCR: STKALIGN Mask */
+
+#define SCB_CCR_UNALIGN_TRP_Pos             3U                                            /*!< SCB CCR: UNALIGN_TRP Position */
+#define SCB_CCR_UNALIGN_TRP_Msk            (1UL << SCB_CCR_UNALIGN_TRP_Pos)               /*!< SCB CCR: UNALIGN_TRP Mask */
+
+/** \brief SCB System Handler Control and State Register Definitions */
+#define SCB_SHCSR_SVCALLPENDED_Pos         15U                                            /*!< SCB SHCSR: SVCALLPENDED Position */
+#define SCB_SHCSR_SVCALLPENDED_Msk         (1UL << SCB_SHCSR_SVCALLPENDED_Pos)            /*!< SCB SHCSR: SVCALLPENDED Mask */
+
+/*@} end of group CMSIS_SCB */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SysTick     System Tick Timer (SysTick)
+  \brief    Type definitions for the System Timer Registers.
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Timer (SysTick).
+ */
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  SysTick Control and Status Register */
+  __IOM uint32_t LOAD;                   /*!< Offset: 0x004 (R/W)  SysTick Reload Value Register */
+  __IOM uint32_t VAL;                    /*!< Offset: 0x008 (R/W)  SysTick Current Value Register */
+  __IM  uint32_t CALIB;                  /*!< Offset: 0x00C (R/ )  SysTick Calibration Register */
+} SysTick_Type;
+
+/** \brief SysTick Control / Status Register Definitions */
+#define SysTick_CTRL_COUNTFLAG_Pos         16U                                            /*!< SysTick CTRL: COUNTFLAG Position */
+#define SysTick_CTRL_COUNTFLAG_Msk         (1UL << SysTick_CTRL_COUNTFLAG_Pos)            /*!< SysTick CTRL: COUNTFLAG Mask */
+
+#define SysTick_CTRL_CLKSOURCE_Pos          2U                                            /*!< SysTick CTRL: CLKSOURCE Position */
+#define SysTick_CTRL_CLKSOURCE_Msk         (1UL << SysTick_CTRL_CLKSOURCE_Pos)            /*!< SysTick CTRL: CLKSOURCE Mask */
+
+#define SysTick_CTRL_TICKINT_Pos            1U                                            /*!< SysTick CTRL: TICKINT Position */
+#define SysTick_CTRL_TICKINT_Msk           (1UL << SysTick_CTRL_TICKINT_Pos)              /*!< SysTick CTRL: TICKINT Mask */
+
+#define SysTick_CTRL_ENABLE_Pos             0U                                            /*!< SysTick CTRL: ENABLE Position */
+#define SysTick_CTRL_ENABLE_Msk            (1UL /*<< SysTick_CTRL_ENABLE_Pos*/)           /*!< SysTick CTRL: ENABLE Mask */
+
+/** \brief SysTick Reload Register Definitions */
+#define SysTick_LOAD_RELOAD_Pos             0U                                            /*!< SysTick LOAD: RELOAD Position */
+#define SysTick_LOAD_RELOAD_Msk            (0xFFFFFFUL /*<< SysTick_LOAD_RELOAD_Pos*/)    /*!< SysTick LOAD: RELOAD Mask */
+
+/** \brief SysTick Current Register Definitions */
+#define SysTick_VAL_CURRENT_Pos             0U                                            /*!< SysTick VAL: CURRENT Position */
+#define SysTick_VAL_CURRENT_Msk            (0xFFFFFFUL /*<< SysTick_VAL_CURRENT_Pos*/)    /*!< SysTick VAL: CURRENT Mask */
+
+/** \brief SysTick Calibration Register Definitions */
+#define SysTick_CALIB_NOREF_Pos            31U                                            /*!< SysTick CALIB: NOREF Position */
+#define SysTick_CALIB_NOREF_Msk            (1UL << SysTick_CALIB_NOREF_Pos)               /*!< SysTick CALIB: NOREF Mask */
+
+#define SysTick_CALIB_SKEW_Pos             30U                                            /*!< SysTick CALIB: SKEW Position */
+#define SysTick_CALIB_SKEW_Msk             (1UL << SysTick_CALIB_SKEW_Pos)                /*!< SysTick CALIB: SKEW Mask */
+
+#define SysTick_CALIB_TENMS_Pos             0U                                            /*!< SysTick CALIB: TENMS Position */
+#define SysTick_CALIB_TENMS_Msk            (0xFFFFFFUL /*<< SysTick_CALIB_TENMS_Pos*/)    /*!< SysTick CALIB: TENMS Mask */
+
+/*@} end of group CMSIS_SysTick */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_CoreDebug       Core Debug Registers (CoreDebug)
+  \brief    Cortex-M0 Core Debug Registers (DCB registers, SHCSR, and DFSR) are only accessible over DAP and not via processor.
+            Therefore they are not covered by the Cortex-M0 header file.
+  @{
+ */
+/*@} end of group CMSIS_CoreDebug */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_core_bitfield     Core register bit field macros
+  \brief      Macros for use with bit field definitions (xxx_Pos, xxx_Msk).
+  @{
+ */
+
+/**
+  \brief   Mask and shift a bit field value for use in a register bit range.
+  \param[in] field  Name of the register bit field.
+  \param[in] value  Value of the bit field. This parameter is interpreted as an uint32_t type.
+  \return           Masked and shifted value.
+*/
+#define _VAL2FLD(field, value)    (((uint32_t)(value) << field ## _Pos) & field ## _Msk)
+
+/**
+  \brief     Mask and shift a register value to extract a bit filed value.
+  \param[in] field  Name of the register bit field.
+  \param[in] value  Value of register. This parameter is interpreted as an uint32_t type.
+  \return           Masked and shifted bit field value.
+*/
+#define _FLD2VAL(field, value)    (((uint32_t)(value) & field ## _Msk) >> field ## _Pos)
+
+/*@} end of group CMSIS_core_bitfield */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_core_base     Core Definitions
+  \brief      Definitions for base addresses, unions, and structures.
+  @{
+ */
+
+/* Memory mapping of Core Hardware */
+#define SCS_BASE            (0xE000E000UL)                            /*!< System Control Space Base Address */
+#define SysTick_BASE        (SCS_BASE +  0x0010UL)                    /*!< SysTick Base Address */
+#define NVIC_BASE           (SCS_BASE +  0x0100UL)                    /*!< NVIC Base Address */
+#define SCB_BASE            (SCS_BASE +  0x0D00UL)                    /*!< System Control Block Base Address */
+
+#define SCB                 ((SCB_Type       *)     SCB_BASE      )   /*!< SCB configuration struct */
+#define SysTick             ((SysTick_Type   *)     SysTick_BASE  )   /*!< SysTick configuration struct */
+#define NVIC                ((NVIC_Type      *)     NVIC_BASE     )   /*!< NVIC configuration struct */
+
+
+/*@} */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_register_aliases     Backwards Compatibility Aliases
+  \brief      Register alias definitions for backwards compatibility.
+  @{
+ */
+
+/*@} */
+
+
+/*******************************************************************************
+ *                Hardware Abstraction Layer
+  Core Function Interface contains:
+  - Core NVIC Functions
+  - Core SysTick Functions
+  - Core Register Access Functions
+ ******************************************************************************/
+/**
+  \defgroup CMSIS_Core_FunctionInterface Functions and Instructions Reference
+*/
+
+
+
+/* ##########################   NVIC functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_NVICFunctions NVIC Functions
+  \brief    Functions that manage interrupts and exceptions via the NVIC.
+  @{
+ */
+
+#ifdef CMSIS_NVIC_VIRTUAL
+  #ifndef CMSIS_NVIC_VIRTUAL_HEADER_FILE
+    #define CMSIS_NVIC_VIRTUAL_HEADER_FILE "cmsis_nvic_virtual.h"
+  #endif
+  #include CMSIS_NVIC_VIRTUAL_HEADER_FILE
+#else
+  #define NVIC_SetPriorityGrouping    __NVIC_SetPriorityGrouping
+  #define NVIC_GetPriorityGrouping    __NVIC_GetPriorityGrouping
+  #define NVIC_EnableIRQ              __NVIC_EnableIRQ
+  #define NVIC_GetEnableIRQ           __NVIC_GetEnableIRQ
+  #define NVIC_DisableIRQ             __NVIC_DisableIRQ
+  #define NVIC_GetPendingIRQ          __NVIC_GetPendingIRQ
+  #define NVIC_SetPendingIRQ          __NVIC_SetPendingIRQ
+  #define NVIC_ClearPendingIRQ        __NVIC_ClearPendingIRQ
+/*        NVIC_GetActive              not available for Cortex-M0 */
+  #define NVIC_SetPriority            __NVIC_SetPriority
+  #define NVIC_GetPriority            __NVIC_GetPriority
+  #define NVIC_SystemReset            __NVIC_SystemReset
+#endif /* CMSIS_NVIC_VIRTUAL */
+
+#ifdef CMSIS_VECTAB_VIRTUAL
+  #ifndef CMSIS_VECTAB_VIRTUAL_HEADER_FILE
+    #define CMSIS_VECTAB_VIRTUAL_HEADER_FILE "cmsis_vectab_virtual.h"
+  #endif
+  #include CMSIS_VECTAB_VIRTUAL_HEADER_FILE
+#else
+  #define NVIC_SetVector              __NVIC_SetVector
+  #define NVIC_GetVector              __NVIC_GetVector
+#endif  /* (CMSIS_VECTAB_VIRTUAL) */
+
+#define NVIC_USER_IRQ_OFFSET          16
+
+
+/* The following EXC_RETURN values are saved the LR on exception entry */
+#define EXC_RETURN_HANDLER         (0xFFFFFFF1UL)     /* return to Handler mode, uses MSP after return                               */
+#define EXC_RETURN_THREAD_MSP      (0xFFFFFFF9UL)     /* return to Thread mode, uses MSP after return                                */
+#define EXC_RETURN_THREAD_PSP      (0xFFFFFFFDUL)     /* return to Thread mode, uses PSP after return                                */
+
+
+/* Interrupt Priorities are WORD accessible only under Armv6-M                  */
+/* The following MACROS handle generation of the register offset and byte masks */
+#define _BIT_SHIFT(IRQn)         (  ((((uint32_t)(int32_t)(IRQn))         )      &  0x03UL) * 8UL)
+#define _SHP_IDX(IRQn)           ( (((((uint32_t)(int32_t)(IRQn)) & 0x0FUL)-8UL) >>    2UL)      )
+#define _IP_IDX(IRQn)            (   (((uint32_t)(int32_t)(IRQn))                >>    2UL)      )
+
+#define __NVIC_SetPriorityGrouping(X) (void)(X)
+#define __NVIC_GetPriorityGrouping()  (0U)
+
+/**
+  \brief   Enable Interrupt
+  \details Enables a device specific interrupt in the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_EnableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    __COMPILER_BARRIER();
+    NVIC->ISER[0U] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+    __COMPILER_BARRIER();
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Enable status
+  \details Returns a device specific interrupt enable status from the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt is not enabled.
+  \return             1  Interrupt is enabled.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetEnableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ISER[0U] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Disable Interrupt
+  \details Disables a device specific interrupt in the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_DisableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ICER[0U] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+    __DSB();
+    __ISB();
+  }
+}
+
+
+/**
+  \brief   Get Pending Interrupt
+  \details Reads the NVIC pending register and returns the pending bit for the specified device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not pending.
+  \return             1  Interrupt status is pending.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ISPR[0U] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Pending Interrupt
+  \details Sets the pending bit of a device specific interrupt in the NVIC pending register.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_SetPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ISPR[0U] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Clear Pending Interrupt
+  \details Clears the pending bit of a device specific interrupt in the NVIC pending register.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_ClearPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ICPR[0U] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Set Interrupt Priority
+  \details Sets the priority of a device specific interrupt or a processor exception.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]      IRQn  Interrupt number.
+  \param [in]  priority  Priority to set.
+  \note    The priority cannot be set for every processor exception.
+ */
+__STATIC_INLINE void __NVIC_SetPriority(IRQn_Type IRQn, uint32_t priority)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->IPR[_IP_IDX(IRQn)]  = ((uint32_t)(NVIC->IPR[_IP_IDX(IRQn)]  & ~(0xFFUL << _BIT_SHIFT(IRQn))) |
+       (((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL) << _BIT_SHIFT(IRQn)));
+  }
+  else
+  {
+    SCB->SHPR[_SHP_IDX(IRQn)] = ((uint32_t)(SCB->SHPR[_SHP_IDX(IRQn)] & ~(0xFFUL << _BIT_SHIFT(IRQn))) |
+       (((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL) << _BIT_SHIFT(IRQn)));
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Priority
+  \details Reads the priority of a device specific interrupt or a processor exception.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn  Interrupt number.
+  \return             Interrupt Priority.
+                      Value is aligned automatically to the implemented priority bits of the microcontroller.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPriority(IRQn_Type IRQn)
+{
+
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->IPR[ _IP_IDX(IRQn)] >> _BIT_SHIFT(IRQn) ) & (uint32_t)0xFFUL) >> (8U - __NVIC_PRIO_BITS)));
+  }
+  else
+  {
+    return((uint32_t)(((SCB->SHPR[_SHP_IDX(IRQn)] >> _BIT_SHIFT(IRQn) ) & (uint32_t)0xFFUL) >> (8U - __NVIC_PRIO_BITS)));
+  }
+}
+
+
+/**
+  \brief   Encode Priority
+  \details Encodes the priority for an interrupt with the given priority group,
+           preemptive priority value, and subpriority value.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+  \param [in]     PriorityGroup  Used priority group.
+  \param [in]   PreemptPriority  Preemptive priority value (starting from 0).
+  \param [in]       SubPriority  Subpriority value (starting from 0).
+  \return                        Encoded priority. Value can be used in the function \ref NVIC_SetPriority().
+ */
+__STATIC_INLINE uint32_t NVIC_EncodePriority (uint32_t PriorityGroup, uint32_t PreemptPriority, uint32_t SubPriority)
+{
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);   /* only values 0..7 are used          */
+  uint32_t PreemptPriorityBits;
+  uint32_t SubPriorityBits;
+
+  PreemptPriorityBits = ((7UL - PriorityGroupTmp) > (uint32_t)(__NVIC_PRIO_BITS)) ? (uint32_t)(__NVIC_PRIO_BITS) : (uint32_t)(7UL - PriorityGroupTmp);
+  SubPriorityBits     = ((PriorityGroupTmp + (uint32_t)(__NVIC_PRIO_BITS)) < (uint32_t)7UL) ? (uint32_t)0UL : (uint32_t)((PriorityGroupTmp - 7UL) + (uint32_t)(__NVIC_PRIO_BITS));
+
+  return (
+           ((PreemptPriority & (uint32_t)((1UL << (PreemptPriorityBits)) - 1UL)) << SubPriorityBits) |
+           ((SubPriority     & (uint32_t)((1UL << (SubPriorityBits    )) - 1UL)))
+         );
+}
+
+
+/**
+  \brief   Decode Priority
+  \details Decodes an interrupt priority value with a given priority group to
+           preemptive priority value and subpriority value.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS) the smallest possible priority group is set.
+  \param [in]         Priority   Priority value, which can be retrieved with the function \ref NVIC_GetPriority().
+  \param [in]     PriorityGroup  Used priority group.
+  \param [out] pPreemptPriority  Preemptive priority value (starting from 0).
+  \param [out]     pSubPriority  Subpriority value (starting from 0).
+ */
+__STATIC_INLINE void NVIC_DecodePriority (uint32_t Priority, uint32_t PriorityGroup, uint32_t* const pPreemptPriority, uint32_t* const pSubPriority)
+{
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);   /* only values 0..7 are used          */
+  uint32_t PreemptPriorityBits;
+  uint32_t SubPriorityBits;
+
+  PreemptPriorityBits = ((7UL - PriorityGroupTmp) > (uint32_t)(__NVIC_PRIO_BITS)) ? (uint32_t)(__NVIC_PRIO_BITS) : (uint32_t)(7UL - PriorityGroupTmp);
+  SubPriorityBits     = ((PriorityGroupTmp + (uint32_t)(__NVIC_PRIO_BITS)) < (uint32_t)7UL) ? (uint32_t)0UL : (uint32_t)((PriorityGroupTmp - 7UL) + (uint32_t)(__NVIC_PRIO_BITS));
+
+  *pPreemptPriority = (Priority >> SubPriorityBits) & (uint32_t)((1UL << (PreemptPriorityBits)) - 1UL);
+  *pSubPriority     = (Priority                   ) & (uint32_t)((1UL << (SubPriorityBits    )) - 1UL);
+}
+
+
+/**
+  \brief   Set Interrupt Vector
+  \details Sets an interrupt vector in SRAM based interrupt vector table.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+           Address 0 must be mapped to SRAM.
+  \param [in]   IRQn      Interrupt number
+  \param [in]   vector    Address of interrupt handler function
+ */
+__STATIC_INLINE void __NVIC_SetVector(IRQn_Type IRQn, uint32_t vector)
+{
+  uint32_t *vectors = (uint32_t *)(NVIC_USER_IRQ_OFFSET << 2);      /* point to 1st user interrupt */
+  *(vectors + (int32_t)IRQn) = vector;                              /* use pointer arithmetic to access vector */
+  /* ARM Application Note 321 states that the M0 does not require the architectural barrier */
+}
+
+
+/**
+  \brief   Get Interrupt Vector
+  \details Reads an interrupt vector from interrupt vector table.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn      Interrupt number.
+  \return                 Address of interrupt handler function
+ */
+__STATIC_INLINE uint32_t __NVIC_GetVector(IRQn_Type IRQn)
+{
+  uint32_t *vectors = (uint32_t *)(NVIC_USER_IRQ_OFFSET << 2);      /* point to 1st user interrupt */
+  return *(vectors + (int32_t)IRQn);                                /* use pointer arithmetic to access vector */
+}
+
+
+/**
+  \brief   System Reset
+  \details Initiates a system reset request to reset the MCU.
+ */
+__NO_RETURN __STATIC_INLINE void __NVIC_SystemReset(void)
+{
+  __DSB();                                                          /* Ensure all outstanding memory accesses included
+                                                                       buffered write are completed before reset */
+  SCB->AIRCR  = ((0x5FAUL << SCB_AIRCR_VECTKEY_Pos) |
+                 SCB_AIRCR_SYSRESETREQ_Msk);
+  __DSB();                                                          /* Ensure completion of memory access */
+
+  for(;;)                                                           /* wait until reset */
+  {
+    __NOP();
+  }
+}
+
+/*@} end of CMSIS_Core_NVICFunctions */
+
+
+/* ##########################  FPU functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_FpuFunctions FPU Functions
+  \brief    Function that provides FPU type.
+  @{
+ */
+
+/**
+  \brief   get FPU type
+  \details returns the FPU type
+  \returns
+   - \b  0: No FPU
+   - \b  1: Single precision FPU
+   - \b  2: Double + Single precision FPU
+ */
+__STATIC_INLINE uint32_t SCB_GetFPUType(void)
+{
+    return 0U;           /* No FPU */
+}
+
+
+/*@} end of CMSIS_Core_FpuFunctions */
+
+
+
+/* ##################################    SysTick function  ############################################ */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_SysTickFunctions SysTick Functions
+  \brief    Functions that configure the System.
+  @{
+ */
+
+#if defined (__Vendor_SysTickConfig) && (__Vendor_SysTickConfig == 0U)
+
+/**
+  \brief   System Tick Configuration
+  \details Initializes the System Timer and its interrupt, and starts the System Tick Timer.
+           Counter is in free running mode to generate periodic interrupts.
+  \param [in]  ticks  Number of ticks between two interrupts.
+  \return          0  Function succeeded.
+  \return          1  Function failed.
+  \note    When the variable <b>__Vendor_SysTickConfig</b> is set to 1, then the
+           function <b>SysTick_Config</b> is not included. In this case, the file <b><i>device</i>.h</b>
+           must contain a vendor-specific implementation of this function.
+ */
+__STATIC_INLINE uint32_t SysTick_Config(uint32_t ticks)
+{
+  if ((ticks - 1UL) > SysTick_LOAD_RELOAD_Msk)
+  {
+    return (1UL);                                                   /* Reload value impossible */
+  }
+
+  SysTick->LOAD  = (uint32_t)(ticks - 1UL);                         /* set reload register */
+  NVIC_SetPriority (SysTick_IRQn, (1UL << __NVIC_PRIO_BITS) - 1UL); /* set Priority for Systick Interrupt */
+  SysTick->VAL   = 0UL;                                             /* Load the SysTick Counter Value */
+  SysTick->CTRL  = SysTick_CTRL_CLKSOURCE_Msk |
+                   SysTick_CTRL_TICKINT_Msk   |
+                   SysTick_CTRL_ENABLE_Msk;                         /* Enable SysTick IRQ and SysTick Timer */
+  return (0UL);                                                     /* Function successful */
+}
+
+#endif
+
+/*@} end of CMSIS_Core_SysTickFunctions */
+
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_CM0_H_DEPENDANT */
+
+#endif /* __CMSIS_GENERIC */

--- a/platform/ext/cmsis/CMSIS/Core/Include/core_cm0plus.h
+++ b/platform/ext/cmsis/CMSIS/Core/Include/core_cm0plus.h
@@ -1,0 +1,1097 @@
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS Cortex-M0+ Core Peripheral Access Layer Header File
+ */
+
+#if   defined ( __ICCARM__ )
+  #pragma system_include                        /* treat file as system include file for MISRA check */
+#elif defined (__clang__)
+  #pragma clang system_header                   /* treat file as system include file */
+#elif defined ( __GNUC__ )
+  #pragma GCC diagnostic ignored "-Wpedantic"   /* disable pedantic warning due to unnamed structs/unions */
+#endif
+
+#ifndef __CORE_CM0PLUS_H_GENERIC
+#define __CORE_CM0PLUS_H_GENERIC
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/**
+  \page CMSIS_MISRA_Exceptions  MISRA-C:2004 Compliance Exceptions
+  CMSIS violates the following MISRA-C:2004 rules:
+
+   \li Required Rule 8.5, object/function definition in header file.<br>
+     Function definitions in header files are used to allow 'inlining'.
+
+   \li Required Rule 18.4, declaration of union type or object of union type: '{...}'.<br>
+     Unions are used for effective representation of core registers.
+
+   \li Advisory Rule 19.7, Function-like macro defined.<br>
+     Function-like macros are used to allow more efficient code.
+ */
+
+
+/*******************************************************************************
+ *                 CMSIS definitions
+ ******************************************************************************/
+/**
+  \ingroup Cortex-M0+
+  @{
+ */
+
+#include "cmsis_version.h"
+
+/* CMSIS CM0+ definitions */
+
+#define __CORTEX_M                (0U)                                /*!< Cortex-M Core */
+
+/** __FPU_USED indicates whether an FPU is used or not.
+    This core does not support an FPU at all
+*/
+#define __FPU_USED       0U
+
+#if defined ( __CC_ARM )
+  #if defined (__TARGET_FPU_VFP)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #if defined (__ARM_FP)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined (__ti__)
+  #if defined (__ARM_FP)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __GNUC__ )
+  #if defined (__VFP_FP__) && !defined(__SOFTFP__)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __ICCARM__ )
+  #if defined (__ARMVFP__)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __TI_ARM__ )
+  #if defined (__TI_VFP_SUPPORT__)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __TASKING__ )
+  #if defined (__FPU_VFP__)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __CSMC__ )
+  #if ( __CSMC__ & 0x400U)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#endif
+
+#include "cmsis_compiler.h"               /* CMSIS compiler specific defines */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_CM0PLUS_H_GENERIC */
+
+#ifndef __CMSIS_GENERIC
+
+#ifndef __CORE_CM0PLUS_H_DEPENDANT
+#define __CORE_CM0PLUS_H_DEPENDANT
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* check device defines and use defaults */
+#if defined __CHECK_DEVICE_DEFINES
+  #ifndef __CM0PLUS_REV
+    #define __CM0PLUS_REV             0x0000U
+    #warning "__CM0PLUS_REV not defined in device header file; using default!"
+  #endif
+
+  #ifndef __MPU_PRESENT
+    #define __MPU_PRESENT             0U
+    #warning "__MPU_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __VTOR_PRESENT
+    #define __VTOR_PRESENT            0U
+    #warning "__VTOR_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __NVIC_PRIO_BITS
+    #define __NVIC_PRIO_BITS          2U
+    #warning "__NVIC_PRIO_BITS not defined in device header file; using default!"
+  #endif
+
+  #ifndef __Vendor_SysTickConfig
+    #define __Vendor_SysTickConfig    0U
+    #warning "__Vendor_SysTickConfig not defined in device header file; using default!"
+  #endif
+#endif
+
+/* IO definitions (access restrictions to peripheral registers) */
+/**
+    \defgroup CMSIS_glob_defs CMSIS Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+*/
+#ifdef __cplusplus
+  #define   __I     volatile             /*!< Defines 'read only' permissions */
+#else
+  #define   __I     volatile const       /*!< Defines 'read only' permissions */
+#endif
+#define     __O     volatile             /*!< Defines 'write only' permissions */
+#define     __IO    volatile             /*!< Defines 'read / write' permissions */
+
+/* following defines should be used for structure members */
+#define     __IM     volatile const      /*! Defines 'read only' structure member permissions */
+#define     __OM     volatile            /*! Defines 'write only' structure member permissions */
+#define     __IOM    volatile            /*! Defines 'read / write' structure member permissions */
+
+/*@} end of group Cortex-M0+ */
+
+
+
+/*******************************************************************************
+ *                 Register Abstraction
+  Core Register contain:
+  - Core Register
+  - Core NVIC Register
+  - Core SCB Register
+  - Core SysTick Register
+  - Core MPU Register
+ ******************************************************************************/
+/**
+  \defgroup CMSIS_core_register Defines and Type Definitions
+  \brief Type definitions and defines for Cortex-M processor based devices.
+*/
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_CORE  Status and Control Registers
+  \brief      Core Register type definitions.
+  @{
+ */
+
+/**
+  \brief  Union type to access the Application Program Status Register (APSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t _reserved0:28;              /*!< bit:  0..27  Reserved */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} APSR_Type;
+
+/** \brief APSR Register Definitions */
+#define APSR_N_Pos                         31U                                            /*!< APSR: N Position */
+#define APSR_N_Msk                         (1UL << APSR_N_Pos)                            /*!< APSR: N Mask */
+
+#define APSR_Z_Pos                         30U                                            /*!< APSR: Z Position */
+#define APSR_Z_Msk                         (1UL << APSR_Z_Pos)                            /*!< APSR: Z Mask */
+
+#define APSR_C_Pos                         29U                                            /*!< APSR: C Position */
+#define APSR_C_Msk                         (1UL << APSR_C_Pos)                            /*!< APSR: C Mask */
+
+#define APSR_V_Pos                         28U                                            /*!< APSR: V Position */
+#define APSR_V_Msk                         (1UL << APSR_V_Pos)                            /*!< APSR: V Mask */
+
+
+/**
+  \brief  Union type to access the Interrupt Program Status Register (IPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number */
+    uint32_t _reserved0:23;              /*!< bit:  9..31  Reserved */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} IPSR_Type;
+
+/** \brief IPSR Register Definitions */
+#define IPSR_ISR_Pos                        0U                                            /*!< IPSR: ISR Position */
+#define IPSR_ISR_Msk                       (0x1FFUL /*<< IPSR_ISR_Pos*/)                  /*!< IPSR: ISR Mask */
+
+
+/**
+  \brief  Union type to access the Special-Purpose Program Status Registers (xPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number */
+    uint32_t _reserved0:15;              /*!< bit:  9..23  Reserved */
+    uint32_t T:1;                        /*!< bit:     24  Thumb bit        (read 0) */
+    uint32_t _reserved1:3;               /*!< bit: 25..27  Reserved */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} xPSR_Type;
+
+/** \brief xPSR Register Definitions */
+#define xPSR_N_Pos                         31U                                            /*!< xPSR: N Position */
+#define xPSR_N_Msk                         (1UL << xPSR_N_Pos)                            /*!< xPSR: N Mask */
+
+#define xPSR_Z_Pos                         30U                                            /*!< xPSR: Z Position */
+#define xPSR_Z_Msk                         (1UL << xPSR_Z_Pos)                            /*!< xPSR: Z Mask */
+
+#define xPSR_C_Pos                         29U                                            /*!< xPSR: C Position */
+#define xPSR_C_Msk                         (1UL << xPSR_C_Pos)                            /*!< xPSR: C Mask */
+
+#define xPSR_V_Pos                         28U                                            /*!< xPSR: V Position */
+#define xPSR_V_Msk                         (1UL << xPSR_V_Pos)                            /*!< xPSR: V Mask */
+
+#define xPSR_T_Pos                         24U                                            /*!< xPSR: T Position */
+#define xPSR_T_Msk                         (1UL << xPSR_T_Pos)                            /*!< xPSR: T Mask */
+
+#define xPSR_ISR_Pos                        0U                                            /*!< xPSR: ISR Position */
+#define xPSR_ISR_Msk                       (0x1FFUL /*<< xPSR_ISR_Pos*/)                  /*!< xPSR: ISR Mask */
+
+
+/**
+  \brief  Union type to access the Control Registers (CONTROL).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t nPRIV:1;                    /*!< bit:      0  Execution privilege in Thread mode */
+    uint32_t SPSEL:1;                    /*!< bit:      1  Stack to be used */
+    uint32_t _reserved1:30;              /*!< bit:  2..31  Reserved */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} CONTROL_Type;
+
+/** \brief CONTROL Register Definitions */
+#define CONTROL_SPSEL_Pos                   1U                                            /*!< CONTROL: SPSEL Position */
+#define CONTROL_SPSEL_Msk                  (1UL << CONTROL_SPSEL_Pos)                     /*!< CONTROL: SPSEL Mask */
+
+#define CONTROL_nPRIV_Pos                   0U                                            /*!< CONTROL: nPRIV Position */
+#define CONTROL_nPRIV_Msk                  (1UL /*<< CONTROL_nPRIV_Pos*/)                 /*!< CONTROL: nPRIV Mask */
+
+/*@} end of group CMSIS_CORE */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_NVIC  Nested Vectored Interrupt Controller (NVIC)
+  \brief      Type definitions for the NVIC Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Nested Vectored Interrupt Controller (NVIC).
+ */
+typedef struct
+{
+  __IOM uint32_t ISER[1U];               /*!< Offset: 0x000 (R/W)  Interrupt Set Enable Register */
+        uint32_t RESERVED0[31U];
+  __IOM uint32_t ICER[1U];               /*!< Offset: 0x080 (R/W)  Interrupt Clear Enable Register */
+        uint32_t RESERVED1[31U];
+  __IOM uint32_t ISPR[1U];               /*!< Offset: 0x100 (R/W)  Interrupt Set Pending Register */
+        uint32_t RESERVED2[31U];
+  __IOM uint32_t ICPR[1U];               /*!< Offset: 0x180 (R/W)  Interrupt Clear Pending Register */
+        uint32_t RESERVED3[31U];
+        uint32_t RESERVED4[64U];
+  __IOM uint32_t IPR[8U];                /*!< Offset: 0x300 (R/W)  Interrupt Priority Register */
+}  NVIC_Type;
+
+/*@} end of group CMSIS_NVIC */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SCB     System Control Block (SCB)
+  \brief    Type definitions for the System Control Block Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Control Block (SCB).
+ */
+typedef struct
+{
+  __IM  uint32_t CPUID;                  /*!< Offset: 0x000 (R/ )  CPUID Base Register */
+  __IOM uint32_t ICSR;                   /*!< Offset: 0x004 (R/W)  Interrupt Control and State Register */
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  __IOM uint32_t VTOR;                   /*!< Offset: 0x008 (R/W)  Vector Table Offset Register */
+#else
+        uint32_t RESERVED0;
+#endif
+  __IOM uint32_t AIRCR;                  /*!< Offset: 0x00C (R/W)  Application Interrupt and Reset Control Register */
+  __IOM uint32_t SCR;                    /*!< Offset: 0x010 (R/W)  System Control Register */
+  __IOM uint32_t CCR;                    /*!< Offset: 0x014 (R/W)  Configuration Control Register */
+        uint32_t RESERVED1;
+  __IOM uint32_t SHPR[2U];               /*!< Offset: 0x01C (R/W)  System Handlers Priority Registers. [0] is RESERVED */
+  __IOM uint32_t SHCSR;                  /*!< Offset: 0x024 (R/W)  System Handler Control and State Register */
+} SCB_Type;
+
+/** \brief SCB CPUID Register Definitions */
+#define SCB_CPUID_IMPLEMENTER_Pos          24U                                            /*!< SCB CPUID: IMPLEMENTER Position */
+#define SCB_CPUID_IMPLEMENTER_Msk          (0xFFUL << SCB_CPUID_IMPLEMENTER_Pos)          /*!< SCB CPUID: IMPLEMENTER Mask */
+
+#define SCB_CPUID_VARIANT_Pos              20U                                            /*!< SCB CPUID: VARIANT Position */
+#define SCB_CPUID_VARIANT_Msk              (0xFUL << SCB_CPUID_VARIANT_Pos)               /*!< SCB CPUID: VARIANT Mask */
+
+#define SCB_CPUID_ARCHITECTURE_Pos         16U                                            /*!< SCB CPUID: ARCHITECTURE Position */
+#define SCB_CPUID_ARCHITECTURE_Msk         (0xFUL << SCB_CPUID_ARCHITECTURE_Pos)          /*!< SCB CPUID: ARCHITECTURE Mask */
+
+#define SCB_CPUID_PARTNO_Pos                4U                                            /*!< SCB CPUID: PARTNO Position */
+#define SCB_CPUID_PARTNO_Msk               (0xFFFUL << SCB_CPUID_PARTNO_Pos)              /*!< SCB CPUID: PARTNO Mask */
+
+#define SCB_CPUID_REVISION_Pos              0U                                            /*!< SCB CPUID: REVISION Position */
+#define SCB_CPUID_REVISION_Msk             (0xFUL /*<< SCB_CPUID_REVISION_Pos*/)          /*!< SCB CPUID: REVISION Mask */
+
+/** \brief SCB Interrupt Control State Register Definitions */
+#define SCB_ICSR_NMIPENDSET_Pos            31U                                            /*!< SCB ICSR: NMIPENDSET Position */
+#define SCB_ICSR_NMIPENDSET_Msk            (1UL << SCB_ICSR_NMIPENDSET_Pos)               /*!< SCB ICSR: NMIPENDSET Mask */
+
+#define SCB_ICSR_PENDSVSET_Pos             28U                                            /*!< SCB ICSR: PENDSVSET Position */
+#define SCB_ICSR_PENDSVSET_Msk             (1UL << SCB_ICSR_PENDSVSET_Pos)                /*!< SCB ICSR: PENDSVSET Mask */
+
+#define SCB_ICSR_PENDSVCLR_Pos             27U                                            /*!< SCB ICSR: PENDSVCLR Position */
+#define SCB_ICSR_PENDSVCLR_Msk             (1UL << SCB_ICSR_PENDSVCLR_Pos)                /*!< SCB ICSR: PENDSVCLR Mask */
+
+#define SCB_ICSR_PENDSTSET_Pos             26U                                            /*!< SCB ICSR: PENDSTSET Position */
+#define SCB_ICSR_PENDSTSET_Msk             (1UL << SCB_ICSR_PENDSTSET_Pos)                /*!< SCB ICSR: PENDSTSET Mask */
+
+#define SCB_ICSR_PENDSTCLR_Pos             25U                                            /*!< SCB ICSR: PENDSTCLR Position */
+#define SCB_ICSR_PENDSTCLR_Msk             (1UL << SCB_ICSR_PENDSTCLR_Pos)                /*!< SCB ICSR: PENDSTCLR Mask */
+
+#define SCB_ICSR_ISRPREEMPT_Pos            23U                                            /*!< SCB ICSR: ISRPREEMPT Position */
+#define SCB_ICSR_ISRPREEMPT_Msk            (1UL << SCB_ICSR_ISRPREEMPT_Pos)               /*!< SCB ICSR: ISRPREEMPT Mask */
+
+#define SCB_ICSR_ISRPENDING_Pos            22U                                            /*!< SCB ICSR: ISRPENDING Position */
+#define SCB_ICSR_ISRPENDING_Msk            (1UL << SCB_ICSR_ISRPENDING_Pos)               /*!< SCB ICSR: ISRPENDING Mask */
+
+#define SCB_ICSR_VECTPENDING_Pos           12U                                            /*!< SCB ICSR: VECTPENDING Position */
+#define SCB_ICSR_VECTPENDING_Msk           (0x1FFUL << SCB_ICSR_VECTPENDING_Pos)          /*!< SCB ICSR: VECTPENDING Mask */
+
+#define SCB_ICSR_VECTACTIVE_Pos             0U                                            /*!< SCB ICSR: VECTACTIVE Position */
+#define SCB_ICSR_VECTACTIVE_Msk            (0x1FFUL /*<< SCB_ICSR_VECTACTIVE_Pos*/)       /*!< SCB ICSR: VECTACTIVE Mask */
+
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+/** \brief SCB Vector Table Offset Register Definitions */
+#define SCB_VTOR_TBLOFF_Pos                 8U                                            /*!< SCB VTOR: TBLOFF Position */
+#define SCB_VTOR_TBLOFF_Msk                (0xFFFFFFUL << SCB_VTOR_TBLOFF_Pos)            /*!< SCB VTOR: TBLOFF Mask */
+#endif
+
+/** \brief SCB Application Interrupt and Reset Control Register Definitions */
+#define SCB_AIRCR_VECTKEY_Pos              16U                                            /*!< SCB AIRCR: VECTKEY Position */
+#define SCB_AIRCR_VECTKEY_Msk              (0xFFFFUL << SCB_AIRCR_VECTKEY_Pos)            /*!< SCB AIRCR: VECTKEY Mask */
+
+#define SCB_AIRCR_VECTKEYSTAT_Pos          16U                                            /*!< SCB AIRCR: VECTKEYSTAT Position */
+#define SCB_AIRCR_VECTKEYSTAT_Msk          (0xFFFFUL << SCB_AIRCR_VECTKEYSTAT_Pos)        /*!< SCB AIRCR: VECTKEYSTAT Mask */
+
+#define SCB_AIRCR_ENDIANESS_Pos            15U                                            /*!< SCB AIRCR: ENDIANESS Position */
+#define SCB_AIRCR_ENDIANESS_Msk            (1UL << SCB_AIRCR_ENDIANESS_Pos)               /*!< SCB AIRCR: ENDIANESS Mask */
+
+#define SCB_AIRCR_SYSRESETREQ_Pos           2U                                            /*!< SCB AIRCR: SYSRESETREQ Position */
+#define SCB_AIRCR_SYSRESETREQ_Msk          (1UL << SCB_AIRCR_SYSRESETREQ_Pos)             /*!< SCB AIRCR: SYSRESETREQ Mask */
+
+#define SCB_AIRCR_VECTCLRACTIVE_Pos         1U                                            /*!< SCB AIRCR: VECTCLRACTIVE Position */
+#define SCB_AIRCR_VECTCLRACTIVE_Msk        (1UL << SCB_AIRCR_VECTCLRACTIVE_Pos)           /*!< SCB AIRCR: VECTCLRACTIVE Mask */
+
+/** \brief SCB System Control Register Definitions */
+#define SCB_SCR_SEVONPEND_Pos               4U                                            /*!< SCB SCR: SEVONPEND Position */
+#define SCB_SCR_SEVONPEND_Msk              (1UL << SCB_SCR_SEVONPEND_Pos)                 /*!< SCB SCR: SEVONPEND Mask */
+
+#define SCB_SCR_SLEEPDEEP_Pos               2U                                            /*!< SCB SCR: SLEEPDEEP Position */
+#define SCB_SCR_SLEEPDEEP_Msk              (1UL << SCB_SCR_SLEEPDEEP_Pos)                 /*!< SCB SCR: SLEEPDEEP Mask */
+
+#define SCB_SCR_SLEEPONEXIT_Pos             1U                                            /*!< SCB SCR: SLEEPONEXIT Position */
+#define SCB_SCR_SLEEPONEXIT_Msk            (1UL << SCB_SCR_SLEEPONEXIT_Pos)               /*!< SCB SCR: SLEEPONEXIT Mask */
+
+/** \brief SCB Configuration Control Register Definitions */
+#define SCB_CCR_STKALIGN_Pos                9U                                            /*!< SCB CCR: STKALIGN Position */
+#define SCB_CCR_STKALIGN_Msk               (1UL << SCB_CCR_STKALIGN_Pos)                  /*!< SCB CCR: STKALIGN Mask */
+
+#define SCB_CCR_UNALIGN_TRP_Pos             3U                                            /*!< SCB CCR: UNALIGN_TRP Position */
+#define SCB_CCR_UNALIGN_TRP_Msk            (1UL << SCB_CCR_UNALIGN_TRP_Pos)               /*!< SCB CCR: UNALIGN_TRP Mask */
+
+/** \brief SCB System Handler Control and State Register Definitions */
+#define SCB_SHCSR_SVCALLPENDED_Pos         15U                                            /*!< SCB SHCSR: SVCALLPENDED Position */
+#define SCB_SHCSR_SVCALLPENDED_Msk         (1UL << SCB_SHCSR_SVCALLPENDED_Pos)            /*!< SCB SHCSR: SVCALLPENDED Mask */
+
+/*@} end of group CMSIS_SCB */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SysTick     System Tick Timer (SysTick)
+  \brief    Type definitions for the System Timer Registers.
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Timer (SysTick).
+ */
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  SysTick Control and Status Register */
+  __IOM uint32_t LOAD;                   /*!< Offset: 0x004 (R/W)  SysTick Reload Value Register */
+  __IOM uint32_t VAL;                    /*!< Offset: 0x008 (R/W)  SysTick Current Value Register */
+  __IM  uint32_t CALIB;                  /*!< Offset: 0x00C (R/ )  SysTick Calibration Register */
+} SysTick_Type;
+
+/** \brief SysTick Control / Status Register Definitions */
+#define SysTick_CTRL_COUNTFLAG_Pos         16U                                            /*!< SysTick CTRL: COUNTFLAG Position */
+#define SysTick_CTRL_COUNTFLAG_Msk         (1UL << SysTick_CTRL_COUNTFLAG_Pos)            /*!< SysTick CTRL: COUNTFLAG Mask */
+
+#define SysTick_CTRL_CLKSOURCE_Pos          2U                                            /*!< SysTick CTRL: CLKSOURCE Position */
+#define SysTick_CTRL_CLKSOURCE_Msk         (1UL << SysTick_CTRL_CLKSOURCE_Pos)            /*!< SysTick CTRL: CLKSOURCE Mask */
+
+#define SysTick_CTRL_TICKINT_Pos            1U                                            /*!< SysTick CTRL: TICKINT Position */
+#define SysTick_CTRL_TICKINT_Msk           (1UL << SysTick_CTRL_TICKINT_Pos)              /*!< SysTick CTRL: TICKINT Mask */
+
+#define SysTick_CTRL_ENABLE_Pos             0U                                            /*!< SysTick CTRL: ENABLE Position */
+#define SysTick_CTRL_ENABLE_Msk            (1UL /*<< SysTick_CTRL_ENABLE_Pos*/)           /*!< SysTick CTRL: ENABLE Mask */
+
+/** \brief SysTick Reload Register Definitions */
+#define SysTick_LOAD_RELOAD_Pos             0U                                            /*!< SysTick LOAD: RELOAD Position */
+#define SysTick_LOAD_RELOAD_Msk            (0xFFFFFFUL /*<< SysTick_LOAD_RELOAD_Pos*/)    /*!< SysTick LOAD: RELOAD Mask */
+
+/** \brief SysTick Current Register Definitions */
+#define SysTick_VAL_CURRENT_Pos             0U                                            /*!< SysTick VAL: CURRENT Position */
+#define SysTick_VAL_CURRENT_Msk            (0xFFFFFFUL /*<< SysTick_VAL_CURRENT_Pos*/)    /*!< SysTick VAL: CURRENT Mask */
+
+/** \brief SysTick Calibration Register Definitions */
+#define SysTick_CALIB_NOREF_Pos            31U                                            /*!< SysTick CALIB: NOREF Position */
+#define SysTick_CALIB_NOREF_Msk            (1UL << SysTick_CALIB_NOREF_Pos)               /*!< SysTick CALIB: NOREF Mask */
+
+#define SysTick_CALIB_SKEW_Pos             30U                                            /*!< SysTick CALIB: SKEW Position */
+#define SysTick_CALIB_SKEW_Msk             (1UL << SysTick_CALIB_SKEW_Pos)                /*!< SysTick CALIB: SKEW Mask */
+
+#define SysTick_CALIB_TENMS_Pos             0U                                            /*!< SysTick CALIB: TENMS Position */
+#define SysTick_CALIB_TENMS_Msk            (0xFFFFFFUL /*<< SysTick_CALIB_TENMS_Pos*/)    /*!< SysTick CALIB: TENMS Mask */
+
+/*@} end of group CMSIS_SysTick */
+
+#if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_MPU     Memory Protection Unit (MPU)
+  \brief    Type definitions for the Memory Protection Unit (MPU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Memory Protection Unit (MPU).
+ */
+typedef struct
+{
+  __IM  uint32_t TYPE;                   /*!< Offset: 0x000 (R/ )  MPU Type Register */
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x004 (R/W)  MPU Control Register */
+  __IOM uint32_t RNR;                    /*!< Offset: 0x008 (R/W)  MPU Region Number Register */
+  __IOM uint32_t RBAR;                   /*!< Offset: 0x00C (R/W)  MPU Region Base Address Register */
+  __IOM uint32_t RASR;                   /*!< Offset: 0x010 (R/W)  MPU Region Attribute and Size Register */
+} MPU_Type;
+
+#define MPU_TYPE_RALIASES                  1U
+
+/** \brief MPU Type Register Definitions */
+#define MPU_TYPE_IREGION_Pos               16U                                            /*!< MPU TYPE: IREGION Position */
+#define MPU_TYPE_IREGION_Msk               (0xFFUL << MPU_TYPE_IREGION_Pos)               /*!< MPU TYPE: IREGION Mask */
+
+#define MPU_TYPE_DREGION_Pos                8U                                            /*!< MPU TYPE: DREGION Position */
+#define MPU_TYPE_DREGION_Msk               (0xFFUL << MPU_TYPE_DREGION_Pos)               /*!< MPU TYPE: DREGION Mask */
+
+#define MPU_TYPE_SEPARATE_Pos               0U                                            /*!< MPU TYPE: SEPARATE Position */
+#define MPU_TYPE_SEPARATE_Msk              (1UL /*<< MPU_TYPE_SEPARATE_Pos*/)             /*!< MPU TYPE: SEPARATE Mask */
+
+/** \brief MPU Control Register Definitions */
+#define MPU_CTRL_PRIVDEFENA_Pos             2U                                            /*!< MPU CTRL: PRIVDEFENA Position */
+#define MPU_CTRL_PRIVDEFENA_Msk            (1UL << MPU_CTRL_PRIVDEFENA_Pos)               /*!< MPU CTRL: PRIVDEFENA Mask */
+
+#define MPU_CTRL_HFNMIENA_Pos               1U                                            /*!< MPU CTRL: HFNMIENA Position */
+#define MPU_CTRL_HFNMIENA_Msk              (1UL << MPU_CTRL_HFNMIENA_Pos)                 /*!< MPU CTRL: HFNMIENA Mask */
+
+#define MPU_CTRL_ENABLE_Pos                 0U                                            /*!< MPU CTRL: ENABLE Position */
+#define MPU_CTRL_ENABLE_Msk                (1UL /*<< MPU_CTRL_ENABLE_Pos*/)               /*!< MPU CTRL: ENABLE Mask */
+
+/** \brief MPU Region Number Register Definitions */
+#define MPU_RNR_REGION_Pos                  0U                                            /*!< MPU RNR: REGION Position */
+#define MPU_RNR_REGION_Msk                 (0xFFUL /*<< MPU_RNR_REGION_Pos*/)             /*!< MPU RNR: REGION Mask */
+
+/** \brief MPU Region Base Address Register Definitions */
+#define MPU_RBAR_ADDR_Pos                   8U                                            /*!< MPU RBAR: ADDR Position */
+#define MPU_RBAR_ADDR_Msk                  (0xFFFFFFUL << MPU_RBAR_ADDR_Pos)              /*!< MPU RBAR: ADDR Mask */
+
+#define MPU_RBAR_VALID_Pos                  4U                                            /*!< MPU RBAR: VALID Position */
+#define MPU_RBAR_VALID_Msk                 (1UL << MPU_RBAR_VALID_Pos)                    /*!< MPU RBAR: VALID Mask */
+
+#define MPU_RBAR_REGION_Pos                 0U                                            /*!< MPU RBAR: REGION Position */
+#define MPU_RBAR_REGION_Msk                (0xFUL /*<< MPU_RBAR_REGION_Pos*/)             /*!< MPU RBAR: REGION Mask */
+
+/** \brief MPU Region Attribute and Size Register Definitions */
+#define MPU_RASR_ATTRS_Pos                 16U                                            /*!< MPU RASR: MPU Region Attribute field Position */
+#define MPU_RASR_ATTRS_Msk                 (0xFFFFUL << MPU_RASR_ATTRS_Pos)               /*!< MPU RASR: MPU Region Attribute field Mask */
+
+#define MPU_RASR_XN_Pos                    28U                                            /*!< MPU RASR: ATTRS.XN Position */
+#define MPU_RASR_XN_Msk                    (1UL << MPU_RASR_XN_Pos)                       /*!< MPU RASR: ATTRS.XN Mask */
+
+#define MPU_RASR_AP_Pos                    24U                                            /*!< MPU RASR: ATTRS.AP Position */
+#define MPU_RASR_AP_Msk                    (0x7UL << MPU_RASR_AP_Pos)                     /*!< MPU RASR: ATTRS.AP Mask */
+
+#define MPU_RASR_TEX_Pos                   19U                                            /*!< MPU RASR: ATTRS.TEX Position */
+#define MPU_RASR_TEX_Msk                   (0x7UL << MPU_RASR_TEX_Pos)                    /*!< MPU RASR: ATTRS.TEX Mask */
+
+#define MPU_RASR_S_Pos                     18U                                            /*!< MPU RASR: ATTRS.S Position */
+#define MPU_RASR_S_Msk                     (1UL << MPU_RASR_S_Pos)                        /*!< MPU RASR: ATTRS.S Mask */
+
+#define MPU_RASR_C_Pos                     17U                                            /*!< MPU RASR: ATTRS.C Position */
+#define MPU_RASR_C_Msk                     (1UL << MPU_RASR_C_Pos)                        /*!< MPU RASR: ATTRS.C Mask */
+
+#define MPU_RASR_B_Pos                     16U                                            /*!< MPU RASR: ATTRS.B Position */
+#define MPU_RASR_B_Msk                     (1UL << MPU_RASR_B_Pos)                        /*!< MPU RASR: ATTRS.B Mask */
+
+#define MPU_RASR_SRD_Pos                    8U                                            /*!< MPU RASR: Sub-Region Disable Position */
+#define MPU_RASR_SRD_Msk                   (0xFFUL << MPU_RASR_SRD_Pos)                   /*!< MPU RASR: Sub-Region Disable Mask */
+
+#define MPU_RASR_SIZE_Pos                   1U                                            /*!< MPU RASR: Region Size Field Position */
+#define MPU_RASR_SIZE_Msk                  (0x1FUL << MPU_RASR_SIZE_Pos)                  /*!< MPU RASR: Region Size Field Mask */
+
+#define MPU_RASR_ENABLE_Pos                 0U                                            /*!< MPU RASR: Region enable bit Position */
+#define MPU_RASR_ENABLE_Msk                (1UL /*<< MPU_RASR_ENABLE_Pos*/)               /*!< MPU RASR: Region enable bit Disable Mask */
+
+/*@} end of group CMSIS_MPU */
+#endif
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_CoreDebug       Core Debug Registers (CoreDebug)
+  \brief    Cortex-M0+ Core Debug Registers (DCB registers, SHCSR, and DFSR) are only accessible over DAP and not via processor.
+            Therefore they are not covered by the Cortex-M0+ header file.
+  @{
+ */
+/*@} end of group CMSIS_CoreDebug */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_core_bitfield     Core register bit field macros
+  \brief      Macros for use with bit field definitions (xxx_Pos, xxx_Msk).
+  @{
+ */
+
+/**
+  \brief   Mask and shift a bit field value for use in a register bit range.
+  \param[in] field  Name of the register bit field.
+  \param[in] value  Value of the bit field. This parameter is interpreted as an uint32_t type.
+  \return           Masked and shifted value.
+*/
+#define _VAL2FLD(field, value)    (((uint32_t)(value) << field ## _Pos) & field ## _Msk)
+
+/**
+  \brief     Mask and shift a register value to extract a bit filed value.
+  \param[in] field  Name of the register bit field.
+  \param[in] value  Value of register. This parameter is interpreted as an uint32_t type.
+  \return           Masked and shifted bit field value.
+*/
+#define _FLD2VAL(field, value)    (((uint32_t)(value) & field ## _Msk) >> field ## _Pos)
+
+/*@} end of group CMSIS_core_bitfield */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_core_base     Core Definitions
+  \brief      Definitions for base addresses, unions, and structures.
+  @{
+ */
+
+/* Memory mapping of Core Hardware */
+#define SCS_BASE            (0xE000E000UL)                            /*!< System Control Space Base Address */
+#define SysTick_BASE        (SCS_BASE +  0x0010UL)                    /*!< SysTick Base Address */
+#define NVIC_BASE           (SCS_BASE +  0x0100UL)                    /*!< NVIC Base Address */
+#define SCB_BASE            (SCS_BASE +  0x0D00UL)                    /*!< System Control Block Base Address */
+
+#define SCB                 ((SCB_Type       *)     SCB_BASE      )   /*!< SCB configuration struct */
+#define SysTick             ((SysTick_Type   *)     SysTick_BASE  )   /*!< SysTick configuration struct */
+#define NVIC                ((NVIC_Type      *)     NVIC_BASE     )   /*!< NVIC configuration struct */
+
+#if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+  #define MPU_BASE          (SCS_BASE +  0x0D90UL)                    /*!< Memory Protection Unit */
+  #define MPU               ((MPU_Type       *)     MPU_BASE      )   /*!< Memory Protection Unit */
+#endif
+
+/*@} */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_register_aliases     Backwards Compatibility Aliases
+  \brief      Register alias definitions for backwards compatibility.
+  @{
+ */
+
+/*@} */
+
+
+/*******************************************************************************
+ *                Hardware Abstraction Layer
+  Core Function Interface contains:
+  - Core NVIC Functions
+  - Core SysTick Functions
+  - Core Register Access Functions
+ ******************************************************************************/
+/**
+  \defgroup CMSIS_Core_FunctionInterface Functions and Instructions Reference
+*/
+
+
+
+/* ##########################   NVIC functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_NVICFunctions NVIC Functions
+  \brief    Functions that manage interrupts and exceptions via the NVIC.
+  @{
+ */
+
+#ifdef CMSIS_NVIC_VIRTUAL
+  #ifndef CMSIS_NVIC_VIRTUAL_HEADER_FILE
+    #define CMSIS_NVIC_VIRTUAL_HEADER_FILE "cmsis_nvic_virtual.h"
+  #endif
+  #include CMSIS_NVIC_VIRTUAL_HEADER_FILE
+#else
+  #define NVIC_SetPriorityGrouping    __NVIC_SetPriorityGrouping
+  #define NVIC_GetPriorityGrouping    __NVIC_GetPriorityGrouping
+  #define NVIC_EnableIRQ              __NVIC_EnableIRQ
+  #define NVIC_GetEnableIRQ           __NVIC_GetEnableIRQ
+  #define NVIC_DisableIRQ             __NVIC_DisableIRQ
+  #define NVIC_GetPendingIRQ          __NVIC_GetPendingIRQ
+  #define NVIC_SetPendingIRQ          __NVIC_SetPendingIRQ
+  #define NVIC_ClearPendingIRQ        __NVIC_ClearPendingIRQ
+/*        NVIC_GetActive              not available for Cortex-M0+ */
+  #define NVIC_SetPriority            __NVIC_SetPriority
+  #define NVIC_GetPriority            __NVIC_GetPriority
+  #define NVIC_SystemReset            __NVIC_SystemReset
+#endif /* CMSIS_NVIC_VIRTUAL */
+
+#ifdef CMSIS_VECTAB_VIRTUAL
+  #ifndef CMSIS_VECTAB_VIRTUAL_HEADER_FILE
+    #define CMSIS_VECTAB_VIRTUAL_HEADER_FILE "cmsis_vectab_virtual.h"
+  #endif
+  #include CMSIS_VECTAB_VIRTUAL_HEADER_FILE
+#else
+  #define NVIC_SetVector              __NVIC_SetVector
+  #define NVIC_GetVector              __NVIC_GetVector
+#endif  /* (CMSIS_VECTAB_VIRTUAL) */
+
+#define NVIC_USER_IRQ_OFFSET          16
+
+
+/* The following EXC_RETURN values are saved the LR on exception entry */
+#define EXC_RETURN_HANDLER         (0xFFFFFFF1UL)     /* return to Handler mode, uses MSP after return                               */
+#define EXC_RETURN_THREAD_MSP      (0xFFFFFFF9UL)     /* return to Thread mode, uses MSP after return                                */
+#define EXC_RETURN_THREAD_PSP      (0xFFFFFFFDUL)     /* return to Thread mode, uses PSP after return                                */
+
+
+/* Interrupt Priorities are WORD accessible only under Armv6-M                  */
+/* The following MACROS handle generation of the register offset and byte masks */
+#define _BIT_SHIFT(IRQn)         (  ((((uint32_t)(int32_t)(IRQn))         )      &  0x03UL) * 8UL)
+#define _SHP_IDX(IRQn)           ( (((((uint32_t)(int32_t)(IRQn)) & 0x0FUL)-8UL) >>    2UL)      )
+#define _IP_IDX(IRQn)            (   (((uint32_t)(int32_t)(IRQn))                >>    2UL)      )
+
+#define __NVIC_SetPriorityGrouping(X) (void)(X)
+#define __NVIC_GetPriorityGrouping()  (0U)
+
+/**
+  \brief   Enable Interrupt
+  \details Enables a device specific interrupt in the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_EnableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    __COMPILER_BARRIER();
+    NVIC->ISER[0U] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+    __COMPILER_BARRIER();
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Enable status
+  \details Returns a device specific interrupt enable status from the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt is not enabled.
+  \return             1  Interrupt is enabled.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetEnableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ISER[0U] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Disable Interrupt
+  \details Disables a device specific interrupt in the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_DisableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ICER[0U] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+    __DSB();
+    __ISB();
+  }
+}
+
+
+/**
+  \brief   Get Pending Interrupt
+  \details Reads the NVIC pending register and returns the pending bit for the specified device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not pending.
+  \return             1  Interrupt status is pending.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ISPR[0U] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Pending Interrupt
+  \details Sets the pending bit of a device specific interrupt in the NVIC pending register.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_SetPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ISPR[0U] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Clear Pending Interrupt
+  \details Clears the pending bit of a device specific interrupt in the NVIC pending register.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_ClearPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ICPR[0U] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Set Interrupt Priority
+  \details Sets the priority of a device specific interrupt or a processor exception.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]      IRQn  Interrupt number.
+  \param [in]  priority  Priority to set.
+  \note    The priority cannot be set for every processor exception.
+ */
+__STATIC_INLINE void __NVIC_SetPriority(IRQn_Type IRQn, uint32_t priority)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->IPR[_IP_IDX(IRQn)]  = ((uint32_t)(NVIC->IPR[_IP_IDX(IRQn)]  & ~(0xFFUL << _BIT_SHIFT(IRQn))) |
+       (((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL) << _BIT_SHIFT(IRQn)));
+  }
+  else
+  {
+    SCB->SHPR[_SHP_IDX(IRQn)] = ((uint32_t)(SCB->SHPR[_SHP_IDX(IRQn)] & ~(0xFFUL << _BIT_SHIFT(IRQn))) |
+       (((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL) << _BIT_SHIFT(IRQn)));
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Priority
+  \details Reads the priority of a device specific interrupt or a processor exception.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn  Interrupt number.
+  \return             Interrupt Priority.
+                      Value is aligned automatically to the implemented priority bits of the microcontroller.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPriority(IRQn_Type IRQn)
+{
+
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->IPR[ _IP_IDX(IRQn)] >> _BIT_SHIFT(IRQn) ) & (uint32_t)0xFFUL) >> (8U - __NVIC_PRIO_BITS)));
+  }
+  else
+  {
+    return((uint32_t)(((SCB->SHPR[_SHP_IDX(IRQn)] >> _BIT_SHIFT(IRQn) ) & (uint32_t)0xFFUL) >> (8U - __NVIC_PRIO_BITS)));
+  }
+}
+
+
+/**
+  \brief   Encode Priority
+  \details Encodes the priority for an interrupt with the given priority group,
+           preemptive priority value, and subpriority value.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+  \param [in]     PriorityGroup  Used priority group.
+  \param [in]   PreemptPriority  Preemptive priority value (starting from 0).
+  \param [in]       SubPriority  Subpriority value (starting from 0).
+  \return                        Encoded priority. Value can be used in the function \ref NVIC_SetPriority().
+ */
+__STATIC_INLINE uint32_t NVIC_EncodePriority (uint32_t PriorityGroup, uint32_t PreemptPriority, uint32_t SubPriority)
+{
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);   /* only values 0..7 are used          */
+  uint32_t PreemptPriorityBits;
+  uint32_t SubPriorityBits;
+
+  PreemptPriorityBits = ((7UL - PriorityGroupTmp) > (uint32_t)(__NVIC_PRIO_BITS)) ? (uint32_t)(__NVIC_PRIO_BITS) : (uint32_t)(7UL - PriorityGroupTmp);
+  SubPriorityBits     = ((PriorityGroupTmp + (uint32_t)(__NVIC_PRIO_BITS)) < (uint32_t)7UL) ? (uint32_t)0UL : (uint32_t)((PriorityGroupTmp - 7UL) + (uint32_t)(__NVIC_PRIO_BITS));
+
+  return (
+           ((PreemptPriority & (uint32_t)((1UL << (PreemptPriorityBits)) - 1UL)) << SubPriorityBits) |
+           ((SubPriority     & (uint32_t)((1UL << (SubPriorityBits    )) - 1UL)))
+         );
+}
+
+
+/**
+  \brief   Decode Priority
+  \details Decodes an interrupt priority value with a given priority group to
+           preemptive priority value and subpriority value.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS) the smallest possible priority group is set.
+  \param [in]         Priority   Priority value, which can be retrieved with the function \ref NVIC_GetPriority().
+  \param [in]     PriorityGroup  Used priority group.
+  \param [out] pPreemptPriority  Preemptive priority value (starting from 0).
+  \param [out]     pSubPriority  Subpriority value (starting from 0).
+ */
+__STATIC_INLINE void NVIC_DecodePriority (uint32_t Priority, uint32_t PriorityGroup, uint32_t* const pPreemptPriority, uint32_t* const pSubPriority)
+{
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);   /* only values 0..7 are used          */
+  uint32_t PreemptPriorityBits;
+  uint32_t SubPriorityBits;
+
+  PreemptPriorityBits = ((7UL - PriorityGroupTmp) > (uint32_t)(__NVIC_PRIO_BITS)) ? (uint32_t)(__NVIC_PRIO_BITS) : (uint32_t)(7UL - PriorityGroupTmp);
+  SubPriorityBits     = ((PriorityGroupTmp + (uint32_t)(__NVIC_PRIO_BITS)) < (uint32_t)7UL) ? (uint32_t)0UL : (uint32_t)((PriorityGroupTmp - 7UL) + (uint32_t)(__NVIC_PRIO_BITS));
+
+  *pPreemptPriority = (Priority >> SubPriorityBits) & (uint32_t)((1UL << (PreemptPriorityBits)) - 1UL);
+  *pSubPriority     = (Priority                   ) & (uint32_t)((1UL << (SubPriorityBits    )) - 1UL);
+}
+
+
+/**
+  \brief   Set Interrupt Vector
+  \details Sets an interrupt vector in SRAM based interrupt vector table.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+           VTOR must been relocated to SRAM before.
+           If VTOR is not present address 0 must be mapped to SRAM.
+  \param [in]   IRQn      Interrupt number
+  \param [in]   vector    Address of interrupt handler function
+ */
+__STATIC_INLINE void __NVIC_SetVector(IRQn_Type IRQn, uint32_t vector)
+{
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  uint32_t *vectors = (uint32_t *) ((uintptr_t) SCB->VTOR);
+  vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET] = vector;
+#else
+  uint32_t *vectors = (uint32_t *)(NVIC_USER_IRQ_OFFSET << 2);      /* point to 1st user interrupt */
+  *(vectors + (int32_t)IRQn) = vector;                              /* use pointer arithmetic to access vector */
+#endif
+  /* ARM Application Note 321 states that the M0+ does not require the architectural barrier */
+}
+
+
+/**
+  \brief   Get Interrupt Vector
+  \details Reads an interrupt vector from interrupt vector table.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn      Interrupt number.
+  \return                 Address of interrupt handler function
+ */
+__STATIC_INLINE uint32_t __NVIC_GetVector(IRQn_Type IRQn)
+{
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  uint32_t *vectors = (uint32_t *) ((uintptr_t) SCB->VTOR);
+  return vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET];
+#else
+  uint32_t *vectors = (uint32_t *)(NVIC_USER_IRQ_OFFSET << 2);      /* point to 1st user interrupt */
+  return *(vectors + (int32_t)IRQn);                                /* use pointer arithmetic to access vector */
+#endif
+}
+
+
+/**
+  \brief   System Reset
+  \details Initiates a system reset request to reset the MCU.
+ */
+__NO_RETURN __STATIC_INLINE void __NVIC_SystemReset(void)
+{
+  __DSB();                                                          /* Ensure all outstanding memory accesses included
+                                                                       buffered write are completed before reset */
+  SCB->AIRCR  = ((0x5FAUL << SCB_AIRCR_VECTKEY_Pos) |
+                 SCB_AIRCR_SYSRESETREQ_Msk);
+  __DSB();                                                          /* Ensure completion of memory access */
+
+  for(;;)                                                           /* wait until reset */
+  {
+    __NOP();
+  }
+}
+
+/*@} end of CMSIS_Core_NVICFunctions */
+
+/* ##########################  MPU functions  #################################### */
+
+#if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+
+#include "m-profile/armv7m_mpu.h"
+
+#endif
+
+/* ##########################  FPU functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_FpuFunctions FPU Functions
+  \brief    Function that provides FPU type.
+  @{
+ */
+
+/**
+  \brief   get FPU type
+  \details returns the FPU type
+  \returns
+   - \b  0: No FPU
+   - \b  1: Single precision FPU
+   - \b  2: Double + Single precision FPU
+ */
+__STATIC_INLINE uint32_t SCB_GetFPUType(void)
+{
+    return 0U;           /* No FPU */
+}
+
+
+/*@} end of CMSIS_Core_FpuFunctions */
+
+
+
+/* ##################################    SysTick function  ############################################ */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_SysTickFunctions SysTick Functions
+  \brief    Functions that configure the System.
+  @{
+ */
+
+#if defined (__Vendor_SysTickConfig) && (__Vendor_SysTickConfig == 0U)
+
+/**
+  \brief   System Tick Configuration
+  \details Initializes the System Timer and its interrupt, and starts the System Tick Timer.
+           Counter is in free running mode to generate periodic interrupts.
+  \param [in]  ticks  Number of ticks between two interrupts.
+  \return          0  Function succeeded.
+  \return          1  Function failed.
+  \note    When the variable <b>__Vendor_SysTickConfig</b> is set to 1, then the
+           function <b>SysTick_Config</b> is not included. In this case, the file <b><i>device</i>.h</b>
+           must contain a vendor-specific implementation of this function.
+ */
+__STATIC_INLINE uint32_t SysTick_Config(uint32_t ticks)
+{
+  if ((ticks - 1UL) > SysTick_LOAD_RELOAD_Msk)
+  {
+    return (1UL);                                                   /* Reload value impossible */
+  }
+
+  SysTick->LOAD  = (uint32_t)(ticks - 1UL);                         /* set reload register */
+  NVIC_SetPriority (SysTick_IRQn, (1UL << __NVIC_PRIO_BITS) - 1UL); /* set Priority for Systick Interrupt */
+  SysTick->VAL   = 0UL;                                             /* Load the SysTick Counter Value */
+  SysTick->CTRL  = SysTick_CTRL_CLKSOURCE_Msk |
+                   SysTick_CTRL_TICKINT_Msk   |
+                   SysTick_CTRL_ENABLE_Msk;                         /* Enable SysTick IRQ and SysTick Timer */
+  return (0UL);                                                     /* Function successful */
+}
+
+#endif
+
+/*@} end of CMSIS_Core_SysTickFunctions */
+
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_CM0PLUS_H_DEPENDANT */
+
+#endif /* __CMSIS_GENERIC */

--- a/platform/ext/cmsis/CMSIS/Core/Include/core_cm1.h
+++ b/platform/ext/cmsis/CMSIS/Core/Include/core_cm1.h
@@ -1,0 +1,986 @@
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS Cortex-M1 Core Peripheral Access Layer Header File
+ */
+
+#if   defined ( __ICCARM__ )
+  #pragma system_include                        /* treat file as system include file for MISRA check */
+#elif defined (__clang__)
+  #pragma clang system_header                   /* treat file as system include file */
+#elif defined ( __GNUC__ )
+  #pragma GCC diagnostic ignored "-Wpedantic"   /* disable pedantic warning due to unnamed structs/unions */
+#endif
+
+#ifndef __CORE_CM1_H_GENERIC
+#define __CORE_CM1_H_GENERIC
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/**
+  \page CMSIS_MISRA_Exceptions  MISRA-C:2004 Compliance Exceptions
+  CMSIS violates the following MISRA-C:2004 rules:
+
+   \li Required Rule 8.5, object/function definition in header file.<br>
+     Function definitions in header files are used to allow 'inlining'.
+
+   \li Required Rule 18.4, declaration of union type or object of union type: '{...}'.<br>
+     Unions are used for effective representation of core registers.
+
+   \li Advisory Rule 19.7, Function-like macro defined.<br>
+     Function-like macros are used to allow more efficient code.
+ */
+
+
+/*******************************************************************************
+ *                 CMSIS definitions
+ ******************************************************************************/
+/**
+  \ingroup Cortex_M1
+  @{
+ */
+
+#include "cmsis_version.h"
+
+/* CMSIS CM1 definitions */
+
+#define __CORTEX_M                (1U)                                /*!< Cortex-M Core */
+
+/** __FPU_USED indicates whether an FPU is used or not.
+    This core does not support an FPU at all
+*/
+#define __FPU_USED       0U
+
+#if defined ( __CC_ARM )
+  #if defined (__TARGET_FPU_VFP)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #if defined (__ARM_FP)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined (__ti__)
+  #if defined (__ARM_FP)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __GNUC__ )
+  #if defined (__VFP_FP__) && !defined(__SOFTFP__)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __ICCARM__ )
+  #if defined (__ARMVFP__)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __TI_ARM__ )
+  #if defined (__TI_VFP_SUPPORT__)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __TASKING__ )
+  #if defined (__FPU_VFP__)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __CSMC__ )
+  #if ( __CSMC__ & 0x400U)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#endif
+
+#include "cmsis_compiler.h"               /* CMSIS compiler specific defines */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_CM1_H_GENERIC */
+
+#ifndef __CMSIS_GENERIC
+
+#ifndef __CORE_CM1_H_DEPENDANT
+#define __CORE_CM1_H_DEPENDANT
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* check device defines and use defaults */
+#if defined __CHECK_DEVICE_DEFINES
+  #ifndef __CM1_REV
+    #define __CM1_REV               0x0100U
+    #warning "__CM1_REV not defined in device header file; using default!"
+  #endif
+
+  #ifndef __NVIC_PRIO_BITS
+    #define __NVIC_PRIO_BITS          2U
+    #warning "__NVIC_PRIO_BITS not defined in device header file; using default!"
+  #endif
+
+  #ifndef __Vendor_SysTickConfig
+    #define __Vendor_SysTickConfig    0U
+    #warning "__Vendor_SysTickConfig not defined in device header file; using default!"
+  #endif
+#endif
+
+/* IO definitions (access restrictions to peripheral registers) */
+/**
+    \defgroup CMSIS_glob_defs CMSIS Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+*/
+#ifdef __cplusplus
+  #define   __I     volatile             /*!< Defines 'read only' permissions */
+#else
+  #define   __I     volatile const       /*!< Defines 'read only' permissions */
+#endif
+#define     __O     volatile             /*!< Defines 'write only' permissions */
+#define     __IO    volatile             /*!< Defines 'read / write' permissions */
+
+/* following defines should be used for structure members */
+#define     __IM     volatile const      /*! Defines 'read only' structure member permissions */
+#define     __OM     volatile            /*! Defines 'write only' structure member permissions */
+#define     __IOM    volatile            /*! Defines 'read / write' structure member permissions */
+
+/*@} end of group Cortex_M1 */
+
+
+
+/*******************************************************************************
+ *                 Register Abstraction
+  Core Register contain:
+  - Core Register
+  - Core NVIC Register
+  - Core SCB Register
+  - Core SysTick Register
+ ******************************************************************************/
+/**
+  \defgroup CMSIS_core_register Defines and Type Definitions
+  \brief Type definitions and defines for Cortex-M processor based devices.
+*/
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_CORE  Status and Control Registers
+  \brief      Core Register type definitions.
+  @{
+ */
+
+/**
+  \brief  Union type to access the Application Program Status Register (APSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t _reserved0:28;              /*!< bit:  0..27  Reserved */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} APSR_Type;
+
+/** \brief APSR Register Definitions */
+#define APSR_N_Pos                         31U                                            /*!< APSR: N Position */
+#define APSR_N_Msk                         (1UL << APSR_N_Pos)                            /*!< APSR: N Mask */
+
+#define APSR_Z_Pos                         30U                                            /*!< APSR: Z Position */
+#define APSR_Z_Msk                         (1UL << APSR_Z_Pos)                            /*!< APSR: Z Mask */
+
+#define APSR_C_Pos                         29U                                            /*!< APSR: C Position */
+#define APSR_C_Msk                         (1UL << APSR_C_Pos)                            /*!< APSR: C Mask */
+
+#define APSR_V_Pos                         28U                                            /*!< APSR: V Position */
+#define APSR_V_Msk                         (1UL << APSR_V_Pos)                            /*!< APSR: V Mask */
+
+
+/**
+  \brief  Union type to access the Interrupt Program Status Register (IPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number */
+    uint32_t _reserved0:23;              /*!< bit:  9..31  Reserved */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} IPSR_Type;
+
+/** \brief IPSR Register Definitions */
+#define IPSR_ISR_Pos                        0U                                            /*!< IPSR: ISR Position */
+#define IPSR_ISR_Msk                       (0x1FFUL /*<< IPSR_ISR_Pos*/)                  /*!< IPSR: ISR Mask */
+
+
+/**
+  \brief  Union type to access the Special-Purpose Program Status Registers (xPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number */
+    uint32_t _reserved0:15;              /*!< bit:  9..23  Reserved */
+    uint32_t T:1;                        /*!< bit:     24  Thumb bit        (read 0) */
+    uint32_t _reserved1:3;               /*!< bit: 25..27  Reserved */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} xPSR_Type;
+
+/** \brief xPSR Register Definitions */
+#define xPSR_N_Pos                         31U                                            /*!< xPSR: N Position */
+#define xPSR_N_Msk                         (1UL << xPSR_N_Pos)                            /*!< xPSR: N Mask */
+
+#define xPSR_Z_Pos                         30U                                            /*!< xPSR: Z Position */
+#define xPSR_Z_Msk                         (1UL << xPSR_Z_Pos)                            /*!< xPSR: Z Mask */
+
+#define xPSR_C_Pos                         29U                                            /*!< xPSR: C Position */
+#define xPSR_C_Msk                         (1UL << xPSR_C_Pos)                            /*!< xPSR: C Mask */
+
+#define xPSR_V_Pos                         28U                                            /*!< xPSR: V Position */
+#define xPSR_V_Msk                         (1UL << xPSR_V_Pos)                            /*!< xPSR: V Mask */
+
+#define xPSR_T_Pos                         24U                                            /*!< xPSR: T Position */
+#define xPSR_T_Msk                         (1UL << xPSR_T_Pos)                            /*!< xPSR: T Mask */
+
+#define xPSR_ISR_Pos                        0U                                            /*!< xPSR: ISR Position */
+#define xPSR_ISR_Msk                       (0x1FFUL /*<< xPSR_ISR_Pos*/)                  /*!< xPSR: ISR Mask */
+
+
+/**
+  \brief  Union type to access the Control Registers (CONTROL).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t _reserved0:1;               /*!< bit:      0  Reserved */
+    uint32_t SPSEL:1;                    /*!< bit:      1  Stack to be used */
+    uint32_t _reserved1:30;              /*!< bit:  2..31  Reserved */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} CONTROL_Type;
+
+/** \brief CONTROL Register Definitions */
+#define CONTROL_SPSEL_Pos                   1U                                            /*!< CONTROL: SPSEL Position */
+#define CONTROL_SPSEL_Msk                  (1UL << CONTROL_SPSEL_Pos)                     /*!< CONTROL: SPSEL Mask */
+
+/*@} end of group CMSIS_CORE */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_NVIC  Nested Vectored Interrupt Controller (NVIC)
+  \brief      Type definitions for the NVIC Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Nested Vectored Interrupt Controller (NVIC).
+ */
+typedef struct
+{
+  __IOM uint32_t ISER[1U];               /*!< Offset: 0x000 (R/W)  Interrupt Set Enable Register */
+        uint32_t RESERVED0[31U];
+  __IOM uint32_t ICER[1U];               /*!< Offset: 0x080 (R/W)  Interrupt Clear Enable Register */
+        uint32_t RESERVED1[31U];
+  __IOM uint32_t ISPR[1U];               /*!< Offset: 0x100 (R/W)  Interrupt Set Pending Register */
+        uint32_t RESERVED2[31U];
+  __IOM uint32_t ICPR[1U];               /*!< Offset: 0x180 (R/W)  Interrupt Clear Pending Register */
+        uint32_t RESERVED3[31U];
+        uint32_t RESERVED4[64U];
+  __IOM uint32_t IPR[8U];                /*!< Offset: 0x300 (R/W)  Interrupt Priority Register */
+}  NVIC_Type;
+
+/*@} end of group CMSIS_NVIC */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SCB     System Control Block (SCB)
+  \brief    Type definitions for the System Control Block Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Control Block (SCB).
+ */
+typedef struct
+{
+  __IM  uint32_t CPUID;                  /*!< Offset: 0x000 (R/ )  CPUID Base Register */
+  __IOM uint32_t ICSR;                   /*!< Offset: 0x004 (R/W)  Interrupt Control and State Register */
+        uint32_t RESERVED0;
+  __IOM uint32_t AIRCR;                  /*!< Offset: 0x00C (R/W)  Application Interrupt and Reset Control Register */
+  __IOM uint32_t SCR;                    /*!< Offset: 0x010 (R/W)  System Control Register */
+  __IOM uint32_t CCR;                    /*!< Offset: 0x014 (R/W)  Configuration Control Register */
+        uint32_t RESERVED1;
+  __IOM uint32_t SHPR[2U];               /*!< Offset: 0x01C (R/W)  System Handlers Priority Registers. [0] is RESERVED */
+  __IOM uint32_t SHCSR;                  /*!< Offset: 0x024 (R/W)  System Handler Control and State Register */
+} SCB_Type;
+
+/** \brief SCB CPUID Register Definitions */
+#define SCB_CPUID_IMPLEMENTER_Pos          24U                                            /*!< SCB CPUID: IMPLEMENTER Position */
+#define SCB_CPUID_IMPLEMENTER_Msk          (0xFFUL << SCB_CPUID_IMPLEMENTER_Pos)          /*!< SCB CPUID: IMPLEMENTER Mask */
+
+#define SCB_CPUID_VARIANT_Pos              20U                                            /*!< SCB CPUID: VARIANT Position */
+#define SCB_CPUID_VARIANT_Msk              (0xFUL << SCB_CPUID_VARIANT_Pos)               /*!< SCB CPUID: VARIANT Mask */
+
+#define SCB_CPUID_ARCHITECTURE_Pos         16U                                            /*!< SCB CPUID: ARCHITECTURE Position */
+#define SCB_CPUID_ARCHITECTURE_Msk         (0xFUL << SCB_CPUID_ARCHITECTURE_Pos)          /*!< SCB CPUID: ARCHITECTURE Mask */
+
+#define SCB_CPUID_PARTNO_Pos                4U                                            /*!< SCB CPUID: PARTNO Position */
+#define SCB_CPUID_PARTNO_Msk               (0xFFFUL << SCB_CPUID_PARTNO_Pos)              /*!< SCB CPUID: PARTNO Mask */
+
+#define SCB_CPUID_REVISION_Pos              0U                                            /*!< SCB CPUID: REVISION Position */
+#define SCB_CPUID_REVISION_Msk             (0xFUL /*<< SCB_CPUID_REVISION_Pos*/)          /*!< SCB CPUID: REVISION Mask */
+
+/** \brief SCB Interrupt Control State Register Definitions */
+#define SCB_ICSR_NMIPENDSET_Pos            31U                                            /*!< SCB ICSR: NMIPENDSET Position */
+#define SCB_ICSR_NMIPENDSET_Msk            (1UL << SCB_ICSR_NMIPENDSET_Pos)               /*!< SCB ICSR: NMIPENDSET Mask */
+
+#define SCB_ICSR_PENDSVSET_Pos             28U                                            /*!< SCB ICSR: PENDSVSET Position */
+#define SCB_ICSR_PENDSVSET_Msk             (1UL << SCB_ICSR_PENDSVSET_Pos)                /*!< SCB ICSR: PENDSVSET Mask */
+
+#define SCB_ICSR_PENDSVCLR_Pos             27U                                            /*!< SCB ICSR: PENDSVCLR Position */
+#define SCB_ICSR_PENDSVCLR_Msk             (1UL << SCB_ICSR_PENDSVCLR_Pos)                /*!< SCB ICSR: PENDSVCLR Mask */
+
+#define SCB_ICSR_PENDSTSET_Pos             26U                                            /*!< SCB ICSR: PENDSTSET Position */
+#define SCB_ICSR_PENDSTSET_Msk             (1UL << SCB_ICSR_PENDSTSET_Pos)                /*!< SCB ICSR: PENDSTSET Mask */
+
+#define SCB_ICSR_PENDSTCLR_Pos             25U                                            /*!< SCB ICSR: PENDSTCLR Position */
+#define SCB_ICSR_PENDSTCLR_Msk             (1UL << SCB_ICSR_PENDSTCLR_Pos)                /*!< SCB ICSR: PENDSTCLR Mask */
+
+#define SCB_ICSR_ISRPREEMPT_Pos            23U                                            /*!< SCB ICSR: ISRPREEMPT Position */
+#define SCB_ICSR_ISRPREEMPT_Msk            (1UL << SCB_ICSR_ISRPREEMPT_Pos)               /*!< SCB ICSR: ISRPREEMPT Mask */
+
+#define SCB_ICSR_ISRPENDING_Pos            22U                                            /*!< SCB ICSR: ISRPENDING Position */
+#define SCB_ICSR_ISRPENDING_Msk            (1UL << SCB_ICSR_ISRPENDING_Pos)               /*!< SCB ICSR: ISRPENDING Mask */
+
+#define SCB_ICSR_VECTPENDING_Pos           12U                                            /*!< SCB ICSR: VECTPENDING Position */
+#define SCB_ICSR_VECTPENDING_Msk           (0x1FFUL << SCB_ICSR_VECTPENDING_Pos)          /*!< SCB ICSR: VECTPENDING Mask */
+
+#define SCB_ICSR_VECTACTIVE_Pos             0U                                            /*!< SCB ICSR: VECTACTIVE Position */
+#define SCB_ICSR_VECTACTIVE_Msk            (0x1FFUL /*<< SCB_ICSR_VECTACTIVE_Pos*/)       /*!< SCB ICSR: VECTACTIVE Mask */
+
+/** \brief SCB Application Interrupt and Reset Control Register Definitions */
+#define SCB_AIRCR_VECTKEY_Pos              16U                                            /*!< SCB AIRCR: VECTKEY Position */
+#define SCB_AIRCR_VECTKEY_Msk              (0xFFFFUL << SCB_AIRCR_VECTKEY_Pos)            /*!< SCB AIRCR: VECTKEY Mask */
+
+#define SCB_AIRCR_VECTKEYSTAT_Pos          16U                                            /*!< SCB AIRCR: VECTKEYSTAT Position */
+#define SCB_AIRCR_VECTKEYSTAT_Msk          (0xFFFFUL << SCB_AIRCR_VECTKEYSTAT_Pos)        /*!< SCB AIRCR: VECTKEYSTAT Mask */
+
+#define SCB_AIRCR_ENDIANESS_Pos            15U                                            /*!< SCB AIRCR: ENDIANESS Position */
+#define SCB_AIRCR_ENDIANESS_Msk            (1UL << SCB_AIRCR_ENDIANESS_Pos)               /*!< SCB AIRCR: ENDIANESS Mask */
+
+#define SCB_AIRCR_SYSRESETREQ_Pos           2U                                            /*!< SCB AIRCR: SYSRESETREQ Position */
+#define SCB_AIRCR_SYSRESETREQ_Msk          (1UL << SCB_AIRCR_SYSRESETREQ_Pos)             /*!< SCB AIRCR: SYSRESETREQ Mask */
+
+#define SCB_AIRCR_VECTCLRACTIVE_Pos         1U                                            /*!< SCB AIRCR: VECTCLRACTIVE Position */
+#define SCB_AIRCR_VECTCLRACTIVE_Msk        (1UL << SCB_AIRCR_VECTCLRACTIVE_Pos)           /*!< SCB AIRCR: VECTCLRACTIVE Mask */
+
+/** \brief SCB System Control Register Definitions */
+#define SCB_SCR_SEVONPEND_Pos               4U                                            /*!< SCB SCR: SEVONPEND Position */
+#define SCB_SCR_SEVONPEND_Msk              (1UL << SCB_SCR_SEVONPEND_Pos)                 /*!< SCB SCR: SEVONPEND Mask */
+
+#define SCB_SCR_SLEEPDEEP_Pos               2U                                            /*!< SCB SCR: SLEEPDEEP Position */
+#define SCB_SCR_SLEEPDEEP_Msk              (1UL << SCB_SCR_SLEEPDEEP_Pos)                 /*!< SCB SCR: SLEEPDEEP Mask */
+
+#define SCB_SCR_SLEEPONEXIT_Pos             1U                                            /*!< SCB SCR: SLEEPONEXIT Position */
+#define SCB_SCR_SLEEPONEXIT_Msk            (1UL << SCB_SCR_SLEEPONEXIT_Pos)               /*!< SCB SCR: SLEEPONEXIT Mask */
+
+/** \brief SCB Configuration Control Register Definitions */
+#define SCB_CCR_STKALIGN_Pos                9U                                            /*!< SCB CCR: STKALIGN Position */
+#define SCB_CCR_STKALIGN_Msk               (1UL << SCB_CCR_STKALIGN_Pos)                  /*!< SCB CCR: STKALIGN Mask */
+
+#define SCB_CCR_UNALIGN_TRP_Pos             3U                                            /*!< SCB CCR: UNALIGN_TRP Position */
+#define SCB_CCR_UNALIGN_TRP_Msk            (1UL << SCB_CCR_UNALIGN_TRP_Pos)               /*!< SCB CCR: UNALIGN_TRP Mask */
+
+/** \brief SCB System Handler Control and State Register Definitions */
+#define SCB_SHCSR_SVCALLPENDED_Pos         15U                                            /*!< SCB SHCSR: SVCALLPENDED Position */
+#define SCB_SHCSR_SVCALLPENDED_Msk         (1UL << SCB_SHCSR_SVCALLPENDED_Pos)            /*!< SCB SHCSR: SVCALLPENDED Mask */
+
+/*@} end of group CMSIS_SCB */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SCnSCB System Controls not in SCB (SCnSCB)
+  \brief    Type definitions for the System Control and ID Register not in the SCB
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Control and ID Register not in the SCB.
+ */
+typedef struct
+{
+        uint32_t RESERVED0[2U];
+  __IOM uint32_t ACTLR;                  /*!< Offset: 0x008 (R/W)  Auxiliary Control Register */
+} SCnSCB_Type;
+
+/** \brief SCnSCB Auxiliary Control Register Definitions */
+#define SCnSCB_ACTLR_ITCMUAEN_Pos            4U                                        /*!< ACTLR: Instruction TCM Upper Alias Enable Position */
+#define SCnSCB_ACTLR_ITCMUAEN_Msk           (1UL << SCnSCB_ACTLR_ITCMUAEN_Pos)         /*!< ACTLR: Instruction TCM Upper Alias Enable Mask */
+
+#define SCnSCB_ACTLR_ITCMLAEN_Pos            3U                                        /*!< ACTLR: Instruction TCM Lower Alias Enable Position */
+#define SCnSCB_ACTLR_ITCMLAEN_Msk           (1UL << SCnSCB_ACTLR_ITCMLAEN_Pos)         /*!< ACTLR: Instruction TCM Lower Alias Enable Mask */
+
+/*@} end of group CMSIS_SCnotSCB */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SysTick     System Tick Timer (SysTick)
+  \brief    Type definitions for the System Timer Registers.
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Timer (SysTick).
+ */
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  SysTick Control and Status Register */
+  __IOM uint32_t LOAD;                   /*!< Offset: 0x004 (R/W)  SysTick Reload Value Register */
+  __IOM uint32_t VAL;                    /*!< Offset: 0x008 (R/W)  SysTick Current Value Register */
+  __IM  uint32_t CALIB;                  /*!< Offset: 0x00C (R/ )  SysTick Calibration Register */
+} SysTick_Type;
+
+/** \brief SysTick Control / Status Register Definitions */
+#define SysTick_CTRL_COUNTFLAG_Pos         16U                                            /*!< SysTick CTRL: COUNTFLAG Position */
+#define SysTick_CTRL_COUNTFLAG_Msk         (1UL << SysTick_CTRL_COUNTFLAG_Pos)            /*!< SysTick CTRL: COUNTFLAG Mask */
+
+#define SysTick_CTRL_CLKSOURCE_Pos          2U                                            /*!< SysTick CTRL: CLKSOURCE Position */
+#define SysTick_CTRL_CLKSOURCE_Msk         (1UL << SysTick_CTRL_CLKSOURCE_Pos)            /*!< SysTick CTRL: CLKSOURCE Mask */
+
+#define SysTick_CTRL_TICKINT_Pos            1U                                            /*!< SysTick CTRL: TICKINT Position */
+#define SysTick_CTRL_TICKINT_Msk           (1UL << SysTick_CTRL_TICKINT_Pos)              /*!< SysTick CTRL: TICKINT Mask */
+
+#define SysTick_CTRL_ENABLE_Pos             0U                                            /*!< SysTick CTRL: ENABLE Position */
+#define SysTick_CTRL_ENABLE_Msk            (1UL /*<< SysTick_CTRL_ENABLE_Pos*/)           /*!< SysTick CTRL: ENABLE Mask */
+
+/** \brief SysTick Reload Register Definitions */
+#define SysTick_LOAD_RELOAD_Pos             0U                                            /*!< SysTick LOAD: RELOAD Position */
+#define SysTick_LOAD_RELOAD_Msk            (0xFFFFFFUL /*<< SysTick_LOAD_RELOAD_Pos*/)    /*!< SysTick LOAD: RELOAD Mask */
+
+/** \brief SysTick Current Register Definitions */
+#define SysTick_VAL_CURRENT_Pos             0U                                            /*!< SysTick VAL: CURRENT Position */
+#define SysTick_VAL_CURRENT_Msk            (0xFFFFFFUL /*<< SysTick_VAL_CURRENT_Pos*/)    /*!< SysTick VAL: CURRENT Mask */
+
+/** \brief SysTick Calibration Register Definitions */
+#define SysTick_CALIB_NOREF_Pos            31U                                            /*!< SysTick CALIB: NOREF Position */
+#define SysTick_CALIB_NOREF_Msk            (1UL << SysTick_CALIB_NOREF_Pos)               /*!< SysTick CALIB: NOREF Mask */
+
+#define SysTick_CALIB_SKEW_Pos             30U                                            /*!< SysTick CALIB: SKEW Position */
+#define SysTick_CALIB_SKEW_Msk             (1UL << SysTick_CALIB_SKEW_Pos)                /*!< SysTick CALIB: SKEW Mask */
+
+#define SysTick_CALIB_TENMS_Pos             0U                                            /*!< SysTick CALIB: TENMS Position */
+#define SysTick_CALIB_TENMS_Msk            (0xFFFFFFUL /*<< SysTick_CALIB_TENMS_Pos*/)    /*!< SysTick CALIB: TENMS Mask */
+
+/*@} end of group CMSIS_SysTick */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_CoreDebug       Core Debug Registers (CoreDebug)
+  \brief    Cortex-M1 Core Debug Registers (DCB registers, SHCSR, and DFSR) are only accessible over DAP and not via processor.
+            Therefore they are not covered by the Cortex-M1 header file.
+  @{
+ */
+/*@} end of group CMSIS_CoreDebug */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_core_bitfield     Core register bit field macros
+  \brief      Macros for use with bit field definitions (xxx_Pos, xxx_Msk).
+  @{
+ */
+
+/**
+  \brief   Mask and shift a bit field value for use in a register bit range.
+  \param[in] field  Name of the register bit field.
+  \param[in] value  Value of the bit field. This parameter is interpreted as an uint32_t type.
+  \return           Masked and shifted value.
+*/
+#define _VAL2FLD(field, value)    (((uint32_t)(value) << field ## _Pos) & field ## _Msk)
+
+/**
+  \brief     Mask and shift a register value to extract a bit filed value.
+  \param[in] field  Name of the register bit field.
+  \param[in] value  Value of register. This parameter is interpreted as an uint32_t type.
+  \return           Masked and shifted bit field value.
+*/
+#define _FLD2VAL(field, value)    (((uint32_t)(value) & field ## _Msk) >> field ## _Pos)
+
+/*@} end of group CMSIS_core_bitfield */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_core_base     Core Definitions
+  \brief      Definitions for base addresses, unions, and structures.
+  @{
+ */
+
+/* Memory mapping of Core Hardware */
+#define SCS_BASE            (0xE000E000UL)                            /*!< System Control Space Base Address */
+#define SysTick_BASE        (SCS_BASE +  0x0010UL)                    /*!< SysTick Base Address */
+#define NVIC_BASE           (SCS_BASE +  0x0100UL)                    /*!< NVIC Base Address */
+#define SCB_BASE            (SCS_BASE +  0x0D00UL)                    /*!< System Control Block Base Address */
+
+#define SCnSCB              ((SCnSCB_Type    *)     SCS_BASE      )   /*!< System control Register not in SCB */
+#define SCB                 ((SCB_Type       *)     SCB_BASE      )   /*!< SCB configuration struct */
+#define SysTick             ((SysTick_Type   *)     SysTick_BASE  )   /*!< SysTick configuration struct */
+#define NVIC                ((NVIC_Type      *)     NVIC_BASE     )   /*!< NVIC configuration struct */
+
+
+/*@} */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_register_aliases     Backwards Compatibility Aliases
+  \brief      Register alias definitions for backwards compatibility.
+  @{
+ */
+
+/*@} */
+
+
+/*******************************************************************************
+ *                Hardware Abstraction Layer
+  Core Function Interface contains:
+  - Core NVIC Functions
+  - Core SysTick Functions
+  - Core Register Access Functions
+ ******************************************************************************/
+/**
+  \defgroup CMSIS_Core_FunctionInterface Functions and Instructions Reference
+*/
+
+
+
+/* ##########################   NVIC functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_NVICFunctions NVIC Functions
+  \brief    Functions that manage interrupts and exceptions via the NVIC.
+  @{
+ */
+
+#ifdef CMSIS_NVIC_VIRTUAL
+  #ifndef CMSIS_NVIC_VIRTUAL_HEADER_FILE
+    #define CMSIS_NVIC_VIRTUAL_HEADER_FILE "cmsis_nvic_virtual.h"
+  #endif
+  #include CMSIS_NVIC_VIRTUAL_HEADER_FILE
+#else
+  #define NVIC_SetPriorityGrouping    __NVIC_SetPriorityGrouping
+  #define NVIC_GetPriorityGrouping    __NVIC_GetPriorityGrouping
+  #define NVIC_EnableIRQ              __NVIC_EnableIRQ
+  #define NVIC_GetEnableIRQ           __NVIC_GetEnableIRQ
+  #define NVIC_DisableIRQ             __NVIC_DisableIRQ
+  #define NVIC_GetPendingIRQ          __NVIC_GetPendingIRQ
+  #define NVIC_SetPendingIRQ          __NVIC_SetPendingIRQ
+  #define NVIC_ClearPendingIRQ        __NVIC_ClearPendingIRQ
+/*#define NVIC_GetActive              __NVIC_GetActive             not available for Cortex-M1 */
+  #define NVIC_SetPriority            __NVIC_SetPriority
+  #define NVIC_GetPriority            __NVIC_GetPriority
+  #define NVIC_SystemReset            __NVIC_SystemReset
+#endif /* CMSIS_NVIC_VIRTUAL */
+
+#ifdef CMSIS_VECTAB_VIRTUAL
+  #ifndef CMSIS_VECTAB_VIRTUAL_HEADER_FILE
+    #define CMSIS_VECTAB_VIRTUAL_HEADER_FILE "cmsis_vectab_virtual.h"
+  #endif
+  #include CMSIS_VECTAB_VIRTUAL_HEADER_FILE
+#else
+  #define NVIC_SetVector              __NVIC_SetVector
+  #define NVIC_GetVector              __NVIC_GetVector
+#endif  /* (CMSIS_VECTAB_VIRTUAL) */
+
+#define NVIC_USER_IRQ_OFFSET          16
+
+
+/* The following EXC_RETURN values are saved the LR on exception entry */
+#define EXC_RETURN_HANDLER         (0xFFFFFFF1UL)     /* return to Handler mode, uses MSP after return                               */
+#define EXC_RETURN_THREAD_MSP      (0xFFFFFFF9UL)     /* return to Thread mode, uses MSP after return                                */
+#define EXC_RETURN_THREAD_PSP      (0xFFFFFFFDUL)     /* return to Thread mode, uses PSP after return                                */
+
+
+/* Interrupt Priorities are WORD accessible only under Armv6-M                  */
+/* The following MACROS handle generation of the register offset and byte masks */
+#define _BIT_SHIFT(IRQn)         (  ((((uint32_t)(int32_t)(IRQn))         )      &  0x03UL) * 8UL)
+#define _SHP_IDX(IRQn)           ( (((((uint32_t)(int32_t)(IRQn)) & 0x0FUL)-8UL) >>    2UL)      )
+#define _IP_IDX(IRQn)            (   (((uint32_t)(int32_t)(IRQn))                >>    2UL)      )
+
+#define __NVIC_SetPriorityGrouping(X) (void)(X)
+#define __NVIC_GetPriorityGrouping()  (0U)
+
+/**
+  \brief   Enable Interrupt
+  \details Enables a device specific interrupt in the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_EnableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    __COMPILER_BARRIER();
+    NVIC->ISER[0U] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+    __COMPILER_BARRIER();
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Enable status
+  \details Returns a device specific interrupt enable status from the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt is not enabled.
+  \return             1  Interrupt is enabled.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetEnableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ISER[0U] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Disable Interrupt
+  \details Disables a device specific interrupt in the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_DisableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ICER[0U] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+    __DSB();
+    __ISB();
+  }
+}
+
+
+/**
+  \brief   Get Pending Interrupt
+  \details Reads the NVIC pending register and returns the pending bit for the specified device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not pending.
+  \return             1  Interrupt status is pending.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ISPR[0U] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Pending Interrupt
+  \details Sets the pending bit of a device specific interrupt in the NVIC pending register.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_SetPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ISPR[0U] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Clear Pending Interrupt
+  \details Clears the pending bit of a device specific interrupt in the NVIC pending register.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_ClearPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ICPR[0U] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Set Interrupt Priority
+  \details Sets the priority of a device specific interrupt or a processor exception.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]      IRQn  Interrupt number.
+  \param [in]  priority  Priority to set.
+  \note    The priority cannot be set for every processor exception.
+ */
+__STATIC_INLINE void __NVIC_SetPriority(IRQn_Type IRQn, uint32_t priority)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->IPR[_IP_IDX(IRQn)]  = ((uint32_t)(NVIC->IPR[_IP_IDX(IRQn)]  & ~(0xFFUL << _BIT_SHIFT(IRQn))) |
+       (((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL) << _BIT_SHIFT(IRQn)));
+  }
+  else
+  {
+    SCB->SHPR[_SHP_IDX(IRQn)] = ((uint32_t)(SCB->SHPR[_SHP_IDX(IRQn)] & ~(0xFFUL << _BIT_SHIFT(IRQn))) |
+       (((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL) << _BIT_SHIFT(IRQn)));
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Priority
+  \details Reads the priority of a device specific interrupt or a processor exception.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn  Interrupt number.
+  \return             Interrupt Priority.
+                      Value is aligned automatically to the implemented priority bits of the microcontroller.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPriority(IRQn_Type IRQn)
+{
+
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->IPR[ _IP_IDX(IRQn)] >> _BIT_SHIFT(IRQn) ) & (uint32_t)0xFFUL) >> (8U - __NVIC_PRIO_BITS)));
+  }
+  else
+  {
+    return((uint32_t)(((SCB->SHPR[_SHP_IDX(IRQn)] >> _BIT_SHIFT(IRQn) ) & (uint32_t)0xFFUL) >> (8U - __NVIC_PRIO_BITS)));
+  }
+}
+
+
+/**
+  \brief   Encode Priority
+  \details Encodes the priority for an interrupt with the given priority group,
+           preemptive priority value, and subpriority value.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+  \param [in]     PriorityGroup  Used priority group.
+  \param [in]   PreemptPriority  Preemptive priority value (starting from 0).
+  \param [in]       SubPriority  Subpriority value (starting from 0).
+  \return                        Encoded priority. Value can be used in the function \ref NVIC_SetPriority().
+ */
+__STATIC_INLINE uint32_t NVIC_EncodePriority (uint32_t PriorityGroup, uint32_t PreemptPriority, uint32_t SubPriority)
+{
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);   /* only values 0..7 are used          */
+  uint32_t PreemptPriorityBits;
+  uint32_t SubPriorityBits;
+
+  PreemptPriorityBits = ((7UL - PriorityGroupTmp) > (uint32_t)(__NVIC_PRIO_BITS)) ? (uint32_t)(__NVIC_PRIO_BITS) : (uint32_t)(7UL - PriorityGroupTmp);
+  SubPriorityBits     = ((PriorityGroupTmp + (uint32_t)(__NVIC_PRIO_BITS)) < (uint32_t)7UL) ? (uint32_t)0UL : (uint32_t)((PriorityGroupTmp - 7UL) + (uint32_t)(__NVIC_PRIO_BITS));
+
+  return (
+           ((PreemptPriority & (uint32_t)((1UL << (PreemptPriorityBits)) - 1UL)) << SubPriorityBits) |
+           ((SubPriority     & (uint32_t)((1UL << (SubPriorityBits    )) - 1UL)))
+         );
+}
+
+
+/**
+  \brief   Decode Priority
+  \details Decodes an interrupt priority value with a given priority group to
+           preemptive priority value and subpriority value.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS) the smallest possible priority group is set.
+  \param [in]         Priority   Priority value, which can be retrieved with the function \ref NVIC_GetPriority().
+  \param [in]     PriorityGroup  Used priority group.
+  \param [out] pPreemptPriority  Preemptive priority value (starting from 0).
+  \param [out]     pSubPriority  Subpriority value (starting from 0).
+ */
+__STATIC_INLINE void NVIC_DecodePriority (uint32_t Priority, uint32_t PriorityGroup, uint32_t* const pPreemptPriority, uint32_t* const pSubPriority)
+{
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);   /* only values 0..7 are used          */
+  uint32_t PreemptPriorityBits;
+  uint32_t SubPriorityBits;
+
+  PreemptPriorityBits = ((7UL - PriorityGroupTmp) > (uint32_t)(__NVIC_PRIO_BITS)) ? (uint32_t)(__NVIC_PRIO_BITS) : (uint32_t)(7UL - PriorityGroupTmp);
+  SubPriorityBits     = ((PriorityGroupTmp + (uint32_t)(__NVIC_PRIO_BITS)) < (uint32_t)7UL) ? (uint32_t)0UL : (uint32_t)((PriorityGroupTmp - 7UL) + (uint32_t)(__NVIC_PRIO_BITS));
+
+  *pPreemptPriority = (Priority >> SubPriorityBits) & (uint32_t)((1UL << (PreemptPriorityBits)) - 1UL);
+  *pSubPriority     = (Priority                   ) & (uint32_t)((1UL << (SubPriorityBits    )) - 1UL);
+}
+
+
+/**
+  \brief   Set Interrupt Vector
+  \details Sets an interrupt vector in SRAM based interrupt vector table.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+           Address 0 must be mapped to SRAM.
+  \param [in]   IRQn      Interrupt number
+  \param [in]   vector    Address of interrupt handler function
+ */
+__STATIC_INLINE void __NVIC_SetVector(IRQn_Type IRQn, uint32_t vector)
+{
+  uint32_t *vectors = (uint32_t *)0x0U;
+  vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET] = vector;
+  /* ARM Application Note 321 states that the M1 does not require the architectural barrier */
+}
+
+
+/**
+  \brief   Get Interrupt Vector
+  \details Reads an interrupt vector from interrupt vector table.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn      Interrupt number.
+  \return                 Address of interrupt handler function
+ */
+__STATIC_INLINE uint32_t __NVIC_GetVector(IRQn_Type IRQn)
+{
+  uint32_t *vectors = (uint32_t *)0x0U;
+  return vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET];
+}
+
+
+/**
+  \brief   System Reset
+  \details Initiates a system reset request to reset the MCU.
+ */
+__NO_RETURN __STATIC_INLINE void __NVIC_SystemReset(void)
+{
+  __DSB();                                                          /* Ensure all outstanding memory accesses included
+                                                                       buffered write are completed before reset */
+  SCB->AIRCR  = ((0x5FAUL << SCB_AIRCR_VECTKEY_Pos) |
+                 SCB_AIRCR_SYSRESETREQ_Msk);
+  __DSB();                                                          /* Ensure completion of memory access */
+
+  for(;;)                                                           /* wait until reset */
+  {
+    __NOP();
+  }
+}
+
+/*@} end of CMSIS_Core_NVICFunctions */
+
+
+/* ##########################  FPU functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_FpuFunctions FPU Functions
+  \brief    Function that provides FPU type.
+  @{
+ */
+
+/**
+  \brief   get FPU type
+  \details returns the FPU type
+  \returns
+   - \b  0: No FPU
+   - \b  1: Single precision FPU
+   - \b  2: Double + Single precision FPU
+ */
+__STATIC_INLINE uint32_t SCB_GetFPUType(void)
+{
+    return 0U;           /* No FPU */
+}
+
+/*@} end of CMSIS_Core_FpuFunctions */
+
+
+/* ##################################    SysTick function  ############################################ */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_SysTickFunctions SysTick Functions
+  \brief    Functions that configure the System.
+  @{
+ */
+
+#if defined (__Vendor_SysTickConfig) && (__Vendor_SysTickConfig == 0U)
+
+/**
+  \brief   System Tick Configuration
+  \details Initializes the System Timer and its interrupt, and starts the System Tick Timer.
+           Counter is in free running mode to generate periodic interrupts.
+  \param [in]  ticks  Number of ticks between two interrupts.
+  \return          0  Function succeeded.
+  \return          1  Function failed.
+  \note    When the variable <b>__Vendor_SysTickConfig</b> is set to 1, then the
+           function <b>SysTick_Config</b> is not included. In this case, the file <b><i>device</i>.h</b>
+           must contain a vendor-specific implementation of this function.
+ */
+__STATIC_INLINE uint32_t SysTick_Config(uint32_t ticks)
+{
+  if ((ticks - 1UL) > SysTick_LOAD_RELOAD_Msk)
+  {
+    return (1UL);                                                   /* Reload value impossible */
+  }
+
+  SysTick->LOAD  = (uint32_t)(ticks - 1UL);                         /* set reload register */
+  NVIC_SetPriority (SysTick_IRQn, (1UL << __NVIC_PRIO_BITS) - 1UL); /* set Priority for Systick Interrupt */
+  SysTick->VAL   = 0UL;                                             /* Load the SysTick Counter Value */
+  SysTick->CTRL  = SysTick_CTRL_CLKSOURCE_Msk |
+                   SysTick_CTRL_TICKINT_Msk   |
+                   SysTick_CTRL_ENABLE_Msk;                         /* Enable SysTick IRQ and SysTick Timer */
+  return (0UL);                                                     /* Function successful */
+}
+
+#endif
+
+/*@} end of CMSIS_Core_SysTickFunctions */
+
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_CM1_H_DEPENDANT */
+
+#endif /* __CMSIS_GENERIC */

--- a/platform/ext/cmsis/CMSIS/Core/Include/core_cm23.h
+++ b/platform/ext/cmsis/CMSIS/Core/Include/core_cm23.h
@@ -1,0 +1,2144 @@
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS Cortex-M23 Core Peripheral Access Layer Header File
+ */
+
+#if   defined ( __ICCARM__ )
+  #pragma system_include                        /* treat file as system include file for MISRA check */
+#elif defined (__clang__)
+  #pragma clang system_header                   /* treat file as system include file */
+#elif defined ( __GNUC__ )
+  #pragma GCC diagnostic ignored "-Wpedantic"   /* disable pedantic warning due to unnamed structs/unions */
+#endif
+
+#ifndef __CORE_CM23_H_GENERIC
+#define __CORE_CM23_H_GENERIC
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/**
+  \page CMSIS_MISRA_Exceptions  MISRA-C:2004 Compliance Exceptions
+  CMSIS violates the following MISRA-C:2004 rules:
+
+   \li Required Rule 8.5, object/function definition in header file.<br>
+     Function definitions in header files are used to allow 'inlining'.
+
+   \li Required Rule 18.4, declaration of union type or object of union type: '{...}'.<br>
+     Unions are used for effective representation of core registers.
+
+   \li Advisory Rule 19.7, Function-like macro defined.<br>
+     Function-like macros are used to allow more efficient code.
+ */
+
+
+/*******************************************************************************
+ *                 CMSIS definitions
+ ******************************************************************************/
+/**
+  \ingroup Cortex_M23
+  @{
+ */
+
+#include "cmsis_version.h"
+
+/* CMSIS CM23 definitions */
+
+#define __CORTEX_M                (23U)                               /*!< Cortex-M Core */
+
+/** __FPU_USED indicates whether an FPU is used or not.
+    This core does not support an FPU at all
+*/
+#define __FPU_USED       0U
+
+#if defined ( __CC_ARM )
+  #if defined (__TARGET_FPU_VFP)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #if defined (__ARM_FP)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined (__ti__)
+  #if defined (__ARM_FP)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __GNUC__ )
+  #if defined (__VFP_FP__) && !defined(__SOFTFP__)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __ICCARM__ )
+  #if defined (__ARMVFP__)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __TI_ARM__ )
+  #if defined (__TI_VFP_SUPPORT__)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __TASKING__ )
+  #if defined (__FPU_VFP__)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __CSMC__ )
+  #if ( __CSMC__ & 0x400U)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#endif
+
+#include "cmsis_compiler.h"               /* CMSIS compiler specific defines */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_CM23_H_GENERIC */
+
+#ifndef __CMSIS_GENERIC
+
+#ifndef __CORE_CM23_H_DEPENDANT
+#define __CORE_CM23_H_DEPENDANT
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* check device defines and use defaults */
+#if defined __CHECK_DEVICE_DEFINES
+  #ifndef __CM23_REV
+    #define __CM23_REV                0x0000U
+    #warning "__CM23_REV not defined in device header file; using default!"
+  #endif
+
+  #ifndef __FPU_PRESENT
+    #define __FPU_PRESENT             0U
+    #warning "__FPU_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __MPU_PRESENT
+    #define __MPU_PRESENT             0U
+    #warning "__MPU_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __SAUREGION_PRESENT
+    #define __SAUREGION_PRESENT       0U
+    #warning "__SAUREGION_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __VTOR_PRESENT
+    #define __VTOR_PRESENT            0U
+    #warning "__VTOR_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __NVIC_PRIO_BITS
+    #define __NVIC_PRIO_BITS          2U
+    #warning "__NVIC_PRIO_BITS not defined in device header file; using default!"
+  #endif
+
+  #ifndef __Vendor_SysTickConfig
+    #define __Vendor_SysTickConfig    0U
+    #warning "__Vendor_SysTickConfig not defined in device header file; using default!"
+  #endif
+
+  #ifndef __ETM_PRESENT
+    #define __ETM_PRESENT             0U
+    #warning "__ETM_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __MTB_PRESENT
+    #define __MTB_PRESENT             0U
+    #warning "__MTB_PRESENT not defined in device header file; using default!"
+  #endif
+
+#endif
+
+/* IO definitions (access restrictions to peripheral registers) */
+/**
+    \defgroup CMSIS_glob_defs CMSIS Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+*/
+#ifdef __cplusplus
+  #define   __I     volatile             /*!< Defines 'read only' permissions */
+#else
+  #define   __I     volatile const       /*!< Defines 'read only' permissions */
+#endif
+#define     __O     volatile             /*!< Defines 'write only' permissions */
+#define     __IO    volatile             /*!< Defines 'read / write' permissions */
+
+/* following defines should be used for structure members */
+#define     __IM     volatile const      /*! Defines 'read only' structure member permissions */
+#define     __OM     volatile            /*! Defines 'write only' structure member permissions */
+#define     __IOM    volatile            /*! Defines 'read / write' structure member permissions */
+
+/*@} end of group Cortex_M23 */
+
+
+
+/*******************************************************************************
+ *                 Register Abstraction
+  Core Register contain:
+  - Core Register
+  - Core NVIC Register
+  - Core SCB Register
+  - Core SysTick Register
+  - Core Debug Register
+  - Core MPU Register
+  - Core SAU Register
+ ******************************************************************************/
+/**
+  \defgroup CMSIS_core_register Defines and Type Definitions
+  \brief Type definitions and defines for Cortex-M processor based devices.
+*/
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_CORE  Status and Control Registers
+  \brief      Core Register type definitions.
+  @{
+ */
+
+/**
+  \brief  Union type to access the Application Program Status Register (APSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t _reserved0:28;              /*!< bit:  0..27  Reserved */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} APSR_Type;
+
+/** \brief APSR Register Definitions */
+#define APSR_N_Pos                         31U                                            /*!< APSR: N Position */
+#define APSR_N_Msk                         (1UL << APSR_N_Pos)                            /*!< APSR: N Mask */
+
+#define APSR_Z_Pos                         30U                                            /*!< APSR: Z Position */
+#define APSR_Z_Msk                         (1UL << APSR_Z_Pos)                            /*!< APSR: Z Mask */
+
+#define APSR_C_Pos                         29U                                            /*!< APSR: C Position */
+#define APSR_C_Msk                         (1UL << APSR_C_Pos)                            /*!< APSR: C Mask */
+
+#define APSR_V_Pos                         28U                                            /*!< APSR: V Position */
+#define APSR_V_Msk                         (1UL << APSR_V_Pos)                            /*!< APSR: V Mask */
+
+
+/**
+  \brief  Union type to access the Interrupt Program Status Register (IPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number */
+    uint32_t _reserved0:23;              /*!< bit:  9..31  Reserved */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} IPSR_Type;
+
+/** \brief IPSR Register Definitions */
+#define IPSR_ISR_Pos                        0U                                            /*!< IPSR: ISR Position */
+#define IPSR_ISR_Msk                       (0x1FFUL /*<< IPSR_ISR_Pos*/)                  /*!< IPSR: ISR Mask */
+
+
+/**
+  \brief  Union type to access the Special-Purpose Program Status Registers (xPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number */
+    uint32_t _reserved0:15;              /*!< bit:  9..23  Reserved */
+    uint32_t T:1;                        /*!< bit:     24  Thumb bit        (read 0) */
+    uint32_t _reserved1:3;               /*!< bit: 25..27  Reserved */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} xPSR_Type;
+
+/** \brief xPSR Register Definitions */
+#define xPSR_N_Pos                         31U                                            /*!< xPSR: N Position */
+#define xPSR_N_Msk                         (1UL << xPSR_N_Pos)                            /*!< xPSR: N Mask */
+
+#define xPSR_Z_Pos                         30U                                            /*!< xPSR: Z Position */
+#define xPSR_Z_Msk                         (1UL << xPSR_Z_Pos)                            /*!< xPSR: Z Mask */
+
+#define xPSR_C_Pos                         29U                                            /*!< xPSR: C Position */
+#define xPSR_C_Msk                         (1UL << xPSR_C_Pos)                            /*!< xPSR: C Mask */
+
+#define xPSR_V_Pos                         28U                                            /*!< xPSR: V Position */
+#define xPSR_V_Msk                         (1UL << xPSR_V_Pos)                            /*!< xPSR: V Mask */
+
+#define xPSR_T_Pos                         24U                                            /*!< xPSR: T Position */
+#define xPSR_T_Msk                         (1UL << xPSR_T_Pos)                            /*!< xPSR: T Mask */
+
+#define xPSR_ISR_Pos                        0U                                            /*!< xPSR: ISR Position */
+#define xPSR_ISR_Msk                       (0x1FFUL /*<< xPSR_ISR_Pos*/)                  /*!< xPSR: ISR Mask */
+
+
+/**
+  \brief  Union type to access the Control Registers (CONTROL).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t nPRIV:1;                    /*!< bit:      0  Execution privilege in Thread mode */
+    uint32_t SPSEL:1;                    /*!< bit:      1  Stack-pointer select */
+    uint32_t _reserved1:30;              /*!< bit:  2..31  Reserved */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} CONTROL_Type;
+
+/** \brief CONTROL Register Definitions */
+#define CONTROL_SPSEL_Pos                   1U                                            /*!< CONTROL: SPSEL Position */
+#define CONTROL_SPSEL_Msk                  (1UL << CONTROL_SPSEL_Pos)                     /*!< CONTROL: SPSEL Mask */
+
+#define CONTROL_nPRIV_Pos                   0U                                            /*!< CONTROL: nPRIV Position */
+#define CONTROL_nPRIV_Msk                  (1UL /*<< CONTROL_nPRIV_Pos*/)                 /*!< CONTROL: nPRIV Mask */
+
+/*@} end of group CMSIS_CORE */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_NVIC  Nested Vectored Interrupt Controller (NVIC)
+  \brief      Type definitions for the NVIC Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Nested Vectored Interrupt Controller (NVIC).
+ */
+typedef struct
+{
+  __IOM uint32_t ISER[16U];              /*!< Offset: 0x000 (R/W)  Interrupt Set Enable Register */
+        uint32_t RESERVED0[16U];
+  __IOM uint32_t ICER[16U];              /*!< Offset: 0x080 (R/W)  Interrupt Clear Enable Register */
+        uint32_t RESERVED1[16U];
+  __IOM uint32_t ISPR[16U];              /*!< Offset: 0x100 (R/W)  Interrupt Set Pending Register */
+        uint32_t RESERVED2[16U];
+  __IOM uint32_t ICPR[16U];              /*!< Offset: 0x180 (R/W)  Interrupt Clear Pending Register */
+        uint32_t RESERVED3[16U];
+  __IOM uint32_t IABR[16U];              /*!< Offset: 0x200 (R/W)  Interrupt Active bit Register */
+        uint32_t RESERVED4[16U];
+  __IOM uint32_t ITNS[16U];              /*!< Offset: 0x280 (R/W)  Interrupt Non-Secure State Register */
+        uint32_t RESERVED5[16U];
+  __IOM uint32_t IPR[124U];              /*!< Offset: 0x300 (R/W)  Interrupt Priority Register */
+}  NVIC_Type;
+
+/*@} end of group CMSIS_NVIC */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SCB     System Control Block (SCB)
+  \brief    Type definitions for the System Control Block Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Control Block (SCB).
+ */
+typedef struct
+{
+  __IM  uint32_t CPUID;                  /*!< Offset: 0x000 (R/ )  CPUID Base Register */
+  __IOM uint32_t ICSR;                   /*!< Offset: 0x004 (R/W)  Interrupt Control and State Register */
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  __IOM uint32_t VTOR;                   /*!< Offset: 0x008 (R/W)  Vector Table Offset Register */
+#else
+        uint32_t RESERVED0;
+#endif
+  __IOM uint32_t AIRCR;                  /*!< Offset: 0x00C (R/W)  Application Interrupt and Reset Control Register */
+  __IOM uint32_t SCR;                    /*!< Offset: 0x010 (R/W)  System Control Register */
+  __IOM uint32_t CCR;                    /*!< Offset: 0x014 (R/W)  Configuration Control Register */
+        uint32_t RESERVED1;
+  __IOM uint32_t SHPR[2U];               /*!< Offset: 0x01C (R/W)  System Handlers Priority Registers. [0] is RESERVED */
+  __IOM uint32_t SHCSR;                  /*!< Offset: 0x024 (R/W)  System Handler Control and State Register */
+} SCB_Type;
+
+/** \brief SCB CPUID Register Definitions */
+#define SCB_CPUID_IMPLEMENTER_Pos          24U                                            /*!< SCB CPUID: IMPLEMENTER Position */
+#define SCB_CPUID_IMPLEMENTER_Msk          (0xFFUL << SCB_CPUID_IMPLEMENTER_Pos)          /*!< SCB CPUID: IMPLEMENTER Mask */
+
+#define SCB_CPUID_VARIANT_Pos              20U                                            /*!< SCB CPUID: VARIANT Position */
+#define SCB_CPUID_VARIANT_Msk              (0xFUL << SCB_CPUID_VARIANT_Pos)               /*!< SCB CPUID: VARIANT Mask */
+
+#define SCB_CPUID_ARCHITECTURE_Pos         16U                                            /*!< SCB CPUID: ARCHITECTURE Position */
+#define SCB_CPUID_ARCHITECTURE_Msk         (0xFUL << SCB_CPUID_ARCHITECTURE_Pos)          /*!< SCB CPUID: ARCHITECTURE Mask */
+
+#define SCB_CPUID_PARTNO_Pos                4U                                            /*!< SCB CPUID: PARTNO Position */
+#define SCB_CPUID_PARTNO_Msk               (0xFFFUL << SCB_CPUID_PARTNO_Pos)              /*!< SCB CPUID: PARTNO Mask */
+
+#define SCB_CPUID_REVISION_Pos              0U                                            /*!< SCB CPUID: REVISION Position */
+#define SCB_CPUID_REVISION_Msk             (0xFUL /*<< SCB_CPUID_REVISION_Pos*/)          /*!< SCB CPUID: REVISION Mask */
+
+/** \brief SCB Interrupt Control State Register Definitions */
+#define SCB_ICSR_PENDNMISET_Pos            31U                                            /*!< SCB ICSR: PENDNMISET Position */
+#define SCB_ICSR_PENDNMISET_Msk            (1UL << SCB_ICSR_PENDNMISET_Pos)               /*!< SCB ICSR: PENDNMISET Mask */
+
+#define SCB_ICSR_NMIPENDSET_Pos            SCB_ICSR_PENDNMISET_Pos                        /*!< SCB ICSR: NMIPENDSET Position, backward compatibility */
+#define SCB_ICSR_NMIPENDSET_Msk            SCB_ICSR_PENDNMISET_Msk                        /*!< SCB ICSR: NMIPENDSET Mask, backward compatibility */
+
+#define SCB_ICSR_PENDNMICLR_Pos            30U                                            /*!< SCB ICSR: PENDNMICLR Position */
+#define SCB_ICSR_PENDNMICLR_Msk            (1UL << SCB_ICSR_PENDNMICLR_Pos)               /*!< SCB ICSR: PENDNMICLR Mask */
+
+#define SCB_ICSR_PENDSVSET_Pos             28U                                            /*!< SCB ICSR: PENDSVSET Position */
+#define SCB_ICSR_PENDSVSET_Msk             (1UL << SCB_ICSR_PENDSVSET_Pos)                /*!< SCB ICSR: PENDSVSET Mask */
+
+#define SCB_ICSR_PENDSVCLR_Pos             27U                                            /*!< SCB ICSR: PENDSVCLR Position */
+#define SCB_ICSR_PENDSVCLR_Msk             (1UL << SCB_ICSR_PENDSVCLR_Pos)                /*!< SCB ICSR: PENDSVCLR Mask */
+
+#define SCB_ICSR_PENDSTSET_Pos             26U                                            /*!< SCB ICSR: PENDSTSET Position */
+#define SCB_ICSR_PENDSTSET_Msk             (1UL << SCB_ICSR_PENDSTSET_Pos)                /*!< SCB ICSR: PENDSTSET Mask */
+
+#define SCB_ICSR_PENDSTCLR_Pos             25U                                            /*!< SCB ICSR: PENDSTCLR Position */
+#define SCB_ICSR_PENDSTCLR_Msk             (1UL << SCB_ICSR_PENDSTCLR_Pos)                /*!< SCB ICSR: PENDSTCLR Mask */
+
+#define SCB_ICSR_STTNS_Pos                 24U                                            /*!< SCB ICSR: STTNS Position (Security Extension) */
+#define SCB_ICSR_STTNS_Msk                 (1UL << SCB_ICSR_STTNS_Pos)                    /*!< SCB ICSR: STTNS Mask (Security Extension) */
+
+#define SCB_ICSR_ISRPREEMPT_Pos            23U                                            /*!< SCB ICSR: ISRPREEMPT Position */
+#define SCB_ICSR_ISRPREEMPT_Msk            (1UL << SCB_ICSR_ISRPREEMPT_Pos)               /*!< SCB ICSR: ISRPREEMPT Mask */
+
+#define SCB_ICSR_ISRPENDING_Pos            22U                                            /*!< SCB ICSR: ISRPENDING Position */
+#define SCB_ICSR_ISRPENDING_Msk            (1UL << SCB_ICSR_ISRPENDING_Pos)               /*!< SCB ICSR: ISRPENDING Mask */
+
+#define SCB_ICSR_VECTPENDING_Pos           12U                                            /*!< SCB ICSR: VECTPENDING Position */
+#define SCB_ICSR_VECTPENDING_Msk           (0x1FFUL << SCB_ICSR_VECTPENDING_Pos)          /*!< SCB ICSR: VECTPENDING Mask */
+
+#define SCB_ICSR_RETTOBASE_Pos             11U                                            /*!< SCB ICSR: RETTOBASE Position */
+#define SCB_ICSR_RETTOBASE_Msk             (1UL << SCB_ICSR_RETTOBASE_Pos)                /*!< SCB ICSR: RETTOBASE Mask */
+
+#define SCB_ICSR_VECTACTIVE_Pos             0U                                            /*!< SCB ICSR: VECTACTIVE Position */
+#define SCB_ICSR_VECTACTIVE_Msk            (0x1FFUL /*<< SCB_ICSR_VECTACTIVE_Pos*/)       /*!< SCB ICSR: VECTACTIVE Mask */
+
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+/** \brief SCB Vector Table Offset Register Definitions */
+#define SCB_VTOR_TBLOFF_Pos                 7U                                            /*!< SCB VTOR: TBLOFF Position */
+#define SCB_VTOR_TBLOFF_Msk                (0x1FFFFFFUL << SCB_VTOR_TBLOFF_Pos)           /*!< SCB VTOR: TBLOFF Mask */
+#endif
+
+/** \brief SCB Application Interrupt and Reset Control Register Definitions */
+#define SCB_AIRCR_VECTKEY_Pos              16U                                            /*!< SCB AIRCR: VECTKEY Position */
+#define SCB_AIRCR_VECTKEY_Msk              (0xFFFFUL << SCB_AIRCR_VECTKEY_Pos)            /*!< SCB AIRCR: VECTKEY Mask */
+
+#define SCB_AIRCR_VECTKEYSTAT_Pos          16U                                            /*!< SCB AIRCR: VECTKEYSTAT Position */
+#define SCB_AIRCR_VECTKEYSTAT_Msk          (0xFFFFUL << SCB_AIRCR_VECTKEYSTAT_Pos)        /*!< SCB AIRCR: VECTKEYSTAT Mask */
+
+#define SCB_AIRCR_ENDIANESS_Pos            15U                                            /*!< SCB AIRCR: ENDIANESS Position */
+#define SCB_AIRCR_ENDIANESS_Msk            (1UL << SCB_AIRCR_ENDIANESS_Pos)               /*!< SCB AIRCR: ENDIANESS Mask */
+
+#define SCB_AIRCR_PRIS_Pos                 14U                                            /*!< SCB AIRCR: PRIS Position */
+#define SCB_AIRCR_PRIS_Msk                 (1UL << SCB_AIRCR_PRIS_Pos)                    /*!< SCB AIRCR: PRIS Mask */
+
+#define SCB_AIRCR_BFHFNMINS_Pos            13U                                            /*!< SCB AIRCR: BFHFNMINS Position */
+#define SCB_AIRCR_BFHFNMINS_Msk            (1UL << SCB_AIRCR_BFHFNMINS_Pos)               /*!< SCB AIRCR: BFHFNMINS Mask */
+
+#define SCB_AIRCR_SYSRESETREQS_Pos          3U                                            /*!< SCB AIRCR: SYSRESETREQS Position */
+#define SCB_AIRCR_SYSRESETREQS_Msk         (1UL << SCB_AIRCR_SYSRESETREQS_Pos)            /*!< SCB AIRCR: SYSRESETREQS Mask */
+
+#define SCB_AIRCR_SYSRESETREQ_Pos           2U                                            /*!< SCB AIRCR: SYSRESETREQ Position */
+#define SCB_AIRCR_SYSRESETREQ_Msk          (1UL << SCB_AIRCR_SYSRESETREQ_Pos)             /*!< SCB AIRCR: SYSRESETREQ Mask */
+
+#define SCB_AIRCR_VECTCLRACTIVE_Pos         1U                                            /*!< SCB AIRCR: VECTCLRACTIVE Position */
+#define SCB_AIRCR_VECTCLRACTIVE_Msk        (1UL << SCB_AIRCR_VECTCLRACTIVE_Pos)           /*!< SCB AIRCR: VECTCLRACTIVE Mask */
+
+/** \brief SCB System Control Register Definitions */
+#define SCB_SCR_SEVONPEND_Pos               4U                                            /*!< SCB SCR: SEVONPEND Position */
+#define SCB_SCR_SEVONPEND_Msk              (1UL << SCB_SCR_SEVONPEND_Pos)                 /*!< SCB SCR: SEVONPEND Mask */
+
+#define SCB_SCR_SLEEPDEEPS_Pos              3U                                            /*!< SCB SCR: SLEEPDEEPS Position */
+#define SCB_SCR_SLEEPDEEPS_Msk             (1UL << SCB_SCR_SLEEPDEEPS_Pos)                /*!< SCB SCR: SLEEPDEEPS Mask */
+
+#define SCB_SCR_SLEEPDEEP_Pos               2U                                            /*!< SCB SCR: SLEEPDEEP Position */
+#define SCB_SCR_SLEEPDEEP_Msk              (1UL << SCB_SCR_SLEEPDEEP_Pos)                 /*!< SCB SCR: SLEEPDEEP Mask */
+
+#define SCB_SCR_SLEEPONEXIT_Pos             1U                                            /*!< SCB SCR: SLEEPONEXIT Position */
+#define SCB_SCR_SLEEPONEXIT_Msk            (1UL << SCB_SCR_SLEEPONEXIT_Pos)               /*!< SCB SCR: SLEEPONEXIT Mask */
+
+/** \brief SCB Configuration Control Register Definitions */
+#define SCB_CCR_BP_Pos                     18U                                            /*!< SCB CCR: BP Position */
+#define SCB_CCR_BP_Msk                     (1UL << SCB_CCR_BP_Pos)                        /*!< SCB CCR: BP Mask */
+
+#define SCB_CCR_IC_Pos                     17U                                            /*!< SCB CCR: IC Position */
+#define SCB_CCR_IC_Msk                     (1UL << SCB_CCR_IC_Pos)                        /*!< SCB CCR: IC Mask */
+
+#define SCB_CCR_DC_Pos                     16U                                            /*!< SCB CCR: DC Position */
+#define SCB_CCR_DC_Msk                     (1UL << SCB_CCR_DC_Pos)                        /*!< SCB CCR: DC Mask */
+
+#define SCB_CCR_STKOFHFNMIGN_Pos           10U                                            /*!< SCB CCR: STKOFHFNMIGN Position */
+#define SCB_CCR_STKOFHFNMIGN_Msk           (1UL << SCB_CCR_STKOFHFNMIGN_Pos)              /*!< SCB CCR: STKOFHFNMIGN Mask */
+
+#define SCB_CCR_BFHFNMIGN_Pos               8U                                            /*!< SCB CCR: BFHFNMIGN Position */
+#define SCB_CCR_BFHFNMIGN_Msk              (1UL << SCB_CCR_BFHFNMIGN_Pos)                 /*!< SCB CCR: BFHFNMIGN Mask */
+
+#define SCB_CCR_DIV_0_TRP_Pos               4U                                            /*!< SCB CCR: DIV_0_TRP Position */
+#define SCB_CCR_DIV_0_TRP_Msk              (1UL << SCB_CCR_DIV_0_TRP_Pos)                 /*!< SCB CCR: DIV_0_TRP Mask */
+
+#define SCB_CCR_UNALIGN_TRP_Pos             3U                                            /*!< SCB CCR: UNALIGN_TRP Position */
+#define SCB_CCR_UNALIGN_TRP_Msk            (1UL << SCB_CCR_UNALIGN_TRP_Pos)               /*!< SCB CCR: UNALIGN_TRP Mask */
+
+#define SCB_CCR_USERSETMPEND_Pos            1U                                            /*!< SCB CCR: USERSETMPEND Position */
+#define SCB_CCR_USERSETMPEND_Msk           (1UL << SCB_CCR_USERSETMPEND_Pos)              /*!< SCB CCR: USERSETMPEND Mask */
+
+/** \brief SCB System Handler Control and State Register Definitions */
+#define SCB_SHCSR_HARDFAULTPENDED_Pos      21U                                            /*!< SCB SHCSR: HARDFAULTPENDED Position */
+#define SCB_SHCSR_HARDFAULTPENDED_Msk      (1UL << SCB_SHCSR_HARDFAULTPENDED_Pos)         /*!< SCB SHCSR: HARDFAULTPENDED Mask */
+
+#define SCB_SHCSR_SVCALLPENDED_Pos         15U                                            /*!< SCB SHCSR: SVCALLPENDED Position */
+#define SCB_SHCSR_SVCALLPENDED_Msk         (1UL << SCB_SHCSR_SVCALLPENDED_Pos)            /*!< SCB SHCSR: SVCALLPENDED Mask */
+
+#define SCB_SHCSR_SYSTICKACT_Pos           11U                                            /*!< SCB SHCSR: SYSTICKACT Position */
+#define SCB_SHCSR_SYSTICKACT_Msk           (1UL << SCB_SHCSR_SYSTICKACT_Pos)              /*!< SCB SHCSR: SYSTICKACT Mask */
+
+#define SCB_SHCSR_PENDSVACT_Pos            10U                                            /*!< SCB SHCSR: PENDSVACT Position */
+#define SCB_SHCSR_PENDSVACT_Msk            (1UL << SCB_SHCSR_PENDSVACT_Pos)               /*!< SCB SHCSR: PENDSVACT Mask */
+
+#define SCB_SHCSR_SVCALLACT_Pos             7U                                            /*!< SCB SHCSR: SVCALLACT Position */
+#define SCB_SHCSR_SVCALLACT_Msk            (1UL << SCB_SHCSR_SVCALLACT_Pos)               /*!< SCB SHCSR: SVCALLACT Mask */
+
+#define SCB_SHCSR_NMIACT_Pos                5U                                            /*!< SCB SHCSR: NMIACT Position */
+#define SCB_SHCSR_NMIACT_Msk               (1UL << SCB_SHCSR_NMIACT_Pos)                  /*!< SCB SHCSR: NMIACT Mask */
+
+#define SCB_SHCSR_HARDFAULTACT_Pos          2U                                            /*!< SCB SHCSR: HARDFAULTACT Position */
+#define SCB_SHCSR_HARDFAULTACT_Msk         (1UL << SCB_SHCSR_HARDFAULTACT_Pos)            /*!< SCB SHCSR: HARDFAULTACT Mask */
+
+/*@} end of group CMSIS_SCB */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SysTick     System Tick Timer (SysTick)
+  \brief    Type definitions for the System Timer Registers.
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Timer (SysTick).
+ */
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  SysTick Control and Status Register */
+  __IOM uint32_t LOAD;                   /*!< Offset: 0x004 (R/W)  SysTick Reload Value Register */
+  __IOM uint32_t VAL;                    /*!< Offset: 0x008 (R/W)  SysTick Current Value Register */
+  __IM  uint32_t CALIB;                  /*!< Offset: 0x00C (R/ )  SysTick Calibration Register */
+} SysTick_Type;
+
+/** \brief SysTick Control / Status Register Definitions */
+#define SysTick_CTRL_COUNTFLAG_Pos         16U                                            /*!< SysTick CTRL: COUNTFLAG Position */
+#define SysTick_CTRL_COUNTFLAG_Msk         (1UL << SysTick_CTRL_COUNTFLAG_Pos)            /*!< SysTick CTRL: COUNTFLAG Mask */
+
+#define SysTick_CTRL_CLKSOURCE_Pos          2U                                            /*!< SysTick CTRL: CLKSOURCE Position */
+#define SysTick_CTRL_CLKSOURCE_Msk         (1UL << SysTick_CTRL_CLKSOURCE_Pos)            /*!< SysTick CTRL: CLKSOURCE Mask */
+
+#define SysTick_CTRL_TICKINT_Pos            1U                                            /*!< SysTick CTRL: TICKINT Position */
+#define SysTick_CTRL_TICKINT_Msk           (1UL << SysTick_CTRL_TICKINT_Pos)              /*!< SysTick CTRL: TICKINT Mask */
+
+#define SysTick_CTRL_ENABLE_Pos             0U                                            /*!< SysTick CTRL: ENABLE Position */
+#define SysTick_CTRL_ENABLE_Msk            (1UL /*<< SysTick_CTRL_ENABLE_Pos*/)           /*!< SysTick CTRL: ENABLE Mask */
+
+/** \brief SysTick Reload Register Definitions */
+#define SysTick_LOAD_RELOAD_Pos             0U                                            /*!< SysTick LOAD: RELOAD Position */
+#define SysTick_LOAD_RELOAD_Msk            (0xFFFFFFUL /*<< SysTick_LOAD_RELOAD_Pos*/)    /*!< SysTick LOAD: RELOAD Mask */
+
+/** \brief SysTick Current Register Definitions */
+#define SysTick_VAL_CURRENT_Pos             0U                                            /*!< SysTick VAL: CURRENT Position */
+#define SysTick_VAL_CURRENT_Msk            (0xFFFFFFUL /*<< SysTick_VAL_CURRENT_Pos*/)    /*!< SysTick VAL: CURRENT Mask */
+
+/** \brief SysTick Calibration Register Definitions */
+#define SysTick_CALIB_NOREF_Pos            31U                                            /*!< SysTick CALIB: NOREF Position */
+#define SysTick_CALIB_NOREF_Msk            (1UL << SysTick_CALIB_NOREF_Pos)               /*!< SysTick CALIB: NOREF Mask */
+
+#define SysTick_CALIB_SKEW_Pos             30U                                            /*!< SysTick CALIB: SKEW Position */
+#define SysTick_CALIB_SKEW_Msk             (1UL << SysTick_CALIB_SKEW_Pos)                /*!< SysTick CALIB: SKEW Mask */
+
+#define SysTick_CALIB_TENMS_Pos             0U                                            /*!< SysTick CALIB: TENMS Position */
+#define SysTick_CALIB_TENMS_Msk            (0xFFFFFFUL /*<< SysTick_CALIB_TENMS_Pos*/)    /*!< SysTick CALIB: TENMS Mask */
+
+/*@} end of group CMSIS_SysTick */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_DWT     Data Watchpoint and Trace (DWT)
+  \brief    Type definitions for the Data Watchpoint and Trace (DWT)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Data Watchpoint and Trace Register (DWT).
+ */
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  Control Register */
+  __IOM uint32_t CYCCNT;                 /*!< Offset: 0x004 (R/W)  Cycle Count Register */
+  __IOM uint32_t CPICNT;                 /*!< Offset: 0x008 (R/W)  CPI Count Register */
+  __IOM uint32_t EXCCNT;                 /*!< Offset: 0x00C (R/W)  Exception Overhead Count Register */
+  __IOM uint32_t SLEEPCNT;               /*!< Offset: 0x010 (R/W)  Sleep Count Register */
+  __IOM uint32_t LSUCNT;                 /*!< Offset: 0x014 (R/W)  LSU Count Register */
+  __IOM uint32_t FOLDCNT;                /*!< Offset: 0x018 (R/W)  Folded-instruction Count Register */
+  __IM  uint32_t PCSR;                   /*!< Offset: 0x01C (R/ )  Program Counter Sample Register */
+  __IOM uint32_t COMP0;                  /*!< Offset: 0x020 (R/W)  Comparator Register 0 */
+        uint32_t RESERVED1[1U];
+  __IOM uint32_t FUNCTION0;              /*!< Offset: 0x028 (R/W)  Function Register 0 */
+        uint32_t RESERVED2[1U];
+  __IOM uint32_t COMP1;                  /*!< Offset: 0x030 (R/W)  Comparator Register 1 */
+        uint32_t RESERVED3[1U];
+  __IOM uint32_t FUNCTION1;              /*!< Offset: 0x038 (R/W)  Function Register 1 */
+        uint32_t RESERVED14[992U];
+  __IM  uint32_t DEVARCH;                /*!< Offset: 0xFBC (R/ )  Device Type Architecture Register */
+} DWT_Type;
+
+/** \brief DWT Control Register Definitions */
+#define DWT_CTRL_NUMCOMP_Pos               28U                                         /*!< DWT CTRL: NUMCOMP Position */
+#define DWT_CTRL_NUMCOMP_Msk               (0xFUL << DWT_CTRL_NUMCOMP_Pos)             /*!< DWT CTRL: NUMCOMP Mask */
+
+#define DWT_CTRL_NOTRCPKT_Pos              27U                                         /*!< DWT CTRL: NOTRCPKT Position */
+#define DWT_CTRL_NOTRCPKT_Msk              (1UL << DWT_CTRL_NOTRCPKT_Pos)              /*!< DWT CTRL: NOTRCPKT Mask */
+
+#define DWT_CTRL_NOEXTTRIG_Pos             26U                                         /*!< DWT CTRL: NOEXTTRIG Position */
+#define DWT_CTRL_NOEXTTRIG_Msk             (1UL << DWT_CTRL_NOEXTTRIG_Pos)             /*!< DWT CTRL: NOEXTTRIG Mask */
+
+#define DWT_CTRL_NOCYCCNT_Pos              25U                                         /*!< DWT CTRL: NOCYCCNT Position */
+#define DWT_CTRL_NOCYCCNT_Msk              (1UL << DWT_CTRL_NOCYCCNT_Pos)              /*!< DWT CTRL: NOCYCCNT Mask */
+
+#define DWT_CTRL_NOPRFCNT_Pos              24U                                         /*!< DWT CTRL: NOPRFCNT Position */
+#define DWT_CTRL_NOPRFCNT_Msk              (1UL << DWT_CTRL_NOPRFCNT_Pos)              /*!< DWT CTRL: NOPRFCNT Mask */
+
+/** \brief DWT Comparator Function Register Definitions */
+#define DWT_FUNCTION_ID_Pos                27U                                         /*!< DWT FUNCTION: ID Position */
+#define DWT_FUNCTION_ID_Msk                (0x1FUL << DWT_FUNCTION_ID_Pos)             /*!< DWT FUNCTION: ID Mask */
+
+#define DWT_FUNCTION_MATCHED_Pos           24U                                         /*!< DWT FUNCTION: MATCHED Position */
+#define DWT_FUNCTION_MATCHED_Msk           (1UL << DWT_FUNCTION_MATCHED_Pos)           /*!< DWT FUNCTION: MATCHED Mask */
+
+#define DWT_FUNCTION_DATAVSIZE_Pos         10U                                         /*!< DWT FUNCTION: DATAVSIZE Position */
+#define DWT_FUNCTION_DATAVSIZE_Msk         (0x3UL << DWT_FUNCTION_DATAVSIZE_Pos)       /*!< DWT FUNCTION: DATAVSIZE Mask */
+
+#define DWT_FUNCTION_ACTION_Pos             4U                                         /*!< DWT FUNCTION: ACTION Position */
+#define DWT_FUNCTION_ACTION_Msk            (0x3UL << DWT_FUNCTION_ACTION_Pos)          /*!< DWT FUNCTION: ACTION Mask */
+
+#define DWT_FUNCTION_MATCH_Pos              0U                                         /*!< DWT FUNCTION: MATCH Position */
+#define DWT_FUNCTION_MATCH_Msk             (0xFUL /*<< DWT_FUNCTION_MATCH_Pos*/)       /*!< DWT FUNCTION: MATCH Mask */
+
+/*@}*/ /* end of group CMSIS_DWT */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_TPIU     Trace Port Interface Unit (TPIU)
+  \brief    Type definitions for the Trace Port Interface Unit (TPIU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Trace Port Interface Unit Register (TPIU).
+ */
+typedef struct
+{
+  __IM  uint32_t SSPSR;                  /*!< Offset: 0x000 (R/ )  Supported Parallel Port Size Register */
+  __IOM uint32_t CSPSR;                  /*!< Offset: 0x004 (R/W)  Current Parallel Port Size Register */
+        uint32_t RESERVED0[2U];
+  __IOM uint32_t ACPR;                   /*!< Offset: 0x010 (R/W)  Asynchronous Clock Prescaler Register */
+        uint32_t RESERVED1[55U];
+  __IOM uint32_t SPPR;                   /*!< Offset: 0x0F0 (R/W)  Selected Pin Protocol Register */
+        uint32_t RESERVED2[131U];
+  __IM  uint32_t FFSR;                   /*!< Offset: 0x300 (R/ )  Formatter and Flush Status Register */
+  __IOM uint32_t FFCR;                   /*!< Offset: 0x304 (R/W)  Formatter and Flush Control Register */
+  __IOM uint32_t PSCR;                   /*!< Offset: 0x308 (R/W)  Periodic Synchronization Control Register */
+        uint32_t RESERVED3[759U];
+  __IM  uint32_t TRIGGER;                /*!< Offset: 0xEE8 (R/ )  TRIGGER Register */
+  __IM  uint32_t ITFTTD0;                /*!< Offset: 0xEEC (R/ )  Integration Test FIFO Test Data 0 Register */
+  __IOM uint32_t ITATBCTR2;              /*!< Offset: 0xEF0 (R/W)  Integration Test ATB Control Register 2 */
+        uint32_t RESERVED4[1U];
+  __IM  uint32_t ITATBCTR0;              /*!< Offset: 0xEF8 (R/ )  Integration Test ATB Control Register 0 */
+  __IM  uint32_t ITFTTD1;                /*!< Offset: 0xEFC (R/ )  Integration Test FIFO Test Data 1 Register */
+  __IOM uint32_t ITCTRL;                 /*!< Offset: 0xF00 (R/W)  Integration Mode Control */
+        uint32_t RESERVED5[39U];
+  __IOM uint32_t CLAIMSET;               /*!< Offset: 0xFA0 (R/W)  Claim tag set */
+  __IOM uint32_t CLAIMCLR;               /*!< Offset: 0xFA4 (R/W)  Claim tag clear */
+        uint32_t RESERVED7[8U];
+  __IM  uint32_t DEVID;                  /*!< Offset: 0xFC8 (R/ )  Device Configuration Register */
+  __IM  uint32_t DEVTYPE;                /*!< Offset: 0xFCC (R/ )  Device Type Identifier Register */
+} TPIU_Type;
+
+/** \brief TPIU Asynchronous Clock Prescaler Register Definitions */
+#define TPIU_ACPR_PRESCALER_Pos             0U                                         /*!< TPIU ACPR: PRESCALER Position */
+#define TPIU_ACPR_PRESCALER_Msk            (0x1FFFUL /*<< TPIU_ACPR_PRESCALER_Pos*/)   /*!< TPIU ACPR: PRESCALER Mask */
+
+/** \brief TPIU Selected Pin Protocol Register Definitions */
+#define TPIU_SPPR_TXMODE_Pos                0U                                         /*!< TPIU SPPR: TXMODE Position */
+#define TPIU_SPPR_TXMODE_Msk               (0x3UL /*<< TPIU_SPPR_TXMODE_Pos*/)         /*!< TPIU SPPR: TXMODE Mask */
+
+/** \brief TPIU Formatter and Flush Status Register Definitions */
+#define TPIU_FFSR_FtNonStop_Pos             3U                                         /*!< TPIU FFSR: FtNonStop Position */
+#define TPIU_FFSR_FtNonStop_Msk            (1UL << TPIU_FFSR_FtNonStop_Pos)            /*!< TPIU FFSR: FtNonStop Mask */
+
+#define TPIU_FFSR_TCPresent_Pos             2U                                         /*!< TPIU FFSR: TCPresent Position */
+#define TPIU_FFSR_TCPresent_Msk            (1UL << TPIU_FFSR_TCPresent_Pos)            /*!< TPIU FFSR: TCPresent Mask */
+
+#define TPIU_FFSR_FtStopped_Pos             1U                                         /*!< TPIU FFSR: FtStopped Position */
+#define TPIU_FFSR_FtStopped_Msk            (1UL << TPIU_FFSR_FtStopped_Pos)            /*!< TPIU FFSR: FtStopped Mask */
+
+#define TPIU_FFSR_FlInProg_Pos              0U                                         /*!< TPIU FFSR: FlInProg Position */
+#define TPIU_FFSR_FlInProg_Msk             (1UL /*<< TPIU_FFSR_FlInProg_Pos*/)         /*!< TPIU FFSR: FlInProg Mask */
+
+/** \brief TPIU Formatter and Flush Control Register Definitions */
+#define TPIU_FFCR_TrigIn_Pos                8U                                         /*!< TPIU FFCR: TrigIn Position */
+#define TPIU_FFCR_TrigIn_Msk               (1UL << TPIU_FFCR_TrigIn_Pos)               /*!< TPIU FFCR: TrigIn Mask */
+
+#define TPIU_FFCR_FOnMan_Pos                6U                                         /*!< TPIU FFCR: FOnMan Position */
+#define TPIU_FFCR_FOnMan_Msk               (1UL << TPIU_FFCR_FOnMan_Pos)               /*!< TPIU FFCR: FOnMan Mask */
+
+#define TPIU_FFCR_EnFCont_Pos               1U                                         /*!< TPIU FFCR: EnFCont Position */
+#define TPIU_FFCR_EnFCont_Msk              (1UL << TPIU_FFCR_EnFCont_Pos)              /*!< TPIU FFCR: EnFCont Mask */
+
+/** \brief TPIU Periodic Synchronization Control Register Definitions */
+#define TPIU_PSCR_PSCount_Pos               0U                                         /*!< TPIU PSCR: PSCount Position */
+#define TPIU_PSCR_PSCount_Msk              (0x1FUL /*<< TPIU_PSCR_PSCount_Pos*/)       /*!< TPIU PSCR: TPSCount Mask */
+
+/** \brief TPIU TRIGGER Register Definitions */
+#define TPIU_TRIGGER_TRIGGER_Pos            0U                                         /*!< TPIU TRIGGER: TRIGGER Position */
+#define TPIU_TRIGGER_TRIGGER_Msk           (1UL /*<< TPIU_TRIGGER_TRIGGER_Pos*/)       /*!< TPIU TRIGGER: TRIGGER Mask */
+
+/** \brief TPIU Integration Test FIFO Test Data 0 Register Definitions */
+#define TPIU_ITFTTD0_ATB_IF2_ATVALID_Pos   29U                                         /*!< TPIU ITFTTD0: ATB Interface 2 ATVALIDPosition */
+#define TPIU_ITFTTD0_ATB_IF2_ATVALID_Msk   (0x3UL << TPIU_ITFTTD0_ATB_IF2_ATVALID_Pos) /*!< TPIU ITFTTD0: ATB Interface 2 ATVALID Mask */
+
+#define TPIU_ITFTTD0_ATB_IF2_bytecount_Pos 27U                                         /*!< TPIU ITFTTD0: ATB Interface 2 byte count Position */
+#define TPIU_ITFTTD0_ATB_IF2_bytecount_Msk (0x3UL << TPIU_ITFTTD0_ATB_IF2_bytecount_Pos) /*!< TPIU ITFTTD0: ATB Interface 2 byte count Mask */
+
+#define TPIU_ITFTTD0_ATB_IF1_ATVALID_Pos   26U                                         /*!< TPIU ITFTTD0: ATB Interface 1 ATVALID Position */
+#define TPIU_ITFTTD0_ATB_IF1_ATVALID_Msk   (0x3UL << TPIU_ITFTTD0_ATB_IF1_ATVALID_Pos) /*!< TPIU ITFTTD0: ATB Interface 1 ATVALID Mask */
+
+#define TPIU_ITFTTD0_ATB_IF1_bytecount_Pos 24U                                         /*!< TPIU ITFTTD0: ATB Interface 1 byte count Position */
+#define TPIU_ITFTTD0_ATB_IF1_bytecount_Msk (0x3UL << TPIU_ITFTTD0_ATB_IF1_bytecount_Pos) /*!< TPIU ITFTTD0: ATB Interface 1 byte countt Mask */
+
+#define TPIU_ITFTTD0_ATB_IF1_data2_Pos     16U                                         /*!< TPIU ITFTTD0: ATB Interface 1 data2 Position */
+#define TPIU_ITFTTD0_ATB_IF1_data2_Msk     (0xFFUL << TPIU_ITFTTD0_ATB_IF1_data1_Pos)  /*!< TPIU ITFTTD0: ATB Interface 1 data2 Mask */
+
+#define TPIU_ITFTTD0_ATB_IF1_data1_Pos      8U                                         /*!< TPIU ITFTTD0: ATB Interface 1 data1 Position */
+#define TPIU_ITFTTD0_ATB_IF1_data1_Msk     (0xFFUL << TPIU_ITFTTD0_ATB_IF1_data1_Pos)  /*!< TPIU ITFTTD0: ATB Interface 1 data1 Mask */
+
+#define TPIU_ITFTTD0_ATB_IF1_data0_Pos      0U                                         /*!< TPIU ITFTTD0: ATB Interface 1 data0 Position */
+#define TPIU_ITFTTD0_ATB_IF1_data0_Msk     (0xFFUL /*<< TPIU_ITFTTD0_ATB_IF1_data0_Pos*/) /*!< TPIU ITFTTD0: ATB Interface 1 data0 Mask */
+
+/** \brief TPIU Integration Test ATB Control Register 2 Register Definitions */
+#define TPIU_ITATBCTR2_AFVALID2S_Pos        1U                                         /*!< TPIU ITATBCTR2: AFVALID2S Position */
+#define TPIU_ITATBCTR2_AFVALID2S_Msk       (1UL << TPIU_ITATBCTR2_AFVALID2S_Pos)       /*!< TPIU ITATBCTR2: AFVALID2SS Mask */
+
+#define TPIU_ITATBCTR2_AFVALID1S_Pos        1U                                         /*!< TPIU ITATBCTR2: AFVALID1S Position */
+#define TPIU_ITATBCTR2_AFVALID1S_Msk       (1UL << TPIU_ITATBCTR2_AFVALID1S_Pos)       /*!< TPIU ITATBCTR2: AFVALID1SS Mask */
+
+#define TPIU_ITATBCTR2_ATREADY2S_Pos        0U                                         /*!< TPIU ITATBCTR2: ATREADY2S Position */
+#define TPIU_ITATBCTR2_ATREADY2S_Msk       (1UL /*<< TPIU_ITATBCTR2_ATREADY2S_Pos*/)   /*!< TPIU ITATBCTR2: ATREADY2S Mask */
+
+#define TPIU_ITATBCTR2_ATREADY1S_Pos        0U                                         /*!< TPIU ITATBCTR2: ATREADY1S Position */
+#define TPIU_ITATBCTR2_ATREADY1S_Msk       (1UL /*<< TPIU_ITATBCTR2_ATREADY1S_Pos*/)   /*!< TPIU ITATBCTR2: ATREADY1S Mask */
+
+/** \brief TPIU Integration Test FIFO Test Data 1 Register Definitions */
+#define TPIU_ITFTTD1_ATB_IF2_ATVALID_Pos   29U                                         /*!< TPIU ITFTTD1: ATB Interface 2 ATVALID Position */
+#define TPIU_ITFTTD1_ATB_IF2_ATVALID_Msk   (0x3UL << TPIU_ITFTTD1_ATB_IF2_ATVALID_Pos) /*!< TPIU ITFTTD1: ATB Interface 2 ATVALID Mask */
+
+#define TPIU_ITFTTD1_ATB_IF2_bytecount_Pos 27U                                         /*!< TPIU ITFTTD1: ATB Interface 2 byte count Position */
+#define TPIU_ITFTTD1_ATB_IF2_bytecount_Msk (0x3UL << TPIU_ITFTTD1_ATB_IF2_bytecount_Pos) /*!< TPIU ITFTTD1: ATB Interface 2 byte count Mask */
+
+#define TPIU_ITFTTD1_ATB_IF1_ATVALID_Pos   26U                                         /*!< TPIU ITFTTD1: ATB Interface 1 ATVALID Position */
+#define TPIU_ITFTTD1_ATB_IF1_ATVALID_Msk   (0x3UL << TPIU_ITFTTD1_ATB_IF1_ATVALID_Pos) /*!< TPIU ITFTTD1: ATB Interface 1 ATVALID Mask */
+
+#define TPIU_ITFTTD1_ATB_IF1_bytecount_Pos 24U                                         /*!< TPIU ITFTTD1: ATB Interface 1 byte count Position */
+#define TPIU_ITFTTD1_ATB_IF1_bytecount_Msk (0x3UL << TPIU_ITFTTD1_ATB_IF1_bytecount_Pos) /*!< TPIU ITFTTD1: ATB Interface 1 byte countt Mask */
+
+#define TPIU_ITFTTD1_ATB_IF2_data2_Pos     16U                                         /*!< TPIU ITFTTD1: ATB Interface 2 data2 Position */
+#define TPIU_ITFTTD1_ATB_IF2_data2_Msk     (0xFFUL << TPIU_ITFTTD1_ATB_IF2_data1_Pos)  /*!< TPIU ITFTTD1: ATB Interface 2 data2 Mask */
+
+#define TPIU_ITFTTD1_ATB_IF2_data1_Pos      8U                                         /*!< TPIU ITFTTD1: ATB Interface 2 data1 Position */
+#define TPIU_ITFTTD1_ATB_IF2_data1_Msk     (0xFFUL << TPIU_ITFTTD1_ATB_IF2_data1_Pos)  /*!< TPIU ITFTTD1: ATB Interface 2 data1 Mask */
+
+#define TPIU_ITFTTD1_ATB_IF2_data0_Pos      0U                                         /*!< TPIU ITFTTD1: ATB Interface 2 data0 Position */
+#define TPIU_ITFTTD1_ATB_IF2_data0_Msk     (0xFFUL /*<< TPIU_ITFTTD1_ATB_IF2_data0_Pos*/) /*!< TPIU ITFTTD1: ATB Interface 2 data0 Mask */
+
+/** \brief TPIU Integration Test ATB Control Register 0 Definitions */
+#define TPIU_ITATBCTR0_AFVALID2S_Pos        1U                                         /*!< TPIU ITATBCTR0: AFVALID2S Position */
+#define TPIU_ITATBCTR0_AFVALID2S_Msk       (1UL << TPIU_ITATBCTR0_AFVALID2S_Pos)       /*!< TPIU ITATBCTR0: AFVALID2SS Mask */
+
+#define TPIU_ITATBCTR0_AFVALID1S_Pos        1U                                         /*!< TPIU ITATBCTR0: AFVALID1S Position */
+#define TPIU_ITATBCTR0_AFVALID1S_Msk       (1UL << TPIU_ITATBCTR0_AFVALID1S_Pos)       /*!< TPIU ITATBCTR0: AFVALID1SS Mask */
+
+#define TPIU_ITATBCTR0_ATREADY2S_Pos        0U                                         /*!< TPIU ITATBCTR0: ATREADY2S Position */
+#define TPIU_ITATBCTR0_ATREADY2S_Msk       (1UL /*<< TPIU_ITATBCTR0_ATREADY2S_Pos*/)   /*!< TPIU ITATBCTR0: ATREADY2S Mask */
+
+#define TPIU_ITATBCTR0_ATREADY1S_Pos        0U                                         /*!< TPIU ITATBCTR0: ATREADY1S Position */
+#define TPIU_ITATBCTR0_ATREADY1S_Msk       (1UL /*<< TPIU_ITATBCTR0_ATREADY1S_Pos*/)   /*!< TPIU ITATBCTR0: ATREADY1S Mask */
+
+/** \brief TPIU Integration Mode Control Register Definitions */
+#define TPIU_ITCTRL_Mode_Pos                0U                                         /*!< TPIU ITCTRL: Mode Position */
+#define TPIU_ITCTRL_Mode_Msk               (0x3UL /*<< TPIU_ITCTRL_Mode_Pos*/)         /*!< TPIU ITCTRL: Mode Mask */
+
+/** \brief TPIU DEVID Register Definitions */
+#define TPIU_DEVID_NRZVALID_Pos            11U                                         /*!< TPIU DEVID: NRZVALID Position */
+#define TPIU_DEVID_NRZVALID_Msk            (1UL << TPIU_DEVID_NRZVALID_Pos)            /*!< TPIU DEVID: NRZVALID Mask */
+
+#define TPIU_DEVID_MANCVALID_Pos           10U                                         /*!< TPIU DEVID: MANCVALID Position */
+#define TPIU_DEVID_MANCVALID_Msk           (1UL << TPIU_DEVID_MANCVALID_Pos)           /*!< TPIU DEVID: MANCVALID Mask */
+
+#define TPIU_DEVID_PTINVALID_Pos            9U                                         /*!< TPIU DEVID: PTINVALID Position */
+#define TPIU_DEVID_PTINVALID_Msk           (1UL << TPIU_DEVID_PTINVALID_Pos)           /*!< TPIU DEVID: PTINVALID Mask */
+
+#define TPIU_DEVID_FIFOSZ_Pos               6U                                         /*!< TPIU DEVID: FIFOSZ Position */
+#define TPIU_DEVID_FIFOSZ_Msk              (0x7UL << TPIU_DEVID_FIFOSZ_Pos)            /*!< TPIU DEVID: FIFOSZ Mask */
+
+#define TPIU_DEVID_NrTraceInput_Pos         0U                                         /*!< TPIU DEVID: NrTraceInput Position */
+#define TPIU_DEVID_NrTraceInput_Msk        (0x3FUL /*<< TPIU_DEVID_NrTraceInput_Pos*/) /*!< TPIU DEVID: NrTraceInput Mask */
+
+/** \brief TPIU DEVTYPE Register Definitions */
+#define TPIU_DEVTYPE_SubType_Pos            4U                                         /*!< TPIU DEVTYPE: SubType Position */
+#define TPIU_DEVTYPE_SubType_Msk           (0xFUL /*<< TPIU_DEVTYPE_SubType_Pos*/)     /*!< TPIU DEVTYPE: SubType Mask */
+
+#define TPIU_DEVTYPE_MajorType_Pos          0U                                         /*!< TPIU DEVTYPE: MajorType Position */
+#define TPIU_DEVTYPE_MajorType_Msk         (0xFUL << TPIU_DEVTYPE_MajorType_Pos)       /*!< TPIU DEVTYPE: MajorType Mask */
+
+/*@}*/ /* end of group CMSIS_TPIU */
+
+
+#if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_MPU     Memory Protection Unit (MPU)
+  \brief    Type definitions for the Memory Protection Unit (MPU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Memory Protection Unit (MPU).
+ */
+typedef struct
+{
+  __IM  uint32_t TYPE;                   /*!< Offset: 0x000 (R/ )  MPU Type Register */
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x004 (R/W)  MPU Control Register */
+  __IOM uint32_t RNR;                    /*!< Offset: 0x008 (R/W)  MPU Region Number Register */
+  __IOM uint32_t RBAR;                   /*!< Offset: 0x00C (R/W)  MPU Region Base Address Register */
+  __IOM uint32_t RLAR;                   /*!< Offset: 0x010 (R/W)  MPU Region Limit Address Register */
+        uint32_t RESERVED0[7U];
+  union {
+  __IOM uint32_t MAIR[2];
+  struct {
+  __IOM uint32_t MAIR0;                  /*!< Offset: 0x030 (R/W)  MPU Memory Attribute Indirection Register 0 */
+  __IOM uint32_t MAIR1;                  /*!< Offset: 0x034 (R/W)  MPU Memory Attribute Indirection Register 1 */
+  };
+  };
+} MPU_Type;
+
+#define MPU_TYPE_RALIASES                  1U
+
+/** \brief MPU Type Register Definitions */
+#define MPU_TYPE_IREGION_Pos               16U                                            /*!< MPU TYPE: IREGION Position */
+#define MPU_TYPE_IREGION_Msk               (0xFFUL << MPU_TYPE_IREGION_Pos)               /*!< MPU TYPE: IREGION Mask */
+
+#define MPU_TYPE_DREGION_Pos                8U                                            /*!< MPU TYPE: DREGION Position */
+#define MPU_TYPE_DREGION_Msk               (0xFFUL << MPU_TYPE_DREGION_Pos)               /*!< MPU TYPE: DREGION Mask */
+
+#define MPU_TYPE_SEPARATE_Pos               0U                                            /*!< MPU TYPE: SEPARATE Position */
+#define MPU_TYPE_SEPARATE_Msk              (1UL /*<< MPU_TYPE_SEPARATE_Pos*/)             /*!< MPU TYPE: SEPARATE Mask */
+
+/** \brief MPU Control Register Definitions */
+#define MPU_CTRL_PRIVDEFENA_Pos             2U                                            /*!< MPU CTRL: PRIVDEFENA Position */
+#define MPU_CTRL_PRIVDEFENA_Msk            (1UL << MPU_CTRL_PRIVDEFENA_Pos)               /*!< MPU CTRL: PRIVDEFENA Mask */
+
+#define MPU_CTRL_HFNMIENA_Pos               1U                                            /*!< MPU CTRL: HFNMIENA Position */
+#define MPU_CTRL_HFNMIENA_Msk              (1UL << MPU_CTRL_HFNMIENA_Pos)                 /*!< MPU CTRL: HFNMIENA Mask */
+
+#define MPU_CTRL_ENABLE_Pos                 0U                                            /*!< MPU CTRL: ENABLE Position */
+#define MPU_CTRL_ENABLE_Msk                (1UL /*<< MPU_CTRL_ENABLE_Pos*/)               /*!< MPU CTRL: ENABLE Mask */
+
+/** \brief MPU Region Number Register Definitions */
+#define MPU_RNR_REGION_Pos                  0U                                            /*!< MPU RNR: REGION Position */
+#define MPU_RNR_REGION_Msk                 (0xFFUL /*<< MPU_RNR_REGION_Pos*/)             /*!< MPU RNR: REGION Mask */
+
+/** \brief MPU Region Base Address Register Definitions */
+#define MPU_RBAR_BASE_Pos                   5U                                            /*!< MPU RBAR: BASE Position */
+#define MPU_RBAR_BASE_Msk                  (0x7FFFFFFUL << MPU_RBAR_BASE_Pos)             /*!< MPU RBAR: BASE Mask */
+
+#define MPU_RBAR_SH_Pos                     3U                                            /*!< MPU RBAR: SH Position */
+#define MPU_RBAR_SH_Msk                    (0x3UL << MPU_RBAR_SH_Pos)                     /*!< MPU RBAR: SH Mask */
+
+#define MPU_RBAR_AP_Pos                     1U                                            /*!< MPU RBAR: AP Position */
+#define MPU_RBAR_AP_Msk                    (0x3UL << MPU_RBAR_AP_Pos)                     /*!< MPU RBAR: AP Mask */
+
+#define MPU_RBAR_XN_Pos                     0U                                            /*!< MPU RBAR: XN Position */
+#define MPU_RBAR_XN_Msk                    (01UL /*<< MPU_RBAR_XN_Pos*/)                  /*!< MPU RBAR: XN Mask */
+
+/** \brief MPU Region Limit Address Register Definitions */
+#define MPU_RLAR_LIMIT_Pos                  5U                                            /*!< MPU RLAR: LIMIT Position */
+#define MPU_RLAR_LIMIT_Msk                 (0x7FFFFFFUL << MPU_RLAR_LIMIT_Pos)            /*!< MPU RLAR: LIMIT Mask */
+
+#define MPU_RLAR_AttrIndx_Pos               1U                                            /*!< MPU RLAR: AttrIndx Position */
+#define MPU_RLAR_AttrIndx_Msk              (0x7UL << MPU_RLAR_AttrIndx_Pos)               /*!< MPU RLAR: AttrIndx Mask */
+
+#define MPU_RLAR_EN_Pos                     0U                                            /*!< MPU RLAR: Region enable bit Position */
+#define MPU_RLAR_EN_Msk                    (1UL /*<< MPU_RLAR_EN_Pos*/)                   /*!< MPU RLAR: Region enable bit Mask */
+
+/** \brief MPU Memory Attribute Indirection Register 0 Definitions */
+#define MPU_MAIR0_Attr3_Pos                24U                                            /*!< MPU MAIR0: Attr3 Position */
+#define MPU_MAIR0_Attr3_Msk                (0xFFUL << MPU_MAIR0_Attr3_Pos)                /*!< MPU MAIR0: Attr3 Mask */
+
+#define MPU_MAIR0_Attr2_Pos                16U                                            /*!< MPU MAIR0: Attr2 Position */
+#define MPU_MAIR0_Attr2_Msk                (0xFFUL << MPU_MAIR0_Attr2_Pos)                /*!< MPU MAIR0: Attr2 Mask */
+
+#define MPU_MAIR0_Attr1_Pos                 8U                                            /*!< MPU MAIR0: Attr1 Position */
+#define MPU_MAIR0_Attr1_Msk                (0xFFUL << MPU_MAIR0_Attr1_Pos)                /*!< MPU MAIR0: Attr1 Mask */
+
+#define MPU_MAIR0_Attr0_Pos                 0U                                            /*!< MPU MAIR0: Attr0 Position */
+#define MPU_MAIR0_Attr0_Msk                (0xFFUL /*<< MPU_MAIR0_Attr0_Pos*/)            /*!< MPU MAIR0: Attr0 Mask */
+
+/** \brief MPU Memory Attribute Indirection Register 1 Definitions */
+#define MPU_MAIR1_Attr7_Pos                24U                                            /*!< MPU MAIR1: Attr7 Position */
+#define MPU_MAIR1_Attr7_Msk                (0xFFUL << MPU_MAIR1_Attr7_Pos)                /*!< MPU MAIR1: Attr7 Mask */
+
+#define MPU_MAIR1_Attr6_Pos                16U                                            /*!< MPU MAIR1: Attr6 Position */
+#define MPU_MAIR1_Attr6_Msk                (0xFFUL << MPU_MAIR1_Attr6_Pos)                /*!< MPU MAIR1: Attr6 Mask */
+
+#define MPU_MAIR1_Attr5_Pos                 8U                                            /*!< MPU MAIR1: Attr5 Position */
+#define MPU_MAIR1_Attr5_Msk                (0xFFUL << MPU_MAIR1_Attr5_Pos)                /*!< MPU MAIR1: Attr5 Mask */
+
+#define MPU_MAIR1_Attr4_Pos                 0U                                            /*!< MPU MAIR1: Attr4 Position */
+#define MPU_MAIR1_Attr4_Msk                (0xFFUL /*<< MPU_MAIR1_Attr4_Pos*/)            /*!< MPU MAIR1: Attr4 Mask */
+
+/*@} end of group CMSIS_MPU */
+#endif
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SAU     Security Attribution Unit (SAU)
+  \brief    Type definitions for the Security Attribution Unit (SAU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Security Attribution Unit (SAU).
+ */
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  SAU Control Register */
+  __IM  uint32_t TYPE;                   /*!< Offset: 0x004 (R/ )  SAU Type Register */
+#if defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U)
+  __IOM uint32_t RNR;                    /*!< Offset: 0x008 (R/W)  SAU Region Number Register */
+  __IOM uint32_t RBAR;                   /*!< Offset: 0x00C (R/W)  SAU Region Base Address Register */
+  __IOM uint32_t RLAR;                   /*!< Offset: 0x010 (R/W)  SAU Region Limit Address Register */
+#endif
+} SAU_Type;
+
+/** \brief SAU Control Register Definitions */
+#define SAU_CTRL_ALLNS_Pos                  1U                                            /*!< SAU CTRL: ALLNS Position */
+#define SAU_CTRL_ALLNS_Msk                 (1UL << SAU_CTRL_ALLNS_Pos)                    /*!< SAU CTRL: ALLNS Mask */
+
+#define SAU_CTRL_ENABLE_Pos                 0U                                            /*!< SAU CTRL: ENABLE Position */
+#define SAU_CTRL_ENABLE_Msk                (1UL /*<< SAU_CTRL_ENABLE_Pos*/)               /*!< SAU CTRL: ENABLE Mask */
+
+/** \brief SAU Type Register Definitions */
+#define SAU_TYPE_SREGION_Pos                0U                                            /*!< SAU TYPE: SREGION Position */
+#define SAU_TYPE_SREGION_Msk               (0xFFUL /*<< SAU_TYPE_SREGION_Pos*/)           /*!< SAU TYPE: SREGION Mask */
+
+#if defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U)
+/** \brief SAU Region Number Register Definitions */
+#define SAU_RNR_REGION_Pos                  0U                                            /*!< SAU RNR: REGION Position */
+#define SAU_RNR_REGION_Msk                 (0xFFUL /*<< SAU_RNR_REGION_Pos*/)             /*!< SAU RNR: REGION Mask */
+
+/** \brief SAU Region Base Address Register Definitions */
+#define SAU_RBAR_BADDR_Pos                  5U                                            /*!< SAU RBAR: BADDR Position */
+#define SAU_RBAR_BADDR_Msk                 (0x7FFFFFFUL << SAU_RBAR_BADDR_Pos)            /*!< SAU RBAR: BADDR Mask */
+
+/** \brief SAU Region Limit Address Register Definitions */
+#define SAU_RLAR_LADDR_Pos                  5U                                            /*!< SAU RLAR: LADDR Position */
+#define SAU_RLAR_LADDR_Msk                 (0x7FFFFFFUL << SAU_RLAR_LADDR_Pos)            /*!< SAU RLAR: LADDR Mask */
+
+#define SAU_RLAR_NSC_Pos                    1U                                            /*!< SAU RLAR: NSC Position */
+#define SAU_RLAR_NSC_Msk                   (1UL << SAU_RLAR_NSC_Pos)                      /*!< SAU RLAR: NSC Mask */
+
+#define SAU_RLAR_ENABLE_Pos                 0U                                            /*!< SAU RLAR: ENABLE Position */
+#define SAU_RLAR_ENABLE_Msk                (1UL /*<< SAU_RLAR_ENABLE_Pos*/)               /*!< SAU RLAR: ENABLE Mask */
+
+#endif /* defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U) */
+
+/*@} end of group CMSIS_SAU */
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup CMSIS_DCB       Debug Control Block
+  \brief    Type definitions for the Debug Control Block Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Debug Control Block Registers (DCB).
+ */
+typedef struct
+{
+  __IOM uint32_t DHCSR;                  /*!< Offset: 0x000 (R/W)  Debug Halting Control and Status Register */
+  __OM  uint32_t DCRSR;                  /*!< Offset: 0x004 ( /W)  Debug Core Register Selector Register */
+  __IOM uint32_t DCRDR;                  /*!< Offset: 0x008 (R/W)  Debug Core Register Data Register */
+  __IOM uint32_t DEMCR;                  /*!< Offset: 0x00C (R/W)  Debug Exception and Monitor Control Register */
+        uint32_t RESERVED0[1U];
+  __IOM uint32_t DAUTHCTRL;              /*!< Offset: 0x014 (R/W)  Debug Authentication Control Register */
+  __IOM uint32_t DSCSR;                  /*!< Offset: 0x018 (R/W)  Debug Security Control and Status Register */
+} DCB_Type;
+
+/** \brief DCB Debug Halting Control and Status Register Definitions */
+#define DCB_DHCSR_DBGKEY_Pos               16U                                            /*!< DCB DHCSR: Debug key Position */
+#define DCB_DHCSR_DBGKEY_Msk               (0xFFFFUL << DCB_DHCSR_DBGKEY_Pos)             /*!< DCB DHCSR: Debug key Mask */
+
+#define DCB_DHCSR_S_RESTART_ST_Pos         26U                                            /*!< DCB DHCSR: Restart sticky status Position */
+#define DCB_DHCSR_S_RESTART_ST_Msk         (1UL << DCB_DHCSR_S_RESTART_ST_Pos)            /*!< DCB DHCSR: Restart sticky status Mask */
+
+#define DCB_DHCSR_S_RESET_ST_Pos           25U                                            /*!< DCB DHCSR: Reset sticky status Position */
+#define DCB_DHCSR_S_RESET_ST_Msk           (1UL << DCB_DHCSR_S_RESET_ST_Pos)              /*!< DCB DHCSR: Reset sticky status Mask */
+
+#define DCB_DHCSR_S_RETIRE_ST_Pos          24U                                            /*!< DCB DHCSR: Retire sticky status Position */
+#define DCB_DHCSR_S_RETIRE_ST_Msk          (1UL << DCB_DHCSR_S_RETIRE_ST_Pos)             /*!< DCB DHCSR: Retire sticky status Mask */
+
+#define DCB_DHCSR_S_SDE_Pos                20U                                            /*!< DCB DHCSR: Secure debug enabled Position */
+#define DCB_DHCSR_S_SDE_Msk                (1UL << DCB_DHCSR_S_SDE_Pos)                   /*!< DCB DHCSR: Secure debug enabled Mask */
+
+#define DCB_DHCSR_S_LOCKUP_Pos             19U                                            /*!< DCB DHCSR: Lockup status Position */
+#define DCB_DHCSR_S_LOCKUP_Msk             (1UL << DCB_DHCSR_S_LOCKUP_Pos)                /*!< DCB DHCSR: Lockup status Mask */
+
+#define DCB_DHCSR_S_SLEEP_Pos              18U                                            /*!< DCB DHCSR: Sleeping status Position */
+#define DCB_DHCSR_S_SLEEP_Msk              (1UL << DCB_DHCSR_S_SLEEP_Pos)                 /*!< DCB DHCSR: Sleeping status Mask */
+
+#define DCB_DHCSR_S_HALT_Pos               17U                                            /*!< DCB DHCSR: Halted status Position */
+#define DCB_DHCSR_S_HALT_Msk               (1UL << DCB_DHCSR_S_HALT_Pos)                  /*!< DCB DHCSR: Halted status Mask */
+
+#define DCB_DHCSR_S_REGRDY_Pos             16U                                            /*!< DCB DHCSR: Register ready status Position */
+#define DCB_DHCSR_S_REGRDY_Msk             (1UL << DCB_DHCSR_S_REGRDY_Pos)                /*!< DCB DHCSR: Register ready status Mask */
+
+#define DCB_DHCSR_C_MASKINTS_Pos            3U                                            /*!< DCB DHCSR: Mask interrupts control Position */
+#define DCB_DHCSR_C_MASKINTS_Msk           (1UL << DCB_DHCSR_C_MASKINTS_Pos)              /*!< DCB DHCSR: Mask interrupts control Mask */
+
+#define DCB_DHCSR_C_STEP_Pos                2U                                            /*!< DCB DHCSR: Step control Position */
+#define DCB_DHCSR_C_STEP_Msk               (1UL << DCB_DHCSR_C_STEP_Pos)                  /*!< DCB DHCSR: Step control Mask */
+
+#define DCB_DHCSR_C_HALT_Pos                1U                                            /*!< DCB DHCSR: Halt control Position */
+#define DCB_DHCSR_C_HALT_Msk               (1UL << DCB_DHCSR_C_HALT_Pos)                  /*!< DCB DHCSR: Halt control Mask */
+
+#define DCB_DHCSR_C_DEBUGEN_Pos             0U                                            /*!< DCB DHCSR: Debug enable control Position */
+#define DCB_DHCSR_C_DEBUGEN_Msk            (1UL /*<< DCB_DHCSR_C_DEBUGEN_Pos*/)           /*!< DCB DHCSR: Debug enable control Mask */
+
+/** \brief DCB Debug Core Register Selector Register Definitions */
+#define DCB_DCRSR_REGWnR_Pos               16U                                            /*!< DCB DCRSR: Register write/not-read Position */
+#define DCB_DCRSR_REGWnR_Msk               (1UL << DCB_DCRSR_REGWnR_Pos)                  /*!< DCB DCRSR: Register write/not-read Mask */
+
+#define DCB_DCRSR_REGSEL_Pos                0U                                            /*!< DCB DCRSR: Register selector Position */
+#define DCB_DCRSR_REGSEL_Msk               (0x7FUL /*<< DCB_DCRSR_REGSEL_Pos*/)           /*!< DCB DCRSR: Register selector Mask */
+
+/** \brief DCB Debug Core Register Data Register Definitions */
+#define DCB_DCRDR_DBGTMP_Pos                0U                                            /*!< DCB DCRDR: Data temporary buffer Position */
+#define DCB_DCRDR_DBGTMP_Msk               (0xFFFFFFFFUL /*<< DCB_DCRDR_DBGTMP_Pos*/)     /*!< DCB DCRDR: Data temporary buffer Mask */
+
+/** \brief DCB Debug Exception and Monitor Control Register Definitions */
+#define DCB_DEMCR_TRCENA_Pos               24U                                            /*!< DCB DEMCR: Trace enable Position */
+#define DCB_DEMCR_TRCENA_Msk               (1UL << DCB_DEMCR_TRCENA_Pos)                  /*!< DCB DEMCR: Trace enable Mask */
+
+#define DCB_DEMCR_VC_HARDERR_Pos           10U                                            /*!< DCB DEMCR: Vector Catch HardFault errors Position */
+#define DCB_DEMCR_VC_HARDERR_Msk           (1UL << DCB_DEMCR_VC_HARDERR_Pos)              /*!< DCB DEMCR: Vector Catch HardFault errors Mask */
+
+#define DCB_DEMCR_VC_CORERESET_Pos          0U                                            /*!< DCB DEMCR: Vector Catch Core reset Position */
+#define DCB_DEMCR_VC_CORERESET_Msk         (1UL /*<< DCB_DEMCR_VC_CORERESET_Pos*/)        /*!< DCB DEMCR: Vector Catch Core reset Mask */
+
+/** \brief DCB Debug Authentication Control Register Definitions */
+#define DCB_DAUTHCTRL_INTSPNIDEN_Pos        3U                                            /*!< DCB DAUTHCTRL: Internal Secure non-invasive debug enable Position */
+#define DCB_DAUTHCTRL_INTSPNIDEN_Msk       (1UL << DCB_DAUTHCTRL_INTSPNIDEN_Pos)          /*!< DCB DAUTHCTRL: Internal Secure non-invasive debug enable Mask */
+
+#define DCB_DAUTHCTRL_SPNIDENSEL_Pos        2U                                            /*!< DCB DAUTHCTRL: Secure non-invasive debug enable select Position */
+#define DCB_DAUTHCTRL_SPNIDENSEL_Msk       (1UL << DCB_DAUTHCTRL_SPNIDENSEL_Pos)          /*!< DCB DAUTHCTRL: Secure non-invasive debug enable select Mask */
+
+#define DCB_DAUTHCTRL_INTSPIDEN_Pos         1U                                            /*!< DCB DAUTHCTRL: Internal Secure invasive debug enable Position */
+#define DCB_DAUTHCTRL_INTSPIDEN_Msk        (1UL << DCB_DAUTHCTRL_INTSPIDEN_Pos)           /*!< DCB DAUTHCTRL: Internal Secure invasive debug enable Mask */
+
+#define DCB_DAUTHCTRL_SPIDENSEL_Pos         0U                                            /*!< DCB DAUTHCTRL: Secure invasive debug enable select Position */
+#define DCB_DAUTHCTRL_SPIDENSEL_Msk        (1UL /*<< DCB_DAUTHCTRL_SPIDENSEL_Pos*/)       /*!< DCB DAUTHCTRL: Secure invasive debug enable select Mask */
+
+/** \brief DCB Debug Security Control and Status Register Definitions */
+#define DCB_DSCSR_CDSKEY_Pos               17U                                            /*!< DCB DSCSR: CDS write-enable key Position */
+#define DCB_DSCSR_CDSKEY_Msk               (1UL << DCB_DSCSR_CDSKEY_Pos)                  /*!< DCB DSCSR: CDS write-enable key Mask */
+
+#define DCB_DSCSR_CDS_Pos                  16U                                            /*!< DCB DSCSR: Current domain Secure Position */
+#define DCB_DSCSR_CDS_Msk                  (1UL << DCB_DSCSR_CDS_Pos)                     /*!< DCB DSCSR: Current domain Secure Mask */
+
+#define DCB_DSCSR_SBRSEL_Pos                1U                                            /*!< DCB DSCSR: Secure banked register select Position */
+#define DCB_DSCSR_SBRSEL_Msk               (1UL << DCB_DSCSR_SBRSEL_Pos)                  /*!< DCB DSCSR: Secure banked register select Mask */
+
+#define DCB_DSCSR_SBRSELEN_Pos              0U                                            /*!< DCB DSCSR: Secure banked register select enable Position */
+#define DCB_DSCSR_SBRSELEN_Msk             (1UL /*<< DCB_DSCSR_SBRSELEN_Pos*/)            /*!< DCB DSCSR: Secure banked register select enable Mask */
+
+/*@} end of group CMSIS_DCB */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_DIB       Debug Identification Block
+  \brief    Type definitions for the Debug Identification Block Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Debug Identification Block Registers (DIB).
+ */
+typedef struct
+{
+  __OM  uint32_t DLAR;                   /*!< Offset: 0x000 ( /W)  SCS Software Lock Access Register */
+  __IM  uint32_t DLSR;                   /*!< Offset: 0x004 (R/ )  SCS Software Lock Status Register */
+  __IM  uint32_t DAUTHSTATUS;            /*!< Offset: 0x008 (R/ )  Debug Authentication Status Register */
+  __IM  uint32_t DDEVARCH;               /*!< Offset: 0x00C (R/ )  SCS Device Architecture Register */
+  __IM  uint32_t DDEVTYPE;               /*!< Offset: 0x010 (R/ )  SCS Device Type Register */
+} DIB_Type;
+
+/** \brief DIB SCS Software Lock Access Register Definitions */
+#define DIB_DLAR_KEY_Pos                    0U                                            /*!< DIB DLAR: KEY Position */
+#define DIB_DLAR_KEY_Msk                   (0xFFFFFFFFUL /*<< DIB_DLAR_KEY_Pos */)        /*!< DIB DLAR: KEY Mask */
+
+/** \brief DIB SCS Software Lock Status Register Definitions */
+#define DIB_DLSR_nTT_Pos                    2U                                            /*!< DIB DLSR: Not thirty-two bit Position */
+#define DIB_DLSR_nTT_Msk                   (1UL << DIB_DLSR_nTT_Pos )                     /*!< DIB DLSR: Not thirty-two bit Mask */
+
+#define DIB_DLSR_SLK_Pos                    1U                                            /*!< DIB DLSR: Software Lock status Position */
+#define DIB_DLSR_SLK_Msk                   (1UL << DIB_DLSR_SLK_Pos )                     /*!< DIB DLSR: Software Lock status Mask */
+
+#define DIB_DLSR_SLI_Pos                    0U                                            /*!< DIB DLSR: Software Lock implemented Position */
+#define DIB_DLSR_SLI_Msk                   (1UL /*<< DIB_DLSR_SLI_Pos*/)                  /*!< DIB DLSR: Software Lock implemented Mask */
+
+/** \brief DIB Debug Authentication Status Register Definitions */
+#define DIB_DAUTHSTATUS_SNID_Pos            6U                                            /*!< DIB DAUTHSTATUS: Secure Non-invasive Debug Position */
+#define DIB_DAUTHSTATUS_SNID_Msk           (0x3UL << DIB_DAUTHSTATUS_SNID_Pos )           /*!< DIB DAUTHSTATUS: Secure Non-invasive Debug Mask */
+
+#define DIB_DAUTHSTATUS_SID_Pos             4U                                            /*!< DIB DAUTHSTATUS: Secure Invasive Debug Position */
+#define DIB_DAUTHSTATUS_SID_Msk            (0x3UL << DIB_DAUTHSTATUS_SID_Pos )            /*!< DIB DAUTHSTATUS: Secure Invasive Debug Mask */
+
+#define DIB_DAUTHSTATUS_NSNID_Pos           2U                                            /*!< DIB DAUTHSTATUS: Non-secure Non-invasive Debug Position */
+#define DIB_DAUTHSTATUS_NSNID_Msk          (0x3UL << DIB_DAUTHSTATUS_NSNID_Pos )          /*!< DIB DAUTHSTATUS: Non-secure Non-invasive Debug Mask */
+
+#define DIB_DAUTHSTATUS_NSID_Pos            0U                                            /*!< DIB DAUTHSTATUS: Non-secure Invasive Debug Position */
+#define DIB_DAUTHSTATUS_NSID_Msk           (0x3UL /*<< DIB_DAUTHSTATUS_NSID_Pos*/)        /*!< DIB DAUTHSTATUS: Non-secure Invasive Debug Mask */
+
+/** \brief DIB SCS Device Architecture Register Definitions */
+#define DIB_DDEVARCH_ARCHITECT_Pos         21U                                            /*!< DIB DDEVARCH: Architect Position */
+#define DIB_DDEVARCH_ARCHITECT_Msk         (0x7FFUL << DIB_DDEVARCH_ARCHITECT_Pos )       /*!< DIB DDEVARCH: Architect Mask */
+
+#define DIB_DDEVARCH_PRESENT_Pos           20U                                            /*!< DIB DDEVARCH: DEVARCH Present Position */
+#define DIB_DDEVARCH_PRESENT_Msk           (0x1FUL << DIB_DDEVARCH_PRESENT_Pos )          /*!< DIB DDEVARCH: DEVARCH Present Mask */
+
+#define DIB_DDEVARCH_REVISION_Pos          16U                                            /*!< DIB DDEVARCH: Revision Position */
+#define DIB_DDEVARCH_REVISION_Msk          (0xFUL << DIB_DDEVARCH_REVISION_Pos )          /*!< DIB DDEVARCH: Revision Mask */
+
+#define DIB_DDEVARCH_ARCHVER_Pos           12U                                            /*!< DIB DDEVARCH: Architecture Version Position */
+#define DIB_DDEVARCH_ARCHVER_Msk           (0xFUL << DIB_DDEVARCH_ARCHVER_Pos )           /*!< DIB DDEVARCH: Architecture Version Mask */
+
+#define DIB_DDEVARCH_ARCHPART_Pos           0U                                            /*!< DIB DDEVARCH: Architecture Part Position */
+#define DIB_DDEVARCH_ARCHPART_Msk          (0xFFFUL /*<< DIB_DDEVARCH_ARCHPART_Pos*/)     /*!< DIB DDEVARCH: Architecture Part Mask */
+
+/** \brief DIB SCS Device Type Register Definitions */
+#define DIB_DDEVTYPE_SUB_Pos                4U                                            /*!< DIB DDEVTYPE: Sub-type Position */
+#define DIB_DDEVTYPE_SUB_Msk               (0xFUL << DIB_DDEVTYPE_SUB_Pos )               /*!< DIB DDEVTYPE: Sub-type Mask */
+
+#define DIB_DDEVTYPE_MAJOR_Pos              0U                                            /*!< DIB DDEVTYPE: Major type Position */
+#define DIB_DDEVTYPE_MAJOR_Msk             (0xFUL /*<< DIB_DDEVTYPE_MAJOR_Pos*/)          /*!< DIB DDEVTYPE: Major type Mask */
+
+/*@} end of group CMSIS_DIB */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_core_bitfield     Core register bit field macros
+  \brief      Macros for use with bit field definitions (xxx_Pos, xxx_Msk).
+  @{
+ */
+
+/**
+  \brief   Mask and shift a bit field value for use in a register bit range.
+  \param[in] field  Name of the register bit field.
+  \param[in] value  Value of the bit field. This parameter is interpreted as an uint32_t type.
+  \return           Masked and shifted value.
+*/
+#define _VAL2FLD(field, value)    (((uint32_t)(value) << field ## _Pos) & field ## _Msk)
+
+/**
+  \brief     Mask and shift a register value to extract a bit filed value.
+  \param[in] field  Name of the register bit field.
+  \param[in] value  Value of register. This parameter is interpreted as an uint32_t type.
+  \return           Masked and shifted bit field value.
+*/
+#define _FLD2VAL(field, value)    (((uint32_t)(value) & field ## _Msk) >> field ## _Pos)
+
+/*@} end of group CMSIS_core_bitfield */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_core_base     Core Definitions
+  \brief      Definitions for base addresses, unions, and structures.
+  @{
+ */
+
+/* Memory mapping of Core Hardware */
+  #define SCS_BASE            (0xE000E000UL)                             /*!< System Control Space Base Address */
+  #define DWT_BASE            (0xE0001000UL)                             /*!< DWT Base Address */
+  #define TPIU_BASE           (0xE0040000UL)                             /*!< TPIU Base Address */
+  #define DCB_BASE            (0xE000EDF0UL)                             /*!< DCB Base Address */
+  #define DIB_BASE            (0xE000EFB0UL)                             /*!< DIB Base Address */
+  #define SysTick_BASE        (SCS_BASE +  0x0010UL)                     /*!< SysTick Base Address */
+  #define NVIC_BASE           (SCS_BASE +  0x0100UL)                     /*!< NVIC Base Address */
+  #define SCB_BASE            (SCS_BASE +  0x0D00UL)                     /*!< System Control Block Base Address */
+
+
+  #define SCB                 ((SCB_Type       *)     SCB_BASE         ) /*!< SCB configuration struct */
+  #define SysTick             ((SysTick_Type   *)     SysTick_BASE     ) /*!< SysTick configuration struct */
+  #define NVIC                ((NVIC_Type      *)     NVIC_BASE        ) /*!< NVIC configuration struct */
+  #define DWT                 ((DWT_Type       *)     DWT_BASE         ) /*!< DWT configuration struct */
+  #define TPIU                ((TPIU_Type      *)     TPIU_BASE        ) /*!< TPIU configuration struct */
+  #define DCB                 ((DCB_Type       *)     DCB_BASE         ) /*!< DCB configuration struct */
+  #define DIB                 ((DIB_Type       *)     DIB_BASE         ) /*!< DIB configuration struct */
+
+  #if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+    #define MPU_BASE          (SCS_BASE +  0x0D90UL)                     /*!< Memory Protection Unit */
+    #define MPU               ((MPU_Type       *)     MPU_BASE         ) /*!< Memory Protection Unit */
+  #endif
+
+  #if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+    #define SAU_BASE          (SCS_BASE +  0x0DD0UL)                     /*!< Security Attribution Unit */
+    #define SAU               ((SAU_Type       *)     SAU_BASE         ) /*!< Security Attribution Unit */
+  #endif
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  #define SCS_BASE_NS         (0xE002E000UL)                             /*!< System Control Space Base Address (non-secure address space) */
+  #define DCB_BASE_NS         (0xE002EDF0UL)                             /*!< DCB Base Address                  (non-secure address space) */
+  #define DIB_BASE_NS         (0xE002EFB0UL)                             /*!< DIB Base Address                  (non-secure address space) */
+  #define SysTick_BASE_NS     (SCS_BASE_NS +  0x0010UL)                  /*!< SysTick Base Address              (non-secure address space) */
+  #define NVIC_BASE_NS        (SCS_BASE_NS +  0x0100UL)                  /*!< NVIC Base Address                 (non-secure address space) */
+  #define SCB_BASE_NS         (SCS_BASE_NS +  0x0D00UL)                  /*!< System Control Block Base Address (non-secure address space) */
+
+  #define SCB_NS              ((SCB_Type       *)     SCB_BASE_NS      ) /*!< SCB configuration struct          (non-secure address space) */
+  #define SysTick_NS          ((SysTick_Type   *)     SysTick_BASE_NS  ) /*!< SysTick configuration struct      (non-secure address space) */
+  #define NVIC_NS             ((NVIC_Type      *)     NVIC_BASE_NS     ) /*!< NVIC configuration struct         (non-secure address space) */
+  #define DCB_NS              ((DCB_Type       *)     DCB_BASE_NS      ) /*!< DCB configuration struct          (non-secure address space) */
+  #define DIB_NS              ((DIB_Type       *)     DIB_BASE_NS      ) /*!< DIB configuration struct          (non-secure address space) */
+
+  #if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+    #define MPU_BASE_NS       (SCS_BASE_NS +  0x0D90UL)                  /*!< Memory Protection Unit            (non-secure address space) */
+    #define MPU_NS            ((MPU_Type       *)     MPU_BASE_NS      ) /*!< Memory Protection Unit            (non-secure address space) */
+  #endif
+
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+/*@} */
+
+
+
+/*******************************************************************************
+ *                Hardware Abstraction Layer
+  Core Function Interface contains:
+  - Core NVIC Functions
+  - Core SysTick Functions
+  - Core Debug Functions
+  - Core Register Access Functions
+ ******************************************************************************/
+/**
+  \defgroup CMSIS_Core_FunctionInterface Functions and Instructions Reference
+*/
+
+
+
+/* ##########################   NVIC functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_NVICFunctions NVIC Functions
+  \brief    Functions that manage interrupts and exceptions via the NVIC.
+  @{
+ */
+
+#ifdef CMSIS_NVIC_VIRTUAL
+  #ifndef CMSIS_NVIC_VIRTUAL_HEADER_FILE
+    #define CMSIS_NVIC_VIRTUAL_HEADER_FILE "cmsis_nvic_virtual.h"
+  #endif
+  #include CMSIS_NVIC_VIRTUAL_HEADER_FILE
+#else
+/*        NVIC_SetPriorityGrouping    not available for Cortex-M23 */
+/*        NVIC_GetPriorityGrouping    not available for Cortex-M23 */
+  #define NVIC_EnableIRQ              __NVIC_EnableIRQ
+  #define NVIC_GetEnableIRQ           __NVIC_GetEnableIRQ
+  #define NVIC_DisableIRQ             __NVIC_DisableIRQ
+  #define NVIC_GetPendingIRQ          __NVIC_GetPendingIRQ
+  #define NVIC_SetPendingIRQ          __NVIC_SetPendingIRQ
+  #define NVIC_ClearPendingIRQ        __NVIC_ClearPendingIRQ
+  #define NVIC_GetActive              __NVIC_GetActive
+  #define NVIC_SetPriority            __NVIC_SetPriority
+  #define NVIC_GetPriority            __NVIC_GetPriority
+  #define NVIC_SystemReset            __NVIC_SystemReset
+#endif /* CMSIS_NVIC_VIRTUAL */
+
+#ifdef CMSIS_VECTAB_VIRTUAL
+  #ifndef CMSIS_VECTAB_VIRTUAL_HEADER_FILE
+    #define CMSIS_VECTAB_VIRTUAL_HEADER_FILE "cmsis_vectab_virtual.h"
+  #endif
+  #include CMSIS_VECTAB_VIRTUAL_HEADER_FILE
+#else
+  #define NVIC_SetVector              __NVIC_SetVector
+  #define NVIC_GetVector              __NVIC_GetVector
+#endif  /* (CMSIS_VECTAB_VIRTUAL) */
+
+#define NVIC_USER_IRQ_OFFSET          16
+
+
+/* Special LR values for Secure/Non-Secure call handling and exception handling                                               */
+
+/* Function Return Payload (from ARMv8-M Architecture Reference Manual) LR value on entry from Secure BLXNS                   */
+#define FNC_RETURN                 (0xFEFFFFFFUL)     /* bit [0] ignored when processing a branch                             */
+
+/* The following EXC_RETURN mask values are used to evaluate the LR on exception entry */
+#define EXC_RETURN_PREFIX          (0xFF000000UL)     /* bits [31:24] set to indicate an EXC_RETURN value                     */
+#define EXC_RETURN_S               (0x00000040UL)     /* bit [6] stack used to push registers: 0=Non-secure 1=Secure          */
+#define EXC_RETURN_DCRS            (0x00000020UL)     /* bit [5] stacking rules for called registers: 0=skipped 1=saved       */
+#define EXC_RETURN_FTYPE           (0x00000010UL)     /* bit [4] allocate stack for floating-point context: 0=done 1=skipped  */
+#define EXC_RETURN_MODE            (0x00000008UL)     /* bit [3] processor mode for return: 0=Handler mode 1=Thread mode      */
+#define EXC_RETURN_SPSEL           (0x00000004UL)     /* bit [2] stack pointer used to restore context: 0=MSP 1=PSP           */
+#define EXC_RETURN_ES              (0x00000001UL)     /* bit [0] security state exception was taken to: 0=Non-secure 1=Secure */
+
+/* Integrity Signature (from ARMv8-M Architecture Reference Manual) for exception context stacking                            */
+#if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)  /* Value for processors with floating-point extension:                  */
+#define EXC_INTEGRITY_SIGNATURE     (0xFEFA125AUL)     /* bit [0] SFTC must match LR bit[4] EXC_RETURN_FTYPE                   */
+#else
+#define EXC_INTEGRITY_SIGNATURE     (0xFEFA125BUL)     /* Value for processors without floating-point extension                */
+#endif
+
+
+/* Interrupt Priorities are WORD accessible only under Armv6-M                  */
+/* The following MACROS handle generation of the register offset and byte masks */
+#define _BIT_SHIFT(IRQn)         (  ((((uint32_t)(int32_t)(IRQn))         )      &  0x03UL) * 8UL)
+#define _SHP_IDX(IRQn)           ( (((((uint32_t)(int32_t)(IRQn)) & 0x0FUL)-8UL) >>    2UL)      )
+#define _IP_IDX(IRQn)            (   (((uint32_t)(int32_t)(IRQn))                >>    2UL)      )
+
+#define __NVIC_SetPriorityGrouping(X) (void)(X)
+#define __NVIC_GetPriorityGrouping()  (0U)
+
+/**
+  \brief   Enable Interrupt
+  \details Enables a device specific interrupt in the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_EnableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    __COMPILER_BARRIER();
+    NVIC->ISER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+    __COMPILER_BARRIER();
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Enable status
+  \details Returns a device specific interrupt enable status from the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt is not enabled.
+  \return             1  Interrupt is enabled.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetEnableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ISER[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Disable Interrupt
+  \details Disables a device specific interrupt in the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_DisableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ICER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+    __DSB();
+    __ISB();
+  }
+}
+
+
+/**
+  \brief   Get Pending Interrupt
+  \details Reads the NVIC pending register and returns the pending bit for the specified device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not pending.
+  \return             1  Interrupt status is pending.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ISPR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Pending Interrupt
+  \details Sets the pending bit of a device specific interrupt in the NVIC pending register.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_SetPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ISPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Clear Pending Interrupt
+  \details Clears the pending bit of a device specific interrupt in the NVIC pending register.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_ClearPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ICPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Active Interrupt
+  \details Reads the active register in the NVIC and returns the active bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not active.
+  \return             1  Interrupt status is active.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetActive(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->IABR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   Get Interrupt Target State
+  \details Reads the interrupt target field in the NVIC and returns the interrupt target bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  if interrupt is assigned to Secure
+  \return             1  if interrupt is assigned to Non Secure
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t NVIC_GetTargetState(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Interrupt Target State
+  \details Sets the interrupt target field in the NVIC and returns the interrupt target bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  if interrupt is assigned to Secure
+                      1  if interrupt is assigned to Non Secure
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t NVIC_SetTargetState(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] |=  ((uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL)));
+    return((uint32_t)(((NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Clear Interrupt Target State
+  \details Clears the interrupt target field in the NVIC and returns the interrupt target bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  if interrupt is assigned to Secure
+                      1  if interrupt is assigned to Non Secure
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t NVIC_ClearTargetState(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] &= ~((uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL)));
+    return((uint32_t)(((NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+
+/**
+  \brief   Set Interrupt Priority
+  \details Sets the priority of a device specific interrupt or a processor exception.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]      IRQn  Interrupt number.
+  \param [in]  priority  Priority to set.
+  \note    The priority cannot be set for every processor exception.
+ */
+__STATIC_INLINE void __NVIC_SetPriority(IRQn_Type IRQn, uint32_t priority)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->IPR[_IP_IDX(IRQn)]  = ((uint32_t)(NVIC->IPR[_IP_IDX(IRQn)]  & ~(0xFFUL << _BIT_SHIFT(IRQn))) |
+       (((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL) << _BIT_SHIFT(IRQn)));
+  }
+  else
+  {
+    SCB->SHPR[_SHP_IDX(IRQn)] = ((uint32_t)(SCB->SHPR[_SHP_IDX(IRQn)] & ~(0xFFUL << _BIT_SHIFT(IRQn))) |
+       (((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL) << _BIT_SHIFT(IRQn)));
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Priority
+  \details Reads the priority of a device specific interrupt or a processor exception.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn  Interrupt number.
+  \return             Interrupt Priority.
+                      Value is aligned automatically to the implemented priority bits of the microcontroller.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPriority(IRQn_Type IRQn)
+{
+
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->IPR[ _IP_IDX(IRQn)] >> _BIT_SHIFT(IRQn) ) & (uint32_t)0xFFUL) >> (8U - __NVIC_PRIO_BITS)));
+  }
+  else
+  {
+    return((uint32_t)(((SCB->SHPR[_SHP_IDX(IRQn)] >> _BIT_SHIFT(IRQn) ) & (uint32_t)0xFFUL) >> (8U - __NVIC_PRIO_BITS)));
+  }
+}
+
+
+/**
+  \brief   Encode Priority
+  \details Encodes the priority for an interrupt with the given priority group,
+           preemptive priority value, and subpriority value.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+  \param [in]     PriorityGroup  Used priority group.
+  \param [in]   PreemptPriority  Preemptive priority value (starting from 0).
+  \param [in]       SubPriority  Subpriority value (starting from 0).
+  \return                        Encoded priority. Value can be used in the function \ref NVIC_SetPriority().
+ */
+__STATIC_INLINE uint32_t NVIC_EncodePriority (uint32_t PriorityGroup, uint32_t PreemptPriority, uint32_t SubPriority)
+{
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);   /* only values 0..7 are used          */
+  uint32_t PreemptPriorityBits;
+  uint32_t SubPriorityBits;
+
+  PreemptPriorityBits = ((7UL - PriorityGroupTmp) > (uint32_t)(__NVIC_PRIO_BITS)) ? (uint32_t)(__NVIC_PRIO_BITS) : (uint32_t)(7UL - PriorityGroupTmp);
+  SubPriorityBits     = ((PriorityGroupTmp + (uint32_t)(__NVIC_PRIO_BITS)) < (uint32_t)7UL) ? (uint32_t)0UL : (uint32_t)((PriorityGroupTmp - 7UL) + (uint32_t)(__NVIC_PRIO_BITS));
+
+  return (
+           ((PreemptPriority & (uint32_t)((1UL << (PreemptPriorityBits)) - 1UL)) << SubPriorityBits) |
+           ((SubPriority     & (uint32_t)((1UL << (SubPriorityBits    )) - 1UL)))
+         );
+}
+
+
+/**
+  \brief   Decode Priority
+  \details Decodes an interrupt priority value with a given priority group to
+           preemptive priority value and subpriority value.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS) the smallest possible priority group is set.
+  \param [in]         Priority   Priority value, which can be retrieved with the function \ref NVIC_GetPriority().
+  \param [in]     PriorityGroup  Used priority group.
+  \param [out] pPreemptPriority  Preemptive priority value (starting from 0).
+  \param [out]     pSubPriority  Subpriority value (starting from 0).
+ */
+__STATIC_INLINE void NVIC_DecodePriority (uint32_t Priority, uint32_t PriorityGroup, uint32_t* const pPreemptPriority, uint32_t* const pSubPriority)
+{
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);   /* only values 0..7 are used          */
+  uint32_t PreemptPriorityBits;
+  uint32_t SubPriorityBits;
+
+  PreemptPriorityBits = ((7UL - PriorityGroupTmp) > (uint32_t)(__NVIC_PRIO_BITS)) ? (uint32_t)(__NVIC_PRIO_BITS) : (uint32_t)(7UL - PriorityGroupTmp);
+  SubPriorityBits     = ((PriorityGroupTmp + (uint32_t)(__NVIC_PRIO_BITS)) < (uint32_t)7UL) ? (uint32_t)0UL : (uint32_t)((PriorityGroupTmp - 7UL) + (uint32_t)(__NVIC_PRIO_BITS));
+
+  *pPreemptPriority = (Priority >> SubPriorityBits) & (uint32_t)((1UL << (PreemptPriorityBits)) - 1UL);
+  *pSubPriority     = (Priority                   ) & (uint32_t)((1UL << (SubPriorityBits    )) - 1UL);
+}
+
+
+/**
+  \brief   Set Interrupt Vector
+  \details Sets an interrupt vector in SRAM based interrupt vector table.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+           VTOR must been relocated to SRAM before.
+           If VTOR is not present address 0 must be mapped to SRAM.
+  \param [in]   IRQn      Interrupt number
+  \param [in]   vector    Address of interrupt handler function
+ */
+__STATIC_INLINE void __NVIC_SetVector(IRQn_Type IRQn, uint32_t vector)
+{
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  uint32_t *vectors = (uint32_t *) ((uintptr_t) SCB->VTOR);
+#else
+  uint32_t *vectors = (uint32_t *)0x0U;
+#endif
+  vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET] = vector;
+  __DSB();
+}
+
+
+/**
+  \brief   Get Interrupt Vector
+  \details Reads an interrupt vector from interrupt vector table.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn      Interrupt number.
+  \return                 Address of interrupt handler function
+ */
+__STATIC_INLINE uint32_t __NVIC_GetVector(IRQn_Type IRQn)
+{
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  uint32_t *vectors = (uint32_t *) ((uintptr_t) SCB->VTOR);
+#else
+  uint32_t *vectors = (uint32_t *)0x0U;
+#endif
+  return vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET];
+}
+
+
+/**
+  \brief   System Reset
+  \details Initiates a system reset request to reset the MCU.
+ */
+__NO_RETURN __STATIC_INLINE void __NVIC_SystemReset(void)
+{
+  __DSB();                                                          /* Ensure all outstanding memory accesses included
+                                                                       buffered write are completed before reset */
+  SCB->AIRCR  = ((0x5FAUL << SCB_AIRCR_VECTKEY_Pos) |
+                 SCB_AIRCR_SYSRESETREQ_Msk);
+  __DSB();                                                          /* Ensure completion of memory access */
+
+  for(;;)                                                           /* wait until reset */
+  {
+    __NOP();
+  }
+}
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   Enable Interrupt (non-secure)
+  \details Enables a device specific interrupt in the non-secure NVIC interrupt controller when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void TZ_NVIC_EnableIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->ISER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Enable status (non-secure)
+  \details Returns a device specific interrupt enable status from the non-secure NVIC interrupt controller when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt is not enabled.
+  \return             1  Interrupt is enabled.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetEnableIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC_NS->ISER[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Disable Interrupt (non-secure)
+  \details Disables a device specific interrupt in the non-secure NVIC interrupt controller when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void TZ_NVIC_DisableIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->ICER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Pending Interrupt (non-secure)
+  \details Reads the NVIC pending register in the non-secure NVIC when in secure state and returns the pending bit for the specified device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not pending.
+  \return             1  Interrupt status is pending.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetPendingIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC_NS->ISPR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Pending Interrupt (non-secure)
+  \details Sets the pending bit of a device specific interrupt in the non-secure NVIC pending register when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void TZ_NVIC_SetPendingIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->ISPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Clear Pending Interrupt (non-secure)
+  \details Clears the pending bit of a device specific interrupt in the non-secure NVIC pending register when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void TZ_NVIC_ClearPendingIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->ICPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Active Interrupt (non-secure)
+  \details Reads the active register in non-secure NVIC when in secure state and returns the active bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not active.
+  \return             1  Interrupt status is active.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetActive_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC_NS->IABR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Interrupt Priority (non-secure)
+  \details Sets the priority of a non-secure device specific interrupt or a non-secure processor exception when in secure state.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]      IRQn  Interrupt number.
+  \param [in]  priority  Priority to set.
+  \note    The priority cannot be set for every non-secure processor exception.
+ */
+__STATIC_INLINE void TZ_NVIC_SetPriority_NS(IRQn_Type IRQn, uint32_t priority)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->IPR[_IP_IDX(IRQn)]  = ((uint32_t)(NVIC_NS->IPR[_IP_IDX(IRQn)]  & ~(0xFFUL << _BIT_SHIFT(IRQn))) |
+       (((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL) << _BIT_SHIFT(IRQn)));
+  }
+  else
+  {
+    SCB_NS->SHPR[_SHP_IDX(IRQn)] = ((uint32_t)(SCB_NS->SHPR[_SHP_IDX(IRQn)] & ~(0xFFUL << _BIT_SHIFT(IRQn))) |
+       (((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL) << _BIT_SHIFT(IRQn)));
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Priority (non-secure)
+  \details Reads the priority of a non-secure device specific interrupt or a non-secure processor exception when in secure state.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn  Interrupt number.
+  \return             Interrupt Priority. Value is aligned automatically to the implemented priority bits of the microcontroller.
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetPriority_NS(IRQn_Type IRQn)
+{
+
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC_NS->IPR[ _IP_IDX(IRQn)] >> _BIT_SHIFT(IRQn) ) & (uint32_t)0xFFUL) >> (8U - __NVIC_PRIO_BITS)));
+  }
+  else
+  {
+    return((uint32_t)(((SCB_NS->SHPR[_SHP_IDX(IRQn)] >> _BIT_SHIFT(IRQn) ) & (uint32_t)0xFFUL) >> (8U - __NVIC_PRIO_BITS)));
+  }
+}
+#endif /*  defined (__ARM_FEATURE_CMSE) &&(__ARM_FEATURE_CMSE == 3U) */
+
+/*@} end of CMSIS_Core_NVICFunctions */
+
+/* ##########################  MPU functions  #################################### */
+
+#if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+
+  #include "m-profile/armv8m_mpu.h"
+
+#endif
+
+
+/* ##########################  FPU functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_FpuFunctions FPU Functions
+  \brief    Function that provides FPU type.
+  @{
+ */
+
+/**
+  \brief   get FPU type
+  \details returns the FPU type
+  \returns
+   - \b  0: No FPU
+   - \b  1: Single precision FPU
+   - \b  2: Double + Single precision FPU
+ */
+__STATIC_INLINE uint32_t SCB_GetFPUType(void)
+{
+    return 0U;           /* No FPU */
+}
+
+/*@} end of CMSIS_Core_FpuFunctions */
+
+
+
+/* ##########################   SAU functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_SAUFunctions SAU Functions
+  \brief    Functions that configure the SAU.
+  @{
+ */
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+
+/**
+  \brief   Enable SAU
+  \details Enables the Security Attribution Unit (SAU).
+ */
+__STATIC_INLINE void TZ_SAU_Enable(void)
+{
+    SAU->CTRL |=  (SAU_CTRL_ENABLE_Msk);
+}
+
+
+
+/**
+  \brief   Disable SAU
+  \details Disables the Security Attribution Unit (SAU).
+ */
+__STATIC_INLINE void TZ_SAU_Disable(void)
+{
+    SAU->CTRL &= ~(SAU_CTRL_ENABLE_Msk);
+}
+
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+/*@} end of CMSIS_Core_SAUFunctions */
+
+
+
+
+/* ##################################    Debug Control function  ############################################ */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_DCBFunctions Debug Control Functions
+  \brief    Functions that access the Debug Control Block.
+  @{
+ */
+
+
+/**
+  \brief   Set Debug Authentication Control Register
+  \details writes to Debug Authentication Control register.
+  \param [in]  value  value to be writen.
+ */
+__STATIC_INLINE void DCB_SetAuthCtrl(uint32_t value)
+{
+    __DSB();
+    __ISB();
+    DCB->DAUTHCTRL = value;
+    __DSB();
+    __ISB();
+}
+
+
+/**
+  \brief   Get Debug Authentication Control Register
+  \details Reads Debug Authentication Control register.
+  \return             Debug Authentication Control Register.
+ */
+__STATIC_INLINE uint32_t DCB_GetAuthCtrl(void)
+{
+    return (DCB->DAUTHCTRL);
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   Set Debug Authentication Control Register (non-secure)
+  \details writes to non-secure Debug Authentication Control register when in secure state.
+  \param [in]  value  value to be writen
+ */
+__STATIC_INLINE void TZ_DCB_SetAuthCtrl_NS(uint32_t value)
+{
+    __DSB();
+    __ISB();
+    DCB_NS->DAUTHCTRL = value;
+    __DSB();
+    __ISB();
+}
+
+
+/**
+  \brief   Get Debug Authentication Control Register (non-secure)
+  \details Reads non-secure Debug Authentication Control register when in secure state.
+  \return             Debug Authentication Control Register.
+ */
+__STATIC_INLINE uint32_t TZ_DCB_GetAuthCtrl_NS(void)
+{
+    return (DCB_NS->DAUTHCTRL);
+}
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+/*@} end of CMSIS_Core_DCBFunctions */
+
+
+
+
+/* ##################################    Debug Identification function  ############################################ */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_DIBFunctions Debug Identification Functions
+  \brief    Functions that access the Debug Identification Block.
+  @{
+ */
+
+
+/**
+  \brief   Get Debug Authentication Status Register
+  \details Reads Debug Authentication Status register.
+  \return             Debug Authentication Status Register.
+ */
+__STATIC_INLINE uint32_t DIB_GetAuthStatus(void)
+{
+    return (DIB->DAUTHSTATUS);
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   Get Debug Authentication Status Register (non-secure)
+  \details Reads non-secure Debug Authentication Status register when in secure state.
+  \return             Debug Authentication Status Register.
+ */
+__STATIC_INLINE uint32_t TZ_DIB_GetAuthStatus_NS(void)
+{
+    return (DIB_NS->DAUTHSTATUS);
+}
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+/*@} end of CMSIS_Core_DCBFunctions */
+
+
+
+
+/* ##################################    SysTick function  ############################################ */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_SysTickFunctions SysTick Functions
+  \brief    Functions that configure the System.
+  @{
+ */
+
+#if defined (__Vendor_SysTickConfig) && (__Vendor_SysTickConfig == 0U)
+
+/**
+  \brief   System Tick Configuration
+  \details Initializes the System Timer and its interrupt, and starts the System Tick Timer.
+           Counter is in free running mode to generate periodic interrupts.
+  \param [in]  ticks  Number of ticks between two interrupts.
+  \return          0  Function succeeded.
+  \return          1  Function failed.
+  \note    When the variable <b>__Vendor_SysTickConfig</b> is set to 1, then the
+           function <b>SysTick_Config</b> is not included. In this case, the file <b><i>device</i>.h</b>
+           must contain a vendor-specific implementation of this function.
+ */
+__STATIC_INLINE uint32_t SysTick_Config(uint32_t ticks)
+{
+  if ((ticks - 1UL) > SysTick_LOAD_RELOAD_Msk)
+  {
+    return (1UL);                                                   /* Reload value impossible */
+  }
+
+  SysTick->LOAD  = (uint32_t)(ticks - 1UL);                         /* set reload register */
+  NVIC_SetPriority (SysTick_IRQn, (1UL << __NVIC_PRIO_BITS) - 1UL); /* set Priority for Systick Interrupt */
+  SysTick->VAL   = 0UL;                                             /* Load the SysTick Counter Value */
+  SysTick->CTRL  = SysTick_CTRL_CLKSOURCE_Msk |
+                   SysTick_CTRL_TICKINT_Msk   |
+                   SysTick_CTRL_ENABLE_Msk;                         /* Enable SysTick IRQ and SysTick Timer */
+  return (0UL);                                                     /* Function successful */
+}
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   System Tick Configuration (non-secure)
+  \details Initializes the non-secure System Timer and its interrupt when in secure state, and starts the System Tick Timer.
+           Counter is in free running mode to generate periodic interrupts.
+  \param [in]  ticks  Number of ticks between two interrupts.
+  \return          0  Function succeeded.
+  \return          1  Function failed.
+  \note    When the variable <b>__Vendor_SysTickConfig</b> is set to 1, then the
+           function <b>TZ_SysTick_Config_NS</b> is not included. In this case, the file <b><i>device</i>.h</b>
+           must contain a vendor-specific implementation of this function.
+
+ */
+__STATIC_INLINE uint32_t TZ_SysTick_Config_NS(uint32_t ticks)
+{
+  if ((ticks - 1UL) > SysTick_LOAD_RELOAD_Msk)
+  {
+    return (1UL);                                                         /* Reload value impossible */
+  }
+
+  SysTick_NS->LOAD  = (uint32_t)(ticks - 1UL);                            /* set reload register */
+  TZ_NVIC_SetPriority_NS (SysTick_IRQn, (1UL << __NVIC_PRIO_BITS) - 1UL); /* set Priority for Systick Interrupt */
+  SysTick_NS->VAL   = 0UL;                                                /* Load the SysTick Counter Value */
+  SysTick_NS->CTRL  = SysTick_CTRL_CLKSOURCE_Msk |
+                      SysTick_CTRL_TICKINT_Msk   |
+                      SysTick_CTRL_ENABLE_Msk;                            /* Enable SysTick IRQ and SysTick Timer */
+  return (0UL);                                                           /* Function successful */
+}
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+#endif
+
+/*@} end of CMSIS_Core_SysTickFunctions */
+
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_CM23_H_DEPENDANT */
+
+#endif /* __CMSIS_GENERIC */

--- a/platform/ext/cmsis/CMSIS/Core/Include/core_cm3.h
+++ b/platform/ext/cmsis/CMSIS/Core/Include/core_cm3.h
@@ -1,0 +1,1944 @@
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS Cortex-M3 Core Peripheral Access Layer Header File
+ */
+
+#if   defined ( __ICCARM__ )
+  #pragma system_include                        /* treat file as system include file for MISRA check */
+#elif defined (__clang__)
+  #pragma clang system_header                   /* treat file as system include file */
+#elif defined ( __GNUC__ )
+  #pragma GCC diagnostic ignored "-Wpedantic"   /* disable pedantic warning due to unnamed structs/unions */
+#endif
+
+#ifndef __CORE_CM3_H_GENERIC
+#define __CORE_CM3_H_GENERIC
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/**
+  \page CMSIS_MISRA_Exceptions  MISRA-C:2004 Compliance Exceptions
+  CMSIS violates the following MISRA-C:2004 rules:
+
+   \li Required Rule 8.5, object/function definition in header file.<br>
+     Function definitions in header files are used to allow 'inlining'.
+
+   \li Required Rule 18.4, declaration of union type or object of union type: '{...}'.<br>
+     Unions are used for effective representation of core registers.
+
+   \li Advisory Rule 19.7, Function-like macro defined.<br>
+     Function-like macros are used to allow more efficient code.
+ */
+
+
+/*******************************************************************************
+ *                 CMSIS definitions
+ ******************************************************************************/
+/**
+  \ingroup Cortex_M3
+  @{
+ */
+
+#include "cmsis_version.h"
+
+/* CMSIS CM3 definitions */
+
+#define __CORTEX_M                (3U)                                /*!< Cortex-M Core */
+
+/** __FPU_USED indicates whether an FPU is used or not.
+    This core does not support an FPU at all
+*/
+#define __FPU_USED       0U
+
+#if defined ( __CC_ARM )
+  #if defined (__TARGET_FPU_VFP)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #if defined (__ARM_FP)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined (__ti__)
+  #if defined (__ARM_FP)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __GNUC__ )
+  #if defined (__VFP_FP__) && !defined(__SOFTFP__)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __ICCARM__ )
+  #if defined (__ARMVFP__)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __TI_ARM__ )
+  #if defined (__TI_VFP_SUPPORT__)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __TASKING__ )
+  #if defined (__FPU_VFP__)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __CSMC__ )
+  #if ( __CSMC__ & 0x400U)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#endif
+
+#include "cmsis_compiler.h"               /* CMSIS compiler specific defines */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_CM3_H_GENERIC */
+
+#ifndef __CMSIS_GENERIC
+
+#ifndef __CORE_CM3_H_DEPENDANT
+#define __CORE_CM3_H_DEPENDANT
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* check device defines and use defaults */
+#if defined __CHECK_DEVICE_DEFINES
+  #ifndef __CM3_REV
+    #define __CM3_REV               0x0200U
+    #warning "__CM3_REV not defined in device header file; using default!"
+  #endif
+
+  #ifndef __MPU_PRESENT
+    #define __MPU_PRESENT             0U
+    #warning "__MPU_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __VTOR_PRESENT
+    #define __VTOR_PRESENT            1U
+    #warning "__VTOR_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __NVIC_PRIO_BITS
+    #define __NVIC_PRIO_BITS          3U
+    #warning "__NVIC_PRIO_BITS not defined in device header file; using default!"
+  #endif
+
+  #ifndef __Vendor_SysTickConfig
+    #define __Vendor_SysTickConfig    0U
+    #warning "__Vendor_SysTickConfig not defined in device header file; using default!"
+  #endif
+#endif
+
+/* IO definitions (access restrictions to peripheral registers) */
+/**
+    \defgroup CMSIS_glob_defs CMSIS Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+*/
+#ifdef __cplusplus
+  #define   __I     volatile             /*!< Defines 'read only' permissions */
+#else
+  #define   __I     volatile const       /*!< Defines 'read only' permissions */
+#endif
+#define     __O     volatile             /*!< Defines 'write only' permissions */
+#define     __IO    volatile             /*!< Defines 'read / write' permissions */
+
+/* following defines should be used for structure members */
+#define     __IM     volatile const      /*! Defines 'read only' structure member permissions */
+#define     __OM     volatile            /*! Defines 'write only' structure member permissions */
+#define     __IOM    volatile            /*! Defines 'read / write' structure member permissions */
+
+/*@} end of group Cortex_M3 */
+
+
+
+/*******************************************************************************
+ *                 Register Abstraction
+  Core Register contain:
+  - Core Register
+  - Core NVIC Register
+  - Core SCB Register
+  - Core SysTick Register
+  - Core Debug Register
+  - Core MPU Register
+ ******************************************************************************/
+/**
+  \defgroup CMSIS_core_register Defines and Type Definitions
+  \brief Type definitions and defines for Cortex-M processor based devices.
+*/
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_CORE  Status and Control Registers
+  \brief      Core Register type definitions.
+  @{
+ */
+
+/**
+  \brief  Union type to access the Application Program Status Register (APSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t _reserved0:27;              /*!< bit:  0..26  Reserved */
+    uint32_t Q:1;                        /*!< bit:     27  Saturation condition flag */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} APSR_Type;
+
+/** \brief APSR Register Definitions */
+#define APSR_N_Pos                         31U                                            /*!< APSR: N Position */
+#define APSR_N_Msk                         (1UL << APSR_N_Pos)                            /*!< APSR: N Mask */
+
+#define APSR_Z_Pos                         30U                                            /*!< APSR: Z Position */
+#define APSR_Z_Msk                         (1UL << APSR_Z_Pos)                            /*!< APSR: Z Mask */
+
+#define APSR_C_Pos                         29U                                            /*!< APSR: C Position */
+#define APSR_C_Msk                         (1UL << APSR_C_Pos)                            /*!< APSR: C Mask */
+
+#define APSR_V_Pos                         28U                                            /*!< APSR: V Position */
+#define APSR_V_Msk                         (1UL << APSR_V_Pos)                            /*!< APSR: V Mask */
+
+#define APSR_Q_Pos                         27U                                            /*!< APSR: Q Position */
+#define APSR_Q_Msk                         (1UL << APSR_Q_Pos)                            /*!< APSR: Q Mask */
+
+
+/**
+  \brief  Union type to access the Interrupt Program Status Register (IPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number */
+    uint32_t _reserved0:23;              /*!< bit:  9..31  Reserved */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} IPSR_Type;
+
+/** \brief IPSR Register Definitions */
+#define IPSR_ISR_Pos                        0U                                            /*!< IPSR: ISR Position */
+#define IPSR_ISR_Msk                       (0x1FFUL /*<< IPSR_ISR_Pos*/)                  /*!< IPSR: ISR Mask */
+
+
+/**
+  \brief  Union type to access the Special-Purpose Program Status Registers (xPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number */
+    uint32_t _reserved0:1;               /*!< bit:      9  Reserved */
+    uint32_t ICI_IT_1:6;                 /*!< bit: 10..15  ICI/IT part 1 */
+    uint32_t _reserved1:8;               /*!< bit: 16..23  Reserved */
+    uint32_t T:1;                        /*!< bit:     24  Thumb bit */
+    uint32_t ICI_IT_2:2;                 /*!< bit: 25..26  ICI/IT part 2 */
+    uint32_t Q:1;                        /*!< bit:     27  Saturation condition flag */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} xPSR_Type;
+
+/** \brief xPSR Register Definitions */
+#define xPSR_N_Pos                         31U                                            /*!< xPSR: N Position */
+#define xPSR_N_Msk                         (1UL << xPSR_N_Pos)                            /*!< xPSR: N Mask */
+
+#define xPSR_Z_Pos                         30U                                            /*!< xPSR: Z Position */
+#define xPSR_Z_Msk                         (1UL << xPSR_Z_Pos)                            /*!< xPSR: Z Mask */
+
+#define xPSR_C_Pos                         29U                                            /*!< xPSR: C Position */
+#define xPSR_C_Msk                         (1UL << xPSR_C_Pos)                            /*!< xPSR: C Mask */
+
+#define xPSR_V_Pos                         28U                                            /*!< xPSR: V Position */
+#define xPSR_V_Msk                         (1UL << xPSR_V_Pos)                            /*!< xPSR: V Mask */
+
+#define xPSR_Q_Pos                         27U                                            /*!< xPSR: Q Position */
+#define xPSR_Q_Msk                         (1UL << xPSR_Q_Pos)                            /*!< xPSR: Q Mask */
+
+#define xPSR_ICI_IT_2_Pos                  25U                                            /*!< xPSR: ICI/IT part 2 Position */
+#define xPSR_ICI_IT_2_Msk                  (3UL << xPSR_ICI_IT_2_Pos)                     /*!< xPSR: ICI/IT part 2 Mask */
+
+#define xPSR_T_Pos                         24U                                            /*!< xPSR: T Position */
+#define xPSR_T_Msk                         (1UL << xPSR_T_Pos)                            /*!< xPSR: T Mask */
+
+#define xPSR_ICI_IT_1_Pos                  10U                                            /*!< xPSR: ICI/IT part 1 Position */
+#define xPSR_ICI_IT_1_Msk                  (0x3FUL << xPSR_ICI_IT_1_Pos)                  /*!< xPSR: ICI/IT part 1 Mask */
+
+#define xPSR_ISR_Pos                        0U                                            /*!< xPSR: ISR Position */
+#define xPSR_ISR_Msk                       (0x1FFUL /*<< xPSR_ISR_Pos*/)                  /*!< xPSR: ISR Mask */
+
+
+/**
+  \brief  Union type to access the Control Registers (CONTROL).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t nPRIV:1;                    /*!< bit:      0  Execution privilege in Thread mode */
+    uint32_t SPSEL:1;                    /*!< bit:      1  Stack to be used */
+    uint32_t _reserved1:30;              /*!< bit:  2..31  Reserved */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} CONTROL_Type;
+
+/** \brief CONTROL Register Definitions */
+#define CONTROL_SPSEL_Pos                   1U                                            /*!< CONTROL: SPSEL Position */
+#define CONTROL_SPSEL_Msk                  (1UL << CONTROL_SPSEL_Pos)                     /*!< CONTROL: SPSEL Mask */
+
+#define CONTROL_nPRIV_Pos                   0U                                            /*!< CONTROL: nPRIV Position */
+#define CONTROL_nPRIV_Msk                  (1UL /*<< CONTROL_nPRIV_Pos*/)                 /*!< CONTROL: nPRIV Mask */
+
+/*@} end of group CMSIS_CORE */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_NVIC  Nested Vectored Interrupt Controller (NVIC)
+  \brief      Type definitions for the NVIC Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Nested Vectored Interrupt Controller (NVIC).
+ */
+typedef struct
+{
+  __IOM uint32_t ISER[8U];               /*!< Offset: 0x000 (R/W)  Interrupt Set Enable Register */
+        uint32_t RESERVED0[24U];
+  __IOM uint32_t ICER[8U];               /*!< Offset: 0x080 (R/W)  Interrupt Clear Enable Register */
+        uint32_t RESERVED1[24U];
+  __IOM uint32_t ISPR[8U];               /*!< Offset: 0x100 (R/W)  Interrupt Set Pending Register */
+        uint32_t RESERVED2[24U];
+  __IOM uint32_t ICPR[8U];               /*!< Offset: 0x180 (R/W)  Interrupt Clear Pending Register */
+        uint32_t RESERVED3[24U];
+  __IOM uint32_t IABR[8U];               /*!< Offset: 0x200 (R/W)  Interrupt Active bit Register */
+        uint32_t RESERVED4[56U];
+  __IOM uint8_t  IPR[240U];              /*!< Offset: 0x300 (R/W)  Interrupt Priority Register (8Bit wide) */
+        uint32_t RESERVED5[644U];
+  __OM  uint32_t STIR;                   /*!< Offset: 0xE00 ( /W)  Software Trigger Interrupt Register */
+}  NVIC_Type;
+
+/** \brief NVIC Software Triggered Interrupt Register Definitions */
+#define NVIC_STIR_INTID_Pos                 0U                                         /*!< STIR: INTLINESNUM Position */
+#define NVIC_STIR_INTID_Msk                (0x1FFUL /*<< NVIC_STIR_INTID_Pos*/)        /*!< STIR: INTLINESNUM Mask */
+
+/*@} end of group CMSIS_NVIC */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SCB     System Control Block (SCB)
+  \brief    Type definitions for the System Control Block Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Control Block (SCB).
+ */
+typedef struct
+{
+  __IM  uint32_t CPUID;                  /*!< Offset: 0x000 (R/ )  CPUID Base Register */
+  __IOM uint32_t ICSR;                   /*!< Offset: 0x004 (R/W)  Interrupt Control and State Register */
+  __IOM uint32_t VTOR;                   /*!< Offset: 0x008 (R/W)  Vector Table Offset Register */
+  __IOM uint32_t AIRCR;                  /*!< Offset: 0x00C (R/W)  Application Interrupt and Reset Control Register */
+  __IOM uint32_t SCR;                    /*!< Offset: 0x010 (R/W)  System Control Register */
+  __IOM uint32_t CCR;                    /*!< Offset: 0x014 (R/W)  Configuration Control Register */
+  __IOM uint8_t  SHPR[12U];              /*!< Offset: 0x018 (R/W)  System Handlers Priority Registers (4-7, 8-11, 12-15) */
+  __IOM uint32_t SHCSR;                  /*!< Offset: 0x024 (R/W)  System Handler Control and State Register */
+  __IOM uint32_t CFSR;                   /*!< Offset: 0x028 (R/W)  Configurable Fault Status Register */
+  __IOM uint32_t HFSR;                   /*!< Offset: 0x02C (R/W)  HardFault Status Register */
+  __IOM uint32_t DFSR;                   /*!< Offset: 0x030 (R/W)  Debug Fault Status Register */
+  __IOM uint32_t MMFAR;                  /*!< Offset: 0x034 (R/W)  MemManage Fault Address Register */
+  __IOM uint32_t BFAR;                   /*!< Offset: 0x038 (R/W)  BusFault Address Register */
+  __IOM uint32_t AFSR;                   /*!< Offset: 0x03C (R/W)  Auxiliary Fault Status Register */
+  __IM  uint32_t ID_PFR[2U];             /*!< Offset: 0x040 (R/ )  Processor Feature Register */
+  __IM  uint32_t ID_DFR;                 /*!< Offset: 0x048 (R/ )  Debug Feature Register */
+  __IM  uint32_t ID_AFR;                 /*!< Offset: 0x04C (R/ )  Auxiliary Feature Register */
+  __IM  uint32_t ID_MMFR[4U];            /*!< Offset: 0x050 (R/ )  Memory Model Feature Register */
+  __IM  uint32_t ID_ISAR[5U];            /*!< Offset: 0x060 (R/ )  Instruction Set Attributes Register */
+        uint32_t RESERVED0[5U];
+  __IOM uint32_t CPACR;                  /*!< Offset: 0x088 (R/W)  Coprocessor Access Control Register */
+        uint32_t RESERVED3[93U];
+  __OM  uint32_t STIR;                   /*!< Offset: 0x200 ( /W)  Software Triggered Interrupt Register */
+} SCB_Type;
+
+/** \brief SCB CPUID Register Definitions */
+#define SCB_CPUID_IMPLEMENTER_Pos          24U                                            /*!< SCB CPUID: IMPLEMENTER Position */
+#define SCB_CPUID_IMPLEMENTER_Msk          (0xFFUL << SCB_CPUID_IMPLEMENTER_Pos)          /*!< SCB CPUID: IMPLEMENTER Mask */
+
+#define SCB_CPUID_VARIANT_Pos              20U                                            /*!< SCB CPUID: VARIANT Position */
+#define SCB_CPUID_VARIANT_Msk              (0xFUL << SCB_CPUID_VARIANT_Pos)               /*!< SCB CPUID: VARIANT Mask */
+
+#define SCB_CPUID_ARCHITECTURE_Pos         16U                                            /*!< SCB CPUID: ARCHITECTURE Position */
+#define SCB_CPUID_ARCHITECTURE_Msk         (0xFUL << SCB_CPUID_ARCHITECTURE_Pos)          /*!< SCB CPUID: ARCHITECTURE Mask */
+
+#define SCB_CPUID_PARTNO_Pos                4U                                            /*!< SCB CPUID: PARTNO Position */
+#define SCB_CPUID_PARTNO_Msk               (0xFFFUL << SCB_CPUID_PARTNO_Pos)              /*!< SCB CPUID: PARTNO Mask */
+
+#define SCB_CPUID_REVISION_Pos              0U                                            /*!< SCB CPUID: REVISION Position */
+#define SCB_CPUID_REVISION_Msk             (0xFUL /*<< SCB_CPUID_REVISION_Pos*/)          /*!< SCB CPUID: REVISION Mask */
+
+/** \brief SCB Interrupt Control State Register Definitions */
+#define SCB_ICSR_NMIPENDSET_Pos            31U                                            /*!< SCB ICSR: NMIPENDSET Position */
+#define SCB_ICSR_NMIPENDSET_Msk            (1UL << SCB_ICSR_NMIPENDSET_Pos)               /*!< SCB ICSR: NMIPENDSET Mask */
+
+#define SCB_ICSR_PENDSVSET_Pos             28U                                            /*!< SCB ICSR: PENDSVSET Position */
+#define SCB_ICSR_PENDSVSET_Msk             (1UL << SCB_ICSR_PENDSVSET_Pos)                /*!< SCB ICSR: PENDSVSET Mask */
+
+#define SCB_ICSR_PENDSVCLR_Pos             27U                                            /*!< SCB ICSR: PENDSVCLR Position */
+#define SCB_ICSR_PENDSVCLR_Msk             (1UL << SCB_ICSR_PENDSVCLR_Pos)                /*!< SCB ICSR: PENDSVCLR Mask */
+
+#define SCB_ICSR_PENDSTSET_Pos             26U                                            /*!< SCB ICSR: PENDSTSET Position */
+#define SCB_ICSR_PENDSTSET_Msk             (1UL << SCB_ICSR_PENDSTSET_Pos)                /*!< SCB ICSR: PENDSTSET Mask */
+
+#define SCB_ICSR_PENDSTCLR_Pos             25U                                            /*!< SCB ICSR: PENDSTCLR Position */
+#define SCB_ICSR_PENDSTCLR_Msk             (1UL << SCB_ICSR_PENDSTCLR_Pos)                /*!< SCB ICSR: PENDSTCLR Mask */
+
+#define SCB_ICSR_ISRPREEMPT_Pos            23U                                            /*!< SCB ICSR: ISRPREEMPT Position */
+#define SCB_ICSR_ISRPREEMPT_Msk            (1UL << SCB_ICSR_ISRPREEMPT_Pos)               /*!< SCB ICSR: ISRPREEMPT Mask */
+
+#define SCB_ICSR_ISRPENDING_Pos            22U                                            /*!< SCB ICSR: ISRPENDING Position */
+#define SCB_ICSR_ISRPENDING_Msk            (1UL << SCB_ICSR_ISRPENDING_Pos)               /*!< SCB ICSR: ISRPENDING Mask */
+
+#define SCB_ICSR_VECTPENDING_Pos           12U                                            /*!< SCB ICSR: VECTPENDING Position */
+#define SCB_ICSR_VECTPENDING_Msk           (0x1FFUL << SCB_ICSR_VECTPENDING_Pos)          /*!< SCB ICSR: VECTPENDING Mask */
+
+#define SCB_ICSR_RETTOBASE_Pos             11U                                            /*!< SCB ICSR: RETTOBASE Position */
+#define SCB_ICSR_RETTOBASE_Msk             (1UL << SCB_ICSR_RETTOBASE_Pos)                /*!< SCB ICSR: RETTOBASE Mask */
+
+#define SCB_ICSR_VECTACTIVE_Pos             0U                                            /*!< SCB ICSR: VECTACTIVE Position */
+#define SCB_ICSR_VECTACTIVE_Msk            (0x1FFUL /*<< SCB_ICSR_VECTACTIVE_Pos*/)       /*!< SCB ICSR: VECTACTIVE Mask */
+
+#if defined (__CM3_REV) && (__CM3_REV < 0x0201U)                   /* core r2p1 */
+/** \brief SCB Vector Table Offset Register Definitions */
+#define SCB_VTOR_TBLBASE_Pos               29U                                            /*!< SCB VTOR: TBLBASE Position */
+#define SCB_VTOR_TBLBASE_Msk               (1UL << SCB_VTOR_TBLBASE_Pos)                  /*!< SCB VTOR: TBLBASE Mask */
+
+#define SCB_VTOR_TBLOFF_Pos                 7U                                            /*!< SCB VTOR: TBLOFF Position */
+#define SCB_VTOR_TBLOFF_Msk                (0x3FFFFFUL << SCB_VTOR_TBLOFF_Pos)            /*!< SCB VTOR: TBLOFF Mask */
+#else
+#define SCB_VTOR_TBLOFF_Pos                 7U                                            /*!< SCB VTOR: TBLOFF Position */
+#define SCB_VTOR_TBLOFF_Msk                (0x1FFFFFFUL << SCB_VTOR_TBLOFF_Pos)           /*!< SCB VTOR: TBLOFF Mask */
+#endif
+
+/** \brief SCB Application Interrupt and Reset Control Register Definitions */
+#define SCB_AIRCR_VECTKEY_Pos              16U                                            /*!< SCB AIRCR: VECTKEY Position */
+#define SCB_AIRCR_VECTKEY_Msk              (0xFFFFUL << SCB_AIRCR_VECTKEY_Pos)            /*!< SCB AIRCR: VECTKEY Mask */
+
+#define SCB_AIRCR_VECTKEYSTAT_Pos          16U                                            /*!< SCB AIRCR: VECTKEYSTAT Position */
+#define SCB_AIRCR_VECTKEYSTAT_Msk          (0xFFFFUL << SCB_AIRCR_VECTKEYSTAT_Pos)        /*!< SCB AIRCR: VECTKEYSTAT Mask */
+
+#define SCB_AIRCR_ENDIANESS_Pos            15U                                            /*!< SCB AIRCR: ENDIANESS Position */
+#define SCB_AIRCR_ENDIANESS_Msk            (1UL << SCB_AIRCR_ENDIANESS_Pos)               /*!< SCB AIRCR: ENDIANESS Mask */
+
+#define SCB_AIRCR_PRIGROUP_Pos              8U                                            /*!< SCB AIRCR: PRIGROUP Position */
+#define SCB_AIRCR_PRIGROUP_Msk             (7UL << SCB_AIRCR_PRIGROUP_Pos)                /*!< SCB AIRCR: PRIGROUP Mask */
+
+#define SCB_AIRCR_SYSRESETREQ_Pos           2U                                            /*!< SCB AIRCR: SYSRESETREQ Position */
+#define SCB_AIRCR_SYSRESETREQ_Msk          (1UL << SCB_AIRCR_SYSRESETREQ_Pos)             /*!< SCB AIRCR: SYSRESETREQ Mask */
+
+#define SCB_AIRCR_VECTCLRACTIVE_Pos         1U                                            /*!< SCB AIRCR: VECTCLRACTIVE Position */
+#define SCB_AIRCR_VECTCLRACTIVE_Msk        (1UL << SCB_AIRCR_VECTCLRACTIVE_Pos)           /*!< SCB AIRCR: VECTCLRACTIVE Mask */
+
+#define SCB_AIRCR_VECTRESET_Pos             0U                                            /*!< SCB AIRCR: VECTRESET Position */
+#define SCB_AIRCR_VECTRESET_Msk            (1UL /*<< SCB_AIRCR_VECTRESET_Pos*/)           /*!< SCB AIRCR: VECTRESET Mask */
+
+/** \brief SCB System Control Register Definitions */
+#define SCB_SCR_SEVONPEND_Pos               4U                                            /*!< SCB SCR: SEVONPEND Position */
+#define SCB_SCR_SEVONPEND_Msk              (1UL << SCB_SCR_SEVONPEND_Pos)                 /*!< SCB SCR: SEVONPEND Mask */
+
+#define SCB_SCR_SLEEPDEEP_Pos               2U                                            /*!< SCB SCR: SLEEPDEEP Position */
+#define SCB_SCR_SLEEPDEEP_Msk              (1UL << SCB_SCR_SLEEPDEEP_Pos)                 /*!< SCB SCR: SLEEPDEEP Mask */
+
+#define SCB_SCR_SLEEPONEXIT_Pos             1U                                            /*!< SCB SCR: SLEEPONEXIT Position */
+#define SCB_SCR_SLEEPONEXIT_Msk            (1UL << SCB_SCR_SLEEPONEXIT_Pos)               /*!< SCB SCR: SLEEPONEXIT Mask */
+
+/** \brief SCB Configuration Control Register Definitions */
+#define SCB_CCR_STKALIGN_Pos                9U                                            /*!< SCB CCR: STKALIGN Position */
+#define SCB_CCR_STKALIGN_Msk               (1UL << SCB_CCR_STKALIGN_Pos)                  /*!< SCB CCR: STKALIGN Mask */
+
+#define SCB_CCR_BFHFNMIGN_Pos               8U                                            /*!< SCB CCR: BFHFNMIGN Position */
+#define SCB_CCR_BFHFNMIGN_Msk              (1UL << SCB_CCR_BFHFNMIGN_Pos)                 /*!< SCB CCR: BFHFNMIGN Mask */
+
+#define SCB_CCR_DIV_0_TRP_Pos               4U                                            /*!< SCB CCR: DIV_0_TRP Position */
+#define SCB_CCR_DIV_0_TRP_Msk              (1UL << SCB_CCR_DIV_0_TRP_Pos)                 /*!< SCB CCR: DIV_0_TRP Mask */
+
+#define SCB_CCR_UNALIGN_TRP_Pos             3U                                            /*!< SCB CCR: UNALIGN_TRP Position */
+#define SCB_CCR_UNALIGN_TRP_Msk            (1UL << SCB_CCR_UNALIGN_TRP_Pos)               /*!< SCB CCR: UNALIGN_TRP Mask */
+
+#define SCB_CCR_USERSETMPEND_Pos            1U                                            /*!< SCB CCR: USERSETMPEND Position */
+#define SCB_CCR_USERSETMPEND_Msk           (1UL << SCB_CCR_USERSETMPEND_Pos)              /*!< SCB CCR: USERSETMPEND Mask */
+
+#define SCB_CCR_NONBASETHRDENA_Pos          0U                                            /*!< SCB CCR: NONBASETHRDENA Position */
+#define SCB_CCR_NONBASETHRDENA_Msk         (1UL /*<< SCB_CCR_NONBASETHRDENA_Pos*/)        /*!< SCB CCR: NONBASETHRDENA Mask */
+
+/** \brief SCB System Handler Control and State Register Definitions */
+#define SCB_SHCSR_USGFAULTENA_Pos          18U                                            /*!< SCB SHCSR: USGFAULTENA Position */
+#define SCB_SHCSR_USGFAULTENA_Msk          (1UL << SCB_SHCSR_USGFAULTENA_Pos)             /*!< SCB SHCSR: USGFAULTENA Mask */
+
+#define SCB_SHCSR_BUSFAULTENA_Pos          17U                                            /*!< SCB SHCSR: BUSFAULTENA Position */
+#define SCB_SHCSR_BUSFAULTENA_Msk          (1UL << SCB_SHCSR_BUSFAULTENA_Pos)             /*!< SCB SHCSR: BUSFAULTENA Mask */
+
+#define SCB_SHCSR_MEMFAULTENA_Pos          16U                                            /*!< SCB SHCSR: MEMFAULTENA Position */
+#define SCB_SHCSR_MEMFAULTENA_Msk          (1UL << SCB_SHCSR_MEMFAULTENA_Pos)             /*!< SCB SHCSR: MEMFAULTENA Mask */
+
+#define SCB_SHCSR_SVCALLPENDED_Pos         15U                                            /*!< SCB SHCSR: SVCALLPENDED Position */
+#define SCB_SHCSR_SVCALLPENDED_Msk         (1UL << SCB_SHCSR_SVCALLPENDED_Pos)            /*!< SCB SHCSR: SVCALLPENDED Mask */
+
+#define SCB_SHCSR_BUSFAULTPENDED_Pos       14U                                            /*!< SCB SHCSR: BUSFAULTPENDED Position */
+#define SCB_SHCSR_BUSFAULTPENDED_Msk       (1UL << SCB_SHCSR_BUSFAULTPENDED_Pos)          /*!< SCB SHCSR: BUSFAULTPENDED Mask */
+
+#define SCB_SHCSR_MEMFAULTPENDED_Pos       13U                                            /*!< SCB SHCSR: MEMFAULTPENDED Position */
+#define SCB_SHCSR_MEMFAULTPENDED_Msk       (1UL << SCB_SHCSR_MEMFAULTPENDED_Pos)          /*!< SCB SHCSR: MEMFAULTPENDED Mask */
+
+#define SCB_SHCSR_USGFAULTPENDED_Pos       12U                                            /*!< SCB SHCSR: USGFAULTPENDED Position */
+#define SCB_SHCSR_USGFAULTPENDED_Msk       (1UL << SCB_SHCSR_USGFAULTPENDED_Pos)          /*!< SCB SHCSR: USGFAULTPENDED Mask */
+
+#define SCB_SHCSR_SYSTICKACT_Pos           11U                                            /*!< SCB SHCSR: SYSTICKACT Position */
+#define SCB_SHCSR_SYSTICKACT_Msk           (1UL << SCB_SHCSR_SYSTICKACT_Pos)              /*!< SCB SHCSR: SYSTICKACT Mask */
+
+#define SCB_SHCSR_PENDSVACT_Pos            10U                                            /*!< SCB SHCSR: PENDSVACT Position */
+#define SCB_SHCSR_PENDSVACT_Msk            (1UL << SCB_SHCSR_PENDSVACT_Pos)               /*!< SCB SHCSR: PENDSVACT Mask */
+
+#define SCB_SHCSR_MONITORACT_Pos            8U                                            /*!< SCB SHCSR: MONITORACT Position */
+#define SCB_SHCSR_MONITORACT_Msk           (1UL << SCB_SHCSR_MONITORACT_Pos)              /*!< SCB SHCSR: MONITORACT Mask */
+
+#define SCB_SHCSR_SVCALLACT_Pos             7U                                            /*!< SCB SHCSR: SVCALLACT Position */
+#define SCB_SHCSR_SVCALLACT_Msk            (1UL << SCB_SHCSR_SVCALLACT_Pos)               /*!< SCB SHCSR: SVCALLACT Mask */
+
+#define SCB_SHCSR_USGFAULTACT_Pos           3U                                            /*!< SCB SHCSR: USGFAULTACT Position */
+#define SCB_SHCSR_USGFAULTACT_Msk          (1UL << SCB_SHCSR_USGFAULTACT_Pos)             /*!< SCB SHCSR: USGFAULTACT Mask */
+
+#define SCB_SHCSR_BUSFAULTACT_Pos           1U                                            /*!< SCB SHCSR: BUSFAULTACT Position */
+#define SCB_SHCSR_BUSFAULTACT_Msk          (1UL << SCB_SHCSR_BUSFAULTACT_Pos)             /*!< SCB SHCSR: BUSFAULTACT Mask */
+
+#define SCB_SHCSR_MEMFAULTACT_Pos           0U                                            /*!< SCB SHCSR: MEMFAULTACT Position */
+#define SCB_SHCSR_MEMFAULTACT_Msk          (1UL /*<< SCB_SHCSR_MEMFAULTACT_Pos*/)         /*!< SCB SHCSR: MEMFAULTACT Mask */
+
+/** \brief SCB Configurable Fault Status Register Definitions */
+#define SCB_CFSR_USGFAULTSR_Pos            16U                                            /*!< SCB CFSR: Usage Fault Status Register Position */
+#define SCB_CFSR_USGFAULTSR_Msk            (0xFFFFUL << SCB_CFSR_USGFAULTSR_Pos)          /*!< SCB CFSR: Usage Fault Status Register Mask */
+
+#define SCB_CFSR_BUSFAULTSR_Pos             8U                                            /*!< SCB CFSR: Bus Fault Status Register Position */
+#define SCB_CFSR_BUSFAULTSR_Msk            (0xFFUL << SCB_CFSR_BUSFAULTSR_Pos)            /*!< SCB CFSR: Bus Fault Status Register Mask */
+
+#define SCB_CFSR_MEMFAULTSR_Pos             0U                                            /*!< SCB CFSR: Memory Manage Fault Status Register Position */
+#define SCB_CFSR_MEMFAULTSR_Msk            (0xFFUL /*<< SCB_CFSR_MEMFAULTSR_Pos*/)        /*!< SCB CFSR: Memory Manage Fault Status Register Mask */
+
+/** \brief SCB MemManage Fault Status Register Definitions (part of SCB Configurable Fault Status Register) */
+#define SCB_CFSR_MMARVALID_Pos             (SCB_CFSR_MEMFAULTSR_Pos + 7U)                 /*!< SCB CFSR (MMFSR): MMARVALID Position */
+#define SCB_CFSR_MMARVALID_Msk             (1UL << SCB_CFSR_MMARVALID_Pos)                /*!< SCB CFSR (MMFSR): MMARVALID Mask */
+
+#define SCB_CFSR_MSTKERR_Pos               (SCB_CFSR_MEMFAULTSR_Pos + 4U)                 /*!< SCB CFSR (MMFSR): MSTKERR Position */
+#define SCB_CFSR_MSTKERR_Msk               (1UL << SCB_CFSR_MSTKERR_Pos)                  /*!< SCB CFSR (MMFSR): MSTKERR Mask */
+
+#define SCB_CFSR_MUNSTKERR_Pos             (SCB_CFSR_MEMFAULTSR_Pos + 3U)                 /*!< SCB CFSR (MMFSR): MUNSTKERR Position */
+#define SCB_CFSR_MUNSTKERR_Msk             (1UL << SCB_CFSR_MUNSTKERR_Pos)                /*!< SCB CFSR (MMFSR): MUNSTKERR Mask */
+
+#define SCB_CFSR_DACCVIOL_Pos              (SCB_CFSR_MEMFAULTSR_Pos + 1U)                 /*!< SCB CFSR (MMFSR): DACCVIOL Position */
+#define SCB_CFSR_DACCVIOL_Msk              (1UL << SCB_CFSR_DACCVIOL_Pos)                 /*!< SCB CFSR (MMFSR): DACCVIOL Mask */
+
+#define SCB_CFSR_IACCVIOL_Pos              (SCB_CFSR_MEMFAULTSR_Pos + 0U)                 /*!< SCB CFSR (MMFSR): IACCVIOL Position */
+#define SCB_CFSR_IACCVIOL_Msk              (1UL /*<< SCB_CFSR_IACCVIOL_Pos*/)             /*!< SCB CFSR (MMFSR): IACCVIOL Mask */
+
+/** \brief SCB BusFault Status Register Definitions (part of SCB Configurable Fault Status Register) */
+#define SCB_CFSR_BFARVALID_Pos            (SCB_CFSR_BUSFAULTSR_Pos + 7U)                  /*!< SCB CFSR (BFSR): BFARVALID Position */
+#define SCB_CFSR_BFARVALID_Msk            (1UL << SCB_CFSR_BFARVALID_Pos)                 /*!< SCB CFSR (BFSR): BFARVALID Mask */
+
+#define SCB_CFSR_STKERR_Pos               (SCB_CFSR_BUSFAULTSR_Pos + 4U)                  /*!< SCB CFSR (BFSR): STKERR Position */
+#define SCB_CFSR_STKERR_Msk               (1UL << SCB_CFSR_STKERR_Pos)                    /*!< SCB CFSR (BFSR): STKERR Mask */
+
+#define SCB_CFSR_UNSTKERR_Pos             (SCB_CFSR_BUSFAULTSR_Pos + 3U)                  /*!< SCB CFSR (BFSR): UNSTKERR Position */
+#define SCB_CFSR_UNSTKERR_Msk             (1UL << SCB_CFSR_UNSTKERR_Pos)                  /*!< SCB CFSR (BFSR): UNSTKERR Mask */
+
+#define SCB_CFSR_IMPRECISERR_Pos          (SCB_CFSR_BUSFAULTSR_Pos + 2U)                  /*!< SCB CFSR (BFSR): IMPRECISERR Position */
+#define SCB_CFSR_IMPRECISERR_Msk          (1UL << SCB_CFSR_IMPRECISERR_Pos)               /*!< SCB CFSR (BFSR): IMPRECISERR Mask */
+
+#define SCB_CFSR_PRECISERR_Pos            (SCB_CFSR_BUSFAULTSR_Pos + 1U)                  /*!< SCB CFSR (BFSR): PRECISERR Position */
+#define SCB_CFSR_PRECISERR_Msk            (1UL << SCB_CFSR_PRECISERR_Pos)                 /*!< SCB CFSR (BFSR): PRECISERR Mask */
+
+#define SCB_CFSR_IBUSERR_Pos              (SCB_CFSR_BUSFAULTSR_Pos + 0U)                  /*!< SCB CFSR (BFSR): IBUSERR Position */
+#define SCB_CFSR_IBUSERR_Msk              (1UL << SCB_CFSR_IBUSERR_Pos)                   /*!< SCB CFSR (BFSR): IBUSERR Mask */
+
+/** \brief SCB UsageFault Status Register Definitions (part of SCB Configurable Fault Status Register) */
+#define SCB_CFSR_DIVBYZERO_Pos            (SCB_CFSR_USGFAULTSR_Pos + 9U)                  /*!< SCB CFSR (UFSR): DIVBYZERO Position */
+#define SCB_CFSR_DIVBYZERO_Msk            (1UL << SCB_CFSR_DIVBYZERO_Pos)                 /*!< SCB CFSR (UFSR): DIVBYZERO Mask */
+
+#define SCB_CFSR_UNALIGNED_Pos            (SCB_CFSR_USGFAULTSR_Pos + 8U)                  /*!< SCB CFSR (UFSR): UNALIGNED Position */
+#define SCB_CFSR_UNALIGNED_Msk            (1UL << SCB_CFSR_UNALIGNED_Pos)                 /*!< SCB CFSR (UFSR): UNALIGNED Mask */
+
+#define SCB_CFSR_NOCP_Pos                 (SCB_CFSR_USGFAULTSR_Pos + 3U)                  /*!< SCB CFSR (UFSR): NOCP Position */
+#define SCB_CFSR_NOCP_Msk                 (1UL << SCB_CFSR_NOCP_Pos)                      /*!< SCB CFSR (UFSR): NOCP Mask */
+
+#define SCB_CFSR_INVPC_Pos                (SCB_CFSR_USGFAULTSR_Pos + 2U)                  /*!< SCB CFSR (UFSR): INVPC Position */
+#define SCB_CFSR_INVPC_Msk                (1UL << SCB_CFSR_INVPC_Pos)                     /*!< SCB CFSR (UFSR): INVPC Mask */
+
+#define SCB_CFSR_INVSTATE_Pos             (SCB_CFSR_USGFAULTSR_Pos + 1U)                  /*!< SCB CFSR (UFSR): INVSTATE Position */
+#define SCB_CFSR_INVSTATE_Msk             (1UL << SCB_CFSR_INVSTATE_Pos)                  /*!< SCB CFSR (UFSR): INVSTATE Mask */
+
+#define SCB_CFSR_UNDEFINSTR_Pos           (SCB_CFSR_USGFAULTSR_Pos + 0U)                  /*!< SCB CFSR (UFSR): UNDEFINSTR Position */
+#define SCB_CFSR_UNDEFINSTR_Msk           (1UL << SCB_CFSR_UNDEFINSTR_Pos)                /*!< SCB CFSR (UFSR): UNDEFINSTR Mask */
+
+/** \brief SCB Hard Fault Status Register Definitions */
+#define SCB_HFSR_DEBUGEVT_Pos              31U                                            /*!< SCB HFSR: DEBUGEVT Position */
+#define SCB_HFSR_DEBUGEVT_Msk              (1UL << SCB_HFSR_DEBUGEVT_Pos)                 /*!< SCB HFSR: DEBUGEVT Mask */
+
+#define SCB_HFSR_FORCED_Pos                30U                                            /*!< SCB HFSR: FORCED Position */
+#define SCB_HFSR_FORCED_Msk                (1UL << SCB_HFSR_FORCED_Pos)                   /*!< SCB HFSR: FORCED Mask */
+
+#define SCB_HFSR_VECTTBL_Pos                1U                                            /*!< SCB HFSR: VECTTBL Position */
+#define SCB_HFSR_VECTTBL_Msk               (1UL << SCB_HFSR_VECTTBL_Pos)                  /*!< SCB HFSR: VECTTBL Mask */
+
+/** \brief SCB Debug Fault Status Register Definitions */
+#define SCB_DFSR_EXTERNAL_Pos               4U                                            /*!< SCB DFSR: EXTERNAL Position */
+#define SCB_DFSR_EXTERNAL_Msk              (1UL << SCB_DFSR_EXTERNAL_Pos)                 /*!< SCB DFSR: EXTERNAL Mask */
+
+#define SCB_DFSR_VCATCH_Pos                 3U                                            /*!< SCB DFSR: VCATCH Position */
+#define SCB_DFSR_VCATCH_Msk                (1UL << SCB_DFSR_VCATCH_Pos)                   /*!< SCB DFSR: VCATCH Mask */
+
+#define SCB_DFSR_DWTTRAP_Pos                2U                                            /*!< SCB DFSR: DWTTRAP Position */
+#define SCB_DFSR_DWTTRAP_Msk               (1UL << SCB_DFSR_DWTTRAP_Pos)                  /*!< SCB DFSR: DWTTRAP Mask */
+
+#define SCB_DFSR_BKPT_Pos                   1U                                            /*!< SCB DFSR: BKPT Position */
+#define SCB_DFSR_BKPT_Msk                  (1UL << SCB_DFSR_BKPT_Pos)                     /*!< SCB DFSR: BKPT Mask */
+
+#define SCB_DFSR_HALTED_Pos                 0U                                            /*!< SCB DFSR: HALTED Position */
+#define SCB_DFSR_HALTED_Msk                (1UL /*<< SCB_DFSR_HALTED_Pos*/)               /*!< SCB DFSR: HALTED Mask */
+
+/*@} end of group CMSIS_SCB */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SCnSCB System Controls not in SCB (SCnSCB)
+  \brief    Type definitions for the System Control and ID Register not in the SCB
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Control and ID Register not in the SCB.
+ */
+typedef struct
+{
+        uint32_t RESERVED0[1U];
+  __IM  uint32_t ICTR;                   /*!< Offset: 0x004 (R/ )  Interrupt Controller Type Register */
+#if defined (__CM3_REV) && (__CM3_REV >= 0x200U)
+  __IOM uint32_t ACTLR;                  /*!< Offset: 0x008 (R/W)  Auxiliary Control Register */
+#else
+        uint32_t RESERVED1[1U];
+#endif
+} SCnSCB_Type;
+
+/** \brief SCnSCB Interrupt Controller Type Register Definitions */
+#define SCnSCB_ICTR_INTLINESNUM_Pos         0U                                         /*!< ICTR: INTLINESNUM Position */
+#define SCnSCB_ICTR_INTLINESNUM_Msk        (0xFUL /*<< SCnSCB_ICTR_INTLINESNUM_Pos*/)  /*!< ICTR: INTLINESNUM Mask */
+
+/** \brief SCnSCB Auxiliary Control Register Definitions */
+#if defined (__CM3_REV) && (__CM3_REV >= 0x200U)
+#define SCnSCB_ACTLR_DISOOFP_Pos            9U                                         /*!< ACTLR: DISOOFP Position */
+#define SCnSCB_ACTLR_DISOOFP_Msk           (1UL << SCnSCB_ACTLR_DISOOFP_Pos)           /*!< ACTLR: DISOOFP Mask */
+
+#define SCnSCB_ACTLR_DISFPCA_Pos            8U                                         /*!< ACTLR: DISFPCA Position */
+#define SCnSCB_ACTLR_DISFPCA_Msk           (1UL << SCnSCB_ACTLR_DISFPCA_Pos)           /*!< ACTLR: DISFPCA Mask */
+
+#define SCnSCB_ACTLR_DISFOLD_Pos            2U                                         /*!< ACTLR: DISFOLD Position */
+#define SCnSCB_ACTLR_DISFOLD_Msk           (1UL << SCnSCB_ACTLR_DISFOLD_Pos)           /*!< ACTLR: DISFOLD Mask */
+
+#define SCnSCB_ACTLR_DISDEFWBUF_Pos         1U                                         /*!< ACTLR: DISDEFWBUF Position */
+#define SCnSCB_ACTLR_DISDEFWBUF_Msk        (1UL << SCnSCB_ACTLR_DISDEFWBUF_Pos)        /*!< ACTLR: DISDEFWBUF Mask */
+
+#define SCnSCB_ACTLR_DISMCYCINT_Pos         0U                                         /*!< ACTLR: DISMCYCINT Position */
+#define SCnSCB_ACTLR_DISMCYCINT_Msk        (1UL /*<< SCnSCB_ACTLR_DISMCYCINT_Pos*/)    /*!< ACTLR: DISMCYCINT Mask */
+#endif
+
+/*@} end of group CMSIS_SCnotSCB */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SysTick     System Tick Timer (SysTick)
+  \brief    Type definitions for the System Timer Registers.
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Timer (SysTick).
+ */
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  SysTick Control and Status Register */
+  __IOM uint32_t LOAD;                   /*!< Offset: 0x004 (R/W)  SysTick Reload Value Register */
+  __IOM uint32_t VAL;                    /*!< Offset: 0x008 (R/W)  SysTick Current Value Register */
+  __IM  uint32_t CALIB;                  /*!< Offset: 0x00C (R/ )  SysTick Calibration Register */
+} SysTick_Type;
+
+/** \brief SysTick Control / Status Register Definitions */
+#define SysTick_CTRL_COUNTFLAG_Pos         16U                                            /*!< SysTick CTRL: COUNTFLAG Position */
+#define SysTick_CTRL_COUNTFLAG_Msk         (1UL << SysTick_CTRL_COUNTFLAG_Pos)            /*!< SysTick CTRL: COUNTFLAG Mask */
+
+#define SysTick_CTRL_CLKSOURCE_Pos          2U                                            /*!< SysTick CTRL: CLKSOURCE Position */
+#define SysTick_CTRL_CLKSOURCE_Msk         (1UL << SysTick_CTRL_CLKSOURCE_Pos)            /*!< SysTick CTRL: CLKSOURCE Mask */
+
+#define SysTick_CTRL_TICKINT_Pos            1U                                            /*!< SysTick CTRL: TICKINT Position */
+#define SysTick_CTRL_TICKINT_Msk           (1UL << SysTick_CTRL_TICKINT_Pos)              /*!< SysTick CTRL: TICKINT Mask */
+
+#define SysTick_CTRL_ENABLE_Pos             0U                                            /*!< SysTick CTRL: ENABLE Position */
+#define SysTick_CTRL_ENABLE_Msk            (1UL /*<< SysTick_CTRL_ENABLE_Pos*/)           /*!< SysTick CTRL: ENABLE Mask */
+
+/** \brief SysTick Reload Register Definitions */
+#define SysTick_LOAD_RELOAD_Pos             0U                                            /*!< SysTick LOAD: RELOAD Position */
+#define SysTick_LOAD_RELOAD_Msk            (0xFFFFFFUL /*<< SysTick_LOAD_RELOAD_Pos*/)    /*!< SysTick LOAD: RELOAD Mask */
+
+/** \brief SysTick Current Register Definitions */
+#define SysTick_VAL_CURRENT_Pos             0U                                            /*!< SysTick VAL: CURRENT Position */
+#define SysTick_VAL_CURRENT_Msk            (0xFFFFFFUL /*<< SysTick_VAL_CURRENT_Pos*/)    /*!< SysTick VAL: CURRENT Mask */
+
+/** \brief SysTick Calibration Register Definitions */
+#define SysTick_CALIB_NOREF_Pos            31U                                            /*!< SysTick CALIB: NOREF Position */
+#define SysTick_CALIB_NOREF_Msk            (1UL << SysTick_CALIB_NOREF_Pos)               /*!< SysTick CALIB: NOREF Mask */
+
+#define SysTick_CALIB_SKEW_Pos             30U                                            /*!< SysTick CALIB: SKEW Position */
+#define SysTick_CALIB_SKEW_Msk             (1UL << SysTick_CALIB_SKEW_Pos)                /*!< SysTick CALIB: SKEW Mask */
+
+#define SysTick_CALIB_TENMS_Pos             0U                                            /*!< SysTick CALIB: TENMS Position */
+#define SysTick_CALIB_TENMS_Msk            (0xFFFFFFUL /*<< SysTick_CALIB_TENMS_Pos*/)    /*!< SysTick CALIB: TENMS Mask */
+
+/*@} end of group CMSIS_SysTick */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_ITM     Instrumentation Trace Macrocell (ITM)
+  \brief    Type definitions for the Instrumentation Trace Macrocell (ITM)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Instrumentation Trace Macrocell Register (ITM).
+ */
+typedef struct
+{
+  __OM  union
+  {
+    __OM  uint8_t    u8;                 /*!< Offset: 0x000 ( /W)  Stimulus Port 8-bit */
+    __OM  uint16_t   u16;                /*!< Offset: 0x000 ( /W)  Stimulus Port 16-bit */
+    __OM  uint32_t   u32;                /*!< Offset: 0x000 ( /W)  Stimulus Port 32-bit */
+  }  PORT [32U];                         /*!< Offset: 0x000 ( /W)  Stimulus Port Registers */
+        uint32_t RESERVED0[864U];
+  __IOM uint32_t TER;                    /*!< Offset: 0xE00 (R/W)  Trace Enable Register */
+        uint32_t RESERVED1[15U];
+  __IOM uint32_t TPR;                    /*!< Offset: 0xE40 (R/W)  Trace Privilege Register */
+        uint32_t RESERVED2[15U];
+  __IOM uint32_t TCR;                    /*!< Offset: 0xE80 (R/W)  Trace Control Register */
+        uint32_t RESERVED3[32U];
+        uint32_t RESERVED4[43U];
+  __OM  uint32_t LAR;                    /*!< Offset: 0xFB0 ( /W)  Lock Access Register */
+  __IM  uint32_t LSR;                    /*!< Offset: 0xFB4 (R/ )  Lock Status Register */
+} ITM_Type;
+
+/** \brief ITM Trace Privilege Register Definitions */
+#define ITM_TPR_PRIVMASK_Pos                0U                                            /*!< ITM TPR: PRIVMASK Position */
+#define ITM_TPR_PRIVMASK_Msk               (0xFFFFFFFFUL /*<< ITM_TPR_PRIVMASK_Pos*/)     /*!< ITM TPR: PRIVMASK Mask */
+
+/** \brief ITM Trace Control Register Definitions */
+#define ITM_TCR_BUSY_Pos                   23U                                            /*!< ITM TCR: BUSY Position */
+#define ITM_TCR_BUSY_Msk                   (1UL << ITM_TCR_BUSY_Pos)                      /*!< ITM TCR: BUSY Mask */
+
+#define ITM_TCR_TRACEBUSID_Pos             16U                                            /*!< ITM TCR: ATBID Position */
+#define ITM_TCR_TRACEBUSID_Msk             (0x7FUL << ITM_TCR_TRACEBUSID_Pos)             /*!< ITM TCR: ATBID Mask */
+
+#define ITM_TCR_GTSFREQ_Pos                10U                                            /*!< ITM TCR: Global timestamp frequency Position */
+#define ITM_TCR_GTSFREQ_Msk                (3UL << ITM_TCR_GTSFREQ_Pos)                   /*!< ITM TCR: Global timestamp frequency Mask */
+
+#define ITM_TCR_TSPRESCALE_Pos              8U                                            /*!< ITM TCR: TSPrescale Position */
+#define ITM_TCR_TSPRESCALE_Msk             (3UL << ITM_TCR_TSPRESCALE_Pos)                /*!< ITM TCR: TSPrescale Mask */
+
+#define ITM_TCR_SWOENA_Pos                  4U                                            /*!< ITM TCR: SWOENA Position */
+#define ITM_TCR_SWOENA_Msk                 (1UL << ITM_TCR_SWOENA_Pos)                    /*!< ITM TCR: SWOENA Mask */
+
+#define ITM_TCR_DWTENA_Pos                  3U                                            /*!< ITM TCR: DWTENA Position */
+#define ITM_TCR_DWTENA_Msk                 (1UL << ITM_TCR_DWTENA_Pos)                    /*!< ITM TCR: DWTENA Mask */
+
+#define ITM_TCR_SYNCENA_Pos                 2U                                            /*!< ITM TCR: SYNCENA Position */
+#define ITM_TCR_SYNCENA_Msk                (1UL << ITM_TCR_SYNCENA_Pos)                   /*!< ITM TCR: SYNCENA Mask */
+
+#define ITM_TCR_TSENA_Pos                   1U                                            /*!< ITM TCR: TSENA Position */
+#define ITM_TCR_TSENA_Msk                  (1UL << ITM_TCR_TSENA_Pos)                     /*!< ITM TCR: TSENA Mask */
+
+#define ITM_TCR_ITMENA_Pos                  0U                                            /*!< ITM TCR: ITM Enable bit Position */
+#define ITM_TCR_ITMENA_Msk                 (1UL /*<< ITM_TCR_ITMENA_Pos*/)                /*!< ITM TCR: ITM Enable bit Mask */
+
+/** \brief ITM Lock Status Register Definitions */
+#define ITM_LSR_BYTEACC_Pos                 2U                                            /*!< ITM LSR: ByteAcc Position */
+#define ITM_LSR_BYTEACC_Msk                (1UL << ITM_LSR_BYTEACC_Pos)                   /*!< ITM LSR: ByteAcc Mask */
+
+#define ITM_LSR_ACCESS_Pos                  1U                                            /*!< ITM LSR: Access Position */
+#define ITM_LSR_ACCESS_Msk                 (1UL << ITM_LSR_ACCESS_Pos)                    /*!< ITM LSR: Access Mask */
+
+#define ITM_LSR_PRESENT_Pos                 0U                                            /*!< ITM LSR: Present Position */
+#define ITM_LSR_PRESENT_Msk                (1UL /*<< ITM_LSR_PRESENT_Pos*/)               /*!< ITM LSR: Present Mask */
+
+/*@}*/ /* end of group CMSIS_ITM */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_DWT     Data Watchpoint and Trace (DWT)
+  \brief    Type definitions for the Data Watchpoint and Trace (DWT)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Data Watchpoint and Trace Register (DWT).
+ */
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  Control Register */
+  __IOM uint32_t CYCCNT;                 /*!< Offset: 0x004 (R/W)  Cycle Count Register */
+  __IOM uint32_t CPICNT;                 /*!< Offset: 0x008 (R/W)  CPI Count Register */
+  __IOM uint32_t EXCCNT;                 /*!< Offset: 0x00C (R/W)  Exception Overhead Count Register */
+  __IOM uint32_t SLEEPCNT;               /*!< Offset: 0x010 (R/W)  Sleep Count Register */
+  __IOM uint32_t LSUCNT;                 /*!< Offset: 0x014 (R/W)  LSU Count Register */
+  __IOM uint32_t FOLDCNT;                /*!< Offset: 0x018 (R/W)  Folded-instruction Count Register */
+  __IM  uint32_t PCSR;                   /*!< Offset: 0x01C (R/ )  Program Counter Sample Register */
+  __IOM uint32_t COMP0;                  /*!< Offset: 0x020 (R/W)  Comparator Register 0 */
+  __IOM uint32_t MASK0;                  /*!< Offset: 0x024 (R/W)  Mask Register 0 */
+  __IOM uint32_t FUNCTION0;              /*!< Offset: 0x028 (R/W)  Function Register 0 */
+        uint32_t RESERVED0[1U];
+  __IOM uint32_t COMP1;                  /*!< Offset: 0x030 (R/W)  Comparator Register 1 */
+  __IOM uint32_t MASK1;                  /*!< Offset: 0x034 (R/W)  Mask Register 1 */
+  __IOM uint32_t FUNCTION1;              /*!< Offset: 0x038 (R/W)  Function Register 1 */
+        uint32_t RESERVED1[1U];
+  __IOM uint32_t COMP2;                  /*!< Offset: 0x040 (R/W)  Comparator Register 2 */
+  __IOM uint32_t MASK2;                  /*!< Offset: 0x044 (R/W)  Mask Register 2 */
+  __IOM uint32_t FUNCTION2;              /*!< Offset: 0x048 (R/W)  Function Register 2 */
+        uint32_t RESERVED2[1U];
+  __IOM uint32_t COMP3;                  /*!< Offset: 0x050 (R/W)  Comparator Register 3 */
+  __IOM uint32_t MASK3;                  /*!< Offset: 0x054 (R/W)  Mask Register 3 */
+  __IOM uint32_t FUNCTION3;              /*!< Offset: 0x058 (R/W)  Function Register 3 */
+} DWT_Type;
+
+/** \brief DWT Control Register Definitions */
+#define DWT_CTRL_NUMCOMP_Pos               28U                                         /*!< DWT CTRL: NUMCOMP Position */
+#define DWT_CTRL_NUMCOMP_Msk               (0xFUL << DWT_CTRL_NUMCOMP_Pos)             /*!< DWT CTRL: NUMCOMP Mask */
+
+#define DWT_CTRL_NOTRCPKT_Pos              27U                                         /*!< DWT CTRL: NOTRCPKT Position */
+#define DWT_CTRL_NOTRCPKT_Msk              (1UL << DWT_CTRL_NOTRCPKT_Pos)              /*!< DWT CTRL: NOTRCPKT Mask */
+
+#define DWT_CTRL_NOEXTTRIG_Pos             26U                                         /*!< DWT CTRL: NOEXTTRIG Position */
+#define DWT_CTRL_NOEXTTRIG_Msk             (1UL << DWT_CTRL_NOEXTTRIG_Pos)             /*!< DWT CTRL: NOEXTTRIG Mask */
+
+#define DWT_CTRL_NOCYCCNT_Pos              25U                                         /*!< DWT CTRL: NOCYCCNT Position */
+#define DWT_CTRL_NOCYCCNT_Msk              (1UL << DWT_CTRL_NOCYCCNT_Pos)              /*!< DWT CTRL: NOCYCCNT Mask */
+
+#define DWT_CTRL_NOPRFCNT_Pos              24U                                         /*!< DWT CTRL: NOPRFCNT Position */
+#define DWT_CTRL_NOPRFCNT_Msk              (1UL << DWT_CTRL_NOPRFCNT_Pos)              /*!< DWT CTRL: NOPRFCNT Mask */
+
+#define DWT_CTRL_CYCEVTENA_Pos             22U                                         /*!< DWT CTRL: CYCEVTENA Position */
+#define DWT_CTRL_CYCEVTENA_Msk             (1UL << DWT_CTRL_CYCEVTENA_Pos)             /*!< DWT CTRL: CYCEVTENA Mask */
+
+#define DWT_CTRL_FOLDEVTENA_Pos            21U                                         /*!< DWT CTRL: FOLDEVTENA Position */
+#define DWT_CTRL_FOLDEVTENA_Msk            (1UL << DWT_CTRL_FOLDEVTENA_Pos)            /*!< DWT CTRL: FOLDEVTENA Mask */
+
+#define DWT_CTRL_LSUEVTENA_Pos             20U                                         /*!< DWT CTRL: LSUEVTENA Position */
+#define DWT_CTRL_LSUEVTENA_Msk             (1UL << DWT_CTRL_LSUEVTENA_Pos)             /*!< DWT CTRL: LSUEVTENA Mask */
+
+#define DWT_CTRL_SLEEPEVTENA_Pos           19U                                         /*!< DWT CTRL: SLEEPEVTENA Position */
+#define DWT_CTRL_SLEEPEVTENA_Msk           (1UL << DWT_CTRL_SLEEPEVTENA_Pos)           /*!< DWT CTRL: SLEEPEVTENA Mask */
+
+#define DWT_CTRL_EXCEVTENA_Pos             18U                                         /*!< DWT CTRL: EXCEVTENA Position */
+#define DWT_CTRL_EXCEVTENA_Msk             (1UL << DWT_CTRL_EXCEVTENA_Pos)             /*!< DWT CTRL: EXCEVTENA Mask */
+
+#define DWT_CTRL_CPIEVTENA_Pos             17U                                         /*!< DWT CTRL: CPIEVTENA Position */
+#define DWT_CTRL_CPIEVTENA_Msk             (1UL << DWT_CTRL_CPIEVTENA_Pos)             /*!< DWT CTRL: CPIEVTENA Mask */
+
+#define DWT_CTRL_EXCTRCENA_Pos             16U                                         /*!< DWT CTRL: EXCTRCENA Position */
+#define DWT_CTRL_EXCTRCENA_Msk             (1UL << DWT_CTRL_EXCTRCENA_Pos)             /*!< DWT CTRL: EXCTRCENA Mask */
+
+#define DWT_CTRL_PCSAMPLENA_Pos            12U                                         /*!< DWT CTRL: PCSAMPLENA Position */
+#define DWT_CTRL_PCSAMPLENA_Msk            (1UL << DWT_CTRL_PCSAMPLENA_Pos)            /*!< DWT CTRL: PCSAMPLENA Mask */
+
+#define DWT_CTRL_SYNCTAP_Pos               10U                                         /*!< DWT CTRL: SYNCTAP Position */
+#define DWT_CTRL_SYNCTAP_Msk               (0x3UL << DWT_CTRL_SYNCTAP_Pos)             /*!< DWT CTRL: SYNCTAP Mask */
+
+#define DWT_CTRL_CYCTAP_Pos                 9U                                         /*!< DWT CTRL: CYCTAP Position */
+#define DWT_CTRL_CYCTAP_Msk                (1UL << DWT_CTRL_CYCTAP_Pos)                /*!< DWT CTRL: CYCTAP Mask */
+
+#define DWT_CTRL_POSTINIT_Pos               5U                                         /*!< DWT CTRL: POSTINIT Position */
+#define DWT_CTRL_POSTINIT_Msk              (0xFUL << DWT_CTRL_POSTINIT_Pos)            /*!< DWT CTRL: POSTINIT Mask */
+
+#define DWT_CTRL_POSTPRESET_Pos             1U                                         /*!< DWT CTRL: POSTPRESET Position */
+#define DWT_CTRL_POSTPRESET_Msk            (0xFUL << DWT_CTRL_POSTPRESET_Pos)          /*!< DWT CTRL: POSTPRESET Mask */
+
+#define DWT_CTRL_CYCCNTENA_Pos              0U                                         /*!< DWT CTRL: CYCCNTENA Position */
+#define DWT_CTRL_CYCCNTENA_Msk             (1UL /*<< DWT_CTRL_CYCCNTENA_Pos*/)         /*!< DWT CTRL: CYCCNTENA Mask */
+
+/** \brief DWT CPI Count Register Definitions */
+#define DWT_CPICNT_CPICNT_Pos               0U                                         /*!< DWT CPICNT: CPICNT Position */
+#define DWT_CPICNT_CPICNT_Msk              (0xFFUL /*<< DWT_CPICNT_CPICNT_Pos*/)       /*!< DWT CPICNT: CPICNT Mask */
+
+/** \brief DWT Exception Overhead Count Register Definitions */
+#define DWT_EXCCNT_EXCCNT_Pos               0U                                         /*!< DWT EXCCNT: EXCCNT Position */
+#define DWT_EXCCNT_EXCCNT_Msk              (0xFFUL /*<< DWT_EXCCNT_EXCCNT_Pos*/)       /*!< DWT EXCCNT: EXCCNT Mask */
+
+/** \brief DWT Sleep Count Register Definitions */
+#define DWT_SLEEPCNT_SLEEPCNT_Pos           0U                                         /*!< DWT SLEEPCNT: SLEEPCNT Position */
+#define DWT_SLEEPCNT_SLEEPCNT_Msk          (0xFFUL /*<< DWT_SLEEPCNT_SLEEPCNT_Pos*/)   /*!< DWT SLEEPCNT: SLEEPCNT Mask */
+
+/** \brief DWT LSU Count Register Definitions */
+#define DWT_LSUCNT_LSUCNT_Pos               0U                                         /*!< DWT LSUCNT: LSUCNT Position */
+#define DWT_LSUCNT_LSUCNT_Msk              (0xFFUL /*<< DWT_LSUCNT_LSUCNT_Pos*/)       /*!< DWT LSUCNT: LSUCNT Mask */
+
+/** \brief DWT Folded-instruction Count Register Definitions */
+#define DWT_FOLDCNT_FOLDCNT_Pos             0U                                         /*!< DWT FOLDCNT: FOLDCNT Position */
+#define DWT_FOLDCNT_FOLDCNT_Msk            (0xFFUL /*<< DWT_FOLDCNT_FOLDCNT_Pos*/)     /*!< DWT FOLDCNT: FOLDCNT Mask */
+
+/** \brief DWT Comparator Mask Register Definitions */
+#define DWT_MASK_MASK_Pos                   0U                                         /*!< DWT MASK: MASK Position */
+#define DWT_MASK_MASK_Msk                  (0x1FUL /*<< DWT_MASK_MASK_Pos*/)           /*!< DWT MASK: MASK Mask */
+
+/** \brief DWT Comparator Function Register Definitions */
+#define DWT_FUNCTION_MATCHED_Pos           24U                                         /*!< DWT FUNCTION: MATCHED Position */
+#define DWT_FUNCTION_MATCHED_Msk           (1UL << DWT_FUNCTION_MATCHED_Pos)           /*!< DWT FUNCTION: MATCHED Mask */
+
+#define DWT_FUNCTION_DATAVADDR1_Pos        16U                                         /*!< DWT FUNCTION: DATAVADDR1 Position */
+#define DWT_FUNCTION_DATAVADDR1_Msk        (0xFUL << DWT_FUNCTION_DATAVADDR1_Pos)      /*!< DWT FUNCTION: DATAVADDR1 Mask */
+
+#define DWT_FUNCTION_DATAVADDR0_Pos        12U                                         /*!< DWT FUNCTION: DATAVADDR0 Position */
+#define DWT_FUNCTION_DATAVADDR0_Msk        (0xFUL << DWT_FUNCTION_DATAVADDR0_Pos)      /*!< DWT FUNCTION: DATAVADDR0 Mask */
+
+#define DWT_FUNCTION_DATAVSIZE_Pos         10U                                         /*!< DWT FUNCTION: DATAVSIZE Position */
+#define DWT_FUNCTION_DATAVSIZE_Msk         (0x3UL << DWT_FUNCTION_DATAVSIZE_Pos)       /*!< DWT FUNCTION: DATAVSIZE Mask */
+
+#define DWT_FUNCTION_LNK1ENA_Pos            9U                                         /*!< DWT FUNCTION: LNK1ENA Position */
+#define DWT_FUNCTION_LNK1ENA_Msk           (1UL << DWT_FUNCTION_LNK1ENA_Pos)           /*!< DWT FUNCTION: LNK1ENA Mask */
+
+#define DWT_FUNCTION_DATAVMATCH_Pos         8U                                         /*!< DWT FUNCTION: DATAVMATCH Position */
+#define DWT_FUNCTION_DATAVMATCH_Msk        (1UL << DWT_FUNCTION_DATAVMATCH_Pos)        /*!< DWT FUNCTION: DATAVMATCH Mask */
+
+#define DWT_FUNCTION_CYCMATCH_Pos           7U                                         /*!< DWT FUNCTION: CYCMATCH Position */
+#define DWT_FUNCTION_CYCMATCH_Msk          (1UL << DWT_FUNCTION_CYCMATCH_Pos)          /*!< DWT FUNCTION: CYCMATCH Mask */
+
+#define DWT_FUNCTION_EMITRANGE_Pos          5U                                         /*!< DWT FUNCTION: EMITRANGE Position */
+#define DWT_FUNCTION_EMITRANGE_Msk         (1UL << DWT_FUNCTION_EMITRANGE_Pos)         /*!< DWT FUNCTION: EMITRANGE Mask */
+
+#define DWT_FUNCTION_FUNCTION_Pos           0U                                         /*!< DWT FUNCTION: FUNCTION Position */
+#define DWT_FUNCTION_FUNCTION_Msk          (0xFUL /*<< DWT_FUNCTION_FUNCTION_Pos*/)    /*!< DWT FUNCTION: FUNCTION Mask */
+
+/*@}*/ /* end of group CMSIS_DWT */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_TPIU    Trace Port Interface Unit (TPIU)
+  \brief    Type definitions for the Trace Port Interface Unit (TPIU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Trace Port Interface Unit Register (TPIU).
+ */
+typedef struct
+{
+  __IM  uint32_t SSPSR;                  /*!< Offset: 0x000 (R/ )  Supported Parallel Port Size Register */
+  __IOM uint32_t CSPSR;                  /*!< Offset: 0x004 (R/W)  Current Parallel Port Size Register */
+        uint32_t RESERVED0[2U];
+  __IOM uint32_t ACPR;                   /*!< Offset: 0x010 (R/W)  Asynchronous Clock Prescaler Register */
+        uint32_t RESERVED1[55U];
+  __IOM uint32_t SPPR;                   /*!< Offset: 0x0F0 (R/W)  Selected Pin Protocol Register */
+        uint32_t RESERVED2[131U];
+  __IM  uint32_t FFSR;                   /*!< Offset: 0x300 (R/ )  Formatter and Flush Status Register */
+  __IOM uint32_t FFCR;                   /*!< Offset: 0x304 (R/W)  Formatter and Flush Control Register */
+  __IM  uint32_t FSCR;                   /*!< Offset: 0x308 (R/ )  Formatter Synchronization Counter Register */
+        uint32_t RESERVED3[759U];
+  __IM  uint32_t TRIGGER;                /*!< Offset: 0xEE8 (R/ )  TRIGGER Register */
+  __IM  uint32_t FIFO0;                  /*!< Offset: 0xEEC (R/ )  Integration ETM Data */
+  __IM  uint32_t ITATBCTR2;              /*!< Offset: 0xEF0 (R/ )  ITATBCTR2 */
+        uint32_t RESERVED4[1U];
+  __IM  uint32_t ITATBCTR0;              /*!< Offset: 0xEF8 (R/ )  ITATBCTR0 */
+  __IM  uint32_t FIFO1;                  /*!< Offset: 0xEFC (R/ )  Integration ITM Data */
+  __IOM uint32_t ITCTRL;                 /*!< Offset: 0xF00 (R/W)  Integration Mode Control */
+        uint32_t RESERVED5[39U];
+  __IOM uint32_t CLAIMSET;               /*!< Offset: 0xFA0 (R/W)  Claim tag set */
+  __IOM uint32_t CLAIMCLR;               /*!< Offset: 0xFA4 (R/W)  Claim tag clear */
+        uint32_t RESERVED7[8U];
+  __IM  uint32_t DEVID;                  /*!< Offset: 0xFC8 (R/ )  Device Configuration Register */
+  __IM  uint32_t DEVTYPE;                /*!< Offset: 0xFCC (R/ )  Device Type Identifier Register */
+} TPIU_Type;
+
+/** \brief TPIU Asynchronous Clock Prescaler Register Definitions */
+#define TPIU_ACPR_PRESCALER_Pos             0U                                         /*!< TPIU ACPR: PRESCALER Position */
+#define TPIU_ACPR_PRESCALER_Msk            (0x1FFFUL /*<< TPIU_ACPR_PRESCALER_Pos*/)   /*!< TPIU ACPR: PRESCALER Mask */
+
+/** \brief TPIU Selected Pin Protocol Register Definitions */
+#define TPIU_SPPR_TXMODE_Pos                0U                                         /*!< TPIU SPPR: TXMODE Position */
+#define TPIU_SPPR_TXMODE_Msk               (0x3UL /*<< TPIU_SPPR_TXMODE_Pos*/)         /*!< TPIU SPPR: TXMODE Mask */
+
+/** \brief TPIU Formatter and Flush Status Register Definitions */
+#define TPIU_FFSR_FtNonStop_Pos             3U                                         /*!< TPIU FFSR: FtNonStop Position */
+#define TPIU_FFSR_FtNonStop_Msk            (1UL << TPIU_FFSR_FtNonStop_Pos)            /*!< TPIU FFSR: FtNonStop Mask */
+
+#define TPIU_FFSR_TCPresent_Pos             2U                                         /*!< TPIU FFSR: TCPresent Position */
+#define TPIU_FFSR_TCPresent_Msk            (1UL << TPIU_FFSR_TCPresent_Pos)            /*!< TPIU FFSR: TCPresent Mask */
+
+#define TPIU_FFSR_FtStopped_Pos             1U                                         /*!< TPIU FFSR: FtStopped Position */
+#define TPIU_FFSR_FtStopped_Msk            (1UL << TPIU_FFSR_FtStopped_Pos)            /*!< TPIU FFSR: FtStopped Mask */
+
+#define TPIU_FFSR_FlInProg_Pos              0U                                         /*!< TPIU FFSR: FlInProg Position */
+#define TPIU_FFSR_FlInProg_Msk             (1UL /*<< TPIU_FFSR_FlInProg_Pos*/)         /*!< TPIU FFSR: FlInProg Mask */
+
+/** \brief TPIU Formatter and Flush Control Register Definitions */
+#define TPIU_FFCR_TrigIn_Pos                8U                                         /*!< TPIU FFCR: TrigIn Position */
+#define TPIU_FFCR_TrigIn_Msk               (1UL << TPIU_FFCR_TrigIn_Pos)               /*!< TPIU FFCR: TrigIn Mask */
+
+#define TPIU_FFCR_EnFCont_Pos               1U                                         /*!< TPIU FFCR: EnFCont Position */
+#define TPIU_FFCR_EnFCont_Msk              (1UL << TPIU_FFCR_EnFCont_Pos)              /*!< TPIU FFCR: EnFCont Mask */
+
+/** \brief TPIU TRIGGER Register Definitions */
+#define TPIU_TRIGGER_TRIGGER_Pos            0U                                         /*!< TPIU TRIGGER: TRIGGER Position */
+#define TPIU_TRIGGER_TRIGGER_Msk           (1UL /*<< TPIU_TRIGGER_TRIGGER_Pos*/)       /*!< TPIU TRIGGER: TRIGGER Mask */
+
+/** \brief TPIU Integration ETM Data Register Definitions (FIFO0) */
+#define TPIU_FIFO0_ITM_ATVALID_Pos         29U                                         /*!< TPIU FIFO0: ITM_ATVALID Position */
+#define TPIU_FIFO0_ITM_ATVALID_Msk         (1UL << TPIU_FIFO0_ITM_ATVALID_Pos)         /*!< TPIU FIFO0: ITM_ATVALID Mask */
+
+#define TPIU_FIFO0_ITM_bytecount_Pos       27U                                         /*!< TPIU FIFO0: ITM_bytecount Position */
+#define TPIU_FIFO0_ITM_bytecount_Msk       (0x3UL << TPIU_FIFO0_ITM_bytecount_Pos)     /*!< TPIU FIFO0: ITM_bytecount Mask */
+
+#define TPIU_FIFO0_ETM_ATVALID_Pos         26U                                         /*!< TPIU FIFO0: ETM_ATVALID Position */
+#define TPIU_FIFO0_ETM_ATVALID_Msk         (1UL << TPIU_FIFO0_ETM_ATVALID_Pos)         /*!< TPIU FIFO0: ETM_ATVALID Mask */
+
+#define TPIU_FIFO0_ETM_bytecount_Pos       24U                                         /*!< TPIU FIFO0: ETM_bytecount Position */
+#define TPIU_FIFO0_ETM_bytecount_Msk       (0x3UL << TPIU_FIFO0_ETM_bytecount_Pos)     /*!< TPIU FIFO0: ETM_bytecount Mask */
+
+#define TPIU_FIFO0_ETM2_Pos                16U                                         /*!< TPIU FIFO0: ETM2 Position */
+#define TPIU_FIFO0_ETM2_Msk                (0xFFUL << TPIU_FIFO0_ETM2_Pos)             /*!< TPIU FIFO0: ETM2 Mask */
+
+#define TPIU_FIFO0_ETM1_Pos                 8U                                         /*!< TPIU FIFO0: ETM1 Position */
+#define TPIU_FIFO0_ETM1_Msk                (0xFFUL << TPIU_FIFO0_ETM1_Pos)             /*!< TPIU FIFO0: ETM1 Mask */
+
+#define TPIU_FIFO0_ETM0_Pos                 0U                                         /*!< TPIU FIFO0: ETM0 Position */
+#define TPIU_FIFO0_ETM0_Msk                (0xFFUL /*<< TPIU_FIFO0_ETM0_Pos*/)         /*!< TPIU FIFO0: ETM0 Mask */
+
+/** \brief TPIU ITATBCTR2 Register Definitions */
+#define TPIU_ITATBCTR2_ATREADY2_Pos         0U                                         /*!< TPIU ITATBCTR2: ATREADY2 Position */
+#define TPIU_ITATBCTR2_ATREADY2_Msk        (1UL /*<< TPIU_ITATBCTR2_ATREADY2_Pos*/)    /*!< TPIU ITATBCTR2: ATREADY2 Mask */
+
+#define TPIU_ITATBCTR2_ATREADY1_Pos         0U                                         /*!< TPIU ITATBCTR2: ATREADY1 Position */
+#define TPIU_ITATBCTR2_ATREADY1_Msk        (1UL /*<< TPIU_ITATBCTR2_ATREADY1_Pos*/)    /*!< TPIU ITATBCTR2: ATREADY1 Mask */
+
+/** \brief TPIU Integration ITM Data Register Definitions (FIFO1) */
+#define TPIU_FIFO1_ITM_ATVALID_Pos         29U                                         /*!< TPIU FIFO1: ITM_ATVALID Position */
+#define TPIU_FIFO1_ITM_ATVALID_Msk         (1UL << TPIU_FIFO1_ITM_ATVALID_Pos)         /*!< TPIU FIFO1: ITM_ATVALID Mask */
+
+#define TPIU_FIFO1_ITM_bytecount_Pos       27U                                         /*!< TPIU FIFO1: ITM_bytecount Position */
+#define TPIU_FIFO1_ITM_bytecount_Msk       (0x3UL << TPIU_FIFO1_ITM_bytecount_Pos)     /*!< TPIU FIFO1: ITM_bytecount Mask */
+
+#define TPIU_FIFO1_ETM_ATVALID_Pos         26U                                         /*!< TPIU FIFO1: ETM_ATVALID Position */
+#define TPIU_FIFO1_ETM_ATVALID_Msk         (1UL << TPIU_FIFO1_ETM_ATVALID_Pos)         /*!< TPIU FIFO1: ETM_ATVALID Mask */
+
+#define TPIU_FIFO1_ETM_bytecount_Pos       24U                                         /*!< TPIU FIFO1: ETM_bytecount Position */
+#define TPIU_FIFO1_ETM_bytecount_Msk       (0x3UL << TPIU_FIFO1_ETM_bytecount_Pos)     /*!< TPIU FIFO1: ETM_bytecount Mask */
+
+#define TPIU_FIFO1_ITM2_Pos                16U                                         /*!< TPIU FIFO1: ITM2 Position */
+#define TPIU_FIFO1_ITM2_Msk                (0xFFUL << TPIU_FIFO1_ITM2_Pos)             /*!< TPIU FIFO1: ITM2 Mask */
+
+#define TPIU_FIFO1_ITM1_Pos                 8U                                         /*!< TPIU FIFO1: ITM1 Position */
+#define TPIU_FIFO1_ITM1_Msk                (0xFFUL << TPIU_FIFO1_ITM1_Pos)             /*!< TPIU FIFO1: ITM1 Mask */
+
+#define TPIU_FIFO1_ITM0_Pos                 0U                                         /*!< TPIU FIFO1: ITM0 Position */
+#define TPIU_FIFO1_ITM0_Msk                (0xFFUL /*<< TPIU_FIFO1_ITM0_Pos*/)         /*!< TPIU FIFO1: ITM0 Mask */
+
+/** \brief TPIU ITATBCTR0 Register Definitions */
+#define TPIU_ITATBCTR0_ATREADY2_Pos         0U                                         /*!< TPIU ITATBCTR0: ATREADY2 Position */
+#define TPIU_ITATBCTR0_ATREADY2_Msk        (1UL /*<< TPIU_ITATBCTR0_ATREADY2_Pos*/)    /*!< TPIU ITATBCTR0: ATREADY2 Mask */
+
+#define TPIU_ITATBCTR0_ATREADY1_Pos         0U                                         /*!< TPIU ITATBCTR0: ATREADY1 Position */
+#define TPIU_ITATBCTR0_ATREADY1_Msk        (1UL /*<< TPIU_ITATBCTR0_ATREADY1_Pos*/)    /*!< TPIU ITATBCTR0: ATREADY1 Mask */
+
+/** \brief TPIU Integration Mode Control Register Definitions */
+#define TPIU_ITCTRL_Mode_Pos                0U                                         /*!< TPIU ITCTRL: Mode Position */
+#define TPIU_ITCTRL_Mode_Msk               (0x3UL /*<< TPIU_ITCTRL_Mode_Pos*/)         /*!< TPIU ITCTRL: Mode Mask */
+
+/** \brief TPIU DEVID Register Definitions */
+#define TPIU_DEVID_NRZVALID_Pos            11U                                         /*!< TPIU DEVID: NRZVALID Position */
+#define TPIU_DEVID_NRZVALID_Msk            (1UL << TPIU_DEVID_NRZVALID_Pos)            /*!< TPIU DEVID: NRZVALID Mask */
+
+#define TPIU_DEVID_MANCVALID_Pos           10U                                         /*!< TPIU DEVID: MANCVALID Position */
+#define TPIU_DEVID_MANCVALID_Msk           (1UL << TPIU_DEVID_MANCVALID_Pos)           /*!< TPIU DEVID: MANCVALID Mask */
+
+#define TPIU_DEVID_PTINVALID_Pos            9U                                         /*!< TPIU DEVID: PTINVALID Position */
+#define TPIU_DEVID_PTINVALID_Msk           (1UL << TPIU_DEVID_PTINVALID_Pos)           /*!< TPIU DEVID: PTINVALID Mask */
+
+#define TPIU_DEVID_MinBufSz_Pos             6U                                         /*!< TPIU DEVID: MinBufSz Position */
+#define TPIU_DEVID_MinBufSz_Msk            (0x7UL << TPIU_DEVID_MinBufSz_Pos)          /*!< TPIU DEVID: MinBufSz Mask */
+
+#define TPIU_DEVID_AsynClkIn_Pos            5U                                         /*!< TPIU DEVID: AsynClkIn Position */
+#define TPIU_DEVID_AsynClkIn_Msk           (1UL << TPIU_DEVID_AsynClkIn_Pos)           /*!< TPIU DEVID: AsynClkIn Mask */
+
+#define TPIU_DEVID_NrTraceInput_Pos         0U                                         /*!< TPIU DEVID: NrTraceInput Position */
+#define TPIU_DEVID_NrTraceInput_Msk        (0x3FUL /*<< TPIU_DEVID_NrTraceInput_Pos*/) /*!< TPIU DEVID: NrTraceInput Mask */
+
+/** \brief TPIU DEVTYPE Register Definitions */
+#define TPIU_DEVTYPE_SubType_Pos            4U                                         /*!< TPIU DEVTYPE: SubType Position */
+#define TPIU_DEVTYPE_SubType_Msk           (0xFUL /*<< TPIU_DEVTYPE_SubType_Pos*/)     /*!< TPIU DEVTYPE: SubType Mask */
+
+#define TPIU_DEVTYPE_MajorType_Pos          0U                                         /*!< TPIU DEVTYPE: MajorType Position */
+#define TPIU_DEVTYPE_MajorType_Msk         (0xFUL << TPIU_DEVTYPE_MajorType_Pos)       /*!< TPIU DEVTYPE: MajorType Mask */
+
+/*@}*/ /* end of group CMSIS_TPIU */
+
+
+#if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_MPU     Memory Protection Unit (MPU)
+  \brief    Type definitions for the Memory Protection Unit (MPU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Memory Protection Unit (MPU).
+ */
+typedef struct
+{
+  __IM  uint32_t TYPE;                   /*!< Offset: 0x000 (R/ )  MPU Type Register */
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x004 (R/W)  MPU Control Register */
+  __IOM uint32_t RNR;                    /*!< Offset: 0x008 (R/W)  MPU Region Number Register */
+  __IOM uint32_t RBAR;                   /*!< Offset: 0x00C (R/W)  MPU Region Base Address Register */
+  __IOM uint32_t RASR;                   /*!< Offset: 0x010 (R/W)  MPU Region Attribute and Size Register */
+  __IOM uint32_t RBAR_A1;                /*!< Offset: 0x014 (R/W)  MPU Alias 1 Region Base Address Register */
+  __IOM uint32_t RASR_A1;                /*!< Offset: 0x018 (R/W)  MPU Alias 1 Region Attribute and Size Register */
+  __IOM uint32_t RBAR_A2;                /*!< Offset: 0x01C (R/W)  MPU Alias 2 Region Base Address Register */
+  __IOM uint32_t RASR_A2;                /*!< Offset: 0x020 (R/W)  MPU Alias 2 Region Attribute and Size Register */
+  __IOM uint32_t RBAR_A3;                /*!< Offset: 0x024 (R/W)  MPU Alias 3 Region Base Address Register */
+  __IOM uint32_t RASR_A3;                /*!< Offset: 0x028 (R/W)  MPU Alias 3 Region Attribute and Size Register */
+} MPU_Type;
+
+#define MPU_TYPE_RALIASES                  4U
+
+/** \brief MPU Type Register Definitions */
+#define MPU_TYPE_IREGION_Pos               16U                                            /*!< MPU TYPE: IREGION Position */
+#define MPU_TYPE_IREGION_Msk               (0xFFUL << MPU_TYPE_IREGION_Pos)               /*!< MPU TYPE: IREGION Mask */
+
+#define MPU_TYPE_DREGION_Pos                8U                                            /*!< MPU TYPE: DREGION Position */
+#define MPU_TYPE_DREGION_Msk               (0xFFUL << MPU_TYPE_DREGION_Pos)               /*!< MPU TYPE: DREGION Mask */
+
+#define MPU_TYPE_SEPARATE_Pos               0U                                            /*!< MPU TYPE: SEPARATE Position */
+#define MPU_TYPE_SEPARATE_Msk              (1UL /*<< MPU_TYPE_SEPARATE_Pos*/)             /*!< MPU TYPE: SEPARATE Mask */
+
+/** \brief MPU Control Register Definitions */
+#define MPU_CTRL_PRIVDEFENA_Pos             2U                                            /*!< MPU CTRL: PRIVDEFENA Position */
+#define MPU_CTRL_PRIVDEFENA_Msk            (1UL << MPU_CTRL_PRIVDEFENA_Pos)               /*!< MPU CTRL: PRIVDEFENA Mask */
+
+#define MPU_CTRL_HFNMIENA_Pos               1U                                            /*!< MPU CTRL: HFNMIENA Position */
+#define MPU_CTRL_HFNMIENA_Msk              (1UL << MPU_CTRL_HFNMIENA_Pos)                 /*!< MPU CTRL: HFNMIENA Mask */
+
+#define MPU_CTRL_ENABLE_Pos                 0U                                            /*!< MPU CTRL: ENABLE Position */
+#define MPU_CTRL_ENABLE_Msk                (1UL /*<< MPU_CTRL_ENABLE_Pos*/)               /*!< MPU CTRL: ENABLE Mask */
+
+/** \brief MPU Region Number Register Definitions */
+#define MPU_RNR_REGION_Pos                  0U                                            /*!< MPU RNR: REGION Position */
+#define MPU_RNR_REGION_Msk                 (0xFFUL /*<< MPU_RNR_REGION_Pos*/)             /*!< MPU RNR: REGION Mask */
+
+/** \brief MPU Region Base Address Register Definitions */
+#define MPU_RBAR_ADDR_Pos                   5U                                            /*!< MPU RBAR: ADDR Position */
+#define MPU_RBAR_ADDR_Msk                  (0x7FFFFFFUL << MPU_RBAR_ADDR_Pos)             /*!< MPU RBAR: ADDR Mask */
+
+#define MPU_RBAR_VALID_Pos                  4U                                            /*!< MPU RBAR: VALID Position */
+#define MPU_RBAR_VALID_Msk                 (1UL << MPU_RBAR_VALID_Pos)                    /*!< MPU RBAR: VALID Mask */
+
+#define MPU_RBAR_REGION_Pos                 0U                                            /*!< MPU RBAR: REGION Position */
+#define MPU_RBAR_REGION_Msk                (0xFUL /*<< MPU_RBAR_REGION_Pos*/)             /*!< MPU RBAR: REGION Mask */
+
+/** \brief MPU Region Attribute and Size Register Definitions */
+#define MPU_RASR_ATTRS_Pos                 16U                                            /*!< MPU RASR: MPU Region Attribute field Position */
+#define MPU_RASR_ATTRS_Msk                 (0xFFFFUL << MPU_RASR_ATTRS_Pos)               /*!< MPU RASR: MPU Region Attribute field Mask */
+
+#define MPU_RASR_XN_Pos                    28U                                            /*!< MPU RASR: ATTRS.XN Position */
+#define MPU_RASR_XN_Msk                    (1UL << MPU_RASR_XN_Pos)                       /*!< MPU RASR: ATTRS.XN Mask */
+
+#define MPU_RASR_AP_Pos                    24U                                            /*!< MPU RASR: ATTRS.AP Position */
+#define MPU_RASR_AP_Msk                    (0x7UL << MPU_RASR_AP_Pos)                     /*!< MPU RASR: ATTRS.AP Mask */
+
+#define MPU_RASR_TEX_Pos                   19U                                            /*!< MPU RASR: ATTRS.TEX Position */
+#define MPU_RASR_TEX_Msk                   (0x7UL << MPU_RASR_TEX_Pos)                    /*!< MPU RASR: ATTRS.TEX Mask */
+
+#define MPU_RASR_S_Pos                     18U                                            /*!< MPU RASR: ATTRS.S Position */
+#define MPU_RASR_S_Msk                     (1UL << MPU_RASR_S_Pos)                        /*!< MPU RASR: ATTRS.S Mask */
+
+#define MPU_RASR_C_Pos                     17U                                            /*!< MPU RASR: ATTRS.C Position */
+#define MPU_RASR_C_Msk                     (1UL << MPU_RASR_C_Pos)                        /*!< MPU RASR: ATTRS.C Mask */
+
+#define MPU_RASR_B_Pos                     16U                                            /*!< MPU RASR: ATTRS.B Position */
+#define MPU_RASR_B_Msk                     (1UL << MPU_RASR_B_Pos)                        /*!< MPU RASR: ATTRS.B Mask */
+
+#define MPU_RASR_SRD_Pos                    8U                                            /*!< MPU RASR: Sub-Region Disable Position */
+#define MPU_RASR_SRD_Msk                   (0xFFUL << MPU_RASR_SRD_Pos)                   /*!< MPU RASR: Sub-Region Disable Mask */
+
+#define MPU_RASR_SIZE_Pos                   1U                                            /*!< MPU RASR: Region Size Field Position */
+#define MPU_RASR_SIZE_Msk                  (0x1FUL << MPU_RASR_SIZE_Pos)                  /*!< MPU RASR: Region Size Field Mask */
+
+#define MPU_RASR_ENABLE_Pos                 0U                                            /*!< MPU RASR: Region enable bit Position */
+#define MPU_RASR_ENABLE_Msk                (1UL /*<< MPU_RASR_ENABLE_Pos*/)               /*!< MPU RASR: Region enable bit Disable Mask */
+
+/*@} end of group CMSIS_MPU */
+#endif
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_DCB       Debug Control Block
+  \brief    Type definitions for the Debug Control Block Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Debug Control Block Registers (DCB).
+ */
+typedef struct
+{
+  __IOM uint32_t DHCSR;                  /*!< Offset: 0x000 (R/W)  Debug Halting Control and Status Register */
+  __OM  uint32_t DCRSR;                  /*!< Offset: 0x004 ( /W)  Debug Core Register Selector Register */
+  __IOM uint32_t DCRDR;                  /*!< Offset: 0x008 (R/W)  Debug Core Register Data Register */
+  __IOM uint32_t DEMCR;                  /*!< Offset: 0x00C (R/W)  Debug Exception and Monitor Control Register */
+} DCB_Type;
+
+/** \brief DCB Debug Halting Control and Status Register Definitions */
+#define DCB_DHCSR_DBGKEY_Pos               16U                                            /*!< DCB DHCSR: Debug key Position */
+#define DCB_DHCSR_DBGKEY_Msk               (0xFFFFUL << DCB_DHCSR_DBGKEY_Pos)             /*!< DCB DHCSR: Debug key Mask */
+
+#define DCB_DHCSR_S_RESET_ST_Pos           25U                                            /*!< DCB DHCSR: Reset sticky status Position */
+#define DCB_DHCSR_S_RESET_ST_Msk           (1UL << DCB_DHCSR_S_RESET_ST_Pos)              /*!< DCB DHCSR: Reset sticky status Mask */
+
+#define DCB_DHCSR_S_RETIRE_ST_Pos          24U                                            /*!< DCB DHCSR: Retire sticky status Position */
+#define DCB_DHCSR_S_RETIRE_ST_Msk          (1UL << DCB_DHCSR_S_RETIRE_ST_Pos)             /*!< DCB DHCSR: Retire sticky status Mask */
+
+#define DCB_DHCSR_S_LOCKUP_Pos             19U                                            /*!< DCB DHCSR: Lockup status Position */
+#define DCB_DHCSR_S_LOCKUP_Msk             (1UL << DCB_DHCSR_S_LOCKUP_Pos)                /*!< DCB DHCSR: Lockup status Mask */
+
+#define DCB_DHCSR_S_SLEEP_Pos              18U                                            /*!< DCB DHCSR: Sleeping status Position */
+#define DCB_DHCSR_S_SLEEP_Msk              (1UL << DCB_DHCSR_S_SLEEP_Pos)                 /*!< DCB DHCSR: Sleeping status Mask */
+
+#define DCB_DHCSR_S_HALT_Pos               17U                                            /*!< DCB DHCSR: Halted status Position */
+#define DCB_DHCSR_S_HALT_Msk               (1UL << DCB_DHCSR_S_HALT_Pos)                  /*!< DCB DHCSR: Halted status Mask */
+
+#define DCB_DHCSR_S_REGRDY_Pos             16U                                            /*!< DCB DHCSR: Register ready status Position */
+#define DCB_DHCSR_S_REGRDY_Msk             (1UL << DCB_DHCSR_S_REGRDY_Pos)                /*!< DCB DHCSR: Register ready status Mask */
+
+#define DCB_DHCSR_C_SNAPSTALL_Pos           5U                                            /*!< DCB DHCSR: Snap stall control Position */
+#define DCB_DHCSR_C_SNAPSTALL_Msk          (1UL << DCB_DHCSR_C_SNAPSTALL_Pos)             /*!< DCB DHCSR: Snap stall control Mask */
+
+#define DCB_DHCSR_C_MASKINTS_Pos            3U                                            /*!< DCB DHCSR: Mask interrupts control Position */
+#define DCB_DHCSR_C_MASKINTS_Msk           (1UL << DCB_DHCSR_C_MASKINTS_Pos)              /*!< DCB DHCSR: Mask interrupts control Mask */
+
+#define DCB_DHCSR_C_STEP_Pos                2U                                            /*!< DCB DHCSR: Step control Position */
+#define DCB_DHCSR_C_STEP_Msk               (1UL << DCB_DHCSR_C_STEP_Pos)                  /*!< DCB DHCSR: Step control Mask */
+
+#define DCB_DHCSR_C_HALT_Pos                1U                                            /*!< DCB DHCSR: Halt control Position */
+#define DCB_DHCSR_C_HALT_Msk               (1UL << DCB_DHCSR_C_HALT_Pos)                  /*!< DCB DHCSR: Halt control Mask */
+
+#define DCB_DHCSR_C_DEBUGEN_Pos             0U                                            /*!< DCB DHCSR: Debug enable control Position */
+#define DCB_DHCSR_C_DEBUGEN_Msk            (1UL /*<< DCB_DHCSR_C_DEBUGEN_Pos*/)           /*!< DCB DHCSR: Debug enable control Mask */
+
+/** \brief DCB Debug Core Register Selector Register Definitions */
+#define DCB_DCRSR_REGWnR_Pos               16U                                            /*!< DCB DCRSR: Register write/not-read Position */
+#define DCB_DCRSR_REGWnR_Msk               (1UL << DCB_DCRSR_REGWnR_Pos)                  /*!< DCB DCRSR: Register write/not-read Mask */
+
+#define DCB_DCRSR_REGSEL_Pos                0U                                            /*!< DCB DCRSR: Register selector Position */
+#define DCB_DCRSR_REGSEL_Msk               (0x7FUL /*<< DCB_DCRSR_REGSEL_Pos*/)           /*!< DCB DCRSR: Register selector Mask */
+
+/** \brief DCB Debug Core Register Data Register Definitions */
+#define DCB_DCRDR_DBGTMP_Pos                0U                                            /*!< DCB DCRDR: Data temporary buffer Position */
+#define DCB_DCRDR_DBGTMP_Msk               (0xFFFFFFFFUL /*<< DCB_DCRDR_DBGTMP_Pos*/)     /*!< DCB DCRDR: Data temporary buffer Mask */
+
+/** \brief DCB Debug Exception and Monitor Control Register Definitions */
+#define DCB_DEMCR_TRCENA_Pos               24U                                            /*!< DCB DEMCR: Trace enable Position */
+#define DCB_DEMCR_TRCENA_Msk               (1UL << DCB_DEMCR_TRCENA_Pos)                  /*!< DCB DEMCR: Trace enable Mask */
+
+#define DCB_DEMCR_MON_REQ_Pos              19U                                            /*!< DCB DEMCR: Monitor request Position */
+#define DCB_DEMCR_MON_REQ_Msk              (1UL << DCB_DEMCR_MON_REQ_Pos)                 /*!< DCB DEMCR: Monitor request Mask */
+
+#define DCB_DEMCR_MON_STEP_Pos             18U                                            /*!< DCB DEMCR: Monitor step Position */
+#define DCB_DEMCR_MON_STEP_Msk             (1UL << DCB_DEMCR_MON_STEP_Pos)                /*!< DCB DEMCR: Monitor step Mask */
+
+#define DCB_DEMCR_MON_PEND_Pos             17U                                            /*!< DCB DEMCR: Monitor pend Position */
+#define DCB_DEMCR_MON_PEND_Msk             (1UL << DCB_DEMCR_MON_PEND_Pos)                /*!< DCB DEMCR: Monitor pend Mask */
+
+#define DCB_DEMCR_MON_EN_Pos               16U                                            /*!< DCB DEMCR: Monitor enable Position */
+#define DCB_DEMCR_MON_EN_Msk               (1UL << DCB_DEMCR_MON_EN_Pos)                  /*!< DCB DEMCR: Monitor enable Mask */
+
+#define DCB_DEMCR_VC_HARDERR_Pos           10U                                            /*!< DCB DEMCR: Vector Catch HardFault errors Position */
+#define DCB_DEMCR_VC_HARDERR_Msk           (1UL << DCB_DEMCR_VC_HARDERR_Pos)              /*!< DCB DEMCR: Vector Catch HardFault errors Mask */
+
+#define DCB_DEMCR_VC_INTERR_Pos             9U                                            /*!< DCB DEMCR: Vector Catch interrupt errors Position */
+#define DCB_DEMCR_VC_INTERR_Msk            (1UL << DCB_DEMCR_VC_INTERR_Pos)               /*!< DCB DEMCR: Vector Catch interrupt errors Mask */
+
+#define DCB_DEMCR_VC_BUSERR_Pos             8U                                            /*!< DCB DEMCR: Vector Catch BusFault errors Position */
+#define DCB_DEMCR_VC_BUSERR_Msk            (1UL << DCB_DEMCR_VC_BUSERR_Pos)               /*!< DCB DEMCR: Vector Catch BusFault errors Mask */
+
+#define DCB_DEMCR_VC_STATERR_Pos            7U                                            /*!< DCB DEMCR: Vector Catch state errors Position */
+#define DCB_DEMCR_VC_STATERR_Msk           (1UL << DCB_DEMCR_VC_STATERR_Pos)              /*!< DCB DEMCR: Vector Catch state errors Mask */
+
+#define DCB_DEMCR_VC_CHKERR_Pos             6U                                            /*!< DCB DEMCR: Vector Catch check errors Position */
+#define DCB_DEMCR_VC_CHKERR_Msk            (1UL << DCB_DEMCR_VC_CHKERR_Pos)               /*!< DCB DEMCR: Vector Catch check errors Mask */
+
+#define DCB_DEMCR_VC_NOCPERR_Pos            5U                                            /*!< DCB DEMCR: Vector Catch NOCP errors Position */
+#define DCB_DEMCR_VC_NOCPERR_Msk           (1UL << DCB_DEMCR_VC_NOCPERR_Pos)              /*!< DCB DEMCR: Vector Catch NOCP errors Mask */
+
+#define DCB_DEMCR_VC_MMERR_Pos              4U                                            /*!< DCB DEMCR: Vector Catch MemManage errors Position */
+#define DCB_DEMCR_VC_MMERR_Msk             (1UL << DCB_DEMCR_VC_MMERR_Pos)                /*!< DCB DEMCR: Vector Catch MemManage errors Mask */
+
+#define DCB_DEMCR_VC_CORERESET_Pos          0U                                            /*!< DCB DEMCR: Vector Catch Core reset Position */
+#define DCB_DEMCR_VC_CORERESET_Msk         (1UL /*<< DCB_DEMCR_VC_CORERESET_Pos*/)        /*!< DCB DEMCR: Vector Catch Core reset Mask */
+
+/*@} end of group CMSIS_DCB */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_core_bitfield     Core register bit field macros
+  \brief      Macros for use with bit field definitions (xxx_Pos, xxx_Msk).
+  @{
+ */
+
+/**
+  \brief   Mask and shift a bit field value for use in a register bit range.
+  \param[in] field  Name of the register bit field.
+  \param[in] value  Value of the bit field. This parameter is interpreted as an uint32_t type.
+  \return           Masked and shifted value.
+*/
+#define _VAL2FLD(field, value)    (((uint32_t)(value) << field ## _Pos) & field ## _Msk)
+
+/**
+  \brief     Mask and shift a register value to extract a bit filed value.
+  \param[in] field  Name of the register bit field.
+  \param[in] value  Value of register. This parameter is interpreted as an uint32_t type.
+  \return           Masked and shifted bit field value.
+*/
+#define _FLD2VAL(field, value)    (((uint32_t)(value) & field ## _Msk) >> field ## _Pos)
+
+/*@} end of group CMSIS_core_bitfield */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_core_base     Core Definitions
+  \brief      Definitions for base addresses, unions, and structures.
+  @{
+ */
+
+/* Memory mapping of Core Hardware */
+#define SCS_BASE            (0xE000E000UL)                            /*!< System Control Space Base Address */
+#define ITM_BASE            (0xE0000000UL)                            /*!< ITM Base Address */
+#define DWT_BASE            (0xE0001000UL)                            /*!< DWT Base Address */
+#define TPIU_BASE           (0xE0040000UL)                            /*!< TPIU Base Address */
+#define DCB_BASE            (0xE000EDF0UL)                            /*!< Core Debug Base Address */
+#define SysTick_BASE        (SCS_BASE +  0x0010UL)                    /*!< SysTick Base Address */
+#define NVIC_BASE           (SCS_BASE +  0x0100UL)                    /*!< NVIC Base Address */
+#define SCB_BASE            (SCS_BASE +  0x0D00UL)                    /*!< System Control Block Base Address */
+
+#define SCnSCB              ((SCnSCB_Type    *)     SCS_BASE      )   /*!< System control Register not in SCB */
+#define SCB                 ((SCB_Type       *)     SCB_BASE      )   /*!< SCB configuration struct */
+#define SysTick             ((SysTick_Type   *)     SysTick_BASE  )   /*!< SysTick configuration struct */
+#define NVIC                ((NVIC_Type      *)     NVIC_BASE     )   /*!< NVIC configuration struct */
+#define ITM                 ((ITM_Type       *)     ITM_BASE      )   /*!< ITM configuration struct */
+#define DWT                 ((DWT_Type       *)     DWT_BASE      )   /*!< DWT configuration struct */
+#define TPIU                ((TPIU_Type      *)     TPIU_BASE     )   /*!< TPIU configuration struct */
+#define DCB                 ((DCB_Type       *)     DCB_BASE      )   /*!< DCB configuration struct */
+
+#if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+  #define MPU_BASE          (SCS_BASE +  0x0D90UL)                    /*!< Memory Protection Unit */
+  #define MPU               ((MPU_Type       *)     MPU_BASE      )   /*!< Memory Protection Unit */
+#endif
+
+/*@} */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_register_aliases     Backwards Compatibility Aliases
+  \brief      Register alias definitions for backwards compatibility.
+  @{
+ */
+
+/*@} */
+
+
+/*******************************************************************************
+ *                Hardware Abstraction Layer
+  Core Function Interface contains:
+  - Core NVIC Functions
+  - Core SysTick Functions
+  - Core Debug Functions
+  - Core Register Access Functions
+ ******************************************************************************/
+/**
+  \defgroup CMSIS_Core_FunctionInterface Functions and Instructions Reference
+*/
+
+
+
+/* ##########################   NVIC functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_NVICFunctions NVIC Functions
+  \brief    Functions that manage interrupts and exceptions via the NVIC.
+  @{
+ */
+
+#ifdef CMSIS_NVIC_VIRTUAL
+  #ifndef CMSIS_NVIC_VIRTUAL_HEADER_FILE
+    #define CMSIS_NVIC_VIRTUAL_HEADER_FILE "cmsis_nvic_virtual.h"
+  #endif
+  #include CMSIS_NVIC_VIRTUAL_HEADER_FILE
+#else
+  #define NVIC_SetPriorityGrouping    __NVIC_SetPriorityGrouping
+  #define NVIC_GetPriorityGrouping    __NVIC_GetPriorityGrouping
+  #define NVIC_EnableIRQ              __NVIC_EnableIRQ
+  #define NVIC_GetEnableIRQ           __NVIC_GetEnableIRQ
+  #define NVIC_DisableIRQ             __NVIC_DisableIRQ
+  #define NVIC_GetPendingIRQ          __NVIC_GetPendingIRQ
+  #define NVIC_SetPendingIRQ          __NVIC_SetPendingIRQ
+  #define NVIC_ClearPendingIRQ        __NVIC_ClearPendingIRQ
+  #define NVIC_GetActive              __NVIC_GetActive
+  #define NVIC_SetPriority            __NVIC_SetPriority
+  #define NVIC_GetPriority            __NVIC_GetPriority
+  #define NVIC_SystemReset            __NVIC_SystemReset
+#endif /* CMSIS_NVIC_VIRTUAL */
+
+#ifdef CMSIS_VECTAB_VIRTUAL
+  #ifndef CMSIS_VECTAB_VIRTUAL_HEADER_FILE
+    #define CMSIS_VECTAB_VIRTUAL_HEADER_FILE "cmsis_vectab_virtual.h"
+  #endif
+  #include CMSIS_VECTAB_VIRTUAL_HEADER_FILE
+#else
+  #define NVIC_SetVector              __NVIC_SetVector
+  #define NVIC_GetVector              __NVIC_GetVector
+#endif  /* (CMSIS_VECTAB_VIRTUAL) */
+
+#define NVIC_USER_IRQ_OFFSET          16
+
+
+/* The following EXC_RETURN values are saved the LR on exception entry */
+#define EXC_RETURN_HANDLER         (0xFFFFFFF1UL)     /* return to Handler mode, uses MSP after return                               */
+#define EXC_RETURN_THREAD_MSP      (0xFFFFFFF9UL)     /* return to Thread mode, uses MSP after return                                */
+#define EXC_RETURN_THREAD_PSP      (0xFFFFFFFDUL)     /* return to Thread mode, uses PSP after return                                */
+
+
+/**
+  \brief   Set Priority Grouping
+  \details Sets the priority grouping field using the required unlock sequence.
+           The parameter PriorityGroup is assigned to the field SCB->AIRCR [10:8] PRIGROUP field.
+           Only values from 0..7 are used.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+  \param [in]      PriorityGroup  Priority grouping field.
+ */
+__STATIC_INLINE void __NVIC_SetPriorityGrouping(uint32_t PriorityGroup)
+{
+  uint32_t reg_value;
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);             /* only values 0..7 are used          */
+
+  reg_value  =  SCB->AIRCR;                                                   /* read old register configuration    */
+  reg_value &= ~((uint32_t)(SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk)); /* clear bits to change               */
+  reg_value  =  (reg_value                                   |
+                ((uint32_t)0x5FAUL << SCB_AIRCR_VECTKEY_Pos) |
+                (PriorityGroupTmp << SCB_AIRCR_PRIGROUP_Pos)  );              /* Insert write key and priority group */
+  SCB->AIRCR =  reg_value;
+}
+
+
+/**
+  \brief   Get Priority Grouping
+  \details Reads the priority grouping field from the NVIC Interrupt Controller.
+  \return                Priority grouping field (SCB->AIRCR [10:8] PRIGROUP field).
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPriorityGrouping(void)
+{
+  return ((uint32_t)((SCB->AIRCR & SCB_AIRCR_PRIGROUP_Msk) >> SCB_AIRCR_PRIGROUP_Pos));
+}
+
+
+/**
+  \brief   Enable Interrupt
+  \details Enables a device specific interrupt in the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_EnableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    __COMPILER_BARRIER();
+    NVIC->ISER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+    __COMPILER_BARRIER();
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Enable status
+  \details Returns a device specific interrupt enable status from the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt is not enabled.
+  \return             1  Interrupt is enabled.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetEnableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ISER[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Disable Interrupt
+  \details Disables a device specific interrupt in the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_DisableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ICER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+    __DSB();
+    __ISB();
+  }
+}
+
+
+/**
+  \brief   Get Pending Interrupt
+  \details Reads the NVIC pending register and returns the pending bit for the specified device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not pending.
+  \return             1  Interrupt status is pending.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ISPR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Pending Interrupt
+  \details Sets the pending bit of a device specific interrupt in the NVIC pending register.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_SetPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ISPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Clear Pending Interrupt
+  \details Clears the pending bit of a device specific interrupt in the NVIC pending register.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_ClearPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ICPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Active Interrupt
+  \details Reads the active register in the NVIC and returns the active bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not active.
+  \return             1  Interrupt status is active.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetActive(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->IABR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Interrupt Priority
+  \details Sets the priority of a device specific interrupt or a processor exception.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]      IRQn  Interrupt number.
+  \param [in]  priority  Priority to set.
+  \note    The priority cannot be set for every processor exception.
+ */
+__STATIC_INLINE void __NVIC_SetPriority(IRQn_Type IRQn, uint32_t priority)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->IPR[((uint32_t)IRQn)]               = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+  else
+  {
+    SCB->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Priority
+  \details Reads the priority of a device specific interrupt or a processor exception.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn  Interrupt number.
+  \return             Interrupt Priority.
+                      Value is aligned automatically to the implemented priority bits of the microcontroller.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPriority(IRQn_Type IRQn)
+{
+
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return(((uint32_t)NVIC->IPR[((uint32_t)IRQn)]               >> (8U - __NVIC_PRIO_BITS)));
+  }
+  else
+  {
+    return(((uint32_t)SCB->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] >> (8U - __NVIC_PRIO_BITS)));
+  }
+}
+
+
+/**
+  \brief   Encode Priority
+  \details Encodes the priority for an interrupt with the given priority group,
+           preemptive priority value, and subpriority value.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+  \param [in]     PriorityGroup  Used priority group.
+  \param [in]   PreemptPriority  Preemptive priority value (starting from 0).
+  \param [in]       SubPriority  Subpriority value (starting from 0).
+  \return                        Encoded priority. Value can be used in the function \ref NVIC_SetPriority().
+ */
+__STATIC_INLINE uint32_t NVIC_EncodePriority (uint32_t PriorityGroup, uint32_t PreemptPriority, uint32_t SubPriority)
+{
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);   /* only values 0..7 are used          */
+  uint32_t PreemptPriorityBits;
+  uint32_t SubPriorityBits;
+
+  PreemptPriorityBits = ((7UL - PriorityGroupTmp) > (uint32_t)(__NVIC_PRIO_BITS)) ? (uint32_t)(__NVIC_PRIO_BITS) : (uint32_t)(7UL - PriorityGroupTmp);
+  SubPriorityBits     = ((PriorityGroupTmp + (uint32_t)(__NVIC_PRIO_BITS)) < (uint32_t)7UL) ? (uint32_t)0UL : (uint32_t)((PriorityGroupTmp - 7UL) + (uint32_t)(__NVIC_PRIO_BITS));
+
+  return (
+           ((PreemptPriority & (uint32_t)((1UL << (PreemptPriorityBits)) - 1UL)) << SubPriorityBits) |
+           ((SubPriority     & (uint32_t)((1UL << (SubPriorityBits    )) - 1UL)))
+         );
+}
+
+
+/**
+  \brief   Decode Priority
+  \details Decodes an interrupt priority value with a given priority group to
+           preemptive priority value and subpriority value.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS) the smallest possible priority group is set.
+  \param [in]         Priority   Priority value, which can be retrieved with the function \ref NVIC_GetPriority().
+  \param [in]     PriorityGroup  Used priority group.
+  \param [out] pPreemptPriority  Preemptive priority value (starting from 0).
+  \param [out]     pSubPriority  Subpriority value (starting from 0).
+ */
+__STATIC_INLINE void NVIC_DecodePriority (uint32_t Priority, uint32_t PriorityGroup, uint32_t* const pPreemptPriority, uint32_t* const pSubPriority)
+{
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);   /* only values 0..7 are used          */
+  uint32_t PreemptPriorityBits;
+  uint32_t SubPriorityBits;
+
+  PreemptPriorityBits = ((7UL - PriorityGroupTmp) > (uint32_t)(__NVIC_PRIO_BITS)) ? (uint32_t)(__NVIC_PRIO_BITS) : (uint32_t)(7UL - PriorityGroupTmp);
+  SubPriorityBits     = ((PriorityGroupTmp + (uint32_t)(__NVIC_PRIO_BITS)) < (uint32_t)7UL) ? (uint32_t)0UL : (uint32_t)((PriorityGroupTmp - 7UL) + (uint32_t)(__NVIC_PRIO_BITS));
+
+  *pPreemptPriority = (Priority >> SubPriorityBits) & (uint32_t)((1UL << (PreemptPriorityBits)) - 1UL);
+  *pSubPriority     = (Priority                   ) & (uint32_t)((1UL << (SubPriorityBits    )) - 1UL);
+}
+
+
+/**
+  \brief   Set Interrupt Vector
+  \details Sets an interrupt vector in SRAM based interrupt vector table.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+           VTOR must been relocated to SRAM before.
+  \param [in]   IRQn      Interrupt number
+  \param [in]   vector    Address of interrupt handler function
+ */
+__STATIC_INLINE void __NVIC_SetVector(IRQn_Type IRQn, uint32_t vector)
+{
+  uint32_t *vectors = (uint32_t *) ((uintptr_t) SCB->VTOR);
+  vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET] = vector;
+  /* ARM Application Note 321 states that the M3 does not require the architectural barrier */
+}
+
+
+/**
+  \brief   Get Interrupt Vector
+  \details Reads an interrupt vector from interrupt vector table.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn      Interrupt number.
+  \return                 Address of interrupt handler function
+ */
+__STATIC_INLINE uint32_t __NVIC_GetVector(IRQn_Type IRQn)
+{
+  uint32_t *vectors = (uint32_t *) ((uintptr_t) SCB->VTOR);
+  return vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET];
+}
+
+
+/**
+  \brief   System Reset
+  \details Initiates a system reset request to reset the MCU.
+ */
+__NO_RETURN __STATIC_INLINE void __NVIC_SystemReset(void)
+{
+  __DSB();                                                          /* Ensure all outstanding memory accesses included
+                                                                       buffered write are completed before reset */
+  SCB->AIRCR  = (uint32_t)((0x5FAUL << SCB_AIRCR_VECTKEY_Pos)    |
+                           (SCB->AIRCR & SCB_AIRCR_PRIGROUP_Msk) |
+                            SCB_AIRCR_SYSRESETREQ_Msk    );         /* Keep priority group unchanged */
+  __DSB();                                                          /* Ensure completion of memory access */
+
+  for(;;)                                                           /* wait until reset */
+  {
+    __NOP();
+  }
+}
+
+/*@} end of CMSIS_Core_NVICFunctions */
+
+
+/* ##########################  MPU functions  #################################### */
+
+#if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+
+#include "m-profile/armv7m_mpu.h"
+
+#endif
+
+
+/* ##########################  FPU functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_FpuFunctions FPU Functions
+  \brief    Function that provides FPU type.
+  @{
+ */
+
+/**
+  \brief   get FPU type
+  \details returns the FPU type
+  \returns
+   - \b  0: No FPU
+   - \b  1: Single precision FPU
+   - \b  2: Double + Single precision FPU
+ */
+__STATIC_INLINE uint32_t SCB_GetFPUType(void)
+{
+    return 0U;           /* No FPU */
+}
+
+/*@} end of CMSIS_Core_FpuFunctions */
+
+
+/* ##################################    SysTick function  ############################################ */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_SysTickFunctions SysTick Functions
+  \brief    Functions that configure the System.
+  @{
+ */
+
+#if defined (__Vendor_SysTickConfig) && (__Vendor_SysTickConfig == 0U)
+
+/**
+  \brief   System Tick Configuration
+  \details Initializes the System Timer and its interrupt, and starts the System Tick Timer.
+           Counter is in free running mode to generate periodic interrupts.
+  \param [in]  ticks  Number of ticks between two interrupts.
+  \return          0  Function succeeded.
+  \return          1  Function failed.
+  \note    When the variable <b>__Vendor_SysTickConfig</b> is set to 1, then the
+           function <b>SysTick_Config</b> is not included. In this case, the file <b><i>device</i>.h</b>
+           must contain a vendor-specific implementation of this function.
+ */
+__STATIC_INLINE uint32_t SysTick_Config(uint32_t ticks)
+{
+  if ((ticks - 1UL) > SysTick_LOAD_RELOAD_Msk)
+  {
+    return (1UL);                                                   /* Reload value impossible */
+  }
+
+  SysTick->LOAD  = (uint32_t)(ticks - 1UL);                         /* set reload register */
+  NVIC_SetPriority (SysTick_IRQn, (1UL << __NVIC_PRIO_BITS) - 1UL); /* set Priority for Systick Interrupt */
+  SysTick->VAL   = 0UL;                                             /* Load the SysTick Counter Value */
+  SysTick->CTRL  = SysTick_CTRL_CLKSOURCE_Msk |
+                   SysTick_CTRL_TICKINT_Msk   |
+                   SysTick_CTRL_ENABLE_Msk;                         /* Enable SysTick IRQ and SysTick Timer */
+  return (0UL);                                                     /* Function successful */
+}
+
+#endif
+
+/*@} end of CMSIS_Core_SysTickFunctions */
+
+
+
+/* ##################################### Debug In/Output function ########################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_core_DebugFunctions ITM Functions
+  \brief    Functions that access the ITM debug interface.
+  @{
+ */
+
+extern volatile int32_t ITM_RxBuffer;                              /*!< External variable to receive characters. */
+#define                 ITM_RXBUFFER_EMPTY  ((int32_t)0x5AA55AA5U) /*!< Value identifying \ref ITM_RxBuffer is ready for next character. */
+
+
+/**
+  \brief   ITM Send Character
+  \details Transmits a character via the ITM channel 0, and
+           \li Just returns when no debugger is connected that has booked the output.
+           \li Is blocking when a debugger is connected, but the previous character sent has not been transmitted.
+  \param [in]     ch  Character to transmit.
+  \returns            Character to transmit.
+ */
+__STATIC_INLINE uint32_t ITM_SendChar (uint32_t ch)
+{
+  if (((ITM->TCR & ITM_TCR_ITMENA_Msk) != 0UL) &&      /* ITM enabled */
+      ((ITM->TER & 1UL               ) != 0UL)   )     /* ITM Port #0 enabled */
+  {
+    while (ITM->PORT[0U].u32 == 0UL)
+    {
+      __NOP();
+    }
+    ITM->PORT[0U].u8 = (uint8_t)ch;
+  }
+  return (ch);
+}
+
+
+/**
+  \brief   ITM Receive Character
+  \details Inputs a character via the external variable \ref ITM_RxBuffer.
+  \return             Received character.
+  \return         -1  No character pending.
+ */
+__STATIC_INLINE int32_t ITM_ReceiveChar (void)
+{
+  int32_t ch = -1;                           /* no character available */
+
+  if (ITM_RxBuffer != ITM_RXBUFFER_EMPTY)
+  {
+    ch = ITM_RxBuffer;
+    ITM_RxBuffer = ITM_RXBUFFER_EMPTY;       /* ready for next character */
+  }
+
+  return (ch);
+}
+
+
+/**
+  \brief   ITM Check Character
+  \details Checks whether a character is pending for reading in the variable \ref ITM_RxBuffer.
+  \return          0  No character available.
+  \return          1  Character available.
+ */
+__STATIC_INLINE int32_t ITM_CheckChar (void)
+{
+
+  if (ITM_RxBuffer == ITM_RXBUFFER_EMPTY)
+  {
+    return (0);                              /* no character available */
+  }
+  else
+  {
+    return (1);                              /*    character available */
+  }
+}
+
+/*@} end of CMSIS_core_DebugFunctions */
+
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_CM3_H_DEPENDANT */
+
+#endif /* __CMSIS_GENERIC */

--- a/platform/ext/cmsis/CMSIS/Core/Include/core_cm33.h
+++ b/platform/ext/cmsis/CMSIS/Core/Include/core_cm33.h
@@ -1,0 +1,3112 @@
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS Cortex-M33 Core Peripheral Access Layer Header File
+ */
+
+#if   defined ( __ICCARM__ )
+  #pragma system_include                        /* treat file as system include file for MISRA check */
+#elif defined (__clang__)
+  #pragma clang system_header                   /* treat file as system include file */
+#elif defined ( __GNUC__ )
+  #pragma GCC diagnostic ignored "-Wpedantic"   /* disable pedantic warning due to unnamed structs/unions */
+#endif
+
+#ifndef __CORE_CM33_H_GENERIC
+#define __CORE_CM33_H_GENERIC
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/**
+  \page CMSIS_MISRA_Exceptions  MISRA-C:2004 Compliance Exceptions
+  CMSIS violates the following MISRA-C:2004 rules:
+
+   \li Required Rule 8.5, object/function definition in header file.<br>
+     Function definitions in header files are used to allow 'inlining'.
+
+   \li Required Rule 18.4, declaration of union type or object of union type: '{...}'.<br>
+     Unions are used for effective representation of core registers.
+
+   \li Advisory Rule 19.7, Function-like macro defined.<br>
+     Function-like macros are used to allow more efficient code.
+ */
+
+
+/*******************************************************************************
+ *                 CMSIS definitions
+ ******************************************************************************/
+/**
+  \ingroup Cortex_M33
+  @{
+ */
+
+#include "cmsis_version.h"
+
+/* CMSIS CM33 definitions */
+
+#define __CORTEX_M                (33U)                               /*!< Cortex-M Core */
+
+/** __FPU_USED indicates whether an FPU is used or not.
+    For this, __FPU_PRESENT has to be checked prior to making use of FPU specific registers and functions.
+*/
+#if defined ( __CC_ARM )
+  #if defined (__TARGET_FPU_VFP)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+  #if defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1U)
+    #if defined (__DSP_PRESENT) && (__DSP_PRESENT == 1U)
+      #define __DSP_USED       1U
+    #else
+      #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
+      #define __DSP_USED         0U
+    #endif
+  #else
+    #define __DSP_USED         0U
+  #endif
+
+#elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #if defined (__ARM_FP)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+  #if defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1U)
+    #if defined (__DSP_PRESENT) && (__DSP_PRESENT == 1U)
+      #define __DSP_USED       1U
+    #else
+      #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
+      #define __DSP_USED       0U
+    #endif
+  #else
+    #define __DSP_USED         0U
+  #endif
+
+#elif defined (__ti__)
+  #if defined (__ARM_FP)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+  #if defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1U)
+    #if defined (__DSP_PRESENT) && (__DSP_PRESENT == 1U)
+      #define __DSP_USED       1U
+    #else
+      #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
+      #define __DSP_USED       0U
+    #endif
+  #else
+    #define __DSP_USED         0U
+  #endif
+
+#elif defined ( __GNUC__ )
+  #if defined (__VFP_FP__) && !defined(__SOFTFP__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+  #if defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1U)
+    #if defined (__DSP_PRESENT) && (__DSP_PRESENT == 1U)
+      #define __DSP_USED       1U
+    #else
+      #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
+      #define __DSP_USED         0U
+    #endif
+  #else
+    #define __DSP_USED         0U
+  #endif
+
+#elif defined ( __ICCARM__ )
+  #if defined (__ARMVFP__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+  #if defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1U)
+    #if defined (__DSP_PRESENT) && (__DSP_PRESENT == 1U)
+      #define __DSP_USED       1U
+    #else
+      #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
+      #define __DSP_USED         0U
+    #endif
+  #else
+    #define __DSP_USED         0U
+  #endif
+
+#elif defined ( __TI_ARM__ )
+  #if defined (__TI_VFP_SUPPORT__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#elif defined ( __TASKING__ )
+  #if defined (__FPU_VFP__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#elif defined ( __CSMC__ )
+  #if ( __CSMC__ & 0x400U)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#endif
+
+#include "cmsis_compiler.h"               /* CMSIS compiler specific defines */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_CM33_H_GENERIC */
+
+#ifndef __CMSIS_GENERIC
+
+#ifndef __CORE_CM33_H_DEPENDANT
+#define __CORE_CM33_H_DEPENDANT
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* check device defines and use defaults */
+#if defined __CHECK_DEVICE_DEFINES
+  #ifndef __CM33_REV
+    #define __CM33_REV                0x0000U
+    #warning "__CM33_REV not defined in device header file; using default!"
+  #endif
+
+  #ifndef __FPU_PRESENT
+    #define __FPU_PRESENT             0U
+    #warning "__FPU_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __MPU_PRESENT
+    #define __MPU_PRESENT             0U
+    #warning "__MPU_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __SAUREGION_PRESENT
+    #define __SAUREGION_PRESENT       0U
+    #warning "__SAUREGION_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __DSP_PRESENT
+    #define __DSP_PRESENT             0U
+    #warning "__DSP_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __VTOR_PRESENT
+    #define __VTOR_PRESENT            1U
+    #warning "__VTOR_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __NVIC_PRIO_BITS
+    #define __NVIC_PRIO_BITS          3U
+    #warning "__NVIC_PRIO_BITS not defined in device header file; using default!"
+  #endif
+
+  #ifndef __Vendor_SysTickConfig
+    #define __Vendor_SysTickConfig    0U
+    #warning "__Vendor_SysTickConfig not defined in device header file; using default!"
+  #endif
+#endif
+
+/* IO definitions (access restrictions to peripheral registers) */
+/**
+    \defgroup CMSIS_glob_defs CMSIS Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+*/
+#ifdef __cplusplus
+  #define   __I     volatile             /*!< Defines 'read only' permissions */
+#else
+  #define   __I     volatile const       /*!< Defines 'read only' permissions */
+#endif
+#define     __O     volatile             /*!< Defines 'write only' permissions */
+#define     __IO    volatile             /*!< Defines 'read / write' permissions */
+
+/* following defines should be used for structure members */
+#define     __IM     volatile const      /*! Defines 'read only' structure member permissions */
+#define     __OM     volatile            /*! Defines 'write only' structure member permissions */
+#define     __IOM    volatile            /*! Defines 'read / write' structure member permissions */
+
+/*@} end of group Cortex_M33 */
+
+
+
+/*******************************************************************************
+ *                 Register Abstraction
+  Core Register contain:
+  - Core Register
+  - Core NVIC Register
+  - Core SCB Register
+  - Core SysTick Register
+  - Core Debug Register
+  - Core MPU Register
+  - Core SAU Register
+  - Core FPU Register
+ ******************************************************************************/
+/**
+  \defgroup CMSIS_core_register Defines and Type Definitions
+  \brief Type definitions and defines for Cortex-M processor based devices.
+*/
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_CORE  Status and Control Registers
+  \brief      Core Register type definitions.
+  @{
+ */
+
+/**
+  \brief  Union type to access the Application Program Status Register (APSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t _reserved0:16;              /*!< bit:  0..15  Reserved */
+    uint32_t GE:4;                       /*!< bit: 16..19  Greater than or Equal flags */
+    uint32_t _reserved1:7;               /*!< bit: 20..26  Reserved */
+    uint32_t Q:1;                        /*!< bit:     27  Saturation condition flag */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} APSR_Type;
+
+/** \brief APSR Register Definitions */
+#define APSR_N_Pos                         31U                                            /*!< APSR: N Position */
+#define APSR_N_Msk                         (1UL << APSR_N_Pos)                            /*!< APSR: N Mask */
+
+#define APSR_Z_Pos                         30U                                            /*!< APSR: Z Position */
+#define APSR_Z_Msk                         (1UL << APSR_Z_Pos)                            /*!< APSR: Z Mask */
+
+#define APSR_C_Pos                         29U                                            /*!< APSR: C Position */
+#define APSR_C_Msk                         (1UL << APSR_C_Pos)                            /*!< APSR: C Mask */
+
+#define APSR_V_Pos                         28U                                            /*!< APSR: V Position */
+#define APSR_V_Msk                         (1UL << APSR_V_Pos)                            /*!< APSR: V Mask */
+
+#define APSR_Q_Pos                         27U                                            /*!< APSR: Q Position */
+#define APSR_Q_Msk                         (1UL << APSR_Q_Pos)                            /*!< APSR: Q Mask */
+
+#define APSR_GE_Pos                        16U                                            /*!< APSR: GE Position */
+#define APSR_GE_Msk                        (0xFUL << APSR_GE_Pos)                         /*!< APSR: GE Mask */
+
+
+/**
+  \brief  Union type to access the Interrupt Program Status Register (IPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number */
+    uint32_t _reserved0:23;              /*!< bit:  9..31  Reserved */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} IPSR_Type;
+
+/** \brief IPSR Register Definitions */
+#define IPSR_ISR_Pos                        0U                                            /*!< IPSR: ISR Position */
+#define IPSR_ISR_Msk                       (0x1FFUL /*<< IPSR_ISR_Pos*/)                  /*!< IPSR: ISR Mask */
+
+
+/**
+  \brief  Union type to access the Special-Purpose Program Status Registers (xPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number */
+    uint32_t _reserved0:7;               /*!< bit:  9..15  Reserved */
+    uint32_t GE:4;                       /*!< bit: 16..19  Greater than or Equal flags */
+    uint32_t _reserved1:4;               /*!< bit: 20..23  Reserved */
+    uint32_t T:1;                        /*!< bit:     24  Thumb bit        (read 0) */
+    uint32_t IT:2;                       /*!< bit: 25..26  saved IT state   (read 0) */
+    uint32_t Q:1;                        /*!< bit:     27  Saturation condition flag */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} xPSR_Type;
+
+/** \brief xPSR Register Definitions */
+#define xPSR_N_Pos                         31U                                            /*!< xPSR: N Position */
+#define xPSR_N_Msk                         (1UL << xPSR_N_Pos)                            /*!< xPSR: N Mask */
+
+#define xPSR_Z_Pos                         30U                                            /*!< xPSR: Z Position */
+#define xPSR_Z_Msk                         (1UL << xPSR_Z_Pos)                            /*!< xPSR: Z Mask */
+
+#define xPSR_C_Pos                         29U                                            /*!< xPSR: C Position */
+#define xPSR_C_Msk                         (1UL << xPSR_C_Pos)                            /*!< xPSR: C Mask */
+
+#define xPSR_V_Pos                         28U                                            /*!< xPSR: V Position */
+#define xPSR_V_Msk                         (1UL << xPSR_V_Pos)                            /*!< xPSR: V Mask */
+
+#define xPSR_Q_Pos                         27U                                            /*!< xPSR: Q Position */
+#define xPSR_Q_Msk                         (1UL << xPSR_Q_Pos)                            /*!< xPSR: Q Mask */
+
+#define xPSR_IT_Pos                        25U                                            /*!< xPSR: IT Position */
+#define xPSR_IT_Msk                        (3UL << xPSR_IT_Pos)                           /*!< xPSR: IT Mask */
+
+#define xPSR_T_Pos                         24U                                            /*!< xPSR: T Position */
+#define xPSR_T_Msk                         (1UL << xPSR_T_Pos)                            /*!< xPSR: T Mask */
+
+#define xPSR_GE_Pos                        16U                                            /*!< xPSR: GE Position */
+#define xPSR_GE_Msk                        (0xFUL << xPSR_GE_Pos)                         /*!< xPSR: GE Mask */
+
+#define xPSR_ISR_Pos                        0U                                            /*!< xPSR: ISR Position */
+#define xPSR_ISR_Msk                       (0x1FFUL /*<< xPSR_ISR_Pos*/)                  /*!< xPSR: ISR Mask */
+
+
+/**
+  \brief  Union type to access the Control Registers (CONTROL).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t nPRIV:1;                    /*!< bit:      0  Execution privilege in Thread mode */
+    uint32_t SPSEL:1;                    /*!< bit:      1  Stack-pointer select */
+    uint32_t FPCA:1;                     /*!< bit:      2  Floating-point context active */
+    uint32_t SFPA:1;                     /*!< bit:      3  Secure floating-point active */
+    uint32_t _reserved1:28;              /*!< bit:  4..31  Reserved */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} CONTROL_Type;
+
+/** \brief CONTROL Register Definitions */
+#define CONTROL_SFPA_Pos                    3U                                            /*!< CONTROL: SFPA Position */
+#define CONTROL_SFPA_Msk                   (1UL << CONTROL_SFPA_Pos)                      /*!< CONTROL: SFPA Mask */
+
+#define CONTROL_FPCA_Pos                    2U                                            /*!< CONTROL: FPCA Position */
+#define CONTROL_FPCA_Msk                   (1UL << CONTROL_FPCA_Pos)                      /*!< CONTROL: FPCA Mask */
+
+#define CONTROL_SPSEL_Pos                   1U                                            /*!< CONTROL: SPSEL Position */
+#define CONTROL_SPSEL_Msk                  (1UL << CONTROL_SPSEL_Pos)                     /*!< CONTROL: SPSEL Mask */
+
+#define CONTROL_nPRIV_Pos                   0U                                            /*!< CONTROL: nPRIV Position */
+#define CONTROL_nPRIV_Msk                  (1UL /*<< CONTROL_nPRIV_Pos*/)                 /*!< CONTROL: nPRIV Mask */
+
+/*@} end of group CMSIS_CORE */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_NVIC  Nested Vectored Interrupt Controller (NVIC)
+  \brief      Type definitions for the NVIC Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Nested Vectored Interrupt Controller (NVIC).
+ */
+typedef struct
+{
+  __IOM uint32_t ISER[16U];              /*!< Offset: 0x000 (R/W)  Interrupt Set Enable Register */
+        uint32_t RESERVED0[16U];
+  __IOM uint32_t ICER[16U];              /*!< Offset: 0x080 (R/W)  Interrupt Clear Enable Register */
+        uint32_t RESERVED1[16U];
+  __IOM uint32_t ISPR[16U];              /*!< Offset: 0x100 (R/W)  Interrupt Set Pending Register */
+        uint32_t RESERVED2[16U];
+  __IOM uint32_t ICPR[16U];              /*!< Offset: 0x180 (R/W)  Interrupt Clear Pending Register */
+        uint32_t RESERVED3[16U];
+  __IOM uint32_t IABR[16U];              /*!< Offset: 0x200 (R/W)  Interrupt Active bit Register */
+        uint32_t RESERVED4[16U];
+  __IOM uint32_t ITNS[16U];              /*!< Offset: 0x280 (R/W)  Interrupt Non-Secure State Register */
+        uint32_t RESERVED5[16U];
+  __IOM uint8_t  IPR[496U];              /*!< Offset: 0x300 (R/W)  Interrupt Priority Register (8Bit wide) */
+        uint32_t RESERVED6[580U];
+  __OM  uint32_t STIR;                   /*!< Offset: 0xE00 ( /W)  Software Trigger Interrupt Register */
+}  NVIC_Type;
+
+/** \brief NVIC Software Triggered Interrupt Register Definitions */
+#define NVIC_STIR_INTID_Pos                 0U                                         /*!< STIR: INTLINESNUM Position */
+#define NVIC_STIR_INTID_Msk                (0x1FFUL /*<< NVIC_STIR_INTID_Pos*/)        /*!< STIR: INTLINESNUM Mask */
+
+/*@} end of group CMSIS_NVIC */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SCB     System Control Block (SCB)
+  \brief    Type definitions for the System Control Block Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Control Block (SCB).
+ */
+typedef struct
+{
+  __IM  uint32_t CPUID;                  /*!< Offset: 0x000 (R/ )  CPUID Base Register */
+  __IOM uint32_t ICSR;                   /*!< Offset: 0x004 (R/W)  Interrupt Control and State Register */
+  __IOM uint32_t VTOR;                   /*!< Offset: 0x008 (R/W)  Vector Table Offset Register */
+  __IOM uint32_t AIRCR;                  /*!< Offset: 0x00C (R/W)  Application Interrupt and Reset Control Register */
+  __IOM uint32_t SCR;                    /*!< Offset: 0x010 (R/W)  System Control Register */
+  __IOM uint32_t CCR;                    /*!< Offset: 0x014 (R/W)  Configuration Control Register */
+  __IOM uint8_t  SHPR[12U];              /*!< Offset: 0x018 (R/W)  System Handlers Priority Registers (4-7, 8-11, 12-15) */
+  __IOM uint32_t SHCSR;                  /*!< Offset: 0x024 (R/W)  System Handler Control and State Register */
+  __IOM uint32_t CFSR;                   /*!< Offset: 0x028 (R/W)  Configurable Fault Status Register */
+  __IOM uint32_t HFSR;                   /*!< Offset: 0x02C (R/W)  HardFault Status Register */
+  __IOM uint32_t DFSR;                   /*!< Offset: 0x030 (R/W)  Debug Fault Status Register */
+  __IOM uint32_t MMFAR;                  /*!< Offset: 0x034 (R/W)  MemManage Fault Address Register */
+  __IOM uint32_t BFAR;                   /*!< Offset: 0x038 (R/W)  BusFault Address Register */
+  __IOM uint32_t AFSR;                   /*!< Offset: 0x03C (R/W)  Auxiliary Fault Status Register */
+  __IM  uint32_t ID_PFR[2U];             /*!< Offset: 0x040 (R/ )  Processor Feature Register */
+  __IM  uint32_t ID_DFR;                 /*!< Offset: 0x048 (R/ )  Debug Feature Register */
+  __IM  uint32_t ID_AFR;                 /*!< Offset: 0x04C (R/ )  Auxiliary Feature Register */
+  __IM  uint32_t ID_MMFR[4U];            /*!< Offset: 0x050 (R/ )  Memory Model Feature Register */
+  __IM  uint32_t ID_ISAR[6U];            /*!< Offset: 0x060 (R/ )  Instruction Set Attributes Register */
+  __IM  uint32_t CLIDR;                  /*!< Offset: 0x078 (R/ )  Cache Level ID register */
+  __IM  uint32_t CTR;                    /*!< Offset: 0x07C (R/ )  Cache Type register */
+  __IM  uint32_t CCSIDR;                 /*!< Offset: 0x080 (R/ )  Cache Size ID Register */
+  __IOM uint32_t CSSELR;                 /*!< Offset: 0x084 (R/W)  Cache Size Selection Register */
+  __IOM uint32_t CPACR;                  /*!< Offset: 0x088 (R/W)  Coprocessor Access Control Register */
+  __IOM uint32_t NSACR;                  /*!< Offset: 0x08C (R/W)  Non-Secure Access Control Register */
+        uint32_t RESERVED7[21U];
+  __IOM uint32_t SFSR;                   /*!< Offset: 0x0E4 (R/W)  Secure Fault Status Register */
+  __IOM uint32_t SFAR;                   /*!< Offset: 0x0E8 (R/W)  Secure Fault Address Register */
+        uint32_t RESERVED3[69U];
+  __OM  uint32_t STIR;                   /*!< Offset: 0x200 ( /W)  Software Triggered Interrupt Register */
+        uint32_t RESERVED4[15U];
+  __IM  uint32_t MVFR0;                  /*!< Offset: 0x240 (R/ )  Media and VFP Feature Register 0 */
+  __IM  uint32_t MVFR1;                  /*!< Offset: 0x244 (R/ )  Media and VFP Feature Register 1 */
+  __IM  uint32_t MVFR2;                  /*!< Offset: 0x248 (R/ )  Media and VFP Feature Register 2 */
+        uint32_t RESERVED5[1U];
+  __OM  uint32_t ICIALLU;                /*!< Offset: 0x250 ( /W)  I-Cache Invalidate All to PoU */
+        uint32_t RESERVED6[1U];
+  __OM  uint32_t ICIMVAU;                /*!< Offset: 0x258 ( /W)  I-Cache Invalidate by MVA to PoU */
+  __OM  uint32_t DCIMVAC;                /*!< Offset: 0x25C ( /W)  D-Cache Invalidate by MVA to PoC */
+  __OM  uint32_t DCISW;                  /*!< Offset: 0x260 ( /W)  D-Cache Invalidate by Set-way */
+  __OM  uint32_t DCCMVAU;                /*!< Offset: 0x264 ( /W)  D-Cache Clean by MVA to PoU */
+  __OM  uint32_t DCCMVAC;                /*!< Offset: 0x268 ( /W)  D-Cache Clean by MVA to PoC */
+  __OM  uint32_t DCCSW;                  /*!< Offset: 0x26C ( /W)  D-Cache Clean by Set-way */
+  __OM  uint32_t DCCIMVAC;               /*!< Offset: 0x270 ( /W)  D-Cache Clean and Invalidate by MVA to PoC */
+  __OM  uint32_t DCCISW;                 /*!< Offset: 0x274 ( /W)  D-Cache Clean and Invalidate by Set-way */
+  __OM  uint32_t BPIALL;                 /*!< Offset: 0x278 ( /W)  Branch Predictor Invalidate All */
+} SCB_Type;
+
+/** \brief SCB CPUID Register Definitions */
+#define SCB_CPUID_IMPLEMENTER_Pos          24U                                            /*!< SCB CPUID: IMPLEMENTER Position */
+#define SCB_CPUID_IMPLEMENTER_Msk          (0xFFUL << SCB_CPUID_IMPLEMENTER_Pos)          /*!< SCB CPUID: IMPLEMENTER Mask */
+
+#define SCB_CPUID_VARIANT_Pos              20U                                            /*!< SCB CPUID: VARIANT Position */
+#define SCB_CPUID_VARIANT_Msk              (0xFUL << SCB_CPUID_VARIANT_Pos)               /*!< SCB CPUID: VARIANT Mask */
+
+#define SCB_CPUID_ARCHITECTURE_Pos         16U                                            /*!< SCB CPUID: ARCHITECTURE Position */
+#define SCB_CPUID_ARCHITECTURE_Msk         (0xFUL << SCB_CPUID_ARCHITECTURE_Pos)          /*!< SCB CPUID: ARCHITECTURE Mask */
+
+#define SCB_CPUID_PARTNO_Pos                4U                                            /*!< SCB CPUID: PARTNO Position */
+#define SCB_CPUID_PARTNO_Msk               (0xFFFUL << SCB_CPUID_PARTNO_Pos)              /*!< SCB CPUID: PARTNO Mask */
+
+#define SCB_CPUID_REVISION_Pos              0U                                            /*!< SCB CPUID: REVISION Position */
+#define SCB_CPUID_REVISION_Msk             (0xFUL /*<< SCB_CPUID_REVISION_Pos*/)          /*!< SCB CPUID: REVISION Mask */
+
+/** \brief SCB Interrupt Control State Register Definitions */
+#define SCB_ICSR_PENDNMISET_Pos            31U                                            /*!< SCB ICSR: PENDNMISET Position */
+#define SCB_ICSR_PENDNMISET_Msk            (1UL << SCB_ICSR_PENDNMISET_Pos)               /*!< SCB ICSR: PENDNMISET Mask */
+
+#define SCB_ICSR_NMIPENDSET_Pos            SCB_ICSR_PENDNMISET_Pos                        /*!< SCB ICSR: NMIPENDSET Position, backward compatibility */
+#define SCB_ICSR_NMIPENDSET_Msk            SCB_ICSR_PENDNMISET_Msk                        /*!< SCB ICSR: NMIPENDSET Mask, backward compatibility */
+
+#define SCB_ICSR_PENDNMICLR_Pos            30U                                            /*!< SCB ICSR: PENDNMICLR Position */
+#define SCB_ICSR_PENDNMICLR_Msk            (1UL << SCB_ICSR_PENDNMICLR_Pos)               /*!< SCB ICSR: PENDNMICLR Mask */
+
+#define SCB_ICSR_PENDSVSET_Pos             28U                                            /*!< SCB ICSR: PENDSVSET Position */
+#define SCB_ICSR_PENDSVSET_Msk             (1UL << SCB_ICSR_PENDSVSET_Pos)                /*!< SCB ICSR: PENDSVSET Mask */
+
+#define SCB_ICSR_PENDSVCLR_Pos             27U                                            /*!< SCB ICSR: PENDSVCLR Position */
+#define SCB_ICSR_PENDSVCLR_Msk             (1UL << SCB_ICSR_PENDSVCLR_Pos)                /*!< SCB ICSR: PENDSVCLR Mask */
+
+#define SCB_ICSR_PENDSTSET_Pos             26U                                            /*!< SCB ICSR: PENDSTSET Position */
+#define SCB_ICSR_PENDSTSET_Msk             (1UL << SCB_ICSR_PENDSTSET_Pos)                /*!< SCB ICSR: PENDSTSET Mask */
+
+#define SCB_ICSR_PENDSTCLR_Pos             25U                                            /*!< SCB ICSR: PENDSTCLR Position */
+#define SCB_ICSR_PENDSTCLR_Msk             (1UL << SCB_ICSR_PENDSTCLR_Pos)                /*!< SCB ICSR: PENDSTCLR Mask */
+
+#define SCB_ICSR_STTNS_Pos                 24U                                            /*!< SCB ICSR: STTNS Position (Security Extension) */
+#define SCB_ICSR_STTNS_Msk                 (1UL << SCB_ICSR_STTNS_Pos)                    /*!< SCB ICSR: STTNS Mask (Security Extension) */
+
+#define SCB_ICSR_ISRPREEMPT_Pos            23U                                            /*!< SCB ICSR: ISRPREEMPT Position */
+#define SCB_ICSR_ISRPREEMPT_Msk            (1UL << SCB_ICSR_ISRPREEMPT_Pos)               /*!< SCB ICSR: ISRPREEMPT Mask */
+
+#define SCB_ICSR_ISRPENDING_Pos            22U                                            /*!< SCB ICSR: ISRPENDING Position */
+#define SCB_ICSR_ISRPENDING_Msk            (1UL << SCB_ICSR_ISRPENDING_Pos)               /*!< SCB ICSR: ISRPENDING Mask */
+
+#define SCB_ICSR_VECTPENDING_Pos           12U                                            /*!< SCB ICSR: VECTPENDING Position */
+#define SCB_ICSR_VECTPENDING_Msk           (0x1FFUL << SCB_ICSR_VECTPENDING_Pos)          /*!< SCB ICSR: VECTPENDING Mask */
+
+#define SCB_ICSR_RETTOBASE_Pos             11U                                            /*!< SCB ICSR: RETTOBASE Position */
+#define SCB_ICSR_RETTOBASE_Msk             (1UL << SCB_ICSR_RETTOBASE_Pos)                /*!< SCB ICSR: RETTOBASE Mask */
+
+#define SCB_ICSR_VECTACTIVE_Pos             0U                                            /*!< SCB ICSR: VECTACTIVE Position */
+#define SCB_ICSR_VECTACTIVE_Msk            (0x1FFUL /*<< SCB_ICSR_VECTACTIVE_Pos*/)       /*!< SCB ICSR: VECTACTIVE Mask */
+
+/** \brief SCB Vector Table Offset Register Definitions */
+#define SCB_VTOR_TBLOFF_Pos                 7U                                            /*!< SCB VTOR: TBLOFF Position */
+#define SCB_VTOR_TBLOFF_Msk                (0x1FFFFFFUL << SCB_VTOR_TBLOFF_Pos)           /*!< SCB VTOR: TBLOFF Mask */
+
+/** \brief SCB Application Interrupt and Reset Control Register Definitions */
+#define SCB_AIRCR_VECTKEY_Pos              16U                                            /*!< SCB AIRCR: VECTKEY Position */
+#define SCB_AIRCR_VECTKEY_Msk              (0xFFFFUL << SCB_AIRCR_VECTKEY_Pos)            /*!< SCB AIRCR: VECTKEY Mask */
+
+#define SCB_AIRCR_VECTKEYSTAT_Pos          16U                                            /*!< SCB AIRCR: VECTKEYSTAT Position */
+#define SCB_AIRCR_VECTKEYSTAT_Msk          (0xFFFFUL << SCB_AIRCR_VECTKEYSTAT_Pos)        /*!< SCB AIRCR: VECTKEYSTAT Mask */
+
+#define SCB_AIRCR_ENDIANESS_Pos            15U                                            /*!< SCB AIRCR: ENDIANESS Position */
+#define SCB_AIRCR_ENDIANESS_Msk            (1UL << SCB_AIRCR_ENDIANESS_Pos)               /*!< SCB AIRCR: ENDIANESS Mask */
+
+#define SCB_AIRCR_PRIS_Pos                 14U                                            /*!< SCB AIRCR: PRIS Position */
+#define SCB_AIRCR_PRIS_Msk                 (1UL << SCB_AIRCR_PRIS_Pos)                    /*!< SCB AIRCR: PRIS Mask */
+
+#define SCB_AIRCR_BFHFNMINS_Pos            13U                                            /*!< SCB AIRCR: BFHFNMINS Position */
+#define SCB_AIRCR_BFHFNMINS_Msk            (1UL << SCB_AIRCR_BFHFNMINS_Pos)               /*!< SCB AIRCR: BFHFNMINS Mask */
+
+#define SCB_AIRCR_PRIGROUP_Pos              8U                                            /*!< SCB AIRCR: PRIGROUP Position */
+#define SCB_AIRCR_PRIGROUP_Msk             (7UL << SCB_AIRCR_PRIGROUP_Pos)                /*!< SCB AIRCR: PRIGROUP Mask */
+
+#define SCB_AIRCR_SYSRESETREQS_Pos          3U                                            /*!< SCB AIRCR: SYSRESETREQS Position */
+#define SCB_AIRCR_SYSRESETREQS_Msk         (1UL << SCB_AIRCR_SYSRESETREQS_Pos)            /*!< SCB AIRCR: SYSRESETREQS Mask */
+
+#define SCB_AIRCR_SYSRESETREQ_Pos           2U                                            /*!< SCB AIRCR: SYSRESETREQ Position */
+#define SCB_AIRCR_SYSRESETREQ_Msk          (1UL << SCB_AIRCR_SYSRESETREQ_Pos)             /*!< SCB AIRCR: SYSRESETREQ Mask */
+
+#define SCB_AIRCR_VECTCLRACTIVE_Pos         1U                                            /*!< SCB AIRCR: VECTCLRACTIVE Position */
+#define SCB_AIRCR_VECTCLRACTIVE_Msk        (1UL << SCB_AIRCR_VECTCLRACTIVE_Pos)           /*!< SCB AIRCR: VECTCLRACTIVE Mask */
+
+/** \brief SCB System Control Register Definitions */
+#define SCB_SCR_SEVONPEND_Pos               4U                                            /*!< SCB SCR: SEVONPEND Position */
+#define SCB_SCR_SEVONPEND_Msk              (1UL << SCB_SCR_SEVONPEND_Pos)                 /*!< SCB SCR: SEVONPEND Mask */
+
+#define SCB_SCR_SLEEPDEEPS_Pos              3U                                            /*!< SCB SCR: SLEEPDEEPS Position */
+#define SCB_SCR_SLEEPDEEPS_Msk             (1UL << SCB_SCR_SLEEPDEEPS_Pos)                /*!< SCB SCR: SLEEPDEEPS Mask */
+
+#define SCB_SCR_SLEEPDEEP_Pos               2U                                            /*!< SCB SCR: SLEEPDEEP Position */
+#define SCB_SCR_SLEEPDEEP_Msk              (1UL << SCB_SCR_SLEEPDEEP_Pos)                 /*!< SCB SCR: SLEEPDEEP Mask */
+
+#define SCB_SCR_SLEEPONEXIT_Pos             1U                                            /*!< SCB SCR: SLEEPONEXIT Position */
+#define SCB_SCR_SLEEPONEXIT_Msk            (1UL << SCB_SCR_SLEEPONEXIT_Pos)               /*!< SCB SCR: SLEEPONEXIT Mask */
+
+/** \brief SCB Configuration Control Register Definitions */
+#define SCB_CCR_BP_Pos                     18U                                            /*!< SCB CCR: BP Position */
+#define SCB_CCR_BP_Msk                     (1UL << SCB_CCR_BP_Pos)                        /*!< SCB CCR: BP Mask */
+
+#define SCB_CCR_IC_Pos                     17U                                            /*!< SCB CCR: IC Position */
+#define SCB_CCR_IC_Msk                     (1UL << SCB_CCR_IC_Pos)                        /*!< SCB CCR: IC Mask */
+
+#define SCB_CCR_DC_Pos                     16U                                            /*!< SCB CCR: DC Position */
+#define SCB_CCR_DC_Msk                     (1UL << SCB_CCR_DC_Pos)                        /*!< SCB CCR: DC Mask */
+
+#define SCB_CCR_STKOFHFNMIGN_Pos           10U                                            /*!< SCB CCR: STKOFHFNMIGN Position */
+#define SCB_CCR_STKOFHFNMIGN_Msk           (1UL << SCB_CCR_STKOFHFNMIGN_Pos)              /*!< SCB CCR: STKOFHFNMIGN Mask */
+
+#define SCB_CCR_BFHFNMIGN_Pos               8U                                            /*!< SCB CCR: BFHFNMIGN Position */
+#define SCB_CCR_BFHFNMIGN_Msk              (1UL << SCB_CCR_BFHFNMIGN_Pos)                 /*!< SCB CCR: BFHFNMIGN Mask */
+
+#define SCB_CCR_DIV_0_TRP_Pos               4U                                            /*!< SCB CCR: DIV_0_TRP Position */
+#define SCB_CCR_DIV_0_TRP_Msk              (1UL << SCB_CCR_DIV_0_TRP_Pos)                 /*!< SCB CCR: DIV_0_TRP Mask */
+
+#define SCB_CCR_UNALIGN_TRP_Pos             3U                                            /*!< SCB CCR: UNALIGN_TRP Position */
+#define SCB_CCR_UNALIGN_TRP_Msk            (1UL << SCB_CCR_UNALIGN_TRP_Pos)               /*!< SCB CCR: UNALIGN_TRP Mask */
+
+#define SCB_CCR_USERSETMPEND_Pos            1U                                            /*!< SCB CCR: USERSETMPEND Position */
+#define SCB_CCR_USERSETMPEND_Msk           (1UL << SCB_CCR_USERSETMPEND_Pos)              /*!< SCB CCR: USERSETMPEND Mask */
+
+/** \brief SCB System Handler Control and State Register Definitions */
+#define SCB_SHCSR_HARDFAULTPENDED_Pos      21U                                            /*!< SCB SHCSR: HARDFAULTPENDED Position */
+#define SCB_SHCSR_HARDFAULTPENDED_Msk      (1UL << SCB_SHCSR_HARDFAULTPENDED_Pos)         /*!< SCB SHCSR: HARDFAULTPENDED Mask */
+
+#define SCB_SHCSR_SECUREFAULTPENDED_Pos    20U                                            /*!< SCB SHCSR: SECUREFAULTPENDED Position */
+#define SCB_SHCSR_SECUREFAULTPENDED_Msk    (1UL << SCB_SHCSR_SECUREFAULTPENDED_Pos)       /*!< SCB SHCSR: SECUREFAULTPENDED Mask */
+
+#define SCB_SHCSR_SECUREFAULTENA_Pos       19U                                            /*!< SCB SHCSR: SECUREFAULTENA Position */
+#define SCB_SHCSR_SECUREFAULTENA_Msk       (1UL << SCB_SHCSR_SECUREFAULTENA_Pos)          /*!< SCB SHCSR: SECUREFAULTENA Mask */
+
+#define SCB_SHCSR_USGFAULTENA_Pos          18U                                            /*!< SCB SHCSR: USGFAULTENA Position */
+#define SCB_SHCSR_USGFAULTENA_Msk          (1UL << SCB_SHCSR_USGFAULTENA_Pos)             /*!< SCB SHCSR: USGFAULTENA Mask */
+
+#define SCB_SHCSR_BUSFAULTENA_Pos          17U                                            /*!< SCB SHCSR: BUSFAULTENA Position */
+#define SCB_SHCSR_BUSFAULTENA_Msk          (1UL << SCB_SHCSR_BUSFAULTENA_Pos)             /*!< SCB SHCSR: BUSFAULTENA Mask */
+
+#define SCB_SHCSR_MEMFAULTENA_Pos          16U                                            /*!< SCB SHCSR: MEMFAULTENA Position */
+#define SCB_SHCSR_MEMFAULTENA_Msk          (1UL << SCB_SHCSR_MEMFAULTENA_Pos)             /*!< SCB SHCSR: MEMFAULTENA Mask */
+
+#define SCB_SHCSR_SVCALLPENDED_Pos         15U                                            /*!< SCB SHCSR: SVCALLPENDED Position */
+#define SCB_SHCSR_SVCALLPENDED_Msk         (1UL << SCB_SHCSR_SVCALLPENDED_Pos)            /*!< SCB SHCSR: SVCALLPENDED Mask */
+
+#define SCB_SHCSR_BUSFAULTPENDED_Pos       14U                                            /*!< SCB SHCSR: BUSFAULTPENDED Position */
+#define SCB_SHCSR_BUSFAULTPENDED_Msk       (1UL << SCB_SHCSR_BUSFAULTPENDED_Pos)          /*!< SCB SHCSR: BUSFAULTPENDED Mask */
+
+#define SCB_SHCSR_MEMFAULTPENDED_Pos       13U                                            /*!< SCB SHCSR: MEMFAULTPENDED Position */
+#define SCB_SHCSR_MEMFAULTPENDED_Msk       (1UL << SCB_SHCSR_MEMFAULTPENDED_Pos)          /*!< SCB SHCSR: MEMFAULTPENDED Mask */
+
+#define SCB_SHCSR_USGFAULTPENDED_Pos       12U                                            /*!< SCB SHCSR: USGFAULTPENDED Position */
+#define SCB_SHCSR_USGFAULTPENDED_Msk       (1UL << SCB_SHCSR_USGFAULTPENDED_Pos)          /*!< SCB SHCSR: USGFAULTPENDED Mask */
+
+#define SCB_SHCSR_SYSTICKACT_Pos           11U                                            /*!< SCB SHCSR: SYSTICKACT Position */
+#define SCB_SHCSR_SYSTICKACT_Msk           (1UL << SCB_SHCSR_SYSTICKACT_Pos)              /*!< SCB SHCSR: SYSTICKACT Mask */
+
+#define SCB_SHCSR_PENDSVACT_Pos            10U                                            /*!< SCB SHCSR: PENDSVACT Position */
+#define SCB_SHCSR_PENDSVACT_Msk            (1UL << SCB_SHCSR_PENDSVACT_Pos)               /*!< SCB SHCSR: PENDSVACT Mask */
+
+#define SCB_SHCSR_MONITORACT_Pos            8U                                            /*!< SCB SHCSR: MONITORACT Position */
+#define SCB_SHCSR_MONITORACT_Msk           (1UL << SCB_SHCSR_MONITORACT_Pos)              /*!< SCB SHCSR: MONITORACT Mask */
+
+#define SCB_SHCSR_SVCALLACT_Pos             7U                                            /*!< SCB SHCSR: SVCALLACT Position */
+#define SCB_SHCSR_SVCALLACT_Msk            (1UL << SCB_SHCSR_SVCALLACT_Pos)               /*!< SCB SHCSR: SVCALLACT Mask */
+
+#define SCB_SHCSR_NMIACT_Pos                5U                                            /*!< SCB SHCSR: NMIACT Position */
+#define SCB_SHCSR_NMIACT_Msk               (1UL << SCB_SHCSR_NMIACT_Pos)                  /*!< SCB SHCSR: NMIACT Mask */
+
+#define SCB_SHCSR_SECUREFAULTACT_Pos        4U                                            /*!< SCB SHCSR: SECUREFAULTACT Position */
+#define SCB_SHCSR_SECUREFAULTACT_Msk       (1UL << SCB_SHCSR_SECUREFAULTACT_Pos)          /*!< SCB SHCSR: SECUREFAULTACT Mask */
+
+#define SCB_SHCSR_USGFAULTACT_Pos           3U                                            /*!< SCB SHCSR: USGFAULTACT Position */
+#define SCB_SHCSR_USGFAULTACT_Msk          (1UL << SCB_SHCSR_USGFAULTACT_Pos)             /*!< SCB SHCSR: USGFAULTACT Mask */
+
+#define SCB_SHCSR_HARDFAULTACT_Pos          2U                                            /*!< SCB SHCSR: HARDFAULTACT Position */
+#define SCB_SHCSR_HARDFAULTACT_Msk         (1UL << SCB_SHCSR_HARDFAULTACT_Pos)            /*!< SCB SHCSR: HARDFAULTACT Mask */
+
+#define SCB_SHCSR_BUSFAULTACT_Pos           1U                                            /*!< SCB SHCSR: BUSFAULTACT Position */
+#define SCB_SHCSR_BUSFAULTACT_Msk          (1UL << SCB_SHCSR_BUSFAULTACT_Pos)             /*!< SCB SHCSR: BUSFAULTACT Mask */
+
+#define SCB_SHCSR_MEMFAULTACT_Pos           0U                                            /*!< SCB SHCSR: MEMFAULTACT Position */
+#define SCB_SHCSR_MEMFAULTACT_Msk          (1UL /*<< SCB_SHCSR_MEMFAULTACT_Pos*/)         /*!< SCB SHCSR: MEMFAULTACT Mask */
+
+/** \brief SCB Configurable Fault Status Register Definitions */
+#define SCB_CFSR_USGFAULTSR_Pos            16U                                            /*!< SCB CFSR: Usage Fault Status Register Position */
+#define SCB_CFSR_USGFAULTSR_Msk            (0xFFFFUL << SCB_CFSR_USGFAULTSR_Pos)          /*!< SCB CFSR: Usage Fault Status Register Mask */
+
+#define SCB_CFSR_BUSFAULTSR_Pos             8U                                            /*!< SCB CFSR: Bus Fault Status Register Position */
+#define SCB_CFSR_BUSFAULTSR_Msk            (0xFFUL << SCB_CFSR_BUSFAULTSR_Pos)            /*!< SCB CFSR: Bus Fault Status Register Mask */
+
+#define SCB_CFSR_MEMFAULTSR_Pos             0U                                            /*!< SCB CFSR: Memory Manage Fault Status Register Position */
+#define SCB_CFSR_MEMFAULTSR_Msk            (0xFFUL /*<< SCB_CFSR_MEMFAULTSR_Pos*/)        /*!< SCB CFSR: Memory Manage Fault Status Register Mask */
+
+/** \brief SCB MemManage Fault Status Register Definitions (part of SCB Configurable Fault Status Register) */
+#define SCB_CFSR_MMARVALID_Pos             (SCB_CFSR_MEMFAULTSR_Pos + 7U)                 /*!< SCB CFSR (MMFSR): MMARVALID Position */
+#define SCB_CFSR_MMARVALID_Msk             (1UL << SCB_CFSR_MMARVALID_Pos)                /*!< SCB CFSR (MMFSR): MMARVALID Mask */
+
+#define SCB_CFSR_MLSPERR_Pos               (SCB_CFSR_MEMFAULTSR_Pos + 5U)                 /*!< SCB CFSR (MMFSR): MLSPERR Position */
+#define SCB_CFSR_MLSPERR_Msk               (1UL << SCB_CFSR_MLSPERR_Pos)                  /*!< SCB CFSR (MMFSR): MLSPERR Mask */
+
+#define SCB_CFSR_MSTKERR_Pos               (SCB_CFSR_MEMFAULTSR_Pos + 4U)                 /*!< SCB CFSR (MMFSR): MSTKERR Position */
+#define SCB_CFSR_MSTKERR_Msk               (1UL << SCB_CFSR_MSTKERR_Pos)                  /*!< SCB CFSR (MMFSR): MSTKERR Mask */
+
+#define SCB_CFSR_MUNSTKERR_Pos             (SCB_CFSR_MEMFAULTSR_Pos + 3U)                 /*!< SCB CFSR (MMFSR): MUNSTKERR Position */
+#define SCB_CFSR_MUNSTKERR_Msk             (1UL << SCB_CFSR_MUNSTKERR_Pos)                /*!< SCB CFSR (MMFSR): MUNSTKERR Mask */
+
+#define SCB_CFSR_DACCVIOL_Pos              (SCB_CFSR_MEMFAULTSR_Pos + 1U)                 /*!< SCB CFSR (MMFSR): DACCVIOL Position */
+#define SCB_CFSR_DACCVIOL_Msk              (1UL << SCB_CFSR_DACCVIOL_Pos)                 /*!< SCB CFSR (MMFSR): DACCVIOL Mask */
+
+#define SCB_CFSR_IACCVIOL_Pos              (SCB_CFSR_MEMFAULTSR_Pos + 0U)                 /*!< SCB CFSR (MMFSR): IACCVIOL Position */
+#define SCB_CFSR_IACCVIOL_Msk              (1UL /*<< SCB_CFSR_IACCVIOL_Pos*/)             /*!< SCB CFSR (MMFSR): IACCVIOL Mask */
+
+/** \brief SCB BusFault Status Register Definitions (part of SCB Configurable Fault Status Register) */
+#define SCB_CFSR_BFARVALID_Pos            (SCB_CFSR_BUSFAULTSR_Pos + 7U)                  /*!< SCB CFSR (BFSR): BFARVALID Position */
+#define SCB_CFSR_BFARVALID_Msk            (1UL << SCB_CFSR_BFARVALID_Pos)                 /*!< SCB CFSR (BFSR): BFARVALID Mask */
+
+#define SCB_CFSR_LSPERR_Pos               (SCB_CFSR_BUSFAULTSR_Pos + 5U)                  /*!< SCB CFSR (BFSR): LSPERR Position */
+#define SCB_CFSR_LSPERR_Msk               (1UL << SCB_CFSR_LSPERR_Pos)                    /*!< SCB CFSR (BFSR): LSPERR Mask */
+
+#define SCB_CFSR_STKERR_Pos               (SCB_CFSR_BUSFAULTSR_Pos + 4U)                  /*!< SCB CFSR (BFSR): STKERR Position */
+#define SCB_CFSR_STKERR_Msk               (1UL << SCB_CFSR_STKERR_Pos)                    /*!< SCB CFSR (BFSR): STKERR Mask */
+
+#define SCB_CFSR_UNSTKERR_Pos             (SCB_CFSR_BUSFAULTSR_Pos + 3U)                  /*!< SCB CFSR (BFSR): UNSTKERR Position */
+#define SCB_CFSR_UNSTKERR_Msk             (1UL << SCB_CFSR_UNSTKERR_Pos)                  /*!< SCB CFSR (BFSR): UNSTKERR Mask */
+
+#define SCB_CFSR_IMPRECISERR_Pos          (SCB_CFSR_BUSFAULTSR_Pos + 2U)                  /*!< SCB CFSR (BFSR): IMPRECISERR Position */
+#define SCB_CFSR_IMPRECISERR_Msk          (1UL << SCB_CFSR_IMPRECISERR_Pos)               /*!< SCB CFSR (BFSR): IMPRECISERR Mask */
+
+#define SCB_CFSR_PRECISERR_Pos            (SCB_CFSR_BUSFAULTSR_Pos + 1U)                  /*!< SCB CFSR (BFSR): PRECISERR Position */
+#define SCB_CFSR_PRECISERR_Msk            (1UL << SCB_CFSR_PRECISERR_Pos)                 /*!< SCB CFSR (BFSR): PRECISERR Mask */
+
+#define SCB_CFSR_IBUSERR_Pos              (SCB_CFSR_BUSFAULTSR_Pos + 0U)                  /*!< SCB CFSR (BFSR): IBUSERR Position */
+#define SCB_CFSR_IBUSERR_Msk              (1UL << SCB_CFSR_IBUSERR_Pos)                   /*!< SCB CFSR (BFSR): IBUSERR Mask */
+
+/** \brief SCB UsageFault Status Register Definitions (part of SCB Configurable Fault Status Register) */
+#define SCB_CFSR_DIVBYZERO_Pos            (SCB_CFSR_USGFAULTSR_Pos + 9U)                  /*!< SCB CFSR (UFSR): DIVBYZERO Position */
+#define SCB_CFSR_DIVBYZERO_Msk            (1UL << SCB_CFSR_DIVBYZERO_Pos)                 /*!< SCB CFSR (UFSR): DIVBYZERO Mask */
+
+#define SCB_CFSR_UNALIGNED_Pos            (SCB_CFSR_USGFAULTSR_Pos + 8U)                  /*!< SCB CFSR (UFSR): UNALIGNED Position */
+#define SCB_CFSR_UNALIGNED_Msk            (1UL << SCB_CFSR_UNALIGNED_Pos)                 /*!< SCB CFSR (UFSR): UNALIGNED Mask */
+
+#define SCB_CFSR_STKOF_Pos                (SCB_CFSR_USGFAULTSR_Pos + 4U)                  /*!< SCB CFSR (UFSR): STKOF Position */
+#define SCB_CFSR_STKOF_Msk                (1UL << SCB_CFSR_STKOF_Pos)                     /*!< SCB CFSR (UFSR): STKOF Mask */
+
+#define SCB_CFSR_NOCP_Pos                 (SCB_CFSR_USGFAULTSR_Pos + 3U)                  /*!< SCB CFSR (UFSR): NOCP Position */
+#define SCB_CFSR_NOCP_Msk                 (1UL << SCB_CFSR_NOCP_Pos)                      /*!< SCB CFSR (UFSR): NOCP Mask */
+
+#define SCB_CFSR_INVPC_Pos                (SCB_CFSR_USGFAULTSR_Pos + 2U)                  /*!< SCB CFSR (UFSR): INVPC Position */
+#define SCB_CFSR_INVPC_Msk                (1UL << SCB_CFSR_INVPC_Pos)                     /*!< SCB CFSR (UFSR): INVPC Mask */
+
+#define SCB_CFSR_INVSTATE_Pos             (SCB_CFSR_USGFAULTSR_Pos + 1U)                  /*!< SCB CFSR (UFSR): INVSTATE Position */
+#define SCB_CFSR_INVSTATE_Msk             (1UL << SCB_CFSR_INVSTATE_Pos)                  /*!< SCB CFSR (UFSR): INVSTATE Mask */
+
+#define SCB_CFSR_UNDEFINSTR_Pos           (SCB_CFSR_USGFAULTSR_Pos + 0U)                  /*!< SCB CFSR (UFSR): UNDEFINSTR Position */
+#define SCB_CFSR_UNDEFINSTR_Msk           (1UL << SCB_CFSR_UNDEFINSTR_Pos)                /*!< SCB CFSR (UFSR): UNDEFINSTR Mask */
+
+/** \brief SCB Hard Fault Status Register Definitions */
+#define SCB_HFSR_DEBUGEVT_Pos              31U                                            /*!< SCB HFSR: DEBUGEVT Position */
+#define SCB_HFSR_DEBUGEVT_Msk              (1UL << SCB_HFSR_DEBUGEVT_Pos)                 /*!< SCB HFSR: DEBUGEVT Mask */
+
+#define SCB_HFSR_FORCED_Pos                30U                                            /*!< SCB HFSR: FORCED Position */
+#define SCB_HFSR_FORCED_Msk                (1UL << SCB_HFSR_FORCED_Pos)                   /*!< SCB HFSR: FORCED Mask */
+
+#define SCB_HFSR_VECTTBL_Pos                1U                                            /*!< SCB HFSR: VECTTBL Position */
+#define SCB_HFSR_VECTTBL_Msk               (1UL << SCB_HFSR_VECTTBL_Pos)                  /*!< SCB HFSR: VECTTBL Mask */
+
+/** \brief SCB Debug Fault Status Register Definitions */
+#define SCB_DFSR_EXTERNAL_Pos               4U                                            /*!< SCB DFSR: EXTERNAL Position */
+#define SCB_DFSR_EXTERNAL_Msk              (1UL << SCB_DFSR_EXTERNAL_Pos)                 /*!< SCB DFSR: EXTERNAL Mask */
+
+#define SCB_DFSR_VCATCH_Pos                 3U                                            /*!< SCB DFSR: VCATCH Position */
+#define SCB_DFSR_VCATCH_Msk                (1UL << SCB_DFSR_VCATCH_Pos)                   /*!< SCB DFSR: VCATCH Mask */
+
+#define SCB_DFSR_DWTTRAP_Pos                2U                                            /*!< SCB DFSR: DWTTRAP Position */
+#define SCB_DFSR_DWTTRAP_Msk               (1UL << SCB_DFSR_DWTTRAP_Pos)                  /*!< SCB DFSR: DWTTRAP Mask */
+
+#define SCB_DFSR_BKPT_Pos                   1U                                            /*!< SCB DFSR: BKPT Position */
+#define SCB_DFSR_BKPT_Msk                  (1UL << SCB_DFSR_BKPT_Pos)                     /*!< SCB DFSR: BKPT Mask */
+
+#define SCB_DFSR_HALTED_Pos                 0U                                            /*!< SCB DFSR: HALTED Position */
+#define SCB_DFSR_HALTED_Msk                (1UL /*<< SCB_DFSR_HALTED_Pos*/)               /*!< SCB DFSR: HALTED Mask */
+
+/** \brief SCB Non-Secure Access Control Register Definitions */
+#define SCB_NSACR_CP11_Pos                 11U                                            /*!< SCB NSACR: CP11 Position */
+#define SCB_NSACR_CP11_Msk                 (1UL << SCB_NSACR_CP11_Pos)                    /*!< SCB NSACR: CP11 Mask */
+
+#define SCB_NSACR_CP10_Pos                 10U                                            /*!< SCB NSACR: CP10 Position */
+#define SCB_NSACR_CP10_Msk                 (1UL << SCB_NSACR_CP10_Pos)                    /*!< SCB NSACR: CP10 Mask */
+
+#define SCB_NSACR_CPn_Pos                   0U                                            /*!< SCB NSACR: CPn Position */
+#define SCB_NSACR_CPn_Msk                  (1UL /*<< SCB_NSACR_CPn_Pos*/)                 /*!< SCB NSACR: CPn Mask */
+
+/** \brief SCB Cache Level ID Register Definitions */
+#define SCB_CLIDR_LOUU_Pos                 27U                                            /*!< SCB CLIDR: LoUU Position */
+#define SCB_CLIDR_LOUU_Msk                 (7UL << SCB_CLIDR_LOUU_Pos)                    /*!< SCB CLIDR: LoUU Mask */
+
+#define SCB_CLIDR_LOC_Pos                  24U                                            /*!< SCB CLIDR: LoC Position */
+#define SCB_CLIDR_LOC_Msk                  (7UL << SCB_CLIDR_LOC_Pos)                     /*!< SCB CLIDR: LoC Mask */
+
+/** \brief SCB Cache Type Register Definitions */
+#define SCB_CTR_FORMAT_Pos                 29U                                            /*!< SCB CTR: Format Position */
+#define SCB_CTR_FORMAT_Msk                 (7UL << SCB_CTR_FORMAT_Pos)                    /*!< SCB CTR: Format Mask */
+
+#define SCB_CTR_CWG_Pos                    24U                                            /*!< SCB CTR: CWG Position */
+#define SCB_CTR_CWG_Msk                    (0xFUL << SCB_CTR_CWG_Pos)                     /*!< SCB CTR: CWG Mask */
+
+#define SCB_CTR_ERG_Pos                    20U                                            /*!< SCB CTR: ERG Position */
+#define SCB_CTR_ERG_Msk                    (0xFUL << SCB_CTR_ERG_Pos)                     /*!< SCB CTR: ERG Mask */
+
+#define SCB_CTR_DMINLINE_Pos               16U                                            /*!< SCB CTR: DminLine Position */
+#define SCB_CTR_DMINLINE_Msk               (0xFUL << SCB_CTR_DMINLINE_Pos)                /*!< SCB CTR: DminLine Mask */
+
+#define SCB_CTR_IMINLINE_Pos                0U                                            /*!< SCB CTR: ImInLine Position */
+#define SCB_CTR_IMINLINE_Msk               (0xFUL /*<< SCB_CTR_IMINLINE_Pos*/)            /*!< SCB CTR: ImInLine Mask */
+
+/** \brief SCB Cache Size ID Register Definitions */
+#define SCB_CCSIDR_WT_Pos                  31U                                            /*!< SCB CCSIDR: WT Position */
+#define SCB_CCSIDR_WT_Msk                  (1UL << SCB_CCSIDR_WT_Pos)                     /*!< SCB CCSIDR: WT Mask */
+
+#define SCB_CCSIDR_WB_Pos                  30U                                            /*!< SCB CCSIDR: WB Position */
+#define SCB_CCSIDR_WB_Msk                  (1UL << SCB_CCSIDR_WB_Pos)                     /*!< SCB CCSIDR: WB Mask */
+
+#define SCB_CCSIDR_RA_Pos                  29U                                            /*!< SCB CCSIDR: RA Position */
+#define SCB_CCSIDR_RA_Msk                  (1UL << SCB_CCSIDR_RA_Pos)                     /*!< SCB CCSIDR: RA Mask */
+
+#define SCB_CCSIDR_WA_Pos                  28U                                            /*!< SCB CCSIDR: WA Position */
+#define SCB_CCSIDR_WA_Msk                  (1UL << SCB_CCSIDR_WA_Pos)                     /*!< SCB CCSIDR: WA Mask */
+
+#define SCB_CCSIDR_NUMSETS_Pos             13U                                            /*!< SCB CCSIDR: NumSets Position */
+#define SCB_CCSIDR_NUMSETS_Msk             (0x7FFFUL << SCB_CCSIDR_NUMSETS_Pos)           /*!< SCB CCSIDR: NumSets Mask */
+
+#define SCB_CCSIDR_ASSOCIATIVITY_Pos        3U                                            /*!< SCB CCSIDR: Associativity Position */
+#define SCB_CCSIDR_ASSOCIATIVITY_Msk       (0x3FFUL << SCB_CCSIDR_ASSOCIATIVITY_Pos)      /*!< SCB CCSIDR: Associativity Mask */
+
+#define SCB_CCSIDR_LINESIZE_Pos             0U                                            /*!< SCB CCSIDR: LineSize Position */
+#define SCB_CCSIDR_LINESIZE_Msk            (7UL /*<< SCB_CCSIDR_LINESIZE_Pos*/)           /*!< SCB CCSIDR: LineSize Mask */
+
+/** \brief SCB Cache Size Selection Register Definitions */
+#define SCB_CSSELR_LEVEL_Pos                1U                                            /*!< SCB CSSELR: Level Position */
+#define SCB_CSSELR_LEVEL_Msk               (7UL << SCB_CSSELR_LEVEL_Pos)                  /*!< SCB CSSELR: Level Mask */
+
+#define SCB_CSSELR_IND_Pos                  0U                                            /*!< SCB CSSELR: InD Position */
+#define SCB_CSSELR_IND_Msk                 (1UL /*<< SCB_CSSELR_IND_Pos*/)                /*!< SCB CSSELR: InD Mask */
+
+/** \brief SCB Software Triggered Interrupt Register Definitions */
+#define SCB_STIR_INTID_Pos                  0U                                            /*!< SCB STIR: INTID Position */
+#define SCB_STIR_INTID_Msk                 (0x1FFUL /*<< SCB_STIR_INTID_Pos*/)            /*!< SCB STIR: INTID Mask */
+
+/** \brief SCB D-Cache Invalidate by Set-way Register Definitions */
+#define SCB_DCISW_WAY_Pos                  30U                                            /*!< SCB DCISW: Way Position */
+#define SCB_DCISW_WAY_Msk                  (3UL << SCB_DCISW_WAY_Pos)                     /*!< SCB DCISW: Way Mask */
+
+#define SCB_DCISW_SET_Pos                   5U                                            /*!< SCB DCISW: Set Position */
+#define SCB_DCISW_SET_Msk                  (0x1FFUL << SCB_DCISW_SET_Pos)                 /*!< SCB DCISW: Set Mask */
+
+/** \brief SCB D-Cache Clean by Set-way Register Definitions */
+#define SCB_DCCSW_WAY_Pos                  30U                                            /*!< SCB DCCSW: Way Position */
+#define SCB_DCCSW_WAY_Msk                  (3UL << SCB_DCCSW_WAY_Pos)                     /*!< SCB DCCSW: Way Mask */
+
+#define SCB_DCCSW_SET_Pos                   5U                                            /*!< SCB DCCSW: Set Position */
+#define SCB_DCCSW_SET_Msk                  (0x1FFUL << SCB_DCCSW_SET_Pos)                 /*!< SCB DCCSW: Set Mask */
+
+/** \brief SCB D-Cache Clean and Invalidate by Set-way Register Definitions */
+#define SCB_DCCISW_WAY_Pos                 30U                                            /*!< SCB DCCISW: Way Position */
+#define SCB_DCCISW_WAY_Msk                 (3UL << SCB_DCCISW_WAY_Pos)                    /*!< SCB DCCISW: Way Mask */
+
+#define SCB_DCCISW_SET_Pos                  5U                                            /*!< SCB DCCISW: Set Position */
+#define SCB_DCCISW_SET_Msk                 (0x1FFUL << SCB_DCCISW_SET_Pos)                /*!< SCB DCCISW: Set Mask */
+
+/*@} end of group CMSIS_SCB */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SCnSCB System Controls not in SCB (SCnSCB)
+  \brief    Type definitions for the System Control and ID Register not in the SCB
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Control and ID Register not in the SCB.
+ */
+typedef struct
+{
+        uint32_t RESERVED0[1U];
+  __IM  uint32_t ICTR;                   /*!< Offset: 0x004 (R/ )  Interrupt Controller Type Register */
+  __IOM uint32_t ACTLR;                  /*!< Offset: 0x008 (R/W)  Auxiliary Control Register */
+  __IOM uint32_t CPPWR;                  /*!< Offset: 0x00C (R/W)  Coprocessor Power Control  Register */
+} SCnSCB_Type;
+
+/** \brief SCnSCB Interrupt Controller Type Register Definitions */
+#define SCnSCB_ICTR_INTLINESNUM_Pos         0U                                         /*!< ICTR: INTLINESNUM Position */
+#define SCnSCB_ICTR_INTLINESNUM_Msk        (0xFUL /*<< SCnSCB_ICTR_INTLINESNUM_Pos*/)  /*!< ICTR: INTLINESNUM Mask */
+
+/*@} end of group CMSIS_SCnotSCB */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SysTick     System Tick Timer (SysTick)
+  \brief    Type definitions for the System Timer Registers.
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Timer (SysTick).
+ */
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  SysTick Control and Status Register */
+  __IOM uint32_t LOAD;                   /*!< Offset: 0x004 (R/W)  SysTick Reload Value Register */
+  __IOM uint32_t VAL;                    /*!< Offset: 0x008 (R/W)  SysTick Current Value Register */
+  __IM  uint32_t CALIB;                  /*!< Offset: 0x00C (R/ )  SysTick Calibration Register */
+} SysTick_Type;
+
+/** \brief SysTick Control / Status Register Definitions */
+#define SysTick_CTRL_COUNTFLAG_Pos         16U                                            /*!< SysTick CTRL: COUNTFLAG Position */
+#define SysTick_CTRL_COUNTFLAG_Msk         (1UL << SysTick_CTRL_COUNTFLAG_Pos)            /*!< SysTick CTRL: COUNTFLAG Mask */
+
+#define SysTick_CTRL_CLKSOURCE_Pos          2U                                            /*!< SysTick CTRL: CLKSOURCE Position */
+#define SysTick_CTRL_CLKSOURCE_Msk         (1UL << SysTick_CTRL_CLKSOURCE_Pos)            /*!< SysTick CTRL: CLKSOURCE Mask */
+
+#define SysTick_CTRL_TICKINT_Pos            1U                                            /*!< SysTick CTRL: TICKINT Position */
+#define SysTick_CTRL_TICKINT_Msk           (1UL << SysTick_CTRL_TICKINT_Pos)              /*!< SysTick CTRL: TICKINT Mask */
+
+#define SysTick_CTRL_ENABLE_Pos             0U                                            /*!< SysTick CTRL: ENABLE Position */
+#define SysTick_CTRL_ENABLE_Msk            (1UL /*<< SysTick_CTRL_ENABLE_Pos*/)           /*!< SysTick CTRL: ENABLE Mask */
+
+/** \brief SysTick Reload Register Definitions */
+#define SysTick_LOAD_RELOAD_Pos             0U                                            /*!< SysTick LOAD: RELOAD Position */
+#define SysTick_LOAD_RELOAD_Msk            (0xFFFFFFUL /*<< SysTick_LOAD_RELOAD_Pos*/)    /*!< SysTick LOAD: RELOAD Mask */
+
+/** \brief SysTick Current Register Definitions */
+#define SysTick_VAL_CURRENT_Pos             0U                                            /*!< SysTick VAL: CURRENT Position */
+#define SysTick_VAL_CURRENT_Msk            (0xFFFFFFUL /*<< SysTick_VAL_CURRENT_Pos*/)    /*!< SysTick VAL: CURRENT Mask */
+
+/** \brief SysTick Calibration Register Definitions */
+#define SysTick_CALIB_NOREF_Pos            31U                                            /*!< SysTick CALIB: NOREF Position */
+#define SysTick_CALIB_NOREF_Msk            (1UL << SysTick_CALIB_NOREF_Pos)               /*!< SysTick CALIB: NOREF Mask */
+
+#define SysTick_CALIB_SKEW_Pos             30U                                            /*!< SysTick CALIB: SKEW Position */
+#define SysTick_CALIB_SKEW_Msk             (1UL << SysTick_CALIB_SKEW_Pos)                /*!< SysTick CALIB: SKEW Mask */
+
+#define SysTick_CALIB_TENMS_Pos             0U                                            /*!< SysTick CALIB: TENMS Position */
+#define SysTick_CALIB_TENMS_Msk            (0xFFFFFFUL /*<< SysTick_CALIB_TENMS_Pos*/)    /*!< SysTick CALIB: TENMS Mask */
+
+/*@} end of group CMSIS_SysTick */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_ITM     Instrumentation Trace Macrocell (ITM)
+  \brief    Type definitions for the Instrumentation Trace Macrocell (ITM)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Instrumentation Trace Macrocell Register (ITM).
+ */
+typedef struct
+{
+  __OM  union
+  {
+    __OM  uint8_t    u8;                 /*!< Offset: 0x000 ( /W)  Stimulus Port 8-bit */
+    __OM  uint16_t   u16;                /*!< Offset: 0x000 ( /W)  Stimulus Port 16-bit */
+    __OM  uint32_t   u32;                /*!< Offset: 0x000 ( /W)  Stimulus Port 32-bit */
+  }  PORT [32U];                         /*!< Offset: 0x000 ( /W)  Stimulus Port Registers */
+        uint32_t RESERVED0[864U];
+  __IOM uint32_t TER;                    /*!< Offset: 0xE00 (R/W)  Trace Enable Register */
+        uint32_t RESERVED1[15U];
+  __IOM uint32_t TPR;                    /*!< Offset: 0xE40 (R/W)  Trace Privilege Register */
+        uint32_t RESERVED2[15U];
+  __IOM uint32_t TCR;                    /*!< Offset: 0xE80 (R/W)  Trace Control Register */
+        uint32_t RESERVED3[27U];
+  __IM  uint32_t ITREAD;                 /*!< Offset: 0xEF0 (R/ )  Integration Read Register */
+        uint32_t RESERVED4[1U];
+  __OM  uint32_t ITWRITE;                /*!< Offset: 0xEF8 ( /W)  Integration Write Register */
+        uint32_t RESERVED5[1U];
+  __IOM uint32_t ITCTRL;                 /*!< Offset: 0xF00 (R/W)  Integration Mode Control Register */
+        uint32_t RESERVED6[46U];
+  __IM  uint32_t DEVARCH;                /*!< Offset: 0xFBC (R/ )  Device Architecture Register */
+        uint32_t RESERVED7[3U];
+  __IM  uint32_t DEVTYPE;                /*!< Offset: 0xFCC (R/ )  Device Type Register */
+} ITM_Type;
+
+/** \brief ITM Stimulus Port Register Definitions */
+#define ITM_STIM_DISABLED_Pos               1U                                            /*!< ITM STIM: DISABLED Position */
+#define ITM_STIM_DISABLED_Msk              (1UL << ITM_STIM_DISABLED_Pos)                 /*!< ITM STIM: DISABLED Mask */
+
+#define ITM_STIM_FIFOREADY_Pos              0U                                            /*!< ITM STIM: FIFOREADY Position */
+#define ITM_STIM_FIFOREADY_Msk             (1UL /*<< ITM_STIM_FIFOREADY_Pos*/)            /*!< ITM STIM: FIFOREADY Mask */
+
+/** \brief ITM Trace Privilege Register Definitions */
+#define ITM_TPR_PRIVMASK_Pos                0U                                            /*!< ITM TPR: PRIVMASK Position */
+#define ITM_TPR_PRIVMASK_Msk               (0xFUL /*<< ITM_TPR_PRIVMASK_Pos*/)            /*!< ITM TPR: PRIVMASK Mask */
+
+/** \brief ITM Trace Control Register Definitions */
+#define ITM_TCR_BUSY_Pos                   23U                                            /*!< ITM TCR: BUSY Position */
+#define ITM_TCR_BUSY_Msk                   (1UL << ITM_TCR_BUSY_Pos)                      /*!< ITM TCR: BUSY Mask */
+
+#define ITM_TCR_TRACEBUSID_Pos             16U                                            /*!< ITM TCR: ATBID Position */
+#define ITM_TCR_TRACEBUSID_Msk             (0x7FUL << ITM_TCR_TRACEBUSID_Pos)             /*!< ITM TCR: ATBID Mask */
+
+#define ITM_TCR_GTSFREQ_Pos                10U                                            /*!< ITM TCR: Global timestamp frequency Position */
+#define ITM_TCR_GTSFREQ_Msk                (3UL << ITM_TCR_GTSFREQ_Pos)                   /*!< ITM TCR: Global timestamp frequency Mask */
+
+#define ITM_TCR_TSPRESCALE_Pos              8U                                            /*!< ITM TCR: TSPRESCALE Position */
+#define ITM_TCR_TSPRESCALE_Msk             (3UL << ITM_TCR_TSPRESCALE_Pos)                /*!< ITM TCR: TSPRESCALE Mask */
+
+#define ITM_TCR_STALLENA_Pos                5U                                            /*!< ITM TCR: STALLENA Position */
+#define ITM_TCR_STALLENA_Msk               (1UL << ITM_TCR_STALLENA_Pos)                  /*!< ITM TCR: STALLENA Mask */
+
+#define ITM_TCR_SWOENA_Pos                  4U                                            /*!< ITM TCR: SWOENA Position */
+#define ITM_TCR_SWOENA_Msk                 (1UL << ITM_TCR_SWOENA_Pos)                    /*!< ITM TCR: SWOENA Mask */
+
+#define ITM_TCR_DWTENA_Pos                  3U                                            /*!< ITM TCR: DWTENA Position */
+#define ITM_TCR_DWTENA_Msk                 (1UL << ITM_TCR_DWTENA_Pos)                    /*!< ITM TCR: DWTENA Mask */
+
+#define ITM_TCR_SYNCENA_Pos                 2U                                            /*!< ITM TCR: SYNCENA Position */
+#define ITM_TCR_SYNCENA_Msk                (1UL << ITM_TCR_SYNCENA_Pos)                   /*!< ITM TCR: SYNCENA Mask */
+
+#define ITM_TCR_TSENA_Pos                   1U                                            /*!< ITM TCR: TSENA Position */
+#define ITM_TCR_TSENA_Msk                  (1UL << ITM_TCR_TSENA_Pos)                     /*!< ITM TCR: TSENA Mask */
+
+#define ITM_TCR_ITMENA_Pos                  0U                                            /*!< ITM TCR: ITM Enable bit Position */
+#define ITM_TCR_ITMENA_Msk                 (1UL /*<< ITM_TCR_ITMENA_Pos*/)                /*!< ITM TCR: ITM Enable bit Mask */
+
+/** \brief ITM Integration Read Register Definitions */
+#define ITM_ITREAD_AFVALID_Pos              1U                                            /*!< ITM ITREAD: AFVALID Position */
+#define ITM_ITREAD_AFVALID_Msk             (1UL << ITM_ITREAD_AFVALID_Pos)                /*!< ITM ITREAD: AFVALID Mask */
+
+#define ITM_ITREAD_ATREADY_Pos              0U                                            /*!< ITM ITREAD: ATREADY Position */
+#define ITM_ITREAD_ATREADY_Msk             (1UL /*<< ITM_ITREAD_ATREADY_Pos*/)            /*!< ITM ITREAD: ATREADY Mask */
+
+/** \brief ITM Integration Write Register Definitions */
+#define ITM_ITWRITE_AFVALID_Pos             1U                                            /*!< ITM ITWRITE: AFVALID Position */
+#define ITM_ITWRITE_AFVALID_Msk            (1UL << ITM_ITWRITE_AFVALID_Pos)               /*!< ITM ITWRITE: AFVALID Mask */
+
+#define ITM_ITWRITE_ATREADY_Pos             0U                                            /*!< ITM ITWRITE: ATREADY Position */
+#define ITM_ITWRITE_ATREADY_Msk            (1UL /*<< ITM_ITWRITE_ATREADY_Pos*/)           /*!< ITM ITWRITE: ATREADY Mask */
+
+/** \brief ITM Integration Mode Control Register Definitions */
+#define ITM_ITCTRL_IME_Pos                  0U                                            /*!< ITM ITCTRL: IME Position */
+#define ITM_ITCTRL_IME_Msk                 (1UL /*<< ITM_ITCTRL_IME_Pos*/)                /*!< ITM ITCTRL: IME Mask */
+
+/*@}*/ /* end of group CMSIS_ITM */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_DWT     Data Watchpoint and Trace (DWT)
+  \brief    Type definitions for the Data Watchpoint and Trace (DWT)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Data Watchpoint and Trace Register (DWT).
+ */
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  Control Register */
+  __IOM uint32_t CYCCNT;                 /*!< Offset: 0x004 (R/W)  Cycle Count Register */
+  __IOM uint32_t CPICNT;                 /*!< Offset: 0x008 (R/W)  CPI Count Register */
+  __IOM uint32_t EXCCNT;                 /*!< Offset: 0x00C (R/W)  Exception Overhead Count Register */
+  __IOM uint32_t SLEEPCNT;               /*!< Offset: 0x010 (R/W)  Sleep Count Register */
+  __IOM uint32_t LSUCNT;                 /*!< Offset: 0x014 (R/W)  LSU Count Register */
+  __IOM uint32_t FOLDCNT;                /*!< Offset: 0x018 (R/W)  Folded-instruction Count Register */
+  __IM  uint32_t PCSR;                   /*!< Offset: 0x01C (R/ )  Program Counter Sample Register */
+  __IOM uint32_t COMP0;                  /*!< Offset: 0x020 (R/W)  Comparator Register 0 */
+        uint32_t RESERVED1[1U];
+  __IOM uint32_t FUNCTION0;              /*!< Offset: 0x028 (R/W)  Function Register 0 */
+        uint32_t RESERVED2[1U];
+  __IOM uint32_t COMP1;                  /*!< Offset: 0x030 (R/W)  Comparator Register 1 */
+        uint32_t RESERVED3[1U];
+  __IOM uint32_t FUNCTION1;              /*!< Offset: 0x038 (R/W)  Function Register 1 */
+        uint32_t RESERVED4[1U];
+  __IOM uint32_t COMP2;                  /*!< Offset: 0x040 (R/W)  Comparator Register 2 */
+        uint32_t RESERVED5[1U];
+  __IOM uint32_t FUNCTION2;              /*!< Offset: 0x048 (R/W)  Function Register 2 */
+        uint32_t RESERVED6[1U];
+  __IOM uint32_t COMP3;                  /*!< Offset: 0x050 (R/W)  Comparator Register 3 */
+        uint32_t RESERVED7[1U];
+  __IOM uint32_t FUNCTION3;              /*!< Offset: 0x058 (R/W)  Function Register 3 */
+        uint32_t RESERVED14[984U];
+  __IM  uint32_t DEVARCH;                /*!< Offset: 0xFBC (R/ )  Device Type Architecture Register */
+        uint32_t RESERVED15[3U];
+  __IM  uint32_t DEVTYPE;                /*!< Offset: 0xFCC (R/ )  Device Type Identifier Register */
+} DWT_Type;
+
+/** \brief DWT Control Register Definitions */
+#define DWT_CTRL_NUMCOMP_Pos               28U                                         /*!< DWT CTRL: NUMCOMP Position */
+#define DWT_CTRL_NUMCOMP_Msk               (0xFUL << DWT_CTRL_NUMCOMP_Pos)             /*!< DWT CTRL: NUMCOMP Mask */
+
+#define DWT_CTRL_NOTRCPKT_Pos              27U                                         /*!< DWT CTRL: NOTRCPKT Position */
+#define DWT_CTRL_NOTRCPKT_Msk              (1UL << DWT_CTRL_NOTRCPKT_Pos)              /*!< DWT CTRL: NOTRCPKT Mask */
+
+#define DWT_CTRL_NOEXTTRIG_Pos             26U                                         /*!< DWT CTRL: NOEXTTRIG Position */
+#define DWT_CTRL_NOEXTTRIG_Msk             (1UL << DWT_CTRL_NOEXTTRIG_Pos)             /*!< DWT CTRL: NOEXTTRIG Mask */
+
+#define DWT_CTRL_NOCYCCNT_Pos              25U                                         /*!< DWT CTRL: NOCYCCNT Position */
+#define DWT_CTRL_NOCYCCNT_Msk              (1UL << DWT_CTRL_NOCYCCNT_Pos)              /*!< DWT CTRL: NOCYCCNT Mask */
+
+#define DWT_CTRL_NOPRFCNT_Pos              24U                                         /*!< DWT CTRL: NOPRFCNT Position */
+#define DWT_CTRL_NOPRFCNT_Msk              (1UL << DWT_CTRL_NOPRFCNT_Pos)              /*!< DWT CTRL: NOPRFCNT Mask */
+
+#define DWT_CTRL_CYCDISS_Pos               23U                                         /*!< DWT CTRL: CYCDISS Position */
+#define DWT_CTRL_CYCDISS_Msk               (1UL << DWT_CTRL_CYCDISS_Pos)               /*!< DWT CTRL: CYCDISS Mask */
+
+#define DWT_CTRL_CYCEVTENA_Pos             22U                                         /*!< DWT CTRL: CYCEVTENA Position */
+#define DWT_CTRL_CYCEVTENA_Msk             (1UL << DWT_CTRL_CYCEVTENA_Pos)             /*!< DWT CTRL: CYCEVTENA Mask */
+
+#define DWT_CTRL_FOLDEVTENA_Pos            21U                                         /*!< DWT CTRL: FOLDEVTENA Position */
+#define DWT_CTRL_FOLDEVTENA_Msk            (1UL << DWT_CTRL_FOLDEVTENA_Pos)            /*!< DWT CTRL: FOLDEVTENA Mask */
+
+#define DWT_CTRL_LSUEVTENA_Pos             20U                                         /*!< DWT CTRL: LSUEVTENA Position */
+#define DWT_CTRL_LSUEVTENA_Msk             (1UL << DWT_CTRL_LSUEVTENA_Pos)             /*!< DWT CTRL: LSUEVTENA Mask */
+
+#define DWT_CTRL_SLEEPEVTENA_Pos           19U                                         /*!< DWT CTRL: SLEEPEVTENA Position */
+#define DWT_CTRL_SLEEPEVTENA_Msk           (1UL << DWT_CTRL_SLEEPEVTENA_Pos)           /*!< DWT CTRL: SLEEPEVTENA Mask */
+
+#define DWT_CTRL_EXCEVTENA_Pos             18U                                         /*!< DWT CTRL: EXCEVTENA Position */
+#define DWT_CTRL_EXCEVTENA_Msk             (1UL << DWT_CTRL_EXCEVTENA_Pos)             /*!< DWT CTRL: EXCEVTENA Mask */
+
+#define DWT_CTRL_CPIEVTENA_Pos             17U                                         /*!< DWT CTRL: CPIEVTENA Position */
+#define DWT_CTRL_CPIEVTENA_Msk             (1UL << DWT_CTRL_CPIEVTENA_Pos)             /*!< DWT CTRL: CPIEVTENA Mask */
+
+#define DWT_CTRL_EXCTRCENA_Pos             16U                                         /*!< DWT CTRL: EXCTRCENA Position */
+#define DWT_CTRL_EXCTRCENA_Msk             (1UL << DWT_CTRL_EXCTRCENA_Pos)             /*!< DWT CTRL: EXCTRCENA Mask */
+
+#define DWT_CTRL_PCSAMPLENA_Pos            12U                                         /*!< DWT CTRL: PCSAMPLENA Position */
+#define DWT_CTRL_PCSAMPLENA_Msk            (1UL << DWT_CTRL_PCSAMPLENA_Pos)            /*!< DWT CTRL: PCSAMPLENA Mask */
+
+#define DWT_CTRL_SYNCTAP_Pos               10U                                         /*!< DWT CTRL: SYNCTAP Position */
+#define DWT_CTRL_SYNCTAP_Msk               (0x3UL << DWT_CTRL_SYNCTAP_Pos)             /*!< DWT CTRL: SYNCTAP Mask */
+
+#define DWT_CTRL_CYCTAP_Pos                 9U                                         /*!< DWT CTRL: CYCTAP Position */
+#define DWT_CTRL_CYCTAP_Msk                (1UL << DWT_CTRL_CYCTAP_Pos)                /*!< DWT CTRL: CYCTAP Mask */
+
+#define DWT_CTRL_POSTINIT_Pos               5U                                         /*!< DWT CTRL: POSTINIT Position */
+#define DWT_CTRL_POSTINIT_Msk              (0xFUL << DWT_CTRL_POSTINIT_Pos)            /*!< DWT CTRL: POSTINIT Mask */
+
+#define DWT_CTRL_POSTPRESET_Pos             1U                                         /*!< DWT CTRL: POSTPRESET Position */
+#define DWT_CTRL_POSTPRESET_Msk            (0xFUL << DWT_CTRL_POSTPRESET_Pos)          /*!< DWT CTRL: POSTPRESET Mask */
+
+#define DWT_CTRL_CYCCNTENA_Pos              0U                                         /*!< DWT CTRL: CYCCNTENA Position */
+#define DWT_CTRL_CYCCNTENA_Msk             (1UL /*<< DWT_CTRL_CYCCNTENA_Pos*/)         /*!< DWT CTRL: CYCCNTENA Mask */
+
+/** \brief DWT CPI Count Register Definitions */
+#define DWT_CPICNT_CPICNT_Pos               0U                                         /*!< DWT CPICNT: CPICNT Position */
+#define DWT_CPICNT_CPICNT_Msk              (0xFFUL /*<< DWT_CPICNT_CPICNT_Pos*/)       /*!< DWT CPICNT: CPICNT Mask */
+
+/** \brief DWT Exception Overhead Count Register Definitions */
+#define DWT_EXCCNT_EXCCNT_Pos               0U                                         /*!< DWT EXCCNT: EXCCNT Position */
+#define DWT_EXCCNT_EXCCNT_Msk              (0xFFUL /*<< DWT_EXCCNT_EXCCNT_Pos*/)       /*!< DWT EXCCNT: EXCCNT Mask */
+
+/** \brief DWT Sleep Count Register Definitions */
+#define DWT_SLEEPCNT_SLEEPCNT_Pos           0U                                         /*!< DWT SLEEPCNT: SLEEPCNT Position */
+#define DWT_SLEEPCNT_SLEEPCNT_Msk          (0xFFUL /*<< DWT_SLEEPCNT_SLEEPCNT_Pos*/)   /*!< DWT SLEEPCNT: SLEEPCNT Mask */
+
+/** \brief DWT LSU Count Register Definitions */
+#define DWT_LSUCNT_LSUCNT_Pos               0U                                         /*!< DWT LSUCNT: LSUCNT Position */
+#define DWT_LSUCNT_LSUCNT_Msk              (0xFFUL /*<< DWT_LSUCNT_LSUCNT_Pos*/)       /*!< DWT LSUCNT: LSUCNT Mask */
+
+/** \brief DWT Folded-instruction Count Register Definitions */
+#define DWT_FOLDCNT_FOLDCNT_Pos             0U                                         /*!< DWT FOLDCNT: FOLDCNT Position */
+#define DWT_FOLDCNT_FOLDCNT_Msk            (0xFFUL /*<< DWT_FOLDCNT_FOLDCNT_Pos*/)     /*!< DWT FOLDCNT: FOLDCNT Mask */
+
+/** \brief DWT Comparator Function Register Definitions */
+#define DWT_FUNCTION_ID_Pos                27U                                         /*!< DWT FUNCTION: ID Position */
+#define DWT_FUNCTION_ID_Msk                (0x1FUL << DWT_FUNCTION_ID_Pos)             /*!< DWT FUNCTION: ID Mask */
+
+#define DWT_FUNCTION_MATCHED_Pos           24U                                         /*!< DWT FUNCTION: MATCHED Position */
+#define DWT_FUNCTION_MATCHED_Msk           (1UL << DWT_FUNCTION_MATCHED_Pos)           /*!< DWT FUNCTION: MATCHED Mask */
+
+#define DWT_FUNCTION_DATAVSIZE_Pos         10U                                         /*!< DWT FUNCTION: DATAVSIZE Position */
+#define DWT_FUNCTION_DATAVSIZE_Msk         (0x3UL << DWT_FUNCTION_DATAVSIZE_Pos)       /*!< DWT FUNCTION: DATAVSIZE Mask */
+
+#define DWT_FUNCTION_ACTION_Pos             4U                                         /*!< DWT FUNCTION: ACTION Position */
+#define DWT_FUNCTION_ACTION_Msk            (0x3UL << DWT_FUNCTION_ACTION_Pos)          /*!< DWT FUNCTION: ACTION Mask */
+
+#define DWT_FUNCTION_MATCH_Pos              0U                                         /*!< DWT FUNCTION: MATCH Position */
+#define DWT_FUNCTION_MATCH_Msk             (0xFUL /*<< DWT_FUNCTION_MATCH_Pos*/)       /*!< DWT FUNCTION: MATCH Mask */
+
+/*@}*/ /* end of group CMSIS_DWT */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_TPIU     Trace Port Interface Unit (TPIU)
+  \brief    Type definitions for the Trace Port Interface Unit (TPIU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Trace Port Interface Unit Register (TPIU).
+ */
+typedef struct
+{
+  __IM  uint32_t SSPSR;                  /*!< Offset: 0x000 (R/ )  Supported Parallel Port Size Register */
+  __IOM uint32_t CSPSR;                  /*!< Offset: 0x004 (R/W)  Current Parallel Port Size Register */
+        uint32_t RESERVED0[2U];
+  __IOM uint32_t ACPR;                   /*!< Offset: 0x010 (R/W)  Asynchronous Clock Prescaler Register */
+        uint32_t RESERVED1[55U];
+  __IOM uint32_t SPPR;                   /*!< Offset: 0x0F0 (R/W)  Selected Pin Protocol Register */
+        uint32_t RESERVED2[131U];
+  __IM  uint32_t FFSR;                   /*!< Offset: 0x300 (R/ )  Formatter and Flush Status Register */
+  __IOM uint32_t FFCR;                   /*!< Offset: 0x304 (R/W)  Formatter and Flush Control Register */
+  __IOM uint32_t PSCR;                   /*!< Offset: 0x308 (R/W)  Periodic Synchronization Control Register */
+        uint32_t RESERVED3[759U];
+  __IM  uint32_t TRIGGER;                /*!< Offset: 0xEE8 (R/ )  TRIGGER Register */
+  __IM  uint32_t ITFTTD0;                /*!< Offset: 0xEEC (R/ )  Integration Test FIFO Test Data 0 Register */
+  __IOM uint32_t ITATBCTR2;              /*!< Offset: 0xEF0 (R/W)  Integration Test ATB Control Register 2 */
+        uint32_t RESERVED4[1U];
+  __IM  uint32_t ITATBCTR0;              /*!< Offset: 0xEF8 (R/ )  Integration Test ATB Control Register 0 */
+  __IM  uint32_t ITFTTD1;                /*!< Offset: 0xEFC (R/ )  Integration Test FIFO Test Data 1 Register */
+  __IOM uint32_t ITCTRL;                 /*!< Offset: 0xF00 (R/W)  Integration Mode Control */
+        uint32_t RESERVED5[39U];
+  __IOM uint32_t CLAIMSET;               /*!< Offset: 0xFA0 (R/W)  Claim tag set */
+  __IOM uint32_t CLAIMCLR;               /*!< Offset: 0xFA4 (R/W)  Claim tag clear */
+        uint32_t RESERVED7[8U];
+  __IM  uint32_t DEVID;                  /*!< Offset: 0xFC8 (R/ )  Device Configuration Register */
+  __IM  uint32_t DEVTYPE;                /*!< Offset: 0xFCC (R/ )  Device Type Identifier Register */
+} TPIU_Type;
+
+/** \brief TPIU Asynchronous Clock Prescaler Register Definitions */
+#define TPIU_ACPR_PRESCALER_Pos             0U                                         /*!< TPIU ACPR: PRESCALER Position */
+#define TPIU_ACPR_PRESCALER_Msk            (0x1FFFUL /*<< TPIU_ACPR_PRESCALER_Pos*/)   /*!< TPIU ACPR: PRESCALER Mask */
+
+/** \brief TPIU Selected Pin Protocol Register Definitions */
+#define TPIU_SPPR_TXMODE_Pos                0U                                         /*!< TPIU SPPR: TXMODE Position */
+#define TPIU_SPPR_TXMODE_Msk               (0x3UL /*<< TPIU_SPPR_TXMODE_Pos*/)         /*!< TPIU SPPR: TXMODE Mask */
+
+/** \brief TPIU Formatter and Flush Status Register Definitions */
+#define TPIU_FFSR_FtNonStop_Pos             3U                                         /*!< TPIU FFSR: FtNonStop Position */
+#define TPIU_FFSR_FtNonStop_Msk            (1UL << TPIU_FFSR_FtNonStop_Pos)            /*!< TPIU FFSR: FtNonStop Mask */
+
+#define TPIU_FFSR_TCPresent_Pos             2U                                         /*!< TPIU FFSR: TCPresent Position */
+#define TPIU_FFSR_TCPresent_Msk            (1UL << TPIU_FFSR_TCPresent_Pos)            /*!< TPIU FFSR: TCPresent Mask */
+
+#define TPIU_FFSR_FtStopped_Pos             1U                                         /*!< TPIU FFSR: FtStopped Position */
+#define TPIU_FFSR_FtStopped_Msk            (1UL << TPIU_FFSR_FtStopped_Pos)            /*!< TPIU FFSR: FtStopped Mask */
+
+#define TPIU_FFSR_FlInProg_Pos              0U                                         /*!< TPIU FFSR: FlInProg Position */
+#define TPIU_FFSR_FlInProg_Msk             (1UL /*<< TPIU_FFSR_FlInProg_Pos*/)         /*!< TPIU FFSR: FlInProg Mask */
+
+/** \brief TPIU Formatter and Flush Control Register Definitions */
+#define TPIU_FFCR_TrigIn_Pos                8U                                         /*!< TPIU FFCR: TrigIn Position */
+#define TPIU_FFCR_TrigIn_Msk               (1UL << TPIU_FFCR_TrigIn_Pos)               /*!< TPIU FFCR: TrigIn Mask */
+
+#define TPIU_FFCR_FOnMan_Pos                6U                                         /*!< TPIU FFCR: FOnMan Position */
+#define TPIU_FFCR_FOnMan_Msk               (1UL << TPIU_FFCR_FOnMan_Pos)               /*!< TPIU FFCR: FOnMan Mask */
+
+#define TPIU_FFCR_EnFCont_Pos               1U                                         /*!< TPIU FFCR: EnFCont Position */
+#define TPIU_FFCR_EnFCont_Msk              (1UL << TPIU_FFCR_EnFCont_Pos)              /*!< TPIU FFCR: EnFCont Mask */
+
+/** \brief TPIU Periodic Synchronization Control Register Definitions */
+#define TPIU_PSCR_PSCount_Pos               0U                                         /*!< TPIU PSCR: PSCount Position */
+#define TPIU_PSCR_PSCount_Msk              (0x1FUL /*<< TPIU_PSCR_PSCount_Pos*/)       /*!< TPIU PSCR: TPSCount Mask */
+
+/** \brief TPIU TRIGGER Register Definitions */
+#define TPIU_TRIGGER_TRIGGER_Pos            0U                                         /*!< TPIU TRIGGER: TRIGGER Position */
+#define TPIU_TRIGGER_TRIGGER_Msk           (1UL /*<< TPIU_TRIGGER_TRIGGER_Pos*/)       /*!< TPIU TRIGGER: TRIGGER Mask */
+
+/** \brief TPIU Integration Test FIFO Test Data 0 Register Definitions */
+#define TPIU_ITFTTD0_ATB_IF2_ATVALID_Pos   29U                                         /*!< TPIU ITFTTD0: ATB Interface 2 ATVALIDPosition */
+#define TPIU_ITFTTD0_ATB_IF2_ATVALID_Msk   (0x3UL << TPIU_ITFTTD0_ATB_IF2_ATVALID_Pos) /*!< TPIU ITFTTD0: ATB Interface 2 ATVALID Mask */
+
+#define TPIU_ITFTTD0_ATB_IF2_bytecount_Pos 27U                                         /*!< TPIU ITFTTD0: ATB Interface 2 byte count Position */
+#define TPIU_ITFTTD0_ATB_IF2_bytecount_Msk (0x3UL << TPIU_ITFTTD0_ATB_IF2_bytecount_Pos) /*!< TPIU ITFTTD0: ATB Interface 2 byte count Mask */
+
+#define TPIU_ITFTTD0_ATB_IF1_ATVALID_Pos   26U                                         /*!< TPIU ITFTTD0: ATB Interface 1 ATVALID Position */
+#define TPIU_ITFTTD0_ATB_IF1_ATVALID_Msk   (0x3UL << TPIU_ITFTTD0_ATB_IF1_ATVALID_Pos) /*!< TPIU ITFTTD0: ATB Interface 1 ATVALID Mask */
+
+#define TPIU_ITFTTD0_ATB_IF1_bytecount_Pos 24U                                         /*!< TPIU ITFTTD0: ATB Interface 1 byte count Position */
+#define TPIU_ITFTTD0_ATB_IF1_bytecount_Msk (0x3UL << TPIU_ITFTTD0_ATB_IF1_bytecount_Pos) /*!< TPIU ITFTTD0: ATB Interface 1 byte countt Mask */
+
+#define TPIU_ITFTTD0_ATB_IF1_data2_Pos     16U                                         /*!< TPIU ITFTTD0: ATB Interface 1 data2 Position */
+#define TPIU_ITFTTD0_ATB_IF1_data2_Msk     (0xFFUL << TPIU_ITFTTD0_ATB_IF1_data1_Pos)  /*!< TPIU ITFTTD0: ATB Interface 1 data2 Mask */
+
+#define TPIU_ITFTTD0_ATB_IF1_data1_Pos      8U                                         /*!< TPIU ITFTTD0: ATB Interface 1 data1 Position */
+#define TPIU_ITFTTD0_ATB_IF1_data1_Msk     (0xFFUL << TPIU_ITFTTD0_ATB_IF1_data1_Pos)  /*!< TPIU ITFTTD0: ATB Interface 1 data1 Mask */
+
+#define TPIU_ITFTTD0_ATB_IF1_data0_Pos      0U                                         /*!< TPIU ITFTTD0: ATB Interface 1 data0 Position */
+#define TPIU_ITFTTD0_ATB_IF1_data0_Msk     (0xFFUL /*<< TPIU_ITFTTD0_ATB_IF1_data0_Pos*/) /*!< TPIU ITFTTD0: ATB Interface 1 data0 Mask */
+
+/** \brief TPIU Integration Test ATB Control Register 2 Register Definitions */
+#define TPIU_ITATBCTR2_AFVALID2S_Pos        1U                                         /*!< TPIU ITATBCTR2: AFVALID2S Position */
+#define TPIU_ITATBCTR2_AFVALID2S_Msk       (1UL << TPIU_ITATBCTR2_AFVALID2S_Pos)       /*!< TPIU ITATBCTR2: AFVALID2SS Mask */
+
+#define TPIU_ITATBCTR2_AFVALID1S_Pos        1U                                         /*!< TPIU ITATBCTR2: AFVALID1S Position */
+#define TPIU_ITATBCTR2_AFVALID1S_Msk       (1UL << TPIU_ITATBCTR2_AFVALID1S_Pos)       /*!< TPIU ITATBCTR2: AFVALID1SS Mask */
+
+#define TPIU_ITATBCTR2_ATREADY2S_Pos        0U                                         /*!< TPIU ITATBCTR2: ATREADY2S Position */
+#define TPIU_ITATBCTR2_ATREADY2S_Msk       (1UL /*<< TPIU_ITATBCTR2_ATREADY2S_Pos*/)   /*!< TPIU ITATBCTR2: ATREADY2S Mask */
+
+#define TPIU_ITATBCTR2_ATREADY1S_Pos        0U                                         /*!< TPIU ITATBCTR2: ATREADY1S Position */
+#define TPIU_ITATBCTR2_ATREADY1S_Msk       (1UL /*<< TPIU_ITATBCTR2_ATREADY1S_Pos*/)   /*!< TPIU ITATBCTR2: ATREADY1S Mask */
+
+/** \brief TPIU Integration Test FIFO Test Data 1 Register Definitions */
+#define TPIU_ITFTTD1_ATB_IF2_ATVALID_Pos   29U                                         /*!< TPIU ITFTTD1: ATB Interface 2 ATVALID Position */
+#define TPIU_ITFTTD1_ATB_IF2_ATVALID_Msk   (0x3UL << TPIU_ITFTTD1_ATB_IF2_ATVALID_Pos) /*!< TPIU ITFTTD1: ATB Interface 2 ATVALID Mask */
+
+#define TPIU_ITFTTD1_ATB_IF2_bytecount_Pos 27U                                         /*!< TPIU ITFTTD1: ATB Interface 2 byte count Position */
+#define TPIU_ITFTTD1_ATB_IF2_bytecount_Msk (0x3UL << TPIU_ITFTTD1_ATB_IF2_bytecount_Pos) /*!< TPIU ITFTTD1: ATB Interface 2 byte count Mask */
+
+#define TPIU_ITFTTD1_ATB_IF1_ATVALID_Pos   26U                                         /*!< TPIU ITFTTD1: ATB Interface 1 ATVALID Position */
+#define TPIU_ITFTTD1_ATB_IF1_ATVALID_Msk   (0x3UL << TPIU_ITFTTD1_ATB_IF1_ATVALID_Pos) /*!< TPIU ITFTTD1: ATB Interface 1 ATVALID Mask */
+
+#define TPIU_ITFTTD1_ATB_IF1_bytecount_Pos 24U                                         /*!< TPIU ITFTTD1: ATB Interface 1 byte count Position */
+#define TPIU_ITFTTD1_ATB_IF1_bytecount_Msk (0x3UL << TPIU_ITFTTD1_ATB_IF1_bytecount_Pos) /*!< TPIU ITFTTD1: ATB Interface 1 byte countt Mask */
+
+#define TPIU_ITFTTD1_ATB_IF2_data2_Pos     16U                                         /*!< TPIU ITFTTD1: ATB Interface 2 data2 Position */
+#define TPIU_ITFTTD1_ATB_IF2_data2_Msk     (0xFFUL << TPIU_ITFTTD1_ATB_IF2_data1_Pos)  /*!< TPIU ITFTTD1: ATB Interface 2 data2 Mask */
+
+#define TPIU_ITFTTD1_ATB_IF2_data1_Pos      8U                                         /*!< TPIU ITFTTD1: ATB Interface 2 data1 Position */
+#define TPIU_ITFTTD1_ATB_IF2_data1_Msk     (0xFFUL << TPIU_ITFTTD1_ATB_IF2_data1_Pos)  /*!< TPIU ITFTTD1: ATB Interface 2 data1 Mask */
+
+#define TPIU_ITFTTD1_ATB_IF2_data0_Pos      0U                                         /*!< TPIU ITFTTD1: ATB Interface 2 data0 Position */
+#define TPIU_ITFTTD1_ATB_IF2_data0_Msk     (0xFFUL /*<< TPIU_ITFTTD1_ATB_IF2_data0_Pos*/) /*!< TPIU ITFTTD1: ATB Interface 2 data0 Mask */
+
+/** \brief TPIU Integration Test ATB Control Register 0 Definitions */
+#define TPIU_ITATBCTR0_AFVALID2S_Pos        1U                                         /*!< TPIU ITATBCTR0: AFVALID2S Position */
+#define TPIU_ITATBCTR0_AFVALID2S_Msk       (1UL << TPIU_ITATBCTR0_AFVALID2S_Pos)       /*!< TPIU ITATBCTR0: AFVALID2SS Mask */
+
+#define TPIU_ITATBCTR0_AFVALID1S_Pos        1U                                         /*!< TPIU ITATBCTR0: AFVALID1S Position */
+#define TPIU_ITATBCTR0_AFVALID1S_Msk       (1UL << TPIU_ITATBCTR0_AFVALID1S_Pos)       /*!< TPIU ITATBCTR0: AFVALID1SS Mask */
+
+#define TPIU_ITATBCTR0_ATREADY2S_Pos        0U                                         /*!< TPIU ITATBCTR0: ATREADY2S Position */
+#define TPIU_ITATBCTR0_ATREADY2S_Msk       (1UL /*<< TPIU_ITATBCTR0_ATREADY2S_Pos*/)   /*!< TPIU ITATBCTR0: ATREADY2S Mask */
+
+#define TPIU_ITATBCTR0_ATREADY1S_Pos        0U                                         /*!< TPIU ITATBCTR0: ATREADY1S Position */
+#define TPIU_ITATBCTR0_ATREADY1S_Msk       (1UL /*<< TPIU_ITATBCTR0_ATREADY1S_Pos*/)   /*!< TPIU ITATBCTR0: ATREADY1S Mask */
+
+/** \brief TPIU Integration Mode Control Register Definitions */
+#define TPIU_ITCTRL_Mode_Pos                0U                                         /*!< TPIU ITCTRL: Mode Position */
+#define TPIU_ITCTRL_Mode_Msk               (0x3UL /*<< TPIU_ITCTRL_Mode_Pos*/)         /*!< TPIU ITCTRL: Mode Mask */
+
+/** \brief TPIU DEVID Register Definitions */
+#define TPIU_DEVID_NRZVALID_Pos            11U                                         /*!< TPIU DEVID: NRZVALID Position */
+#define TPIU_DEVID_NRZVALID_Msk            (1UL << TPIU_DEVID_NRZVALID_Pos)            /*!< TPIU DEVID: NRZVALID Mask */
+
+#define TPIU_DEVID_MANCVALID_Pos           10U                                         /*!< TPIU DEVID: MANCVALID Position */
+#define TPIU_DEVID_MANCVALID_Msk           (1UL << TPIU_DEVID_MANCVALID_Pos)           /*!< TPIU DEVID: MANCVALID Mask */
+
+#define TPIU_DEVID_PTINVALID_Pos            9U                                         /*!< TPIU DEVID: PTINVALID Position */
+#define TPIU_DEVID_PTINVALID_Msk           (1UL << TPIU_DEVID_PTINVALID_Pos)           /*!< TPIU DEVID: PTINVALID Mask */
+
+#define TPIU_DEVID_FIFOSZ_Pos               6U                                         /*!< TPIU DEVID: FIFOSZ Position */
+#define TPIU_DEVID_FIFOSZ_Msk              (0x7UL << TPIU_DEVID_FIFOSZ_Pos)            /*!< TPIU DEVID: FIFOSZ Mask */
+
+#define TPIU_DEVID_NrTraceInput_Pos         0U                                         /*!< TPIU DEVID: NrTraceInput Position */
+#define TPIU_DEVID_NrTraceInput_Msk        (0x3FUL /*<< TPIU_DEVID_NrTraceInput_Pos*/) /*!< TPIU DEVID: NrTraceInput Mask */
+
+/** \brief TPIU DEVTYPE Register Definitions */
+#define TPIU_DEVTYPE_SubType_Pos            4U                                         /*!< TPIU DEVTYPE: SubType Position */
+#define TPIU_DEVTYPE_SubType_Msk           (0xFUL /*<< TPIU_DEVTYPE_SubType_Pos*/)     /*!< TPIU DEVTYPE: SubType Mask */
+
+#define TPIU_DEVTYPE_MajorType_Pos          0U                                         /*!< TPIU DEVTYPE: MajorType Position */
+#define TPIU_DEVTYPE_MajorType_Msk         (0xFUL << TPIU_DEVTYPE_MajorType_Pos)       /*!< TPIU DEVTYPE: MajorType Mask */
+
+/*@}*/ /* end of group CMSIS_TPIU */
+
+
+#if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_MPU     Memory Protection Unit (MPU)
+  \brief    Type definitions for the Memory Protection Unit (MPU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Memory Protection Unit (MPU).
+ */
+typedef struct
+{
+  __IM  uint32_t TYPE;                   /*!< Offset: 0x000 (R/ )  MPU Type Register */
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x004 (R/W)  MPU Control Register */
+  __IOM uint32_t RNR;                    /*!< Offset: 0x008 (R/W)  MPU Region Number Register */
+  __IOM uint32_t RBAR;                   /*!< Offset: 0x00C (R/W)  MPU Region Base Address Register */
+  __IOM uint32_t RLAR;                   /*!< Offset: 0x010 (R/W)  MPU Region Limit Address Register */
+  __IOM uint32_t RBAR_A1;                /*!< Offset: 0x014 (R/W)  MPU Region Base Address Register Alias 1 */
+  __IOM uint32_t RLAR_A1;                /*!< Offset: 0x018 (R/W)  MPU Region Limit Address Register Alias 1 */
+  __IOM uint32_t RBAR_A2;                /*!< Offset: 0x01C (R/W)  MPU Region Base Address Register Alias 2 */
+  __IOM uint32_t RLAR_A2;                /*!< Offset: 0x020 (R/W)  MPU Region Limit Address Register Alias 2 */
+  __IOM uint32_t RBAR_A3;                /*!< Offset: 0x024 (R/W)  MPU Region Base Address Register Alias 3 */
+  __IOM uint32_t RLAR_A3;                /*!< Offset: 0x028 (R/W)  MPU Region Limit Address Register Alias 3 */
+        uint32_t RESERVED0[1];
+  union {
+  __IOM uint32_t MAIR[2];
+  struct {
+  __IOM uint32_t MAIR0;                  /*!< Offset: 0x030 (R/W)  MPU Memory Attribute Indirection Register 0 */
+  __IOM uint32_t MAIR1;                  /*!< Offset: 0x034 (R/W)  MPU Memory Attribute Indirection Register 1 */
+  };
+  };
+} MPU_Type;
+
+#define MPU_TYPE_RALIASES                  4U
+
+/** \brief MPU Type Register Definitions */
+#define MPU_TYPE_IREGION_Pos               16U                                            /*!< MPU TYPE: IREGION Position */
+#define MPU_TYPE_IREGION_Msk               (0xFFUL << MPU_TYPE_IREGION_Pos)               /*!< MPU TYPE: IREGION Mask */
+
+#define MPU_TYPE_DREGION_Pos                8U                                            /*!< MPU TYPE: DREGION Position */
+#define MPU_TYPE_DREGION_Msk               (0xFFUL << MPU_TYPE_DREGION_Pos)               /*!< MPU TYPE: DREGION Mask */
+
+#define MPU_TYPE_SEPARATE_Pos               0U                                            /*!< MPU TYPE: SEPARATE Position */
+#define MPU_TYPE_SEPARATE_Msk              (1UL /*<< MPU_TYPE_SEPARATE_Pos*/)             /*!< MPU TYPE: SEPARATE Mask */
+
+/** \brief MPU Control Register Definitions */
+#define MPU_CTRL_PRIVDEFENA_Pos             2U                                            /*!< MPU CTRL: PRIVDEFENA Position */
+#define MPU_CTRL_PRIVDEFENA_Msk            (1UL << MPU_CTRL_PRIVDEFENA_Pos)               /*!< MPU CTRL: PRIVDEFENA Mask */
+
+#define MPU_CTRL_HFNMIENA_Pos               1U                                            /*!< MPU CTRL: HFNMIENA Position */
+#define MPU_CTRL_HFNMIENA_Msk              (1UL << MPU_CTRL_HFNMIENA_Pos)                 /*!< MPU CTRL: HFNMIENA Mask */
+
+#define MPU_CTRL_ENABLE_Pos                 0U                                            /*!< MPU CTRL: ENABLE Position */
+#define MPU_CTRL_ENABLE_Msk                (1UL /*<< MPU_CTRL_ENABLE_Pos*/)               /*!< MPU CTRL: ENABLE Mask */
+
+/** \brief MPU Region Number Register Definitions */
+#define MPU_RNR_REGION_Pos                  0U                                            /*!< MPU RNR: REGION Position */
+#define MPU_RNR_REGION_Msk                 (0xFFUL /*<< MPU_RNR_REGION_Pos*/)             /*!< MPU RNR: REGION Mask */
+
+/** \brief MPU Region Base Address Register Definitions */
+#define MPU_RBAR_BASE_Pos                   5U                                            /*!< MPU RBAR: BASE Position */
+#define MPU_RBAR_BASE_Msk                  (0x7FFFFFFUL << MPU_RBAR_BASE_Pos)             /*!< MPU RBAR: BASE Mask */
+
+#define MPU_RBAR_SH_Pos                     3U                                            /*!< MPU RBAR: SH Position */
+#define MPU_RBAR_SH_Msk                    (0x3UL << MPU_RBAR_SH_Pos)                     /*!< MPU RBAR: SH Mask */
+
+#define MPU_RBAR_AP_Pos                     1U                                            /*!< MPU RBAR: AP Position */
+#define MPU_RBAR_AP_Msk                    (0x3UL << MPU_RBAR_AP_Pos)                     /*!< MPU RBAR: AP Mask */
+
+#define MPU_RBAR_XN_Pos                     0U                                            /*!< MPU RBAR: XN Position */
+#define MPU_RBAR_XN_Msk                    (01UL /*<< MPU_RBAR_XN_Pos*/)                  /*!< MPU RBAR: XN Mask */
+
+/** \brief MPU Region Limit Address Register Definitions */
+#define MPU_RLAR_LIMIT_Pos                  5U                                            /*!< MPU RLAR: LIMIT Position */
+#define MPU_RLAR_LIMIT_Msk                 (0x7FFFFFFUL << MPU_RLAR_LIMIT_Pos)            /*!< MPU RLAR: LIMIT Mask */
+
+#define MPU_RLAR_PXN_Pos                    4U                                            /*!< MPU RLAR: PXN Position */
+#define MPU_RLAR_PXN_Msk                   (1UL << MPU_RLAR_PXN_Pos)                      /*!< MPU RLAR: PXN Mask */
+
+#define MPU_RLAR_AttrIndx_Pos               1U                                            /*!< MPU RLAR: AttrIndx Position */
+#define MPU_RLAR_AttrIndx_Msk              (0x7UL << MPU_RLAR_AttrIndx_Pos)               /*!< MPU RLAR: AttrIndx Mask */
+
+#define MPU_RLAR_EN_Pos                     0U                                            /*!< MPU RLAR: Region enable bit Position */
+#define MPU_RLAR_EN_Msk                    (1UL /*<< MPU_RLAR_EN_Pos*/)                   /*!< MPU RLAR: Region enable bit Mask */
+
+/** \brief MPU Memory Attribute Indirection Register 0 Definitions */
+#define MPU_MAIR0_Attr3_Pos                24U                                            /*!< MPU MAIR0: Attr3 Position */
+#define MPU_MAIR0_Attr3_Msk                (0xFFUL << MPU_MAIR0_Attr3_Pos)                /*!< MPU MAIR0: Attr3 Mask */
+
+#define MPU_MAIR0_Attr2_Pos                16U                                            /*!< MPU MAIR0: Attr2 Position */
+#define MPU_MAIR0_Attr2_Msk                (0xFFUL << MPU_MAIR0_Attr2_Pos)                /*!< MPU MAIR0: Attr2 Mask */
+
+#define MPU_MAIR0_Attr1_Pos                 8U                                            /*!< MPU MAIR0: Attr1 Position */
+#define MPU_MAIR0_Attr1_Msk                (0xFFUL << MPU_MAIR0_Attr1_Pos)                /*!< MPU MAIR0: Attr1 Mask */
+
+#define MPU_MAIR0_Attr0_Pos                 0U                                            /*!< MPU MAIR0: Attr0 Position */
+#define MPU_MAIR0_Attr0_Msk                (0xFFUL /*<< MPU_MAIR0_Attr0_Pos*/)            /*!< MPU MAIR0: Attr0 Mask */
+
+/** \brief MPU Memory Attribute Indirection Register 1 Definitions */
+#define MPU_MAIR1_Attr7_Pos                24U                                            /*!< MPU MAIR1: Attr7 Position */
+#define MPU_MAIR1_Attr7_Msk                (0xFFUL << MPU_MAIR1_Attr7_Pos)                /*!< MPU MAIR1: Attr7 Mask */
+
+#define MPU_MAIR1_Attr6_Pos                16U                                            /*!< MPU MAIR1: Attr6 Position */
+#define MPU_MAIR1_Attr6_Msk                (0xFFUL << MPU_MAIR1_Attr6_Pos)                /*!< MPU MAIR1: Attr6 Mask */
+
+#define MPU_MAIR1_Attr5_Pos                 8U                                            /*!< MPU MAIR1: Attr5 Position */
+#define MPU_MAIR1_Attr5_Msk                (0xFFUL << MPU_MAIR1_Attr5_Pos)                /*!< MPU MAIR1: Attr5 Mask */
+
+#define MPU_MAIR1_Attr4_Pos                 0U                                            /*!< MPU MAIR1: Attr4 Position */
+#define MPU_MAIR1_Attr4_Msk                (0xFFUL /*<< MPU_MAIR1_Attr4_Pos*/)            /*!< MPU MAIR1: Attr4 Mask */
+
+/*@} end of group CMSIS_MPU */
+#endif
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SAU     Security Attribution Unit (SAU)
+  \brief    Type definitions for the Security Attribution Unit (SAU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Security Attribution Unit (SAU).
+ */
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  SAU Control Register */
+  __IM  uint32_t TYPE;                   /*!< Offset: 0x004 (R/ )  SAU Type Register */
+#if defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U)
+  __IOM uint32_t RNR;                    /*!< Offset: 0x008 (R/W)  SAU Region Number Register */
+  __IOM uint32_t RBAR;                   /*!< Offset: 0x00C (R/W)  SAU Region Base Address Register */
+  __IOM uint32_t RLAR;                   /*!< Offset: 0x010 (R/W)  SAU Region Limit Address Register */
+#else
+        uint32_t RESERVED0[3];
+#endif
+  __IOM uint32_t SFSR;                   /*!< Offset: 0x014 (R/W)  Secure Fault Status Register */
+  __IOM uint32_t SFAR;                   /*!< Offset: 0x018 (R/W)  Secure Fault Address Register */
+} SAU_Type;
+
+/** \brief SAU Control Register Definitions */
+#define SAU_CTRL_ALLNS_Pos                  1U                                            /*!< SAU CTRL: ALLNS Position */
+#define SAU_CTRL_ALLNS_Msk                 (1UL << SAU_CTRL_ALLNS_Pos)                    /*!< SAU CTRL: ALLNS Mask */
+
+#define SAU_CTRL_ENABLE_Pos                 0U                                            /*!< SAU CTRL: ENABLE Position */
+#define SAU_CTRL_ENABLE_Msk                (1UL /*<< SAU_CTRL_ENABLE_Pos*/)               /*!< SAU CTRL: ENABLE Mask */
+
+/** \brief SAU Type Register Definitions */
+#define SAU_TYPE_SREGION_Pos                0U                                            /*!< SAU TYPE: SREGION Position */
+#define SAU_TYPE_SREGION_Msk               (0xFFUL /*<< SAU_TYPE_SREGION_Pos*/)           /*!< SAU TYPE: SREGION Mask */
+
+#if defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U)
+/** \brief SAU Region Number Register Definitions */
+#define SAU_RNR_REGION_Pos                  0U                                            /*!< SAU RNR: REGION Position */
+#define SAU_RNR_REGION_Msk                 (0xFFUL /*<< SAU_RNR_REGION_Pos*/)             /*!< SAU RNR: REGION Mask */
+
+/** \brief SAU Region Base Address Register Definitions */
+#define SAU_RBAR_BADDR_Pos                  5U                                            /*!< SAU RBAR: BADDR Position */
+#define SAU_RBAR_BADDR_Msk                 (0x7FFFFFFUL << SAU_RBAR_BADDR_Pos)            /*!< SAU RBAR: BADDR Mask */
+
+/** \brief SAU Region Limit Address Register Definitions */
+#define SAU_RLAR_LADDR_Pos                  5U                                            /*!< SAU RLAR: LADDR Position */
+#define SAU_RLAR_LADDR_Msk                 (0x7FFFFFFUL << SAU_RLAR_LADDR_Pos)            /*!< SAU RLAR: LADDR Mask */
+
+#define SAU_RLAR_NSC_Pos                    1U                                            /*!< SAU RLAR: NSC Position */
+#define SAU_RLAR_NSC_Msk                   (1UL << SAU_RLAR_NSC_Pos)                      /*!< SAU RLAR: NSC Mask */
+
+#define SAU_RLAR_ENABLE_Pos                 0U                                            /*!< SAU RLAR: ENABLE Position */
+#define SAU_RLAR_ENABLE_Msk                (1UL /*<< SAU_RLAR_ENABLE_Pos*/)               /*!< SAU RLAR: ENABLE Mask */
+
+#endif /* defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U) */
+
+/** \brief SAU Secure Fault Status Register Definitions */
+#define SAU_SFSR_LSERR_Pos                  7U                                            /*!< SAU SFSR: LSERR Position */
+#define SAU_SFSR_LSERR_Msk                 (1UL << SAU_SFSR_LSERR_Pos)                    /*!< SAU SFSR: LSERR Mask */
+
+#define SAU_SFSR_SFARVALID_Pos              6U                                            /*!< SAU SFSR: SFARVALID Position */
+#define SAU_SFSR_SFARVALID_Msk             (1UL << SAU_SFSR_SFARVALID_Pos)                /*!< SAU SFSR: SFARVALID Mask */
+
+#define SAU_SFSR_LSPERR_Pos                 5U                                            /*!< SAU SFSR: LSPERR Position */
+#define SAU_SFSR_LSPERR_Msk                (1UL << SAU_SFSR_LSPERR_Pos)                   /*!< SAU SFSR: LSPERR Mask */
+
+#define SAU_SFSR_INVTRAN_Pos                4U                                            /*!< SAU SFSR: INVTRAN Position */
+#define SAU_SFSR_INVTRAN_Msk               (1UL << SAU_SFSR_INVTRAN_Pos)                  /*!< SAU SFSR: INVTRAN Mask */
+
+#define SAU_SFSR_AUVIOL_Pos                 3U                                            /*!< SAU SFSR: AUVIOL Position */
+#define SAU_SFSR_AUVIOL_Msk                (1UL << SAU_SFSR_AUVIOL_Pos)                   /*!< SAU SFSR: AUVIOL Mask */
+
+#define SAU_SFSR_INVER_Pos                  2U                                            /*!< SAU SFSR: INVER Position */
+#define SAU_SFSR_INVER_Msk                 (1UL << SAU_SFSR_INVER_Pos)                    /*!< SAU SFSR: INVER Mask */
+
+#define SAU_SFSR_INVIS_Pos                  1U                                            /*!< SAU SFSR: INVIS Position */
+#define SAU_SFSR_INVIS_Msk                 (1UL << SAU_SFSR_INVIS_Pos)                    /*!< SAU SFSR: INVIS Mask */
+
+#define SAU_SFSR_INVEP_Pos                  0U                                            /*!< SAU SFSR: INVEP Position */
+#define SAU_SFSR_INVEP_Msk                 (1UL /*<< SAU_SFSR_INVEP_Pos*/)                /*!< SAU SFSR: INVEP Mask */
+
+/*@} end of group CMSIS_SAU */
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_FPU     Floating Point Unit (FPU)
+  \brief    Type definitions for the Floating Point Unit (FPU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Floating Point Unit (FPU).
+ */
+typedef struct
+{
+        uint32_t RESERVED0[1U];
+  __IOM uint32_t FPCCR;                  /*!< Offset: 0x004 (R/W)  Floating-Point Context Control Register */
+  __IOM uint32_t FPCAR;                  /*!< Offset: 0x008 (R/W)  Floating-Point Context Address Register */
+  __IOM uint32_t FPDSCR;                 /*!< Offset: 0x00C (R/W)  Floating-Point Default Status Control Register */
+  __IM  uint32_t MVFR0;                  /*!< Offset: 0x010 (R/ )  Media and VFP Feature Register 0 */
+  __IM  uint32_t MVFR1;                  /*!< Offset: 0x014 (R/ )  Media and VFP Feature Register 1 */
+  __IM  uint32_t MVFR2;                  /*!< Offset: 0x018 (R/ )  Media and VFP Feature Register 2 */
+} FPU_Type;
+
+/** \brief FPU Floating-Point Context Control Register Definitions */
+#define FPU_FPCCR_ASPEN_Pos                31U                                            /*!< FPCCR: ASPEN bit Position */
+#define FPU_FPCCR_ASPEN_Msk                (1UL << FPU_FPCCR_ASPEN_Pos)                   /*!< FPCCR: ASPEN bit Mask */
+
+#define FPU_FPCCR_LSPEN_Pos                30U                                            /*!< FPCCR: LSPEN Position */
+#define FPU_FPCCR_LSPEN_Msk                (1UL << FPU_FPCCR_LSPEN_Pos)                   /*!< FPCCR: LSPEN bit Mask */
+
+#define FPU_FPCCR_LSPENS_Pos               29U                                            /*!< FPCCR: LSPENS Position */
+#define FPU_FPCCR_LSPENS_Msk               (1UL << FPU_FPCCR_LSPENS_Pos)                  /*!< FPCCR: LSPENS bit Mask */
+
+#define FPU_FPCCR_CLRONRET_Pos             28U                                            /*!< FPCCR: CLRONRET Position */
+#define FPU_FPCCR_CLRONRET_Msk             (1UL << FPU_FPCCR_CLRONRET_Pos)                /*!< FPCCR: CLRONRET bit Mask */
+
+#define FPU_FPCCR_CLRONRETS_Pos            27U                                            /*!< FPCCR: CLRONRETS Position */
+#define FPU_FPCCR_CLRONRETS_Msk            (1UL << FPU_FPCCR_CLRONRETS_Pos)               /*!< FPCCR: CLRONRETS bit Mask */
+
+#define FPU_FPCCR_TS_Pos                   26U                                            /*!< FPCCR: TS Position */
+#define FPU_FPCCR_TS_Msk                   (1UL << FPU_FPCCR_TS_Pos)                      /*!< FPCCR: TS bit Mask */
+
+#define FPU_FPCCR_UFRDY_Pos                10U                                            /*!< FPCCR: UFRDY Position */
+#define FPU_FPCCR_UFRDY_Msk                (1UL << FPU_FPCCR_UFRDY_Pos)                   /*!< FPCCR: UFRDY bit Mask */
+
+#define FPU_FPCCR_SPLIMVIOL_Pos             9U                                            /*!< FPCCR: SPLIMVIOL Position */
+#define FPU_FPCCR_SPLIMVIOL_Msk            (1UL << FPU_FPCCR_SPLIMVIOL_Pos)               /*!< FPCCR: SPLIMVIOL bit Mask */
+
+#define FPU_FPCCR_MONRDY_Pos                8U                                            /*!< FPCCR: MONRDY Position */
+#define FPU_FPCCR_MONRDY_Msk               (1UL << FPU_FPCCR_MONRDY_Pos)                  /*!< FPCCR: MONRDY bit Mask */
+
+#define FPU_FPCCR_SFRDY_Pos                 7U                                            /*!< FPCCR: SFRDY Position */
+#define FPU_FPCCR_SFRDY_Msk                (1UL << FPU_FPCCR_SFRDY_Pos)                   /*!< FPCCR: SFRDY bit Mask */
+
+#define FPU_FPCCR_BFRDY_Pos                 6U                                            /*!< FPCCR: BFRDY Position */
+#define FPU_FPCCR_BFRDY_Msk                (1UL << FPU_FPCCR_BFRDY_Pos)                   /*!< FPCCR: BFRDY bit Mask */
+
+#define FPU_FPCCR_MMRDY_Pos                 5U                                            /*!< FPCCR: MMRDY Position */
+#define FPU_FPCCR_MMRDY_Msk                (1UL << FPU_FPCCR_MMRDY_Pos)                   /*!< FPCCR: MMRDY bit Mask */
+
+#define FPU_FPCCR_HFRDY_Pos                 4U                                            /*!< FPCCR: HFRDY Position */
+#define FPU_FPCCR_HFRDY_Msk                (1UL << FPU_FPCCR_HFRDY_Pos)                   /*!< FPCCR: HFRDY bit Mask */
+
+#define FPU_FPCCR_THREAD_Pos                3U                                            /*!< FPCCR: processor mode bit Position */
+#define FPU_FPCCR_THREAD_Msk               (1UL << FPU_FPCCR_THREAD_Pos)                  /*!< FPCCR: processor mode active bit Mask */
+
+#define FPU_FPCCR_S_Pos                     2U                                            /*!< FPCCR: Security status of the FP context bit Position */
+#define FPU_FPCCR_S_Msk                    (1UL << FPU_FPCCR_S_Pos)                       /*!< FPCCR: Security status of the FP context bit Mask */
+
+#define FPU_FPCCR_USER_Pos                  1U                                            /*!< FPCCR: privilege level bit Position */
+#define FPU_FPCCR_USER_Msk                 (1UL << FPU_FPCCR_USER_Pos)                    /*!< FPCCR: privilege level bit Mask */
+
+#define FPU_FPCCR_LSPACT_Pos                0U                                            /*!< FPCCR: Lazy state preservation active bit Position */
+#define FPU_FPCCR_LSPACT_Msk               (1UL /*<< FPU_FPCCR_LSPACT_Pos*/)              /*!< FPCCR: Lazy state preservation active bit Mask */
+
+/** \brief FPU Floating-Point Context Address Register Definitions */
+#define FPU_FPCAR_ADDRESS_Pos               3U                                            /*!< FPCAR: ADDRESS bit Position */
+#define FPU_FPCAR_ADDRESS_Msk              (0x1FFFFFFFUL << FPU_FPCAR_ADDRESS_Pos)        /*!< FPCAR: ADDRESS bit Mask */
+
+/** \brief FPU Floating-Point Default Status Control Register Definitions */
+#define FPU_FPDSCR_AHP_Pos                 26U                                            /*!< FPDSCR: AHP bit Position */
+#define FPU_FPDSCR_AHP_Msk                 (1UL << FPU_FPDSCR_AHP_Pos)                    /*!< FPDSCR: AHP bit Mask */
+
+#define FPU_FPDSCR_DN_Pos                  25U                                            /*!< FPDSCR: DN bit Position */
+#define FPU_FPDSCR_DN_Msk                  (1UL << FPU_FPDSCR_DN_Pos)                     /*!< FPDSCR: DN bit Mask */
+
+#define FPU_FPDSCR_FZ_Pos                  24U                                            /*!< FPDSCR: FZ bit Position */
+#define FPU_FPDSCR_FZ_Msk                  (1UL << FPU_FPDSCR_FZ_Pos)                     /*!< FPDSCR: FZ bit Mask */
+
+#define FPU_FPDSCR_RMode_Pos               22U                                            /*!< FPDSCR: RMode bit Position */
+#define FPU_FPDSCR_RMode_Msk               (3UL << FPU_FPDSCR_RMode_Pos)                  /*!< FPDSCR: RMode bit Mask */
+
+/** \brief FPU Media and VFP Feature Register 0 Definitions */
+#define FPU_MVFR0_FPRound_Pos              28U                                            /*!< MVFR0: Rounding modes bits Position */
+#define FPU_MVFR0_FPRound_Msk              (0xFUL << FPU_MVFR0_FPRound_Pos)               /*!< MVFR0: Rounding modes bits Mask */
+
+#define FPU_MVFR0_FPShortvec_Pos           24U                                            /*!< MVFR0: Short vectors bits Position */
+#define FPU_MVFR0_FPShortvec_Msk          (0xFUL << FPU_MVFR0_FPShortvec_Pos)             /*!< MVFR0: Short vectors bits Mask */
+
+#define FPU_MVFR0_FPSqrt_Pos               20U                                            /*!< MVFR0: Square root bits Position */
+#define FPU_MVFR0_FPSqrt_Msk               (0xFUL << FPU_MVFR0_FPSqrt_Pos)                /*!< MVFR0: Square root bits Mask */
+
+#define FPU_MVFR0_FPDivide_Pos             16U                                            /*!< MVFR0: Divide bits Position */
+#define FPU_MVFR0_FPDivide_Msk             (0xFUL << FPU_MVFR0_FPDivide_Pos)              /*!< MVFR0: Divide bits Mask */
+
+#define FPU_MVFR0_FPExceptrap_Pos    12U                                                  /*!< MVFR0: Exception trapping bits Position */
+#define FPU_MVFR0_FPExceptrap_Msk    (0xFUL << FPU_MVFR0_FPExceptrap_Pos)                 /*!< MVFR0: Exception trapping bits Mask */
+
+#define FPU_MVFR0_FPDP_Pos                  8U                                            /*!< MVFR0: Double-precision bits Position */
+#define FPU_MVFR0_FPDP_Msk                 (0xFUL << FPU_MVFR0_FPDP_Pos)                  /*!< MVFR0: Double-precision bits Mask */
+
+#define FPU_MVFR0_FPSP_Pos                  4U                                            /*!< MVFR0: Single-precision bits Position */
+#define FPU_MVFR0_FPSP_Msk                 (0xFUL << FPU_MVFR0_FPSP_Pos)                  /*!< MVFR0: Single-precision bits Mask */
+
+#define FPU_MVFR0_SIMDReg_Pos               0U                                            /*!< MVFR0: SIMD registers bits Position */
+#define FPU_MVFR0_SIMDReg_Msk              (0xFUL /*<< FPU_MVFR0_SIMDReg_Pos*/)           /*!< MVFR0: SIMD registers bits Mask */
+
+/** \brief FPU Media and VFP Feature Register 1 Definitions */
+#define FPU_MVFR1_FMAC_Pos                 28U                                            /*!< MVFR1: Fused MAC bits Position */
+#define FPU_MVFR1_FMAC_Msk                 (0xFUL << FPU_MVFR1_FMAC_Pos)                  /*!< MVFR1: Fused MAC bits Mask */
+
+#define FPU_MVFR1_FPHP_Pos                 24U                                            /*!< MVFR1: FP HPFP bits Position */
+#define FPU_MVFR1_FPHP_Msk                 (0xFUL << FPU_MVFR1_FPHP_Pos)                  /*!< MVFR1: FP HPFP bits Mask */
+
+#define FPU_MVFR1_FPDNaN_Pos                4U                                            /*!< MVFR1: D_NaN mode bits Position */
+#define FPU_MVFR1_FPDNaN_Msk               (0xFUL << FPU_MVFR1_FPDNaN_Pos)                /*!< MVFR1: D_NaN mode bits Mask */
+
+#define FPU_MVFR1_FPFtZ_Pos                 0U                                            /*!< MVFR1: FtZ mode bits Position */
+#define FPU_MVFR1_FPFtZ_Msk                (0xFUL /*<< FPU_MVFR1_FPFtZ_Pos*/)             /*!< MVFR1: FtZ mode bits Mask */
+
+/** \brief FPU Media and VFP Feature Register 2 Definitions */
+#define FPU_MVFR2_FPMisc_Pos                4U                                            /*!< MVFR2: VFP Misc bits Position */
+#define FPU_MVFR2_FPMisc_Msk               (0xFUL << FPU_MVFR2_FPMisc_Pos)                /*!< MVFR2: VFP Misc bits Mask */
+
+/*@} end of group CMSIS_FPU */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_DCB       Debug Control Block
+  \brief    Type definitions for the Debug Control Block Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Debug Control Block Registers (DCB).
+ */
+typedef struct
+{
+  __IOM uint32_t DHCSR;                  /*!< Offset: 0x000 (R/W)  Debug Halting Control and Status Register */
+  __OM  uint32_t DCRSR;                  /*!< Offset: 0x004 ( /W)  Debug Core Register Selector Register */
+  __IOM uint32_t DCRDR;                  /*!< Offset: 0x008 (R/W)  Debug Core Register Data Register */
+  __IOM uint32_t DEMCR;                  /*!< Offset: 0x00C (R/W)  Debug Exception and Monitor Control Register */
+        uint32_t RESERVED0[1U];
+  __IOM uint32_t DAUTHCTRL;              /*!< Offset: 0x014 (R/W)  Debug Authentication Control Register */
+  __IOM uint32_t DSCSR;                  /*!< Offset: 0x018 (R/W)  Debug Security Control and Status Register */
+} DCB_Type;
+
+/** \brief DCB Debug Halting Control and Status Register Definitions */
+#define DCB_DHCSR_DBGKEY_Pos               16U                                            /*!< DCB DHCSR: Debug key Position */
+#define DCB_DHCSR_DBGKEY_Msk               (0xFFFFUL << DCB_DHCSR_DBGKEY_Pos)             /*!< DCB DHCSR: Debug key Mask */
+
+#define DCB_DHCSR_S_RESTART_ST_Pos         26U                                            /*!< DCB DHCSR: Restart sticky status Position */
+#define DCB_DHCSR_S_RESTART_ST_Msk         (1UL << DCB_DHCSR_S_RESTART_ST_Pos)            /*!< DCB DHCSR: Restart sticky status Mask */
+
+#define DCB_DHCSR_S_RESET_ST_Pos           25U                                            /*!< DCB DHCSR: Reset sticky status Position */
+#define DCB_DHCSR_S_RESET_ST_Msk           (1UL << DCB_DHCSR_S_RESET_ST_Pos)              /*!< DCB DHCSR: Reset sticky status Mask */
+
+#define DCB_DHCSR_S_RETIRE_ST_Pos          24U                                            /*!< DCB DHCSR: Retire sticky status Position */
+#define DCB_DHCSR_S_RETIRE_ST_Msk          (1UL << DCB_DHCSR_S_RETIRE_ST_Pos)             /*!< DCB DHCSR: Retire sticky status Mask */
+
+#define DCB_DHCSR_S_SDE_Pos                20U                                            /*!< DCB DHCSR: Secure debug enabled Position */
+#define DCB_DHCSR_S_SDE_Msk                (1UL << DCB_DHCSR_S_SDE_Pos)                   /*!< DCB DHCSR: Secure debug enabled Mask */
+
+#define DCB_DHCSR_S_LOCKUP_Pos             19U                                            /*!< DCB DHCSR: Lockup status Position */
+#define DCB_DHCSR_S_LOCKUP_Msk             (1UL << DCB_DHCSR_S_LOCKUP_Pos)                /*!< DCB DHCSR: Lockup status Mask */
+
+#define DCB_DHCSR_S_SLEEP_Pos              18U                                            /*!< DCB DHCSR: Sleeping status Position */
+#define DCB_DHCSR_S_SLEEP_Msk              (1UL << DCB_DHCSR_S_SLEEP_Pos)                 /*!< DCB DHCSR: Sleeping status Mask */
+
+#define DCB_DHCSR_S_HALT_Pos               17U                                            /*!< DCB DHCSR: Halted status Position */
+#define DCB_DHCSR_S_HALT_Msk               (1UL << DCB_DHCSR_S_HALT_Pos)                  /*!< DCB DHCSR: Halted status Mask */
+
+#define DCB_DHCSR_S_REGRDY_Pos             16U                                            /*!< DCB DHCSR: Register ready status Position */
+#define DCB_DHCSR_S_REGRDY_Msk             (1UL << DCB_DHCSR_S_REGRDY_Pos)                /*!< DCB DHCSR: Register ready status Mask */
+
+#define DCB_DHCSR_C_SNAPSTALL_Pos           5U                                            /*!< DCB DHCSR: Snap stall control Position */
+#define DCB_DHCSR_C_SNAPSTALL_Msk          (1UL << DCB_DHCSR_C_SNAPSTALL_Pos)             /*!< DCB DHCSR: Snap stall control Mask */
+
+#define DCB_DHCSR_C_MASKINTS_Pos            3U                                            /*!< DCB DHCSR: Mask interrupts control Position */
+#define DCB_DHCSR_C_MASKINTS_Msk           (1UL << DCB_DHCSR_C_MASKINTS_Pos)              /*!< DCB DHCSR: Mask interrupts control Mask */
+
+#define DCB_DHCSR_C_STEP_Pos                2U                                            /*!< DCB DHCSR: Step control Position */
+#define DCB_DHCSR_C_STEP_Msk               (1UL << DCB_DHCSR_C_STEP_Pos)                  /*!< DCB DHCSR: Step control Mask */
+
+#define DCB_DHCSR_C_HALT_Pos                1U                                            /*!< DCB DHCSR: Halt control Position */
+#define DCB_DHCSR_C_HALT_Msk               (1UL << DCB_DHCSR_C_HALT_Pos)                  /*!< DCB DHCSR: Halt control Mask */
+
+#define DCB_DHCSR_C_DEBUGEN_Pos             0U                                            /*!< DCB DHCSR: Debug enable control Position */
+#define DCB_DHCSR_C_DEBUGEN_Msk            (1UL /*<< DCB_DHCSR_C_DEBUGEN_Pos*/)           /*!< DCB DHCSR: Debug enable control Mask */
+
+/** \brief DCB Debug Core Register Selector Register Definitions */
+#define DCB_DCRSR_REGWnR_Pos               16U                                            /*!< DCB DCRSR: Register write/not-read Position */
+#define DCB_DCRSR_REGWnR_Msk               (1UL << DCB_DCRSR_REGWnR_Pos)                  /*!< DCB DCRSR: Register write/not-read Mask */
+
+#define DCB_DCRSR_REGSEL_Pos                0U                                            /*!< DCB DCRSR: Register selector Position */
+#define DCB_DCRSR_REGSEL_Msk               (0x7FUL /*<< DCB_DCRSR_REGSEL_Pos*/)           /*!< DCB DCRSR: Register selector Mask */
+
+/** \brief DCB Debug Core Register Data Register Definitions */
+#define DCB_DCRDR_DBGTMP_Pos                0U                                            /*!< DCB DCRDR: Data temporary buffer Position */
+#define DCB_DCRDR_DBGTMP_Msk               (0xFFFFFFFFUL /*<< DCB_DCRDR_DBGTMP_Pos*/)     /*!< DCB DCRDR: Data temporary buffer Mask */
+
+/** \brief DCB Debug Exception and Monitor Control Register Definitions */
+#define DCB_DEMCR_TRCENA_Pos               24U                                            /*!< DCB DEMCR: Trace enable Position */
+#define DCB_DEMCR_TRCENA_Msk               (1UL << DCB_DEMCR_TRCENA_Pos)                  /*!< DCB DEMCR: Trace enable Mask */
+
+#define DCB_DEMCR_MONPRKEY_Pos             23U                                            /*!< DCB DEMCR: Monitor pend req key Position */
+#define DCB_DEMCR_MONPRKEY_Msk             (1UL << DCB_DEMCR_MONPRKEY_Pos)                /*!< DCB DEMCR: Monitor pend req key Mask */
+
+#define DCB_DEMCR_UMON_EN_Pos              21U                                            /*!< DCB DEMCR: Unprivileged monitor enable Position */
+#define DCB_DEMCR_UMON_EN_Msk              (1UL << DCB_DEMCR_UMON_EN_Pos)                 /*!< DCB DEMCR: Unprivileged monitor enable Mask */
+
+#define DCB_DEMCR_SDME_Pos                 20U                                            /*!< DCB DEMCR: Secure DebugMonitor enable Position */
+#define DCB_DEMCR_SDME_Msk                 (1UL << DCB_DEMCR_SDME_Pos)                    /*!< DCB DEMCR: Secure DebugMonitor enable Mask */
+
+#define DCB_DEMCR_MON_REQ_Pos              19U                                            /*!< DCB DEMCR: Monitor request Position */
+#define DCB_DEMCR_MON_REQ_Msk              (1UL << DCB_DEMCR_MON_REQ_Pos)                 /*!< DCB DEMCR: Monitor request Mask */
+
+#define DCB_DEMCR_MON_STEP_Pos             18U                                            /*!< DCB DEMCR: Monitor step Position */
+#define DCB_DEMCR_MON_STEP_Msk             (1UL << DCB_DEMCR_MON_STEP_Pos)                /*!< DCB DEMCR: Monitor step Mask */
+
+#define DCB_DEMCR_MON_PEND_Pos             17U                                            /*!< DCB DEMCR: Monitor pend Position */
+#define DCB_DEMCR_MON_PEND_Msk             (1UL << DCB_DEMCR_MON_PEND_Pos)                /*!< DCB DEMCR: Monitor pend Mask */
+
+#define DCB_DEMCR_MON_EN_Pos               16U                                            /*!< DCB DEMCR: Monitor enable Position */
+#define DCB_DEMCR_MON_EN_Msk               (1UL << DCB_DEMCR_MON_EN_Pos)                  /*!< DCB DEMCR: Monitor enable Mask */
+
+#define DCB_DEMCR_VC_SFERR_Pos             11U                                            /*!< DCB DEMCR: Vector Catch SecureFault Position */
+#define DCB_DEMCR_VC_SFERR_Msk             (1UL << DCB_DEMCR_VC_SFERR_Pos)                /*!< DCB DEMCR: Vector Catch SecureFault Mask */
+
+#define DCB_DEMCR_VC_HARDERR_Pos           10U                                            /*!< DCB DEMCR: Vector Catch HardFault errors Position */
+#define DCB_DEMCR_VC_HARDERR_Msk           (1UL << DCB_DEMCR_VC_HARDERR_Pos)              /*!< DCB DEMCR: Vector Catch HardFault errors Mask */
+
+#define DCB_DEMCR_VC_INTERR_Pos             9U                                            /*!< DCB DEMCR: Vector Catch interrupt errors Position */
+#define DCB_DEMCR_VC_INTERR_Msk            (1UL << DCB_DEMCR_VC_INTERR_Pos)               /*!< DCB DEMCR: Vector Catch interrupt errors Mask */
+
+#define DCB_DEMCR_VC_BUSERR_Pos             8U                                            /*!< DCB DEMCR: Vector Catch BusFault errors Position */
+#define DCB_DEMCR_VC_BUSERR_Msk            (1UL << DCB_DEMCR_VC_BUSERR_Pos)               /*!< DCB DEMCR: Vector Catch BusFault errors Mask */
+
+#define DCB_DEMCR_VC_STATERR_Pos            7U                                            /*!< DCB DEMCR: Vector Catch state errors Position */
+#define DCB_DEMCR_VC_STATERR_Msk           (1UL << DCB_DEMCR_VC_STATERR_Pos)              /*!< DCB DEMCR: Vector Catch state errors Mask */
+
+#define DCB_DEMCR_VC_CHKERR_Pos             6U                                            /*!< DCB DEMCR: Vector Catch check errors Position */
+#define DCB_DEMCR_VC_CHKERR_Msk            (1UL << DCB_DEMCR_VC_CHKERR_Pos)               /*!< DCB DEMCR: Vector Catch check errors Mask */
+
+#define DCB_DEMCR_VC_NOCPERR_Pos            5U                                            /*!< DCB DEMCR: Vector Catch NOCP errors Position */
+#define DCB_DEMCR_VC_NOCPERR_Msk           (1UL << DCB_DEMCR_VC_NOCPERR_Pos)              /*!< DCB DEMCR: Vector Catch NOCP errors Mask */
+
+#define DCB_DEMCR_VC_MMERR_Pos              4U                                            /*!< DCB DEMCR: Vector Catch MemManage errors Position */
+#define DCB_DEMCR_VC_MMERR_Msk             (1UL << DCB_DEMCR_VC_MMERR_Pos)                /*!< DCB DEMCR: Vector Catch MemManage errors Mask */
+
+#define DCB_DEMCR_VC_CORERESET_Pos          0U                                            /*!< DCB DEMCR: Vector Catch Core reset Position */
+#define DCB_DEMCR_VC_CORERESET_Msk         (1UL /*<< DCB_DEMCR_VC_CORERESET_Pos*/)        /*!< DCB DEMCR: Vector Catch Core reset Mask */
+
+/** \brief DCB Debug Authentication Control Register Definitions */
+#define DCB_DAUTHCTRL_INTSPNIDEN_Pos        3U                                            /*!< DCB DAUTHCTRL: Internal Secure non-invasive debug enable Position */
+#define DCB_DAUTHCTRL_INTSPNIDEN_Msk       (1UL << DCB_DAUTHCTRL_INTSPNIDEN_Pos)          /*!< DCB DAUTHCTRL: Internal Secure non-invasive debug enable Mask */
+
+#define DCB_DAUTHCTRL_SPNIDENSEL_Pos        2U                                            /*!< DCB DAUTHCTRL: Secure non-invasive debug enable select Position */
+#define DCB_DAUTHCTRL_SPNIDENSEL_Msk       (1UL << DCB_DAUTHCTRL_SPNIDENSEL_Pos)          /*!< DCB DAUTHCTRL: Secure non-invasive debug enable select Mask */
+
+#define DCB_DAUTHCTRL_INTSPIDEN_Pos         1U                                            /*!< DCB DAUTHCTRL: Internal Secure invasive debug enable Position */
+#define DCB_DAUTHCTRL_INTSPIDEN_Msk        (1UL << DCB_DAUTHCTRL_INTSPIDEN_Pos)           /*!< DCB DAUTHCTRL: Internal Secure invasive debug enable Mask */
+
+#define DCB_DAUTHCTRL_SPIDENSEL_Pos         0U                                            /*!< DCB DAUTHCTRL: Secure invasive debug enable select Position */
+#define DCB_DAUTHCTRL_SPIDENSEL_Msk        (1UL /*<< DCB_DAUTHCTRL_SPIDENSEL_Pos*/)       /*!< DCB DAUTHCTRL: Secure invasive debug enable select Mask */
+
+/** \brief DCB Debug Security Control and Status Register Definitions */
+#define DCB_DSCSR_CDSKEY_Pos               17U                                            /*!< DCB DSCSR: CDS write-enable key Position */
+#define DCB_DSCSR_CDSKEY_Msk               (1UL << DCB_DSCSR_CDSKEY_Pos)                  /*!< DCB DSCSR: CDS write-enable key Mask */
+
+#define DCB_DSCSR_CDS_Pos                  16U                                            /*!< DCB DSCSR: Current domain Secure Position */
+#define DCB_DSCSR_CDS_Msk                  (1UL << DCB_DSCSR_CDS_Pos)                     /*!< DCB DSCSR: Current domain Secure Mask */
+
+#define DCB_DSCSR_SBRSEL_Pos                1U                                            /*!< DCB DSCSR: Secure banked register select Position */
+#define DCB_DSCSR_SBRSEL_Msk               (1UL << DCB_DSCSR_SBRSEL_Pos)                  /*!< DCB DSCSR: Secure banked register select Mask */
+
+#define DCB_DSCSR_SBRSELEN_Pos              0U                                            /*!< DCB DSCSR: Secure banked register select enable Position */
+#define DCB_DSCSR_SBRSELEN_Msk             (1UL /*<< DCB_DSCSR_SBRSELEN_Pos*/)            /*!< DCB DSCSR: Secure banked register select enable Mask */
+
+/*@} end of group CMSIS_DCB */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_DIB       Debug Identification Block
+  \brief    Type definitions for the Debug Identification Block Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Debug Identification Block Registers (DIB).
+ */
+typedef struct
+{
+  __OM  uint32_t DLAR;                   /*!< Offset: 0x000 ( /W)  SCS Software Lock Access Register */
+  __IM  uint32_t DLSR;                   /*!< Offset: 0x004 (R/ )  SCS Software Lock Status Register */
+  __IM  uint32_t DAUTHSTATUS;            /*!< Offset: 0x008 (R/ )  Debug Authentication Status Register */
+  __IM  uint32_t DDEVARCH;               /*!< Offset: 0x00C (R/ )  SCS Device Architecture Register */
+  __IM  uint32_t DDEVTYPE;               /*!< Offset: 0x010 (R/ )  SCS Device Type Register */
+} DIB_Type;
+
+/** \brief DIB SCS Software Lock Access Register Definitions */
+#define DIB_DLAR_KEY_Pos                    0U                                            /*!< DIB DLAR: KEY Position */
+#define DIB_DLAR_KEY_Msk                   (0xFFFFFFFFUL /*<< DIB_DLAR_KEY_Pos */)        /*!< DIB DLAR: KEY Mask */
+
+/** \brief DIB SCS Software Lock Status Register Definitions */
+#define DIB_DLSR_nTT_Pos                    2U                                            /*!< DIB DLSR: Not thirty-two bit Position */
+#define DIB_DLSR_nTT_Msk                   (1UL << DIB_DLSR_nTT_Pos )                     /*!< DIB DLSR: Not thirty-two bit Mask */
+
+#define DIB_DLSR_SLK_Pos                    1U                                            /*!< DIB DLSR: Software Lock status Position */
+#define DIB_DLSR_SLK_Msk                   (1UL << DIB_DLSR_SLK_Pos )                     /*!< DIB DLSR: Software Lock status Mask */
+
+#define DIB_DLSR_SLI_Pos                    0U                                            /*!< DIB DLSR: Software Lock implemented Position */
+#define DIB_DLSR_SLI_Msk                   (1UL /*<< DIB_DLSR_SLI_Pos*/)                  /*!< DIB DLSR: Software Lock implemented Mask */
+
+/** \brief DIB Debug Authentication Status Register Definitions */
+#define DIB_DAUTHSTATUS_SNID_Pos            6U                                            /*!< DIB DAUTHSTATUS: Secure Non-invasive Debug Position */
+#define DIB_DAUTHSTATUS_SNID_Msk           (0x3UL << DIB_DAUTHSTATUS_SNID_Pos )           /*!< DIB DAUTHSTATUS: Secure Non-invasive Debug Mask */
+
+#define DIB_DAUTHSTATUS_SID_Pos             4U                                            /*!< DIB DAUTHSTATUS: Secure Invasive Debug Position */
+#define DIB_DAUTHSTATUS_SID_Msk            (0x3UL << DIB_DAUTHSTATUS_SID_Pos )            /*!< DIB DAUTHSTATUS: Secure Invasive Debug Mask */
+
+#define DIB_DAUTHSTATUS_NSNID_Pos           2U                                            /*!< DIB DAUTHSTATUS: Non-secure Non-invasive Debug Position */
+#define DIB_DAUTHSTATUS_NSNID_Msk          (0x3UL << DIB_DAUTHSTATUS_NSNID_Pos )          /*!< DIB DAUTHSTATUS: Non-secure Non-invasive Debug Mask */
+
+#define DIB_DAUTHSTATUS_NSID_Pos            0U                                            /*!< DIB DAUTHSTATUS: Non-secure Invasive Debug Position */
+#define DIB_DAUTHSTATUS_NSID_Msk           (0x3UL /*<< DIB_DAUTHSTATUS_NSID_Pos*/)        /*!< DIB DAUTHSTATUS: Non-secure Invasive Debug Mask */
+
+/** \brief DIB SCS Device Architecture Register Definitions */
+#define DIB_DDEVARCH_ARCHITECT_Pos         21U                                            /*!< DIB DDEVARCH: Architect Position */
+#define DIB_DDEVARCH_ARCHITECT_Msk         (0x7FFUL << DIB_DDEVARCH_ARCHITECT_Pos )       /*!< DIB DDEVARCH: Architect Mask */
+
+#define DIB_DDEVARCH_PRESENT_Pos           20U                                            /*!< DIB DDEVARCH: DEVARCH Present Position */
+#define DIB_DDEVARCH_PRESENT_Msk           (0x1FUL << DIB_DDEVARCH_PRESENT_Pos )          /*!< DIB DDEVARCH: DEVARCH Present Mask */
+
+#define DIB_DDEVARCH_REVISION_Pos          16U                                            /*!< DIB DDEVARCH: Revision Position */
+#define DIB_DDEVARCH_REVISION_Msk          (0xFUL << DIB_DDEVARCH_REVISION_Pos )          /*!< DIB DDEVARCH: Revision Mask */
+
+#define DIB_DDEVARCH_ARCHVER_Pos           12U                                            /*!< DIB DDEVARCH: Architecture Version Position */
+#define DIB_DDEVARCH_ARCHVER_Msk           (0xFUL << DIB_DDEVARCH_ARCHVER_Pos )           /*!< DIB DDEVARCH: Architecture Version Mask */
+
+#define DIB_DDEVARCH_ARCHPART_Pos           0U                                            /*!< DIB DDEVARCH: Architecture Part Position */
+#define DIB_DDEVARCH_ARCHPART_Msk          (0xFFFUL /*<< DIB_DDEVARCH_ARCHPART_Pos*/)     /*!< DIB DDEVARCH: Architecture Part Mask */
+
+/** \brief DIB SCS Device Type Register Definitions */
+#define DIB_DDEVTYPE_SUB_Pos                4U                                            /*!< DIB DDEVTYPE: Sub-type Position */
+#define DIB_DDEVTYPE_SUB_Msk               (0xFUL << DIB_DDEVTYPE_SUB_Pos )               /*!< DIB DDEVTYPE: Sub-type Mask */
+
+#define DIB_DDEVTYPE_MAJOR_Pos              0U                                            /*!< DIB DDEVTYPE: Major type Position */
+#define DIB_DDEVTYPE_MAJOR_Msk             (0xFUL /*<< DIB_DDEVTYPE_MAJOR_Pos*/)          /*!< DIB DDEVTYPE: Major type Mask */
+
+/*@} end of group CMSIS_DIB */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_core_bitfield     Core register bit field macros
+  \brief      Macros for use with bit field definitions (xxx_Pos, xxx_Msk).
+  @{
+ */
+
+/**
+  \brief   Mask and shift a bit field value for use in a register bit range.
+  \param[in] field  Name of the register bit field.
+  \param[in] value  Value of the bit field. This parameter is interpreted as an uint32_t type.
+  \return           Masked and shifted value.
+*/
+#define _VAL2FLD(field, value)    (((uint32_t)(value) << field ## _Pos) & field ## _Msk)
+
+/**
+  \brief     Mask and shift a register value to extract a bit filed value.
+  \param[in] field  Name of the register bit field.
+  \param[in] value  Value of register. This parameter is interpreted as an uint32_t type.
+  \return           Masked and shifted bit field value.
+*/
+#define _FLD2VAL(field, value)    (((uint32_t)(value) & field ## _Msk) >> field ## _Pos)
+
+/*@} end of group CMSIS_core_bitfield */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_core_base     Core Definitions
+  \brief      Definitions for base addresses, unions, and structures.
+  @{
+ */
+
+/* Memory mapping of Core Hardware */
+  #define SCS_BASE            (0xE000E000UL)                             /*!< System Control Space Base Address */
+  #define ITM_BASE            (0xE0000000UL)                             /*!< ITM Base Address */
+  #define DWT_BASE            (0xE0001000UL)                             /*!< DWT Base Address */
+  #define TPIU_BASE           (0xE0040000UL)                             /*!< TPIU Base Address */
+  #define DCB_BASE            (0xE000EDF0UL)                             /*!< DCB Base Address */
+  #define DIB_BASE            (0xE000EFB0UL)                             /*!< DIB Base Address */
+  #define SysTick_BASE        (SCS_BASE +  0x0010UL)                     /*!< SysTick Base Address */
+  #define NVIC_BASE           (SCS_BASE +  0x0100UL)                     /*!< NVIC Base Address */
+  #define SCB_BASE            (SCS_BASE +  0x0D00UL)                     /*!< System Control Block Base Address */
+
+  #define SCnSCB              ((SCnSCB_Type    *)     SCS_BASE         ) /*!< System control Register not in SCB */
+  #define SCB                 ((SCB_Type       *)     SCB_BASE         ) /*!< SCB configuration struct */
+  #define SysTick             ((SysTick_Type   *)     SysTick_BASE     ) /*!< SysTick configuration struct */
+  #define NVIC                ((NVIC_Type      *)     NVIC_BASE        ) /*!< NVIC configuration struct */
+  #define ITM                 ((ITM_Type       *)     ITM_BASE         ) /*!< ITM configuration struct */
+  #define DWT                 ((DWT_Type       *)     DWT_BASE         ) /*!< DWT configuration struct */
+  #define TPIU                ((TPIU_Type      *)     TPIU_BASE        ) /*!< TPIU configuration struct */
+  #define DCB                 ((DCB_Type       *)     DCB_BASE         ) /*!< DCB configuration struct */
+  #define DIB                 ((DIB_Type       *)     DIB_BASE         ) /*!< DIB configuration struct */
+
+  #if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+    #define MPU_BASE          (SCS_BASE +  0x0D90UL)                     /*!< Memory Protection Unit */
+    #define MPU               ((MPU_Type       *)     MPU_BASE         ) /*!< Memory Protection Unit */
+  #endif
+
+  #if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+    #define SAU_BASE          (SCS_BASE +  0x0DD0UL)                     /*!< Security Attribution Unit */
+    #define SAU               ((SAU_Type       *)     SAU_BASE         ) /*!< Security Attribution Unit */
+  #endif
+
+  #define FPU_BASE            (SCS_BASE +  0x0F30UL)                     /*!< Floating Point Unit */
+  #define FPU                 ((FPU_Type       *)     FPU_BASE         ) /*!< Floating Point Unit */
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  #define SCS_BASE_NS         (0xE002E000UL)                             /*!< System Control Space Base Address (non-secure address space) */
+  #define DCB_BASE_NS         (0xE002EDF0UL)                             /*!< DCB Base Address                  (non-secure address space) */
+  #define DIB_BASE_NS         (0xE002EFB0UL)                             /*!< DIB Base Address                  (non-secure address space) */
+  #define SysTick_BASE_NS     (SCS_BASE_NS +  0x0010UL)                  /*!< SysTick Base Address              (non-secure address space) */
+  #define NVIC_BASE_NS        (SCS_BASE_NS +  0x0100UL)                  /*!< NVIC Base Address                 (non-secure address space) */
+  #define SCB_BASE_NS         (SCS_BASE_NS +  0x0D00UL)                  /*!< System Control Block Base Address (non-secure address space) */
+
+  #define SCnSCB_NS           ((SCnSCB_Type    *)     SCS_BASE_NS      ) /*!< System control Register not in SCB(non-secure address space) */
+  #define SCB_NS              ((SCB_Type       *)     SCB_BASE_NS      ) /*!< SCB configuration struct          (non-secure address space) */
+  #define SysTick_NS          ((SysTick_Type   *)     SysTick_BASE_NS  ) /*!< SysTick configuration struct      (non-secure address space) */
+  #define NVIC_NS             ((NVIC_Type      *)     NVIC_BASE_NS     ) /*!< NVIC configuration struct         (non-secure address space) */
+  #define DCB_NS              ((DCB_Type       *)     DCB_BASE_NS      ) /*!< DCB configuration struct          (non-secure address space) */
+  #define DIB_NS              ((DIB_Type       *)     DIB_BASE_NS      ) /*!< DIB configuration struct          (non-secure address space) */
+
+  #if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+    #define MPU_BASE_NS       (SCS_BASE_NS +  0x0D90UL)                  /*!< Memory Protection Unit            (non-secure address space) */
+    #define MPU_NS            ((MPU_Type       *)     MPU_BASE_NS      ) /*!< Memory Protection Unit            (non-secure address space) */
+  #endif
+
+  #define FPU_BASE_NS         (SCS_BASE_NS +  0x0F30UL)                  /*!< Floating Point Unit               (non-secure address space) */
+  #define FPU_NS              ((FPU_Type       *)     FPU_BASE_NS      ) /*!< Floating Point Unit               (non-secure address space) */
+
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+/*@} */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_register_aliases     Backwards Compatibility Aliases
+  \brief      Register alias definitions for backwards compatibility.
+  @{
+ */
+
+/*@} */
+
+
+/*******************************************************************************
+ *                Hardware Abstraction Layer
+  Core Function Interface contains:
+  - Core NVIC Functions
+  - Core SysTick Functions
+  - Core Debug Functions
+  - Core Register Access Functions
+ ******************************************************************************/
+/**
+  \defgroup CMSIS_Core_FunctionInterface Functions and Instructions Reference
+*/
+
+
+
+/* ##########################   NVIC functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_NVICFunctions NVIC Functions
+  \brief    Functions that manage interrupts and exceptions via the NVIC.
+  @{
+ */
+
+#ifdef CMSIS_NVIC_VIRTUAL
+  #ifndef CMSIS_NVIC_VIRTUAL_HEADER_FILE
+    #define CMSIS_NVIC_VIRTUAL_HEADER_FILE "cmsis_nvic_virtual.h"
+  #endif
+  #include CMSIS_NVIC_VIRTUAL_HEADER_FILE
+#else
+  #define NVIC_SetPriorityGrouping    __NVIC_SetPriorityGrouping
+  #define NVIC_GetPriorityGrouping    __NVIC_GetPriorityGrouping
+  #define NVIC_EnableIRQ              __NVIC_EnableIRQ
+  #define NVIC_GetEnableIRQ           __NVIC_GetEnableIRQ
+  #define NVIC_DisableIRQ             __NVIC_DisableIRQ
+  #define NVIC_GetPendingIRQ          __NVIC_GetPendingIRQ
+  #define NVIC_SetPendingIRQ          __NVIC_SetPendingIRQ
+  #define NVIC_ClearPendingIRQ        __NVIC_ClearPendingIRQ
+  #define NVIC_GetActive              __NVIC_GetActive
+  #define NVIC_SetPriority            __NVIC_SetPriority
+  #define NVIC_GetPriority            __NVIC_GetPriority
+  #define NVIC_SystemReset            __NVIC_SystemReset
+#endif /* CMSIS_NVIC_VIRTUAL */
+
+#ifdef CMSIS_VECTAB_VIRTUAL
+  #ifndef CMSIS_VECTAB_VIRTUAL_HEADER_FILE
+    #define CMSIS_VECTAB_VIRTUAL_HEADER_FILE "cmsis_vectab_virtual.h"
+  #endif
+  #include CMSIS_VECTAB_VIRTUAL_HEADER_FILE
+#else
+  #define NVIC_SetVector              __NVIC_SetVector
+  #define NVIC_GetVector              __NVIC_GetVector
+#endif  /* (CMSIS_VECTAB_VIRTUAL) */
+
+#define NVIC_USER_IRQ_OFFSET          16
+
+
+/* Special LR values for Secure/Non-Secure call handling and exception handling                                               */
+
+/* Function Return Payload (from ARMv8-M Architecture Reference Manual) LR value on entry from Secure BLXNS                   */
+#define FNC_RETURN                 (0xFEFFFFFFUL)     /* bit [0] ignored when processing a branch                             */
+
+/* The following EXC_RETURN mask values are used to evaluate the LR on exception entry */
+#define EXC_RETURN_PREFIX          (0xFF000000UL)     /* bits [31:24] set to indicate an EXC_RETURN value                     */
+#define EXC_RETURN_S               (0x00000040UL)     /* bit [6] stack used to push registers: 0=Non-secure 1=Secure          */
+#define EXC_RETURN_DCRS            (0x00000020UL)     /* bit [5] stacking rules for called registers: 0=skipped 1=saved       */
+#define EXC_RETURN_FTYPE           (0x00000010UL)     /* bit [4] allocate stack for floating-point context: 0=done 1=skipped  */
+#define EXC_RETURN_MODE            (0x00000008UL)     /* bit [3] processor mode for return: 0=Handler mode 1=Thread mode      */
+#define EXC_RETURN_SPSEL           (0x00000004UL)     /* bit [2] stack pointer used to restore context: 0=MSP 1=PSP           */
+#define EXC_RETURN_ES              (0x00000001UL)     /* bit [0] security state exception was taken to: 0=Non-secure 1=Secure */
+
+/* Integrity Signature (from ARMv8-M Architecture Reference Manual) for exception context stacking                            */
+#if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)  /* Value for processors with floating-point extension:                  */
+#define EXC_INTEGRITY_SIGNATURE     (0xFEFA125AUL)     /* bit [0] SFTC must match LR bit[4] EXC_RETURN_FTYPE                   */
+#else
+#define EXC_INTEGRITY_SIGNATURE     (0xFEFA125BUL)     /* Value for processors without floating-point extension                */
+#endif
+
+
+/**
+  \brief   Set Priority Grouping
+  \details Sets the priority grouping field using the required unlock sequence.
+           The parameter PriorityGroup is assigned to the field SCB->AIRCR [10:8] PRIGROUP field.
+           Only values from 0..7 are used.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+  \param [in]      PriorityGroup  Priority grouping field.
+ */
+__STATIC_INLINE void __NVIC_SetPriorityGrouping(uint32_t PriorityGroup)
+{
+  uint32_t reg_value;
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);             /* only values 0..7 are used          */
+
+  reg_value  =  SCB->AIRCR;                                                   /* read old register configuration    */
+  reg_value &= ~((uint32_t)(SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk)); /* clear bits to change               */
+  reg_value  =  (reg_value                                   |
+                ((uint32_t)0x5FAUL << SCB_AIRCR_VECTKEY_Pos) |
+                (PriorityGroupTmp << SCB_AIRCR_PRIGROUP_Pos)  );              /* Insert write key and priority group */
+  SCB->AIRCR =  reg_value;
+}
+
+
+/**
+  \brief   Get Priority Grouping
+  \details Reads the priority grouping field from the NVIC Interrupt Controller.
+  \return                Priority grouping field (SCB->AIRCR [10:8] PRIGROUP field).
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPriorityGrouping(void)
+{
+  return ((uint32_t)((SCB->AIRCR & SCB_AIRCR_PRIGROUP_Msk) >> SCB_AIRCR_PRIGROUP_Pos));
+}
+
+
+/**
+  \brief   Enable Interrupt
+  \details Enables a device specific interrupt in the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_EnableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    __COMPILER_BARRIER();
+    NVIC->ISER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+    __COMPILER_BARRIER();
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Enable status
+  \details Returns a device specific interrupt enable status from the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt is not enabled.
+  \return             1  Interrupt is enabled.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetEnableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ISER[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Disable Interrupt
+  \details Disables a device specific interrupt in the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_DisableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ICER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+    __DSB();
+    __ISB();
+  }
+}
+
+
+/**
+  \brief   Get Pending Interrupt
+  \details Reads the NVIC pending register and returns the pending bit for the specified device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not pending.
+  \return             1  Interrupt status is pending.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ISPR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Pending Interrupt
+  \details Sets the pending bit of a device specific interrupt in the NVIC pending register.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_SetPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ISPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Clear Pending Interrupt
+  \details Clears the pending bit of a device specific interrupt in the NVIC pending register.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_ClearPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ICPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Active Interrupt
+  \details Reads the active register in the NVIC and returns the active bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not active.
+  \return             1  Interrupt status is active.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetActive(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->IABR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   Get Interrupt Target State
+  \details Reads the interrupt target field in the NVIC and returns the interrupt target bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  if interrupt is assigned to Secure
+  \return             1  if interrupt is assigned to Non Secure
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t NVIC_GetTargetState(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Interrupt Target State
+  \details Sets the interrupt target field in the NVIC and returns the interrupt target bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  if interrupt is assigned to Secure
+                      1  if interrupt is assigned to Non Secure
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t NVIC_SetTargetState(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] |=  ((uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL)));
+    return((uint32_t)(((NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Clear Interrupt Target State
+  \details Clears the interrupt target field in the NVIC and returns the interrupt target bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  if interrupt is assigned to Secure
+                      1  if interrupt is assigned to Non Secure
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t NVIC_ClearTargetState(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] &= ~((uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL)));
+    return((uint32_t)(((NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+
+/**
+  \brief   Set Interrupt Priority
+  \details Sets the priority of a device specific interrupt or a processor exception.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]      IRQn  Interrupt number.
+  \param [in]  priority  Priority to set.
+  \note    The priority cannot be set for every processor exception.
+ */
+__STATIC_INLINE void __NVIC_SetPriority(IRQn_Type IRQn, uint32_t priority)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->IPR[((uint32_t)IRQn)]               = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+  else
+  {
+    SCB->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Priority
+  \details Reads the priority of a device specific interrupt or a processor exception.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn  Interrupt number.
+  \return             Interrupt Priority.
+                      Value is aligned automatically to the implemented priority bits of the microcontroller.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPriority(IRQn_Type IRQn)
+{
+
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return(((uint32_t)NVIC->IPR[((uint32_t)IRQn)]               >> (8U - __NVIC_PRIO_BITS)));
+  }
+  else
+  {
+    return(((uint32_t)SCB->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] >> (8U - __NVIC_PRIO_BITS)));
+  }
+}
+
+
+/**
+  \brief   Encode Priority
+  \details Encodes the priority for an interrupt with the given priority group,
+           preemptive priority value, and subpriority value.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+  \param [in]     PriorityGroup  Used priority group.
+  \param [in]   PreemptPriority  Preemptive priority value (starting from 0).
+  \param [in]       SubPriority  Subpriority value (starting from 0).
+  \return                        Encoded priority. Value can be used in the function \ref NVIC_SetPriority().
+ */
+__STATIC_INLINE uint32_t NVIC_EncodePriority (uint32_t PriorityGroup, uint32_t PreemptPriority, uint32_t SubPriority)
+{
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);   /* only values 0..7 are used          */
+  uint32_t PreemptPriorityBits;
+  uint32_t SubPriorityBits;
+
+  PreemptPriorityBits = ((7UL - PriorityGroupTmp) > (uint32_t)(__NVIC_PRIO_BITS)) ? (uint32_t)(__NVIC_PRIO_BITS) : (uint32_t)(7UL - PriorityGroupTmp);
+  SubPriorityBits     = ((PriorityGroupTmp + (uint32_t)(__NVIC_PRIO_BITS)) < (uint32_t)7UL) ? (uint32_t)0UL : (uint32_t)((PriorityGroupTmp - 7UL) + (uint32_t)(__NVIC_PRIO_BITS));
+
+  return (
+           ((PreemptPriority & (uint32_t)((1UL << (PreemptPriorityBits)) - 1UL)) << SubPriorityBits) |
+           ((SubPriority     & (uint32_t)((1UL << (SubPriorityBits    )) - 1UL)))
+         );
+}
+
+
+/**
+  \brief   Decode Priority
+  \details Decodes an interrupt priority value with a given priority group to
+           preemptive priority value and subpriority value.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS) the smallest possible priority group is set.
+  \param [in]         Priority   Priority value, which can be retrieved with the function \ref NVIC_GetPriority().
+  \param [in]     PriorityGroup  Used priority group.
+  \param [out] pPreemptPriority  Preemptive priority value (starting from 0).
+  \param [out]     pSubPriority  Subpriority value (starting from 0).
+ */
+__STATIC_INLINE void NVIC_DecodePriority (uint32_t Priority, uint32_t PriorityGroup, uint32_t* const pPreemptPriority, uint32_t* const pSubPriority)
+{
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);   /* only values 0..7 are used          */
+  uint32_t PreemptPriorityBits;
+  uint32_t SubPriorityBits;
+
+  PreemptPriorityBits = ((7UL - PriorityGroupTmp) > (uint32_t)(__NVIC_PRIO_BITS)) ? (uint32_t)(__NVIC_PRIO_BITS) : (uint32_t)(7UL - PriorityGroupTmp);
+  SubPriorityBits     = ((PriorityGroupTmp + (uint32_t)(__NVIC_PRIO_BITS)) < (uint32_t)7UL) ? (uint32_t)0UL : (uint32_t)((PriorityGroupTmp - 7UL) + (uint32_t)(__NVIC_PRIO_BITS));
+
+  *pPreemptPriority = (Priority >> SubPriorityBits) & (uint32_t)((1UL << (PreemptPriorityBits)) - 1UL);
+  *pSubPriority     = (Priority                   ) & (uint32_t)((1UL << (SubPriorityBits    )) - 1UL);
+}
+
+
+/**
+  \brief   Set Interrupt Vector
+  \details Sets an interrupt vector in SRAM based interrupt vector table.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+           VTOR must been relocated to SRAM before.
+  \param [in]   IRQn      Interrupt number
+  \param [in]   vector    Address of interrupt handler function
+ */
+__STATIC_INLINE void __NVIC_SetVector(IRQn_Type IRQn, uint32_t vector)
+{
+  uint32_t *vectors = (uint32_t *) ((uintptr_t) SCB->VTOR);
+  vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET] = vector;
+  __DSB();
+}
+
+
+/**
+  \brief   Get Interrupt Vector
+  \details Reads an interrupt vector from interrupt vector table.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn      Interrupt number.
+  \return                 Address of interrupt handler function
+ */
+__STATIC_INLINE uint32_t __NVIC_GetVector(IRQn_Type IRQn)
+{
+  uint32_t *vectors = (uint32_t *) ((uintptr_t) SCB->VTOR);
+  return vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET];
+}
+
+
+/**
+  \brief   System Reset
+  \details Initiates a system reset request to reset the MCU.
+ */
+__NO_RETURN __STATIC_INLINE void __NVIC_SystemReset(void)
+{
+  __DSB();                                                          /* Ensure all outstanding memory accesses included
+                                                                       buffered write are completed before reset */
+  SCB->AIRCR  = (uint32_t)((0x5FAUL << SCB_AIRCR_VECTKEY_Pos)    |
+                           (SCB->AIRCR & SCB_AIRCR_PRIGROUP_Msk) |
+                            SCB_AIRCR_SYSRESETREQ_Msk    );         /* Keep priority group unchanged */
+  __DSB();                                                          /* Ensure completion of memory access */
+
+  for(;;)                                                           /* wait until reset */
+  {
+    __NOP();
+  }
+}
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   Set Priority Grouping (non-secure)
+  \details Sets the non-secure priority grouping field when in secure state using the required unlock sequence.
+           The parameter PriorityGroup is assigned to the field SCB->AIRCR [10:8] PRIGROUP field.
+           Only values from 0..7 are used.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+  \param [in]      PriorityGroup  Priority grouping field.
+ */
+__STATIC_INLINE void TZ_NVIC_SetPriorityGrouping_NS(uint32_t PriorityGroup)
+{
+  uint32_t reg_value;
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);             /* only values 0..7 are used          */
+
+  reg_value  =  SCB_NS->AIRCR;                                                /* read old register configuration    */
+  reg_value &= ~((uint32_t)(SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk)); /* clear bits to change               */
+  reg_value  =  (reg_value                                   |
+                ((uint32_t)0x5FAUL << SCB_AIRCR_VECTKEY_Pos) |
+                (PriorityGroupTmp << SCB_AIRCR_PRIGROUP_Pos)  );              /* Insert write key and priority group */
+  SCB_NS->AIRCR =  reg_value;
+}
+
+
+/**
+  \brief   Get Priority Grouping (non-secure)
+  \details Reads the priority grouping field from the non-secure NVIC when in secure state.
+  \return                Priority grouping field (SCB->AIRCR [10:8] PRIGROUP field).
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetPriorityGrouping_NS(void)
+{
+  return ((uint32_t)((SCB_NS->AIRCR & SCB_AIRCR_PRIGROUP_Msk) >> SCB_AIRCR_PRIGROUP_Pos));
+}
+
+
+/**
+  \brief   Enable Interrupt (non-secure)
+  \details Enables a device specific interrupt in the non-secure NVIC interrupt controller when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void TZ_NVIC_EnableIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->ISER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Enable status (non-secure)
+  \details Returns a device specific interrupt enable status from the non-secure NVIC interrupt controller when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt is not enabled.
+  \return             1  Interrupt is enabled.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetEnableIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC_NS->ISER[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Disable Interrupt (non-secure)
+  \details Disables a device specific interrupt in the non-secure NVIC interrupt controller when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void TZ_NVIC_DisableIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->ICER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Pending Interrupt (non-secure)
+  \details Reads the NVIC pending register in the non-secure NVIC when in secure state and returns the pending bit for the specified device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not pending.
+  \return             1  Interrupt status is pending.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetPendingIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC_NS->ISPR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Pending Interrupt (non-secure)
+  \details Sets the pending bit of a device specific interrupt in the non-secure NVIC pending register when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void TZ_NVIC_SetPendingIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->ISPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Clear Pending Interrupt (non-secure)
+  \details Clears the pending bit of a device specific interrupt in the non-secure NVIC pending register when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void TZ_NVIC_ClearPendingIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->ICPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Active Interrupt (non-secure)
+  \details Reads the active register in non-secure NVIC when in secure state and returns the active bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not active.
+  \return             1  Interrupt status is active.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetActive_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC_NS->IABR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Interrupt Priority (non-secure)
+  \details Sets the priority of a non-secure device specific interrupt or a non-secure processor exception when in secure state.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]      IRQn  Interrupt number.
+  \param [in]  priority  Priority to set.
+  \note    The priority cannot be set for every non-secure processor exception.
+ */
+__STATIC_INLINE void TZ_NVIC_SetPriority_NS(IRQn_Type IRQn, uint32_t priority)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->IPR[((uint32_t)IRQn)]               = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+  else
+  {
+    SCB_NS->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Priority (non-secure)
+  \details Reads the priority of a non-secure device specific interrupt or a non-secure processor exception when in secure state.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn  Interrupt number.
+  \return             Interrupt Priority. Value is aligned automatically to the implemented priority bits of the microcontroller.
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetPriority_NS(IRQn_Type IRQn)
+{
+
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return(((uint32_t)NVIC_NS->IPR[((uint32_t)IRQn)]               >> (8U - __NVIC_PRIO_BITS)));
+  }
+  else
+  {
+    return(((uint32_t)SCB_NS->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] >> (8U - __NVIC_PRIO_BITS)));
+  }
+}
+#endif /*  defined (__ARM_FEATURE_CMSE) &&(__ARM_FEATURE_CMSE == 3U) */
+
+/*@} end of CMSIS_Core_NVICFunctions */
+
+/* ##########################  MPU functions  #################################### */
+
+#if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+
+  #include "m-profile/armv8m_mpu.h"
+
+#endif
+
+
+/* ##########################  FPU functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_FpuFunctions FPU Functions
+  \brief    Function that provides FPU type.
+  @{
+ */
+
+/**
+  \brief   get FPU type
+  \details returns the FPU type
+  \returns
+   - \b  0: No FPU
+   - \b  1: Single precision FPU
+   - \b  2: Double + Single precision FPU
+ */
+__STATIC_INLINE uint32_t SCB_GetFPUType(void)
+{
+  uint32_t mvfr0;
+
+  mvfr0 = FPU->MVFR0;
+  if      ((mvfr0 & (FPU_MVFR0_FPSP_Msk | FPU_MVFR0_FPDP_Msk)) == 0x220U)
+  {
+    return 2U;           /* Double + Single precision FPU */
+  }
+  else if ((mvfr0 & (FPU_MVFR0_FPSP_Msk | FPU_MVFR0_FPDP_Msk)) == 0x020U)
+  {
+    return 1U;           /* Single precision FPU */
+  }
+  else
+  {
+    return 0U;           /* No FPU */
+  }
+}
+
+/*@} end of CMSIS_Core_FpuFunctions */
+
+
+
+/* ##########################   SAU functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_SAUFunctions SAU Functions
+  \brief    Functions that configure the SAU.
+  @{
+ */
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+
+/**
+  \brief   Enable SAU
+  \details Enables the Security Attribution Unit (SAU).
+ */
+__STATIC_INLINE void TZ_SAU_Enable(void)
+{
+    SAU->CTRL |=  (SAU_CTRL_ENABLE_Msk);
+}
+
+
+
+/**
+  \brief   Disable SAU
+  \details Disables the Security Attribution Unit (SAU).
+ */
+__STATIC_INLINE void TZ_SAU_Disable(void)
+{
+    SAU->CTRL &= ~(SAU_CTRL_ENABLE_Msk);
+}
+
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+/*@} end of CMSIS_Core_SAUFunctions */
+
+
+
+
+/* ##################################    Debug Control function  ############################################ */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_DCBFunctions Debug Control Functions
+  \brief    Functions that access the Debug Control Block.
+  @{
+ */
+
+
+/**
+  \brief   Set Debug Authentication Control Register
+  \details writes to Debug Authentication Control register.
+  \param [in]  value  value to be writen.
+ */
+__STATIC_INLINE void DCB_SetAuthCtrl(uint32_t value)
+{
+    __DSB();
+    __ISB();
+    DCB->DAUTHCTRL = value;
+    __DSB();
+    __ISB();
+}
+
+
+/**
+  \brief   Get Debug Authentication Control Register
+  \details Reads Debug Authentication Control register.
+  \return             Debug Authentication Control Register.
+ */
+__STATIC_INLINE uint32_t DCB_GetAuthCtrl(void)
+{
+    return (DCB->DAUTHCTRL);
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   Set Debug Authentication Control Register (non-secure)
+  \details writes to non-secure Debug Authentication Control register when in secure state.
+  \param [in]  value  value to be writen
+ */
+__STATIC_INLINE void TZ_DCB_SetAuthCtrl_NS(uint32_t value)
+{
+    __DSB();
+    __ISB();
+    DCB_NS->DAUTHCTRL = value;
+    __DSB();
+    __ISB();
+}
+
+
+/**
+  \brief   Get Debug Authentication Control Register (non-secure)
+  \details Reads non-secure Debug Authentication Control register when in secure state.
+  \return             Debug Authentication Control Register.
+ */
+__STATIC_INLINE uint32_t TZ_DCB_GetAuthCtrl_NS(void)
+{
+    return (DCB_NS->DAUTHCTRL);
+}
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+/*@} end of CMSIS_Core_DCBFunctions */
+
+
+
+
+/* ##################################    Debug Identification function  ############################################ */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_DIBFunctions Debug Identification Functions
+  \brief    Functions that access the Debug Identification Block.
+  @{
+ */
+
+
+/**
+  \brief   Get Debug Authentication Status Register
+  \details Reads Debug Authentication Status register.
+  \return             Debug Authentication Status Register.
+ */
+__STATIC_INLINE uint32_t DIB_GetAuthStatus(void)
+{
+    return (DIB->DAUTHSTATUS);
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   Get Debug Authentication Status Register (non-secure)
+  \details Reads non-secure Debug Authentication Status register when in secure state.
+  \return             Debug Authentication Status Register.
+ */
+__STATIC_INLINE uint32_t TZ_DIB_GetAuthStatus_NS(void)
+{
+    return (DIB_NS->DAUTHSTATUS);
+}
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+/*@} end of CMSIS_Core_DCBFunctions */
+
+
+
+
+/* ##################################    SysTick function  ############################################ */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_SysTickFunctions SysTick Functions
+  \brief    Functions that configure the System.
+  @{
+ */
+
+#if defined (__Vendor_SysTickConfig) && (__Vendor_SysTickConfig == 0U)
+
+/**
+  \brief   System Tick Configuration
+  \details Initializes the System Timer and its interrupt, and starts the System Tick Timer.
+           Counter is in free running mode to generate periodic interrupts.
+  \param [in]  ticks  Number of ticks between two interrupts.
+  \return          0  Function succeeded.
+  \return          1  Function failed.
+  \note    When the variable <b>__Vendor_SysTickConfig</b> is set to 1, then the
+           function <b>SysTick_Config</b> is not included. In this case, the file <b><i>device</i>.h</b>
+           must contain a vendor-specific implementation of this function.
+ */
+__STATIC_INLINE uint32_t SysTick_Config(uint32_t ticks)
+{
+  if ((ticks - 1UL) > SysTick_LOAD_RELOAD_Msk)
+  {
+    return (1UL);                                                   /* Reload value impossible */
+  }
+
+  SysTick->LOAD  = (uint32_t)(ticks - 1UL);                         /* set reload register */
+  NVIC_SetPriority (SysTick_IRQn, (1UL << __NVIC_PRIO_BITS) - 1UL); /* set Priority for Systick Interrupt */
+  SysTick->VAL   = 0UL;                                             /* Load the SysTick Counter Value */
+  SysTick->CTRL  = SysTick_CTRL_CLKSOURCE_Msk |
+                   SysTick_CTRL_TICKINT_Msk   |
+                   SysTick_CTRL_ENABLE_Msk;                         /* Enable SysTick IRQ and SysTick Timer */
+  return (0UL);                                                     /* Function successful */
+}
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   System Tick Configuration (non-secure)
+  \details Initializes the non-secure System Timer and its interrupt when in secure state, and starts the System Tick Timer.
+           Counter is in free running mode to generate periodic interrupts.
+  \param [in]  ticks  Number of ticks between two interrupts.
+  \return          0  Function succeeded.
+  \return          1  Function failed.
+  \note    When the variable <b>__Vendor_SysTickConfig</b> is set to 1, then the
+           function <b>TZ_SysTick_Config_NS</b> is not included. In this case, the file <b><i>device</i>.h</b>
+           must contain a vendor-specific implementation of this function.
+
+ */
+__STATIC_INLINE uint32_t TZ_SysTick_Config_NS(uint32_t ticks)
+{
+  if ((ticks - 1UL) > SysTick_LOAD_RELOAD_Msk)
+  {
+    return (1UL);                                                         /* Reload value impossible */
+  }
+
+  SysTick_NS->LOAD  = (uint32_t)(ticks - 1UL);                            /* set reload register */
+  TZ_NVIC_SetPriority_NS (SysTick_IRQn, (1UL << __NVIC_PRIO_BITS) - 1UL); /* set Priority for Systick Interrupt */
+  SysTick_NS->VAL   = 0UL;                                                /* Load the SysTick Counter Value */
+  SysTick_NS->CTRL  = SysTick_CTRL_CLKSOURCE_Msk |
+                      SysTick_CTRL_TICKINT_Msk   |
+                      SysTick_CTRL_ENABLE_Msk;                            /* Enable SysTick IRQ and SysTick Timer */
+  return (0UL);                                                           /* Function successful */
+}
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+#endif
+
+/*@} end of CMSIS_Core_SysTickFunctions */
+
+
+
+/* ##################################### Debug In/Output function ########################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_core_DebugFunctions ITM Functions
+  \brief    Functions that access the ITM debug interface.
+  @{
+ */
+
+extern volatile int32_t ITM_RxBuffer;                              /*!< External variable to receive characters. */
+#define                 ITM_RXBUFFER_EMPTY  ((int32_t)0x5AA55AA5U) /*!< Value identifying \ref ITM_RxBuffer is ready for next character. */
+
+
+/**
+  \brief   ITM Send Character
+  \details Transmits a character via the ITM channel 0, and
+           \li Just returns when no debugger is connected that has booked the output.
+           \li Is blocking when a debugger is connected, but the previous character sent has not been transmitted.
+  \param [in]     ch  Character to transmit.
+  \returns            Character to transmit.
+ */
+__STATIC_INLINE uint32_t ITM_SendChar (uint32_t ch)
+{
+  if (((ITM->TCR & ITM_TCR_ITMENA_Msk) != 0UL) &&      /* ITM enabled */
+      ((ITM->TER & 1UL               ) != 0UL)   )     /* ITM Port #0 enabled */
+  {
+    while (ITM->PORT[0U].u32 == 0UL)
+    {
+      __NOP();
+    }
+    ITM->PORT[0U].u8 = (uint8_t)ch;
+  }
+  return (ch);
+}
+
+
+/**
+  \brief   ITM Receive Character
+  \details Inputs a character via the external variable \ref ITM_RxBuffer.
+  \return             Received character.
+  \return         -1  No character pending.
+ */
+__STATIC_INLINE int32_t ITM_ReceiveChar (void)
+{
+  int32_t ch = -1;                           /* no character available */
+
+  if (ITM_RxBuffer != ITM_RXBUFFER_EMPTY)
+  {
+    ch = ITM_RxBuffer;
+    ITM_RxBuffer = ITM_RXBUFFER_EMPTY;       /* ready for next character */
+  }
+
+  return (ch);
+}
+
+
+/**
+  \brief   ITM Check Character
+  \details Checks whether a character is pending for reading in the variable \ref ITM_RxBuffer.
+  \return          0  No character available.
+  \return          1  Character available.
+ */
+__STATIC_INLINE int32_t ITM_CheckChar (void)
+{
+
+  if (ITM_RxBuffer == ITM_RXBUFFER_EMPTY)
+  {
+    return (0);                              /* no character available */
+  }
+  else
+  {
+    return (1);                              /*    character available */
+  }
+}
+
+/*@} end of CMSIS_core_DebugFunctions */
+
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_CM33_H_DEPENDANT */
+
+#endif /* __CMSIS_GENERIC */

--- a/platform/ext/cmsis/CMSIS/Core/Include/core_cm35p.h
+++ b/platform/ext/cmsis/CMSIS/Core/Include/core_cm35p.h
@@ -1,0 +1,3112 @@
+/*
+ * Copyright (c) 2018-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS Cortex-M35P Core Peripheral Access Layer Header File
+ */
+
+#if   defined ( __ICCARM__ )
+  #pragma system_include                        /* treat file as system include file for MISRA check */
+#elif defined (__clang__)
+  #pragma clang system_header                   /* treat file as system include file */
+#elif defined ( __GNUC__ )
+  #pragma GCC diagnostic ignored "-Wpedantic"   /* disable pedantic warning due to unnamed structs/unions */
+#endif
+
+#ifndef __CORE_CM35P_H_GENERIC
+#define __CORE_CM35P_H_GENERIC
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/**
+  \page CMSIS_MISRA_Exceptions  MISRA-C:2004 Compliance Exceptions
+  CMSIS violates the following MISRA-C:2004 rules:
+
+   \li Required Rule 8.5, object/function definition in header file.<br>
+     Function definitions in header files are used to allow 'inlining'.
+
+   \li Required Rule 18.4, declaration of union type or object of union type: '{...}'.<br>
+     Unions are used for effective representation of core registers.
+
+   \li Advisory Rule 19.7, Function-like macro defined.<br>
+     Function-like macros are used to allow more efficient code.
+ */
+
+
+/*******************************************************************************
+ *                 CMSIS definitions
+ ******************************************************************************/
+/**
+  \ingroup Cortex_M35P
+  @{
+ */
+
+#include "cmsis_version.h"
+
+/* CMSIS CM35 definitions */
+
+#define __CORTEX_M                (35U)                               /*!< Cortex-M Core */
+
+/** __FPU_USED indicates whether an FPU is used or not.
+    For this, __FPU_PRESENT has to be checked prior to making use of FPU specific registers and functions.
+*/
+#if defined ( __CC_ARM )
+  #if defined (__TARGET_FPU_VFP)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+  #if defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1U)
+    #if defined (__DSP_PRESENT) && (__DSP_PRESENT == 1U)
+      #define __DSP_USED       1U
+    #else
+      #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
+      #define __DSP_USED         0U
+    #endif
+  #else
+    #define __DSP_USED         0U
+  #endif
+
+#elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #if defined (__ARM_FP)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+  #if defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1U)
+    #if defined (__DSP_PRESENT) && (__DSP_PRESENT == 1U)
+      #define __DSP_USED       1U
+    #else
+      #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
+      #define __DSP_USED       0U
+    #endif
+  #else
+    #define __DSP_USED         0U
+  #endif
+
+#elif defined (__ti__)
+  #if defined (__ARM_FP)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+  #if defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1U)
+    #if defined (__DSP_PRESENT) && (__DSP_PRESENT == 1U)
+      #define __DSP_USED       1U
+    #else
+      #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
+      #define __DSP_USED       0U
+    #endif
+  #else
+    #define __DSP_USED         0U
+  #endif
+
+#elif defined ( __GNUC__ )
+  #if defined (__VFP_FP__) && !defined(__SOFTFP__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+  #if defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1U)
+    #if defined (__DSP_PRESENT) && (__DSP_PRESENT == 1U)
+      #define __DSP_USED       1U
+    #else
+      #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
+      #define __DSP_USED         0U
+    #endif
+  #else
+    #define __DSP_USED         0U
+  #endif
+
+#elif defined ( __ICCARM__ )
+  #if defined (__ARMVFP__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+  #if defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1U)
+    #if defined (__DSP_PRESENT) && (__DSP_PRESENT == 1U)
+      #define __DSP_USED       1U
+    #else
+      #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
+      #define __DSP_USED         0U
+    #endif
+  #else
+    #define __DSP_USED         0U
+  #endif
+
+#elif defined ( __TI_ARM__ )
+  #if defined (__TI_VFP_SUPPORT__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#elif defined ( __TASKING__ )
+  #if defined (__FPU_VFP__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#elif defined ( __CSMC__ )
+  #if ( __CSMC__ & 0x400U)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#endif
+
+#include "cmsis_compiler.h"               /* CMSIS compiler specific defines */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_CM35P_H_GENERIC */
+
+#ifndef __CMSIS_GENERIC
+
+#ifndef __CORE_CM35P_H_DEPENDANT
+#define __CORE_CM35P_H_DEPENDANT
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* check device defines and use defaults */
+#if defined __CHECK_DEVICE_DEFINES
+  #ifndef __CM35P_REV
+    #define __CM35P_REV               0x0000U
+    #warning "__CM35P_REV not defined in device header file; using default!"
+  #endif
+
+  #ifndef __FPU_PRESENT
+    #define __FPU_PRESENT             0U
+    #warning "__FPU_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __MPU_PRESENT
+    #define __MPU_PRESENT             0U
+    #warning "__MPU_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __SAUREGION_PRESENT
+    #define __SAUREGION_PRESENT       0U
+    #warning "__SAUREGION_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __DSP_PRESENT
+    #define __DSP_PRESENT             0U
+    #warning "__DSP_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __VTOR_PRESENT
+    #define __VTOR_PRESENT             1U
+    #warning "__VTOR_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __NVIC_PRIO_BITS
+    #define __NVIC_PRIO_BITS          3U
+    #warning "__NVIC_PRIO_BITS not defined in device header file; using default!"
+  #endif
+
+  #ifndef __Vendor_SysTickConfig
+    #define __Vendor_SysTickConfig    0U
+    #warning "__Vendor_SysTickConfig not defined in device header file; using default!"
+  #endif
+#endif
+
+/* IO definitions (access restrictions to peripheral registers) */
+/**
+    \defgroup CMSIS_glob_defs CMSIS Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+*/
+#ifdef __cplusplus
+  #define   __I     volatile             /*!< Defines 'read only' permissions */
+#else
+  #define   __I     volatile const       /*!< Defines 'read only' permissions */
+#endif
+#define     __O     volatile             /*!< Defines 'write only' permissions */
+#define     __IO    volatile             /*!< Defines 'read / write' permissions */
+
+/* following defines should be used for structure members */
+#define     __IM     volatile const      /*! Defines 'read only' structure member permissions */
+#define     __OM     volatile            /*! Defines 'write only' structure member permissions */
+#define     __IOM    volatile            /*! Defines 'read / write' structure member permissions */
+
+/*@} end of group Cortex_M35P */
+
+
+
+/*******************************************************************************
+ *                 Register Abstraction
+  Core Register contain:
+  - Core Register
+  - Core NVIC Register
+  - Core SCB Register
+  - Core SysTick Register
+  - Core Debug Register
+  - Core MPU Register
+  - Core SAU Register
+  - Core FPU Register
+ ******************************************************************************/
+/**
+  \defgroup CMSIS_core_register Defines and Type Definitions
+  \brief Type definitions and defines for Cortex-M processor based devices.
+*/
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_CORE  Status and Control Registers
+  \brief      Core Register type definitions.
+  @{
+ */
+
+/**
+  \brief  Union type to access the Application Program Status Register (APSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t _reserved0:16;              /*!< bit:  0..15  Reserved */
+    uint32_t GE:4;                       /*!< bit: 16..19  Greater than or Equal flags */
+    uint32_t _reserved1:7;               /*!< bit: 20..26  Reserved */
+    uint32_t Q:1;                        /*!< bit:     27  Saturation condition flag */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} APSR_Type;
+
+/** \brief APSR Register Definitions */
+#define APSR_N_Pos                         31U                                            /*!< APSR: N Position */
+#define APSR_N_Msk                         (1UL << APSR_N_Pos)                            /*!< APSR: N Mask */
+
+#define APSR_Z_Pos                         30U                                            /*!< APSR: Z Position */
+#define APSR_Z_Msk                         (1UL << APSR_Z_Pos)                            /*!< APSR: Z Mask */
+
+#define APSR_C_Pos                         29U                                            /*!< APSR: C Position */
+#define APSR_C_Msk                         (1UL << APSR_C_Pos)                            /*!< APSR: C Mask */
+
+#define APSR_V_Pos                         28U                                            /*!< APSR: V Position */
+#define APSR_V_Msk                         (1UL << APSR_V_Pos)                            /*!< APSR: V Mask */
+
+#define APSR_Q_Pos                         27U                                            /*!< APSR: Q Position */
+#define APSR_Q_Msk                         (1UL << APSR_Q_Pos)                            /*!< APSR: Q Mask */
+
+#define APSR_GE_Pos                        16U                                            /*!< APSR: GE Position */
+#define APSR_GE_Msk                        (0xFUL << APSR_GE_Pos)                         /*!< APSR: GE Mask */
+
+
+/**
+  \brief  Union type to access the Interrupt Program Status Register (IPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number */
+    uint32_t _reserved0:23;              /*!< bit:  9..31  Reserved */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} IPSR_Type;
+
+/** \brief IPSR Register Definitions */
+#define IPSR_ISR_Pos                        0U                                            /*!< IPSR: ISR Position */
+#define IPSR_ISR_Msk                       (0x1FFUL /*<< IPSR_ISR_Pos*/)                  /*!< IPSR: ISR Mask */
+
+
+/**
+  \brief  Union type to access the Special-Purpose Program Status Registers (xPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number */
+    uint32_t _reserved0:7;               /*!< bit:  9..15  Reserved */
+    uint32_t GE:4;                       /*!< bit: 16..19  Greater than or Equal flags */
+    uint32_t _reserved1:4;               /*!< bit: 20..23  Reserved */
+    uint32_t T:1;                        /*!< bit:     24  Thumb bit        (read 0) */
+    uint32_t IT:2;                       /*!< bit: 25..26  saved IT state   (read 0) */
+    uint32_t Q:1;                        /*!< bit:     27  Saturation condition flag */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} xPSR_Type;
+
+/** \brief xPSR Register Definitions */
+#define xPSR_N_Pos                         31U                                            /*!< xPSR: N Position */
+#define xPSR_N_Msk                         (1UL << xPSR_N_Pos)                            /*!< xPSR: N Mask */
+
+#define xPSR_Z_Pos                         30U                                            /*!< xPSR: Z Position */
+#define xPSR_Z_Msk                         (1UL << xPSR_Z_Pos)                            /*!< xPSR: Z Mask */
+
+#define xPSR_C_Pos                         29U                                            /*!< xPSR: C Position */
+#define xPSR_C_Msk                         (1UL << xPSR_C_Pos)                            /*!< xPSR: C Mask */
+
+#define xPSR_V_Pos                         28U                                            /*!< xPSR: V Position */
+#define xPSR_V_Msk                         (1UL << xPSR_V_Pos)                            /*!< xPSR: V Mask */
+
+#define xPSR_Q_Pos                         27U                                            /*!< xPSR: Q Position */
+#define xPSR_Q_Msk                         (1UL << xPSR_Q_Pos)                            /*!< xPSR: Q Mask */
+
+#define xPSR_IT_Pos                        25U                                            /*!< xPSR: IT Position */
+#define xPSR_IT_Msk                        (3UL << xPSR_IT_Pos)                           /*!< xPSR: IT Mask */
+
+#define xPSR_T_Pos                         24U                                            /*!< xPSR: T Position */
+#define xPSR_T_Msk                         (1UL << xPSR_T_Pos)                            /*!< xPSR: T Mask */
+
+#define xPSR_GE_Pos                        16U                                            /*!< xPSR: GE Position */
+#define xPSR_GE_Msk                        (0xFUL << xPSR_GE_Pos)                         /*!< xPSR: GE Mask */
+
+#define xPSR_ISR_Pos                        0U                                            /*!< xPSR: ISR Position */
+#define xPSR_ISR_Msk                       (0x1FFUL /*<< xPSR_ISR_Pos*/)                  /*!< xPSR: ISR Mask */
+
+
+/**
+  \brief  Union type to access the Control Registers (CONTROL).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t nPRIV:1;                    /*!< bit:      0  Execution privilege in Thread mode */
+    uint32_t SPSEL:1;                    /*!< bit:      1  Stack-pointer select */
+    uint32_t FPCA:1;                     /*!< bit:      2  Floating-point context active */
+    uint32_t SFPA:1;                     /*!< bit:      3  Secure floating-point active */
+    uint32_t _reserved1:28;              /*!< bit:  4..31  Reserved */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} CONTROL_Type;
+
+/** \brief CONTROL Register Definitions */
+#define CONTROL_SFPA_Pos                    3U                                            /*!< CONTROL: SFPA Position */
+#define CONTROL_SFPA_Msk                   (1UL << CONTROL_SFPA_Pos)                      /*!< CONTROL: SFPA Mask */
+
+#define CONTROL_FPCA_Pos                    2U                                            /*!< CONTROL: FPCA Position */
+#define CONTROL_FPCA_Msk                   (1UL << CONTROL_FPCA_Pos)                      /*!< CONTROL: FPCA Mask */
+
+#define CONTROL_SPSEL_Pos                   1U                                            /*!< CONTROL: SPSEL Position */
+#define CONTROL_SPSEL_Msk                  (1UL << CONTROL_SPSEL_Pos)                     /*!< CONTROL: SPSEL Mask */
+
+#define CONTROL_nPRIV_Pos                   0U                                            /*!< CONTROL: nPRIV Position */
+#define CONTROL_nPRIV_Msk                  (1UL /*<< CONTROL_nPRIV_Pos*/)                 /*!< CONTROL: nPRIV Mask */
+
+/*@} end of group CMSIS_CORE */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_NVIC  Nested Vectored Interrupt Controller (NVIC)
+  \brief      Type definitions for the NVIC Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Nested Vectored Interrupt Controller (NVIC).
+ */
+typedef struct
+{
+  __IOM uint32_t ISER[16U];              /*!< Offset: 0x000 (R/W)  Interrupt Set Enable Register */
+        uint32_t RESERVED0[16U];
+  __IOM uint32_t ICER[16U];              /*!< Offset: 0x080 (R/W)  Interrupt Clear Enable Register */
+        uint32_t RESERVED1[16U];
+  __IOM uint32_t ISPR[16U];              /*!< Offset: 0x100 (R/W)  Interrupt Set Pending Register */
+        uint32_t RESERVED2[16U];
+  __IOM uint32_t ICPR[16U];              /*!< Offset: 0x180 (R/W)  Interrupt Clear Pending Register */
+        uint32_t RESERVED3[16U];
+  __IOM uint32_t IABR[16U];              /*!< Offset: 0x200 (R/W)  Interrupt Active bit Register */
+        uint32_t RESERVED4[16U];
+  __IOM uint32_t ITNS[16U];              /*!< Offset: 0x280 (R/W)  Interrupt Non-Secure State Register */
+        uint32_t RESERVED5[16U];
+  __IOM uint8_t  IPR[496U];              /*!< Offset: 0x300 (R/W)  Interrupt Priority Register (8Bit wide) */
+        uint32_t RESERVED6[580U];
+  __OM  uint32_t STIR;                   /*!< Offset: 0xE00 ( /W)  Software Trigger Interrupt Register */
+}  NVIC_Type;
+
+/** \brief NVIC Software Triggered Interrupt Register Definitions */
+#define NVIC_STIR_INTID_Pos                 0U                                         /*!< STIR: INTLINESNUM Position */
+#define NVIC_STIR_INTID_Msk                (0x1FFUL /*<< NVIC_STIR_INTID_Pos*/)        /*!< STIR: INTLINESNUM Mask */
+
+/*@} end of group CMSIS_NVIC */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SCB     System Control Block (SCB)
+  \brief    Type definitions for the System Control Block Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Control Block (SCB).
+ */
+typedef struct
+{
+  __IM  uint32_t CPUID;                  /*!< Offset: 0x000 (R/ )  CPUID Base Register */
+  __IOM uint32_t ICSR;                   /*!< Offset: 0x004 (R/W)  Interrupt Control and State Register */
+  __IOM uint32_t VTOR;                   /*!< Offset: 0x008 (R/W)  Vector Table Offset Register */
+  __IOM uint32_t AIRCR;                  /*!< Offset: 0x00C (R/W)  Application Interrupt and Reset Control Register */
+  __IOM uint32_t SCR;                    /*!< Offset: 0x010 (R/W)  System Control Register */
+  __IOM uint32_t CCR;                    /*!< Offset: 0x014 (R/W)  Configuration Control Register */
+  __IOM uint8_t  SHPR[12U];              /*!< Offset: 0x018 (R/W)  System Handlers Priority Registers (4-7, 8-11, 12-15) */
+  __IOM uint32_t SHCSR;                  /*!< Offset: 0x024 (R/W)  System Handler Control and State Register */
+  __IOM uint32_t CFSR;                   /*!< Offset: 0x028 (R/W)  Configurable Fault Status Register */
+  __IOM uint32_t HFSR;                   /*!< Offset: 0x02C (R/W)  HardFault Status Register */
+  __IOM uint32_t DFSR;                   /*!< Offset: 0x030 (R/W)  Debug Fault Status Register */
+  __IOM uint32_t MMFAR;                  /*!< Offset: 0x034 (R/W)  MemManage Fault Address Register */
+  __IOM uint32_t BFAR;                   /*!< Offset: 0x038 (R/W)  BusFault Address Register */
+  __IOM uint32_t AFSR;                   /*!< Offset: 0x03C (R/W)  Auxiliary Fault Status Register */
+  __IM  uint32_t ID_PFR[2U];             /*!< Offset: 0x040 (R/ )  Processor Feature Register */
+  __IM  uint32_t ID_DFR;                 /*!< Offset: 0x048 (R/ )  Debug Feature Register */
+  __IM  uint32_t ID_AFR;                 /*!< Offset: 0x04C (R/ )  Auxiliary Feature Register */
+  __IM  uint32_t ID_MMFR[4U];            /*!< Offset: 0x050 (R/ )  Memory Model Feature Register */
+  __IM  uint32_t ID_ISAR[6U];            /*!< Offset: 0x060 (R/ )  Instruction Set Attributes Register */
+  __IM  uint32_t CLIDR;                  /*!< Offset: 0x078 (R/ )  Cache Level ID register */
+  __IM  uint32_t CTR;                    /*!< Offset: 0x07C (R/ )  Cache Type register */
+  __IM  uint32_t CCSIDR;                 /*!< Offset: 0x080 (R/ )  Cache Size ID Register */
+  __IOM uint32_t CSSELR;                 /*!< Offset: 0x084 (R/W)  Cache Size Selection Register */
+  __IOM uint32_t CPACR;                  /*!< Offset: 0x088 (R/W)  Coprocessor Access Control Register */
+  __IOM uint32_t NSACR;                  /*!< Offset: 0x08C (R/W)  Non-Secure Access Control Register */
+        uint32_t RESERVED7[21U];
+  __IOM uint32_t SFSR;                   /*!< Offset: 0x0E4 (R/W)  Secure Fault Status Register */
+  __IOM uint32_t SFAR;                   /*!< Offset: 0x0E8 (R/W)  Secure Fault Address Register */
+        uint32_t RESERVED3[69U];
+  __OM  uint32_t STIR;                   /*!< Offset: 0x200 ( /W)  Software Triggered Interrupt Register */
+        uint32_t RESERVED4[15U];
+  __IM  uint32_t MVFR0;                  /*!< Offset: 0x240 (R/ )  Media and VFP Feature Register 0 */
+  __IM  uint32_t MVFR1;                  /*!< Offset: 0x244 (R/ )  Media and VFP Feature Register 1 */
+  __IM  uint32_t MVFR2;                  /*!< Offset: 0x248 (R/ )  Media and VFP Feature Register 2 */
+        uint32_t RESERVED5[1U];
+  __OM  uint32_t ICIALLU;                /*!< Offset: 0x250 ( /W)  I-Cache Invalidate All to PoU */
+        uint32_t RESERVED6[1U];
+  __OM  uint32_t ICIMVAU;                /*!< Offset: 0x258 ( /W)  I-Cache Invalidate by MVA to PoU */
+  __OM  uint32_t DCIMVAC;                /*!< Offset: 0x25C ( /W)  D-Cache Invalidate by MVA to PoC */
+  __OM  uint32_t DCISW;                  /*!< Offset: 0x260 ( /W)  D-Cache Invalidate by Set-way */
+  __OM  uint32_t DCCMVAU;                /*!< Offset: 0x264 ( /W)  D-Cache Clean by MVA to PoU */
+  __OM  uint32_t DCCMVAC;                /*!< Offset: 0x268 ( /W)  D-Cache Clean by MVA to PoC */
+  __OM  uint32_t DCCSW;                  /*!< Offset: 0x26C ( /W)  D-Cache Clean by Set-way */
+  __OM  uint32_t DCCIMVAC;               /*!< Offset: 0x270 ( /W)  D-Cache Clean and Invalidate by MVA to PoC */
+  __OM  uint32_t DCCISW;                 /*!< Offset: 0x274 ( /W)  D-Cache Clean and Invalidate by Set-way */
+  __OM  uint32_t BPIALL;                 /*!< Offset: 0x278 ( /W)  Branch Predictor Invalidate All */
+} SCB_Type;
+
+/** \brief SCB CPUID Register Definitions */
+#define SCB_CPUID_IMPLEMENTER_Pos          24U                                            /*!< SCB CPUID: IMPLEMENTER Position */
+#define SCB_CPUID_IMPLEMENTER_Msk          (0xFFUL << SCB_CPUID_IMPLEMENTER_Pos)          /*!< SCB CPUID: IMPLEMENTER Mask */
+
+#define SCB_CPUID_VARIANT_Pos              20U                                            /*!< SCB CPUID: VARIANT Position */
+#define SCB_CPUID_VARIANT_Msk              (0xFUL << SCB_CPUID_VARIANT_Pos)               /*!< SCB CPUID: VARIANT Mask */
+
+#define SCB_CPUID_ARCHITECTURE_Pos         16U                                            /*!< SCB CPUID: ARCHITECTURE Position */
+#define SCB_CPUID_ARCHITECTURE_Msk         (0xFUL << SCB_CPUID_ARCHITECTURE_Pos)          /*!< SCB CPUID: ARCHITECTURE Mask */
+
+#define SCB_CPUID_PARTNO_Pos                4U                                            /*!< SCB CPUID: PARTNO Position */
+#define SCB_CPUID_PARTNO_Msk               (0xFFFUL << SCB_CPUID_PARTNO_Pos)              /*!< SCB CPUID: PARTNO Mask */
+
+#define SCB_CPUID_REVISION_Pos              0U                                            /*!< SCB CPUID: REVISION Position */
+#define SCB_CPUID_REVISION_Msk             (0xFUL /*<< SCB_CPUID_REVISION_Pos*/)          /*!< SCB CPUID: REVISION Mask */
+
+/** \brief SCB Interrupt Control State Register Definitions */
+#define SCB_ICSR_PENDNMISET_Pos            31U                                            /*!< SCB ICSR: PENDNMISET Position */
+#define SCB_ICSR_PENDNMISET_Msk            (1UL << SCB_ICSR_PENDNMISET_Pos)               /*!< SCB ICSR: PENDNMISET Mask */
+
+#define SCB_ICSR_NMIPENDSET_Pos            SCB_ICSR_PENDNMISET_Pos                        /*!< SCB ICSR: NMIPENDSET Position, backward compatibility */
+#define SCB_ICSR_NMIPENDSET_Msk            SCB_ICSR_PENDNMISET_Msk                        /*!< SCB ICSR: NMIPENDSET Mask, backward compatibility */
+
+#define SCB_ICSR_PENDNMICLR_Pos            30U                                            /*!< SCB ICSR: PENDNMICLR Position */
+#define SCB_ICSR_PENDNMICLR_Msk            (1UL << SCB_ICSR_PENDNMICLR_Pos)               /*!< SCB ICSR: PENDNMICLR Mask */
+
+#define SCB_ICSR_PENDSVSET_Pos             28U                                            /*!< SCB ICSR: PENDSVSET Position */
+#define SCB_ICSR_PENDSVSET_Msk             (1UL << SCB_ICSR_PENDSVSET_Pos)                /*!< SCB ICSR: PENDSVSET Mask */
+
+#define SCB_ICSR_PENDSVCLR_Pos             27U                                            /*!< SCB ICSR: PENDSVCLR Position */
+#define SCB_ICSR_PENDSVCLR_Msk             (1UL << SCB_ICSR_PENDSVCLR_Pos)                /*!< SCB ICSR: PENDSVCLR Mask */
+
+#define SCB_ICSR_PENDSTSET_Pos             26U                                            /*!< SCB ICSR: PENDSTSET Position */
+#define SCB_ICSR_PENDSTSET_Msk             (1UL << SCB_ICSR_PENDSTSET_Pos)                /*!< SCB ICSR: PENDSTSET Mask */
+
+#define SCB_ICSR_PENDSTCLR_Pos             25U                                            /*!< SCB ICSR: PENDSTCLR Position */
+#define SCB_ICSR_PENDSTCLR_Msk             (1UL << SCB_ICSR_PENDSTCLR_Pos)                /*!< SCB ICSR: PENDSTCLR Mask */
+
+#define SCB_ICSR_STTNS_Pos                 24U                                            /*!< SCB ICSR: STTNS Position (Security Extension) */
+#define SCB_ICSR_STTNS_Msk                 (1UL << SCB_ICSR_STTNS_Pos)                    /*!< SCB ICSR: STTNS Mask (Security Extension) */
+
+#define SCB_ICSR_ISRPREEMPT_Pos            23U                                            /*!< SCB ICSR: ISRPREEMPT Position */
+#define SCB_ICSR_ISRPREEMPT_Msk            (1UL << SCB_ICSR_ISRPREEMPT_Pos)               /*!< SCB ICSR: ISRPREEMPT Mask */
+
+#define SCB_ICSR_ISRPENDING_Pos            22U                                            /*!< SCB ICSR: ISRPENDING Position */
+#define SCB_ICSR_ISRPENDING_Msk            (1UL << SCB_ICSR_ISRPENDING_Pos)               /*!< SCB ICSR: ISRPENDING Mask */
+
+#define SCB_ICSR_VECTPENDING_Pos           12U                                            /*!< SCB ICSR: VECTPENDING Position */
+#define SCB_ICSR_VECTPENDING_Msk           (0x1FFUL << SCB_ICSR_VECTPENDING_Pos)          /*!< SCB ICSR: VECTPENDING Mask */
+
+#define SCB_ICSR_RETTOBASE_Pos             11U                                            /*!< SCB ICSR: RETTOBASE Position */
+#define SCB_ICSR_RETTOBASE_Msk             (1UL << SCB_ICSR_RETTOBASE_Pos)                /*!< SCB ICSR: RETTOBASE Mask */
+
+#define SCB_ICSR_VECTACTIVE_Pos             0U                                            /*!< SCB ICSR: VECTACTIVE Position */
+#define SCB_ICSR_VECTACTIVE_Msk            (0x1FFUL /*<< SCB_ICSR_VECTACTIVE_Pos*/)       /*!< SCB ICSR: VECTACTIVE Mask */
+
+/** \brief SCB Vector Table Offset Register Definitions */
+#define SCB_VTOR_TBLOFF_Pos                 7U                                            /*!< SCB VTOR: TBLOFF Position */
+#define SCB_VTOR_TBLOFF_Msk                (0x1FFFFFFUL << SCB_VTOR_TBLOFF_Pos)           /*!< SCB VTOR: TBLOFF Mask */
+
+/** \brief SCB Application Interrupt and Reset Control Register Definitions */
+#define SCB_AIRCR_VECTKEY_Pos              16U                                            /*!< SCB AIRCR: VECTKEY Position */
+#define SCB_AIRCR_VECTKEY_Msk              (0xFFFFUL << SCB_AIRCR_VECTKEY_Pos)            /*!< SCB AIRCR: VECTKEY Mask */
+
+#define SCB_AIRCR_VECTKEYSTAT_Pos          16U                                            /*!< SCB AIRCR: VECTKEYSTAT Position */
+#define SCB_AIRCR_VECTKEYSTAT_Msk          (0xFFFFUL << SCB_AIRCR_VECTKEYSTAT_Pos)        /*!< SCB AIRCR: VECTKEYSTAT Mask */
+
+#define SCB_AIRCR_ENDIANESS_Pos            15U                                            /*!< SCB AIRCR: ENDIANESS Position */
+#define SCB_AIRCR_ENDIANESS_Msk            (1UL << SCB_AIRCR_ENDIANESS_Pos)               /*!< SCB AIRCR: ENDIANESS Mask */
+
+#define SCB_AIRCR_PRIS_Pos                 14U                                            /*!< SCB AIRCR: PRIS Position */
+#define SCB_AIRCR_PRIS_Msk                 (1UL << SCB_AIRCR_PRIS_Pos)                    /*!< SCB AIRCR: PRIS Mask */
+
+#define SCB_AIRCR_BFHFNMINS_Pos            13U                                            /*!< SCB AIRCR: BFHFNMINS Position */
+#define SCB_AIRCR_BFHFNMINS_Msk            (1UL << SCB_AIRCR_BFHFNMINS_Pos)               /*!< SCB AIRCR: BFHFNMINS Mask */
+
+#define SCB_AIRCR_PRIGROUP_Pos              8U                                            /*!< SCB AIRCR: PRIGROUP Position */
+#define SCB_AIRCR_PRIGROUP_Msk             (7UL << SCB_AIRCR_PRIGROUP_Pos)                /*!< SCB AIRCR: PRIGROUP Mask */
+
+#define SCB_AIRCR_SYSRESETREQS_Pos          3U                                            /*!< SCB AIRCR: SYSRESETREQS Position */
+#define SCB_AIRCR_SYSRESETREQS_Msk         (1UL << SCB_AIRCR_SYSRESETREQS_Pos)            /*!< SCB AIRCR: SYSRESETREQS Mask */
+
+#define SCB_AIRCR_SYSRESETREQ_Pos           2U                                            /*!< SCB AIRCR: SYSRESETREQ Position */
+#define SCB_AIRCR_SYSRESETREQ_Msk          (1UL << SCB_AIRCR_SYSRESETREQ_Pos)             /*!< SCB AIRCR: SYSRESETREQ Mask */
+
+#define SCB_AIRCR_VECTCLRACTIVE_Pos         1U                                            /*!< SCB AIRCR: VECTCLRACTIVE Position */
+#define SCB_AIRCR_VECTCLRACTIVE_Msk        (1UL << SCB_AIRCR_VECTCLRACTIVE_Pos)           /*!< SCB AIRCR: VECTCLRACTIVE Mask */
+
+/** \brief SCB System Control Register Definitions */
+#define SCB_SCR_SEVONPEND_Pos               4U                                            /*!< SCB SCR: SEVONPEND Position */
+#define SCB_SCR_SEVONPEND_Msk              (1UL << SCB_SCR_SEVONPEND_Pos)                 /*!< SCB SCR: SEVONPEND Mask */
+
+#define SCB_SCR_SLEEPDEEPS_Pos              3U                                            /*!< SCB SCR: SLEEPDEEPS Position */
+#define SCB_SCR_SLEEPDEEPS_Msk             (1UL << SCB_SCR_SLEEPDEEPS_Pos)                /*!< SCB SCR: SLEEPDEEPS Mask */
+
+#define SCB_SCR_SLEEPDEEP_Pos               2U                                            /*!< SCB SCR: SLEEPDEEP Position */
+#define SCB_SCR_SLEEPDEEP_Msk              (1UL << SCB_SCR_SLEEPDEEP_Pos)                 /*!< SCB SCR: SLEEPDEEP Mask */
+
+#define SCB_SCR_SLEEPONEXIT_Pos             1U                                            /*!< SCB SCR: SLEEPONEXIT Position */
+#define SCB_SCR_SLEEPONEXIT_Msk            (1UL << SCB_SCR_SLEEPONEXIT_Pos)               /*!< SCB SCR: SLEEPONEXIT Mask */
+
+/** \brief SCB Configuration Control Register Definitions */
+#define SCB_CCR_BP_Pos                     18U                                            /*!< SCB CCR: BP Position */
+#define SCB_CCR_BP_Msk                     (1UL << SCB_CCR_BP_Pos)                        /*!< SCB CCR: BP Mask */
+
+#define SCB_CCR_IC_Pos                     17U                                            /*!< SCB CCR: IC Position */
+#define SCB_CCR_IC_Msk                     (1UL << SCB_CCR_IC_Pos)                        /*!< SCB CCR: IC Mask */
+
+#define SCB_CCR_DC_Pos                     16U                                            /*!< SCB CCR: DC Position */
+#define SCB_CCR_DC_Msk                     (1UL << SCB_CCR_DC_Pos)                        /*!< SCB CCR: DC Mask */
+
+#define SCB_CCR_STKOFHFNMIGN_Pos           10U                                            /*!< SCB CCR: STKOFHFNMIGN Position */
+#define SCB_CCR_STKOFHFNMIGN_Msk           (1UL << SCB_CCR_STKOFHFNMIGN_Pos)              /*!< SCB CCR: STKOFHFNMIGN Mask */
+
+#define SCB_CCR_BFHFNMIGN_Pos               8U                                            /*!< SCB CCR: BFHFNMIGN Position */
+#define SCB_CCR_BFHFNMIGN_Msk              (1UL << SCB_CCR_BFHFNMIGN_Pos)                 /*!< SCB CCR: BFHFNMIGN Mask */
+
+#define SCB_CCR_DIV_0_TRP_Pos               4U                                            /*!< SCB CCR: DIV_0_TRP Position */
+#define SCB_CCR_DIV_0_TRP_Msk              (1UL << SCB_CCR_DIV_0_TRP_Pos)                 /*!< SCB CCR: DIV_0_TRP Mask */
+
+#define SCB_CCR_UNALIGN_TRP_Pos             3U                                            /*!< SCB CCR: UNALIGN_TRP Position */
+#define SCB_CCR_UNALIGN_TRP_Msk            (1UL << SCB_CCR_UNALIGN_TRP_Pos)               /*!< SCB CCR: UNALIGN_TRP Mask */
+
+#define SCB_CCR_USERSETMPEND_Pos            1U                                            /*!< SCB CCR: USERSETMPEND Position */
+#define SCB_CCR_USERSETMPEND_Msk           (1UL << SCB_CCR_USERSETMPEND_Pos)              /*!< SCB CCR: USERSETMPEND Mask */
+
+/** \brief SCB System Handler Control and State Register Definitions */
+#define SCB_SHCSR_HARDFAULTPENDED_Pos      21U                                            /*!< SCB SHCSR: HARDFAULTPENDED Position */
+#define SCB_SHCSR_HARDFAULTPENDED_Msk      (1UL << SCB_SHCSR_HARDFAULTPENDED_Pos)         /*!< SCB SHCSR: HARDFAULTPENDED Mask */
+
+#define SCB_SHCSR_SECUREFAULTPENDED_Pos    20U                                            /*!< SCB SHCSR: SECUREFAULTPENDED Position */
+#define SCB_SHCSR_SECUREFAULTPENDED_Msk    (1UL << SCB_SHCSR_SECUREFAULTPENDED_Pos)       /*!< SCB SHCSR: SECUREFAULTPENDED Mask */
+
+#define SCB_SHCSR_SECUREFAULTENA_Pos       19U                                            /*!< SCB SHCSR: SECUREFAULTENA Position */
+#define SCB_SHCSR_SECUREFAULTENA_Msk       (1UL << SCB_SHCSR_SECUREFAULTENA_Pos)          /*!< SCB SHCSR: SECUREFAULTENA Mask */
+
+#define SCB_SHCSR_USGFAULTENA_Pos          18U                                            /*!< SCB SHCSR: USGFAULTENA Position */
+#define SCB_SHCSR_USGFAULTENA_Msk          (1UL << SCB_SHCSR_USGFAULTENA_Pos)             /*!< SCB SHCSR: USGFAULTENA Mask */
+
+#define SCB_SHCSR_BUSFAULTENA_Pos          17U                                            /*!< SCB SHCSR: BUSFAULTENA Position */
+#define SCB_SHCSR_BUSFAULTENA_Msk          (1UL << SCB_SHCSR_BUSFAULTENA_Pos)             /*!< SCB SHCSR: BUSFAULTENA Mask */
+
+#define SCB_SHCSR_MEMFAULTENA_Pos          16U                                            /*!< SCB SHCSR: MEMFAULTENA Position */
+#define SCB_SHCSR_MEMFAULTENA_Msk          (1UL << SCB_SHCSR_MEMFAULTENA_Pos)             /*!< SCB SHCSR: MEMFAULTENA Mask */
+
+#define SCB_SHCSR_SVCALLPENDED_Pos         15U                                            /*!< SCB SHCSR: SVCALLPENDED Position */
+#define SCB_SHCSR_SVCALLPENDED_Msk         (1UL << SCB_SHCSR_SVCALLPENDED_Pos)            /*!< SCB SHCSR: SVCALLPENDED Mask */
+
+#define SCB_SHCSR_BUSFAULTPENDED_Pos       14U                                            /*!< SCB SHCSR: BUSFAULTPENDED Position */
+#define SCB_SHCSR_BUSFAULTPENDED_Msk       (1UL << SCB_SHCSR_BUSFAULTPENDED_Pos)          /*!< SCB SHCSR: BUSFAULTPENDED Mask */
+
+#define SCB_SHCSR_MEMFAULTPENDED_Pos       13U                                            /*!< SCB SHCSR: MEMFAULTPENDED Position */
+#define SCB_SHCSR_MEMFAULTPENDED_Msk       (1UL << SCB_SHCSR_MEMFAULTPENDED_Pos)          /*!< SCB SHCSR: MEMFAULTPENDED Mask */
+
+#define SCB_SHCSR_USGFAULTPENDED_Pos       12U                                            /*!< SCB SHCSR: USGFAULTPENDED Position */
+#define SCB_SHCSR_USGFAULTPENDED_Msk       (1UL << SCB_SHCSR_USGFAULTPENDED_Pos)          /*!< SCB SHCSR: USGFAULTPENDED Mask */
+
+#define SCB_SHCSR_SYSTICKACT_Pos           11U                                            /*!< SCB SHCSR: SYSTICKACT Position */
+#define SCB_SHCSR_SYSTICKACT_Msk           (1UL << SCB_SHCSR_SYSTICKACT_Pos)              /*!< SCB SHCSR: SYSTICKACT Mask */
+
+#define SCB_SHCSR_PENDSVACT_Pos            10U                                            /*!< SCB SHCSR: PENDSVACT Position */
+#define SCB_SHCSR_PENDSVACT_Msk            (1UL << SCB_SHCSR_PENDSVACT_Pos)               /*!< SCB SHCSR: PENDSVACT Mask */
+
+#define SCB_SHCSR_MONITORACT_Pos            8U                                            /*!< SCB SHCSR: MONITORACT Position */
+#define SCB_SHCSR_MONITORACT_Msk           (1UL << SCB_SHCSR_MONITORACT_Pos)              /*!< SCB SHCSR: MONITORACT Mask */
+
+#define SCB_SHCSR_SVCALLACT_Pos             7U                                            /*!< SCB SHCSR: SVCALLACT Position */
+#define SCB_SHCSR_SVCALLACT_Msk            (1UL << SCB_SHCSR_SVCALLACT_Pos)               /*!< SCB SHCSR: SVCALLACT Mask */
+
+#define SCB_SHCSR_NMIACT_Pos                5U                                            /*!< SCB SHCSR: NMIACT Position */
+#define SCB_SHCSR_NMIACT_Msk               (1UL << SCB_SHCSR_NMIACT_Pos)                  /*!< SCB SHCSR: NMIACT Mask */
+
+#define SCB_SHCSR_SECUREFAULTACT_Pos        4U                                            /*!< SCB SHCSR: SECUREFAULTACT Position */
+#define SCB_SHCSR_SECUREFAULTACT_Msk       (1UL << SCB_SHCSR_SECUREFAULTACT_Pos)          /*!< SCB SHCSR: SECUREFAULTACT Mask */
+
+#define SCB_SHCSR_USGFAULTACT_Pos           3U                                            /*!< SCB SHCSR: USGFAULTACT Position */
+#define SCB_SHCSR_USGFAULTACT_Msk          (1UL << SCB_SHCSR_USGFAULTACT_Pos)             /*!< SCB SHCSR: USGFAULTACT Mask */
+
+#define SCB_SHCSR_HARDFAULTACT_Pos          2U                                            /*!< SCB SHCSR: HARDFAULTACT Position */
+#define SCB_SHCSR_HARDFAULTACT_Msk         (1UL << SCB_SHCSR_HARDFAULTACT_Pos)            /*!< SCB SHCSR: HARDFAULTACT Mask */
+
+#define SCB_SHCSR_BUSFAULTACT_Pos           1U                                            /*!< SCB SHCSR: BUSFAULTACT Position */
+#define SCB_SHCSR_BUSFAULTACT_Msk          (1UL << SCB_SHCSR_BUSFAULTACT_Pos)             /*!< SCB SHCSR: BUSFAULTACT Mask */
+
+#define SCB_SHCSR_MEMFAULTACT_Pos           0U                                            /*!< SCB SHCSR: MEMFAULTACT Position */
+#define SCB_SHCSR_MEMFAULTACT_Msk          (1UL /*<< SCB_SHCSR_MEMFAULTACT_Pos*/)         /*!< SCB SHCSR: MEMFAULTACT Mask */
+
+/** \brief SCB Configurable Fault Status Register Definitions */
+#define SCB_CFSR_USGFAULTSR_Pos            16U                                            /*!< SCB CFSR: Usage Fault Status Register Position */
+#define SCB_CFSR_USGFAULTSR_Msk            (0xFFFFUL << SCB_CFSR_USGFAULTSR_Pos)          /*!< SCB CFSR: Usage Fault Status Register Mask */
+
+#define SCB_CFSR_BUSFAULTSR_Pos             8U                                            /*!< SCB CFSR: Bus Fault Status Register Position */
+#define SCB_CFSR_BUSFAULTSR_Msk            (0xFFUL << SCB_CFSR_BUSFAULTSR_Pos)            /*!< SCB CFSR: Bus Fault Status Register Mask */
+
+#define SCB_CFSR_MEMFAULTSR_Pos             0U                                            /*!< SCB CFSR: Memory Manage Fault Status Register Position */
+#define SCB_CFSR_MEMFAULTSR_Msk            (0xFFUL /*<< SCB_CFSR_MEMFAULTSR_Pos*/)        /*!< SCB CFSR: Memory Manage Fault Status Register Mask */
+
+/** \brief SCB MemManage Fault Status Register Definitions (part of SCB Configurable Fault Status Register) */
+#define SCB_CFSR_MMARVALID_Pos             (SCB_CFSR_MEMFAULTSR_Pos + 7U)                 /*!< SCB CFSR (MMFSR): MMARVALID Position */
+#define SCB_CFSR_MMARVALID_Msk             (1UL << SCB_CFSR_MMARVALID_Pos)                /*!< SCB CFSR (MMFSR): MMARVALID Mask */
+
+#define SCB_CFSR_MLSPERR_Pos               (SCB_CFSR_MEMFAULTSR_Pos + 5U)                 /*!< SCB CFSR (MMFSR): MLSPERR Position */
+#define SCB_CFSR_MLSPERR_Msk               (1UL << SCB_CFSR_MLSPERR_Pos)                  /*!< SCB CFSR (MMFSR): MLSPERR Mask */
+
+#define SCB_CFSR_MSTKERR_Pos               (SCB_CFSR_MEMFAULTSR_Pos + 4U)                 /*!< SCB CFSR (MMFSR): MSTKERR Position */
+#define SCB_CFSR_MSTKERR_Msk               (1UL << SCB_CFSR_MSTKERR_Pos)                  /*!< SCB CFSR (MMFSR): MSTKERR Mask */
+
+#define SCB_CFSR_MUNSTKERR_Pos             (SCB_CFSR_MEMFAULTSR_Pos + 3U)                 /*!< SCB CFSR (MMFSR): MUNSTKERR Position */
+#define SCB_CFSR_MUNSTKERR_Msk             (1UL << SCB_CFSR_MUNSTKERR_Pos)                /*!< SCB CFSR (MMFSR): MUNSTKERR Mask */
+
+#define SCB_CFSR_DACCVIOL_Pos              (SCB_CFSR_MEMFAULTSR_Pos + 1U)                 /*!< SCB CFSR (MMFSR): DACCVIOL Position */
+#define SCB_CFSR_DACCVIOL_Msk              (1UL << SCB_CFSR_DACCVIOL_Pos)                 /*!< SCB CFSR (MMFSR): DACCVIOL Mask */
+
+#define SCB_CFSR_IACCVIOL_Pos              (SCB_CFSR_MEMFAULTSR_Pos + 0U)                 /*!< SCB CFSR (MMFSR): IACCVIOL Position */
+#define SCB_CFSR_IACCVIOL_Msk              (1UL /*<< SCB_CFSR_IACCVIOL_Pos*/)             /*!< SCB CFSR (MMFSR): IACCVIOL Mask */
+
+/** \brief SCB BusFault Status Register Definitions (part of SCB Configurable Fault Status Register) */
+#define SCB_CFSR_BFARVALID_Pos            (SCB_CFSR_BUSFAULTSR_Pos + 7U)                  /*!< SCB CFSR (BFSR): BFARVALID Position */
+#define SCB_CFSR_BFARVALID_Msk            (1UL << SCB_CFSR_BFARVALID_Pos)                 /*!< SCB CFSR (BFSR): BFARVALID Mask */
+
+#define SCB_CFSR_LSPERR_Pos               (SCB_CFSR_BUSFAULTSR_Pos + 5U)                  /*!< SCB CFSR (BFSR): LSPERR Position */
+#define SCB_CFSR_LSPERR_Msk               (1UL << SCB_CFSR_LSPERR_Pos)                    /*!< SCB CFSR (BFSR): LSPERR Mask */
+
+#define SCB_CFSR_STKERR_Pos               (SCB_CFSR_BUSFAULTSR_Pos + 4U)                  /*!< SCB CFSR (BFSR): STKERR Position */
+#define SCB_CFSR_STKERR_Msk               (1UL << SCB_CFSR_STKERR_Pos)                    /*!< SCB CFSR (BFSR): STKERR Mask */
+
+#define SCB_CFSR_UNSTKERR_Pos             (SCB_CFSR_BUSFAULTSR_Pos + 3U)                  /*!< SCB CFSR (BFSR): UNSTKERR Position */
+#define SCB_CFSR_UNSTKERR_Msk             (1UL << SCB_CFSR_UNSTKERR_Pos)                  /*!< SCB CFSR (BFSR): UNSTKERR Mask */
+
+#define SCB_CFSR_IMPRECISERR_Pos          (SCB_CFSR_BUSFAULTSR_Pos + 2U)                  /*!< SCB CFSR (BFSR): IMPRECISERR Position */
+#define SCB_CFSR_IMPRECISERR_Msk          (1UL << SCB_CFSR_IMPRECISERR_Pos)               /*!< SCB CFSR (BFSR): IMPRECISERR Mask */
+
+#define SCB_CFSR_PRECISERR_Pos            (SCB_CFSR_BUSFAULTSR_Pos + 1U)                  /*!< SCB CFSR (BFSR): PRECISERR Position */
+#define SCB_CFSR_PRECISERR_Msk            (1UL << SCB_CFSR_PRECISERR_Pos)                 /*!< SCB CFSR (BFSR): PRECISERR Mask */
+
+#define SCB_CFSR_IBUSERR_Pos              (SCB_CFSR_BUSFAULTSR_Pos + 0U)                  /*!< SCB CFSR (BFSR): IBUSERR Position */
+#define SCB_CFSR_IBUSERR_Msk              (1UL << SCB_CFSR_IBUSERR_Pos)                   /*!< SCB CFSR (BFSR): IBUSERR Mask */
+
+/** \brief SCB UsageFault Status Register Definitions (part of SCB Configurable Fault Status Register) */
+#define SCB_CFSR_DIVBYZERO_Pos            (SCB_CFSR_USGFAULTSR_Pos + 9U)                  /*!< SCB CFSR (UFSR): DIVBYZERO Position */
+#define SCB_CFSR_DIVBYZERO_Msk            (1UL << SCB_CFSR_DIVBYZERO_Pos)                 /*!< SCB CFSR (UFSR): DIVBYZERO Mask */
+
+#define SCB_CFSR_UNALIGNED_Pos            (SCB_CFSR_USGFAULTSR_Pos + 8U)                  /*!< SCB CFSR (UFSR): UNALIGNED Position */
+#define SCB_CFSR_UNALIGNED_Msk            (1UL << SCB_CFSR_UNALIGNED_Pos)                 /*!< SCB CFSR (UFSR): UNALIGNED Mask */
+
+#define SCB_CFSR_STKOF_Pos                (SCB_CFSR_USGFAULTSR_Pos + 4U)                  /*!< SCB CFSR (UFSR): STKOF Position */
+#define SCB_CFSR_STKOF_Msk                (1UL << SCB_CFSR_STKOF_Pos)                     /*!< SCB CFSR (UFSR): STKOF Mask */
+
+#define SCB_CFSR_NOCP_Pos                 (SCB_CFSR_USGFAULTSR_Pos + 3U)                  /*!< SCB CFSR (UFSR): NOCP Position */
+#define SCB_CFSR_NOCP_Msk                 (1UL << SCB_CFSR_NOCP_Pos)                      /*!< SCB CFSR (UFSR): NOCP Mask */
+
+#define SCB_CFSR_INVPC_Pos                (SCB_CFSR_USGFAULTSR_Pos + 2U)                  /*!< SCB CFSR (UFSR): INVPC Position */
+#define SCB_CFSR_INVPC_Msk                (1UL << SCB_CFSR_INVPC_Pos)                     /*!< SCB CFSR (UFSR): INVPC Mask */
+
+#define SCB_CFSR_INVSTATE_Pos             (SCB_CFSR_USGFAULTSR_Pos + 1U)                  /*!< SCB CFSR (UFSR): INVSTATE Position */
+#define SCB_CFSR_INVSTATE_Msk             (1UL << SCB_CFSR_INVSTATE_Pos)                  /*!< SCB CFSR (UFSR): INVSTATE Mask */
+
+#define SCB_CFSR_UNDEFINSTR_Pos           (SCB_CFSR_USGFAULTSR_Pos + 0U)                  /*!< SCB CFSR (UFSR): UNDEFINSTR Position */
+#define SCB_CFSR_UNDEFINSTR_Msk           (1UL << SCB_CFSR_UNDEFINSTR_Pos)                /*!< SCB CFSR (UFSR): UNDEFINSTR Mask */
+
+/** \brief SCB Hard Fault Status Register Definitions */
+#define SCB_HFSR_DEBUGEVT_Pos              31U                                            /*!< SCB HFSR: DEBUGEVT Position */
+#define SCB_HFSR_DEBUGEVT_Msk              (1UL << SCB_HFSR_DEBUGEVT_Pos)                 /*!< SCB HFSR: DEBUGEVT Mask */
+
+#define SCB_HFSR_FORCED_Pos                30U                                            /*!< SCB HFSR: FORCED Position */
+#define SCB_HFSR_FORCED_Msk                (1UL << SCB_HFSR_FORCED_Pos)                   /*!< SCB HFSR: FORCED Mask */
+
+#define SCB_HFSR_VECTTBL_Pos                1U                                            /*!< SCB HFSR: VECTTBL Position */
+#define SCB_HFSR_VECTTBL_Msk               (1UL << SCB_HFSR_VECTTBL_Pos)                  /*!< SCB HFSR: VECTTBL Mask */
+
+/** \brief SCB Debug Fault Status Register Definitions */
+#define SCB_DFSR_EXTERNAL_Pos               4U                                            /*!< SCB DFSR: EXTERNAL Position */
+#define SCB_DFSR_EXTERNAL_Msk              (1UL << SCB_DFSR_EXTERNAL_Pos)                 /*!< SCB DFSR: EXTERNAL Mask */
+
+#define SCB_DFSR_VCATCH_Pos                 3U                                            /*!< SCB DFSR: VCATCH Position */
+#define SCB_DFSR_VCATCH_Msk                (1UL << SCB_DFSR_VCATCH_Pos)                   /*!< SCB DFSR: VCATCH Mask */
+
+#define SCB_DFSR_DWTTRAP_Pos                2U                                            /*!< SCB DFSR: DWTTRAP Position */
+#define SCB_DFSR_DWTTRAP_Msk               (1UL << SCB_DFSR_DWTTRAP_Pos)                  /*!< SCB DFSR: DWTTRAP Mask */
+
+#define SCB_DFSR_BKPT_Pos                   1U                                            /*!< SCB DFSR: BKPT Position */
+#define SCB_DFSR_BKPT_Msk                  (1UL << SCB_DFSR_BKPT_Pos)                     /*!< SCB DFSR: BKPT Mask */
+
+#define SCB_DFSR_HALTED_Pos                 0U                                            /*!< SCB DFSR: HALTED Position */
+#define SCB_DFSR_HALTED_Msk                (1UL /*<< SCB_DFSR_HALTED_Pos*/)               /*!< SCB DFSR: HALTED Mask */
+
+/** \brief SCB Non-Secure Access Control Register Definitions */
+#define SCB_NSACR_CP11_Pos                 11U                                            /*!< SCB NSACR: CP11 Position */
+#define SCB_NSACR_CP11_Msk                 (1UL << SCB_NSACR_CP11_Pos)                    /*!< SCB NSACR: CP11 Mask */
+
+#define SCB_NSACR_CP10_Pos                 10U                                            /*!< SCB NSACR: CP10 Position */
+#define SCB_NSACR_CP10_Msk                 (1UL << SCB_NSACR_CP10_Pos)                    /*!< SCB NSACR: CP10 Mask */
+
+#define SCB_NSACR_CPn_Pos                   0U                                            /*!< SCB NSACR: CPn Position */
+#define SCB_NSACR_CPn_Msk                  (1UL /*<< SCB_NSACR_CPn_Pos*/)                 /*!< SCB NSACR: CPn Mask */
+
+/** \brief SCB Cache Level ID Register Definitions */
+#define SCB_CLIDR_LOUU_Pos                 27U                                            /*!< SCB CLIDR: LoUU Position */
+#define SCB_CLIDR_LOUU_Msk                 (7UL << SCB_CLIDR_LOUU_Pos)                    /*!< SCB CLIDR: LoUU Mask */
+
+#define SCB_CLIDR_LOC_Pos                  24U                                            /*!< SCB CLIDR: LoC Position */
+#define SCB_CLIDR_LOC_Msk                  (7UL << SCB_CLIDR_LOC_Pos)                     /*!< SCB CLIDR: LoC Mask */
+
+/** \brief SCB Cache Type Register Definitions */
+#define SCB_CTR_FORMAT_Pos                 29U                                            /*!< SCB CTR: Format Position */
+#define SCB_CTR_FORMAT_Msk                 (7UL << SCB_CTR_FORMAT_Pos)                    /*!< SCB CTR: Format Mask */
+
+#define SCB_CTR_CWG_Pos                    24U                                            /*!< SCB CTR: CWG Position */
+#define SCB_CTR_CWG_Msk                    (0xFUL << SCB_CTR_CWG_Pos)                     /*!< SCB CTR: CWG Mask */
+
+#define SCB_CTR_ERG_Pos                    20U                                            /*!< SCB CTR: ERG Position */
+#define SCB_CTR_ERG_Msk                    (0xFUL << SCB_CTR_ERG_Pos)                     /*!< SCB CTR: ERG Mask */
+
+#define SCB_CTR_DMINLINE_Pos               16U                                            /*!< SCB CTR: DminLine Position */
+#define SCB_CTR_DMINLINE_Msk               (0xFUL << SCB_CTR_DMINLINE_Pos)                /*!< SCB CTR: DminLine Mask */
+
+#define SCB_CTR_IMINLINE_Pos                0U                                            /*!< SCB CTR: ImInLine Position */
+#define SCB_CTR_IMINLINE_Msk               (0xFUL /*<< SCB_CTR_IMINLINE_Pos*/)            /*!< SCB CTR: ImInLine Mask */
+
+/** \brief SCB Cache Size ID Register Definitions */
+#define SCB_CCSIDR_WT_Pos                  31U                                            /*!< SCB CCSIDR: WT Position */
+#define SCB_CCSIDR_WT_Msk                  (1UL << SCB_CCSIDR_WT_Pos)                     /*!< SCB CCSIDR: WT Mask */
+
+#define SCB_CCSIDR_WB_Pos                  30U                                            /*!< SCB CCSIDR: WB Position */
+#define SCB_CCSIDR_WB_Msk                  (1UL << SCB_CCSIDR_WB_Pos)                     /*!< SCB CCSIDR: WB Mask */
+
+#define SCB_CCSIDR_RA_Pos                  29U                                            /*!< SCB CCSIDR: RA Position */
+#define SCB_CCSIDR_RA_Msk                  (1UL << SCB_CCSIDR_RA_Pos)                     /*!< SCB CCSIDR: RA Mask */
+
+#define SCB_CCSIDR_WA_Pos                  28U                                            /*!< SCB CCSIDR: WA Position */
+#define SCB_CCSIDR_WA_Msk                  (1UL << SCB_CCSIDR_WA_Pos)                     /*!< SCB CCSIDR: WA Mask */
+
+#define SCB_CCSIDR_NUMSETS_Pos             13U                                            /*!< SCB CCSIDR: NumSets Position */
+#define SCB_CCSIDR_NUMSETS_Msk             (0x7FFFUL << SCB_CCSIDR_NUMSETS_Pos)           /*!< SCB CCSIDR: NumSets Mask */
+
+#define SCB_CCSIDR_ASSOCIATIVITY_Pos        3U                                            /*!< SCB CCSIDR: Associativity Position */
+#define SCB_CCSIDR_ASSOCIATIVITY_Msk       (0x3FFUL << SCB_CCSIDR_ASSOCIATIVITY_Pos)      /*!< SCB CCSIDR: Associativity Mask */
+
+#define SCB_CCSIDR_LINESIZE_Pos             0U                                            /*!< SCB CCSIDR: LineSize Position */
+#define SCB_CCSIDR_LINESIZE_Msk            (7UL /*<< SCB_CCSIDR_LINESIZE_Pos*/)           /*!< SCB CCSIDR: LineSize Mask */
+
+/** \brief SCB Cache Size Selection Register Definitions */
+#define SCB_CSSELR_LEVEL_Pos                1U                                            /*!< SCB CSSELR: Level Position */
+#define SCB_CSSELR_LEVEL_Msk               (7UL << SCB_CSSELR_LEVEL_Pos)                  /*!< SCB CSSELR: Level Mask */
+
+#define SCB_CSSELR_IND_Pos                  0U                                            /*!< SCB CSSELR: InD Position */
+#define SCB_CSSELR_IND_Msk                 (1UL /*<< SCB_CSSELR_IND_Pos*/)                /*!< SCB CSSELR: InD Mask */
+
+/** \brief SCB Software Triggered Interrupt Register Definitions */
+#define SCB_STIR_INTID_Pos                  0U                                            /*!< SCB STIR: INTID Position */
+#define SCB_STIR_INTID_Msk                 (0x1FFUL /*<< SCB_STIR_INTID_Pos*/)            /*!< SCB STIR: INTID Mask */
+
+/** \brief SCB D-Cache Invalidate by Set-way Register Definitions */
+#define SCB_DCISW_WAY_Pos                  30U                                            /*!< SCB DCISW: Way Position */
+#define SCB_DCISW_WAY_Msk                  (3UL << SCB_DCISW_WAY_Pos)                     /*!< SCB DCISW: Way Mask */
+
+#define SCB_DCISW_SET_Pos                   5U                                            /*!< SCB DCISW: Set Position */
+#define SCB_DCISW_SET_Msk                  (0x1FFUL << SCB_DCISW_SET_Pos)                 /*!< SCB DCISW: Set Mask */
+
+/** \brief SCB D-Cache Clean by Set-way Register Definitions */
+#define SCB_DCCSW_WAY_Pos                  30U                                            /*!< SCB DCCSW: Way Position */
+#define SCB_DCCSW_WAY_Msk                  (3UL << SCB_DCCSW_WAY_Pos)                     /*!< SCB DCCSW: Way Mask */
+
+#define SCB_DCCSW_SET_Pos                   5U                                            /*!< SCB DCCSW: Set Position */
+#define SCB_DCCSW_SET_Msk                  (0x1FFUL << SCB_DCCSW_SET_Pos)                 /*!< SCB DCCSW: Set Mask */
+
+/** \brief SCB D-Cache Clean and Invalidate by Set-way Register Definitions */
+#define SCB_DCCISW_WAY_Pos                 30U                                            /*!< SCB DCCISW: Way Position */
+#define SCB_DCCISW_WAY_Msk                 (3UL << SCB_DCCISW_WAY_Pos)                    /*!< SCB DCCISW: Way Mask */
+
+#define SCB_DCCISW_SET_Pos                  5U                                            /*!< SCB DCCISW: Set Position */
+#define SCB_DCCISW_SET_Msk                 (0x1FFUL << SCB_DCCISW_SET_Pos)                /*!< SCB DCCISW: Set Mask */
+
+/*@} end of group CMSIS_SCB */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SCnSCB System Controls not in SCB (SCnSCB)
+  \brief    Type definitions for the System Control and ID Register not in the SCB
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Control and ID Register not in the SCB.
+ */
+typedef struct
+{
+        uint32_t RESERVED0[1U];
+  __IM  uint32_t ICTR;                   /*!< Offset: 0x004 (R/ )  Interrupt Controller Type Register */
+  __IOM uint32_t ACTLR;                  /*!< Offset: 0x008 (R/W)  Auxiliary Control Register */
+  __IOM uint32_t CPPWR;                  /*!< Offset: 0x00C (R/W)  Coprocessor Power Control  Register */
+} SCnSCB_Type;
+
+/** \brief SCnSCB Interrupt Controller Type Register Definitions */
+#define SCnSCB_ICTR_INTLINESNUM_Pos         0U                                         /*!< ICTR: INTLINESNUM Position */
+#define SCnSCB_ICTR_INTLINESNUM_Msk        (0xFUL /*<< SCnSCB_ICTR_INTLINESNUM_Pos*/)  /*!< ICTR: INTLINESNUM Mask */
+
+/*@} end of group CMSIS_SCnotSCB */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SysTick     System Tick Timer (SysTick)
+  \brief    Type definitions for the System Timer Registers.
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Timer (SysTick).
+ */
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  SysTick Control and Status Register */
+  __IOM uint32_t LOAD;                   /*!< Offset: 0x004 (R/W)  SysTick Reload Value Register */
+  __IOM uint32_t VAL;                    /*!< Offset: 0x008 (R/W)  SysTick Current Value Register */
+  __IM  uint32_t CALIB;                  /*!< Offset: 0x00C (R/ )  SysTick Calibration Register */
+} SysTick_Type;
+
+/** \brief SysTick Control / Status Register Definitions */
+#define SysTick_CTRL_COUNTFLAG_Pos         16U                                            /*!< SysTick CTRL: COUNTFLAG Position */
+#define SysTick_CTRL_COUNTFLAG_Msk         (1UL << SysTick_CTRL_COUNTFLAG_Pos)            /*!< SysTick CTRL: COUNTFLAG Mask */
+
+#define SysTick_CTRL_CLKSOURCE_Pos          2U                                            /*!< SysTick CTRL: CLKSOURCE Position */
+#define SysTick_CTRL_CLKSOURCE_Msk         (1UL << SysTick_CTRL_CLKSOURCE_Pos)            /*!< SysTick CTRL: CLKSOURCE Mask */
+
+#define SysTick_CTRL_TICKINT_Pos            1U                                            /*!< SysTick CTRL: TICKINT Position */
+#define SysTick_CTRL_TICKINT_Msk           (1UL << SysTick_CTRL_TICKINT_Pos)              /*!< SysTick CTRL: TICKINT Mask */
+
+#define SysTick_CTRL_ENABLE_Pos             0U                                            /*!< SysTick CTRL: ENABLE Position */
+#define SysTick_CTRL_ENABLE_Msk            (1UL /*<< SysTick_CTRL_ENABLE_Pos*/)           /*!< SysTick CTRL: ENABLE Mask */
+
+/** \brief SysTick Reload Register Definitions */
+#define SysTick_LOAD_RELOAD_Pos             0U                                            /*!< SysTick LOAD: RELOAD Position */
+#define SysTick_LOAD_RELOAD_Msk            (0xFFFFFFUL /*<< SysTick_LOAD_RELOAD_Pos*/)    /*!< SysTick LOAD: RELOAD Mask */
+
+/** \brief SysTick Current Register Definitions */
+#define SysTick_VAL_CURRENT_Pos             0U                                            /*!< SysTick VAL: CURRENT Position */
+#define SysTick_VAL_CURRENT_Msk            (0xFFFFFFUL /*<< SysTick_VAL_CURRENT_Pos*/)    /*!< SysTick VAL: CURRENT Mask */
+
+/** \brief SysTick Calibration Register Definitions */
+#define SysTick_CALIB_NOREF_Pos            31U                                            /*!< SysTick CALIB: NOREF Position */
+#define SysTick_CALIB_NOREF_Msk            (1UL << SysTick_CALIB_NOREF_Pos)               /*!< SysTick CALIB: NOREF Mask */
+
+#define SysTick_CALIB_SKEW_Pos             30U                                            /*!< SysTick CALIB: SKEW Position */
+#define SysTick_CALIB_SKEW_Msk             (1UL << SysTick_CALIB_SKEW_Pos)                /*!< SysTick CALIB: SKEW Mask */
+
+#define SysTick_CALIB_TENMS_Pos             0U                                            /*!< SysTick CALIB: TENMS Position */
+#define SysTick_CALIB_TENMS_Msk            (0xFFFFFFUL /*<< SysTick_CALIB_TENMS_Pos*/)    /*!< SysTick CALIB: TENMS Mask */
+
+/*@} end of group CMSIS_SysTick */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_ITM     Instrumentation Trace Macrocell (ITM)
+  \brief    Type definitions for the Instrumentation Trace Macrocell (ITM)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Instrumentation Trace Macrocell Register (ITM).
+ */
+typedef struct
+{
+  __OM  union
+  {
+    __OM  uint8_t    u8;                 /*!< Offset: 0x000 ( /W)  Stimulus Port 8-bit */
+    __OM  uint16_t   u16;                /*!< Offset: 0x000 ( /W)  Stimulus Port 16-bit */
+    __OM  uint32_t   u32;                /*!< Offset: 0x000 ( /W)  Stimulus Port 32-bit */
+  }  PORT [32U];                         /*!< Offset: 0x000 ( /W)  Stimulus Port Registers */
+        uint32_t RESERVED0[864U];
+  __IOM uint32_t TER;                    /*!< Offset: 0xE00 (R/W)  Trace Enable Register */
+        uint32_t RESERVED1[15U];
+  __IOM uint32_t TPR;                    /*!< Offset: 0xE40 (R/W)  Trace Privilege Register */
+        uint32_t RESERVED2[15U];
+  __IOM uint32_t TCR;                    /*!< Offset: 0xE80 (R/W)  Trace Control Register */
+        uint32_t RESERVED3[27U];
+  __IM  uint32_t ITREAD;                 /*!< Offset: 0xEF0 (R/ )  Integration Read Register */
+        uint32_t RESERVED4[1U];
+  __OM  uint32_t ITWRITE;                /*!< Offset: 0xEF8 ( /W)  Integration Write Register */
+        uint32_t RESERVED5[1U];
+  __IOM uint32_t ITCTRL;                 /*!< Offset: 0xF00 (R/W)  Integration Mode Control Register */
+        uint32_t RESERVED6[46U];
+  __IM  uint32_t DEVARCH;                /*!< Offset: 0xFBC (R/ )  Device Architecture Register */
+        uint32_t RESERVED7[3U];
+  __IM  uint32_t DEVTYPE;                /*!< Offset: 0xFCC (R/ )  Device Type Register */
+} ITM_Type;
+
+/** \brief ITM Stimulus Port Register Definitions */
+#define ITM_STIM_DISABLED_Pos               1U                                            /*!< ITM STIM: DISABLED Position */
+#define ITM_STIM_DISABLED_Msk              (1UL << ITM_STIM_DISABLED_Pos)                 /*!< ITM STIM: DISABLED Mask */
+
+#define ITM_STIM_FIFOREADY_Pos              0U                                            /*!< ITM STIM: FIFOREADY Position */
+#define ITM_STIM_FIFOREADY_Msk             (1UL /*<< ITM_STIM_FIFOREADY_Pos*/)            /*!< ITM STIM: FIFOREADY Mask */
+
+/** \brief ITM Trace Privilege Register Definitions */
+#define ITM_TPR_PRIVMASK_Pos                0U                                            /*!< ITM TPR: PRIVMASK Position */
+#define ITM_TPR_PRIVMASK_Msk               (0xFUL /*<< ITM_TPR_PRIVMASK_Pos*/)            /*!< ITM TPR: PRIVMASK Mask */
+
+/** \brief ITM Trace Control Register Definitions */
+#define ITM_TCR_BUSY_Pos                   23U                                            /*!< ITM TCR: BUSY Position */
+#define ITM_TCR_BUSY_Msk                   (1UL << ITM_TCR_BUSY_Pos)                      /*!< ITM TCR: BUSY Mask */
+
+#define ITM_TCR_TRACEBUSID_Pos             16U                                            /*!< ITM TCR: ATBID Position */
+#define ITM_TCR_TRACEBUSID_Msk             (0x7FUL << ITM_TCR_TRACEBUSID_Pos)             /*!< ITM TCR: ATBID Mask */
+
+#define ITM_TCR_GTSFREQ_Pos                10U                                            /*!< ITM TCR: Global timestamp frequency Position */
+#define ITM_TCR_GTSFREQ_Msk                (3UL << ITM_TCR_GTSFREQ_Pos)                   /*!< ITM TCR: Global timestamp frequency Mask */
+
+#define ITM_TCR_TSPRESCALE_Pos              8U                                            /*!< ITM TCR: TSPRESCALE Position */
+#define ITM_TCR_TSPRESCALE_Msk             (3UL << ITM_TCR_TSPRESCALE_Pos)                /*!< ITM TCR: TSPRESCALE Mask */
+
+#define ITM_TCR_STALLENA_Pos                5U                                            /*!< ITM TCR: STALLENA Position */
+#define ITM_TCR_STALLENA_Msk               (1UL << ITM_TCR_STALLENA_Pos)                  /*!< ITM TCR: STALLENA Mask */
+
+#define ITM_TCR_SWOENA_Pos                  4U                                            /*!< ITM TCR: SWOENA Position */
+#define ITM_TCR_SWOENA_Msk                 (1UL << ITM_TCR_SWOENA_Pos)                    /*!< ITM TCR: SWOENA Mask */
+
+#define ITM_TCR_DWTENA_Pos                  3U                                            /*!< ITM TCR: DWTENA Position */
+#define ITM_TCR_DWTENA_Msk                 (1UL << ITM_TCR_DWTENA_Pos)                    /*!< ITM TCR: DWTENA Mask */
+
+#define ITM_TCR_SYNCENA_Pos                 2U                                            /*!< ITM TCR: SYNCENA Position */
+#define ITM_TCR_SYNCENA_Msk                (1UL << ITM_TCR_SYNCENA_Pos)                   /*!< ITM TCR: SYNCENA Mask */
+
+#define ITM_TCR_TSENA_Pos                   1U                                            /*!< ITM TCR: TSENA Position */
+#define ITM_TCR_TSENA_Msk                  (1UL << ITM_TCR_TSENA_Pos)                     /*!< ITM TCR: TSENA Mask */
+
+#define ITM_TCR_ITMENA_Pos                  0U                                            /*!< ITM TCR: ITM Enable bit Position */
+#define ITM_TCR_ITMENA_Msk                 (1UL /*<< ITM_TCR_ITMENA_Pos*/)                /*!< ITM TCR: ITM Enable bit Mask */
+
+/** \brief ITM Integration Read Register Definitions */
+#define ITM_ITREAD_AFVALID_Pos              1U                                            /*!< ITM ITREAD: AFVALID Position */
+#define ITM_ITREAD_AFVALID_Msk             (1UL << ITM_ITREAD_AFVALID_Pos)                /*!< ITM ITREAD: AFVALID Mask */
+
+#define ITM_ITREAD_ATREADY_Pos              0U                                            /*!< ITM ITREAD: ATREADY Position */
+#define ITM_ITREAD_ATREADY_Msk             (1UL /*<< ITM_ITREAD_ATREADY_Pos*/)            /*!< ITM ITREAD: ATREADY Mask */
+
+/** \brief ITM Integration Write Register Definitions */
+#define ITM_ITWRITE_AFVALID_Pos             1U                                            /*!< ITM ITWRITE: AFVALID Position */
+#define ITM_ITWRITE_AFVALID_Msk            (1UL << ITM_ITWRITE_AFVALID_Pos)               /*!< ITM ITWRITE: AFVALID Mask */
+
+#define ITM_ITWRITE_ATREADY_Pos             0U                                            /*!< ITM ITWRITE: ATREADY Position */
+#define ITM_ITWRITE_ATREADY_Msk            (1UL /*<< ITM_ITWRITE_ATREADY_Pos*/)           /*!< ITM ITWRITE: ATREADY Mask */
+
+/** \brief ITM Integration Mode Control Register Definitions */
+#define ITM_ITCTRL_IME_Pos                  0U                                            /*!< ITM ITCTRL: IME Position */
+#define ITM_ITCTRL_IME_Msk                 (1UL /*<< ITM_ITCTRL_IME_Pos*/)                /*!< ITM ITCTRL: IME Mask */
+
+/*@}*/ /* end of group CMSIS_ITM */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_DWT     Data Watchpoint and Trace (DWT)
+  \brief    Type definitions for the Data Watchpoint and Trace (DWT)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Data Watchpoint and Trace Register (DWT).
+ */
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  Control Register */
+  __IOM uint32_t CYCCNT;                 /*!< Offset: 0x004 (R/W)  Cycle Count Register */
+  __IOM uint32_t CPICNT;                 /*!< Offset: 0x008 (R/W)  CPI Count Register */
+  __IOM uint32_t EXCCNT;                 /*!< Offset: 0x00C (R/W)  Exception Overhead Count Register */
+  __IOM uint32_t SLEEPCNT;               /*!< Offset: 0x010 (R/W)  Sleep Count Register */
+  __IOM uint32_t LSUCNT;                 /*!< Offset: 0x014 (R/W)  LSU Count Register */
+  __IOM uint32_t FOLDCNT;                /*!< Offset: 0x018 (R/W)  Folded-instruction Count Register */
+  __IM  uint32_t PCSR;                   /*!< Offset: 0x01C (R/ )  Program Counter Sample Register */
+  __IOM uint32_t COMP0;                  /*!< Offset: 0x020 (R/W)  Comparator Register 0 */
+        uint32_t RESERVED1[1U];
+  __IOM uint32_t FUNCTION0;              /*!< Offset: 0x028 (R/W)  Function Register 0 */
+        uint32_t RESERVED2[1U];
+  __IOM uint32_t COMP1;                  /*!< Offset: 0x030 (R/W)  Comparator Register 1 */
+        uint32_t RESERVED3[1U];
+  __IOM uint32_t FUNCTION1;              /*!< Offset: 0x038 (R/W)  Function Register 1 */
+        uint32_t RESERVED4[1U];
+  __IOM uint32_t COMP2;                  /*!< Offset: 0x040 (R/W)  Comparator Register 2 */
+        uint32_t RESERVED5[1U];
+  __IOM uint32_t FUNCTION2;              /*!< Offset: 0x048 (R/W)  Function Register 2 */
+        uint32_t RESERVED6[1U];
+  __IOM uint32_t COMP3;                  /*!< Offset: 0x050 (R/W)  Comparator Register 3 */
+        uint32_t RESERVED7[1U];
+  __IOM uint32_t FUNCTION3;              /*!< Offset: 0x058 (R/W)  Function Register 3 */
+        uint32_t RESERVED14[984U];
+  __IM  uint32_t DEVARCH;                /*!< Offset: 0xFBC (R/ )  Device Type Architecture Register */
+        uint32_t RESERVED15[3U];
+  __IM  uint32_t DEVTYPE;                /*!< Offset: 0xFCC (R/ )  Device Type Identifier Register */
+} DWT_Type;
+
+/** \brief DWT Control Register Definitions */
+#define DWT_CTRL_NUMCOMP_Pos               28U                                         /*!< DWT CTRL: NUMCOMP Position */
+#define DWT_CTRL_NUMCOMP_Msk               (0xFUL << DWT_CTRL_NUMCOMP_Pos)             /*!< DWT CTRL: NUMCOMP Mask */
+
+#define DWT_CTRL_NOTRCPKT_Pos              27U                                         /*!< DWT CTRL: NOTRCPKT Position */
+#define DWT_CTRL_NOTRCPKT_Msk              (1UL << DWT_CTRL_NOTRCPKT_Pos)              /*!< DWT CTRL: NOTRCPKT Mask */
+
+#define DWT_CTRL_NOEXTTRIG_Pos             26U                                         /*!< DWT CTRL: NOEXTTRIG Position */
+#define DWT_CTRL_NOEXTTRIG_Msk             (1UL << DWT_CTRL_NOEXTTRIG_Pos)             /*!< DWT CTRL: NOEXTTRIG Mask */
+
+#define DWT_CTRL_NOCYCCNT_Pos              25U                                         /*!< DWT CTRL: NOCYCCNT Position */
+#define DWT_CTRL_NOCYCCNT_Msk              (1UL << DWT_CTRL_NOCYCCNT_Pos)              /*!< DWT CTRL: NOCYCCNT Mask */
+
+#define DWT_CTRL_NOPRFCNT_Pos              24U                                         /*!< DWT CTRL: NOPRFCNT Position */
+#define DWT_CTRL_NOPRFCNT_Msk              (1UL << DWT_CTRL_NOPRFCNT_Pos)              /*!< DWT CTRL: NOPRFCNT Mask */
+
+#define DWT_CTRL_CYCDISS_Pos               23U                                         /*!< DWT CTRL: CYCDISS Position */
+#define DWT_CTRL_CYCDISS_Msk               (1UL << DWT_CTRL_CYCDISS_Pos)               /*!< DWT CTRL: CYCDISS Mask */
+
+#define DWT_CTRL_CYCEVTENA_Pos             22U                                         /*!< DWT CTRL: CYCEVTENA Position */
+#define DWT_CTRL_CYCEVTENA_Msk             (1UL << DWT_CTRL_CYCEVTENA_Pos)             /*!< DWT CTRL: CYCEVTENA Mask */
+
+#define DWT_CTRL_FOLDEVTENA_Pos            21U                                         /*!< DWT CTRL: FOLDEVTENA Position */
+#define DWT_CTRL_FOLDEVTENA_Msk            (1UL << DWT_CTRL_FOLDEVTENA_Pos)            /*!< DWT CTRL: FOLDEVTENA Mask */
+
+#define DWT_CTRL_LSUEVTENA_Pos             20U                                         /*!< DWT CTRL: LSUEVTENA Position */
+#define DWT_CTRL_LSUEVTENA_Msk             (1UL << DWT_CTRL_LSUEVTENA_Pos)             /*!< DWT CTRL: LSUEVTENA Mask */
+
+#define DWT_CTRL_SLEEPEVTENA_Pos           19U                                         /*!< DWT CTRL: SLEEPEVTENA Position */
+#define DWT_CTRL_SLEEPEVTENA_Msk           (1UL << DWT_CTRL_SLEEPEVTENA_Pos)           /*!< DWT CTRL: SLEEPEVTENA Mask */
+
+#define DWT_CTRL_EXCEVTENA_Pos             18U                                         /*!< DWT CTRL: EXCEVTENA Position */
+#define DWT_CTRL_EXCEVTENA_Msk             (1UL << DWT_CTRL_EXCEVTENA_Pos)             /*!< DWT CTRL: EXCEVTENA Mask */
+
+#define DWT_CTRL_CPIEVTENA_Pos             17U                                         /*!< DWT CTRL: CPIEVTENA Position */
+#define DWT_CTRL_CPIEVTENA_Msk             (1UL << DWT_CTRL_CPIEVTENA_Pos)             /*!< DWT CTRL: CPIEVTENA Mask */
+
+#define DWT_CTRL_EXCTRCENA_Pos             16U                                         /*!< DWT CTRL: EXCTRCENA Position */
+#define DWT_CTRL_EXCTRCENA_Msk             (1UL << DWT_CTRL_EXCTRCENA_Pos)             /*!< DWT CTRL: EXCTRCENA Mask */
+
+#define DWT_CTRL_PCSAMPLENA_Pos            12U                                         /*!< DWT CTRL: PCSAMPLENA Position */
+#define DWT_CTRL_PCSAMPLENA_Msk            (1UL << DWT_CTRL_PCSAMPLENA_Pos)            /*!< DWT CTRL: PCSAMPLENA Mask */
+
+#define DWT_CTRL_SYNCTAP_Pos               10U                                         /*!< DWT CTRL: SYNCTAP Position */
+#define DWT_CTRL_SYNCTAP_Msk               (0x3UL << DWT_CTRL_SYNCTAP_Pos)             /*!< DWT CTRL: SYNCTAP Mask */
+
+#define DWT_CTRL_CYCTAP_Pos                 9U                                         /*!< DWT CTRL: CYCTAP Position */
+#define DWT_CTRL_CYCTAP_Msk                (1UL << DWT_CTRL_CYCTAP_Pos)                /*!< DWT CTRL: CYCTAP Mask */
+
+#define DWT_CTRL_POSTINIT_Pos               5U                                         /*!< DWT CTRL: POSTINIT Position */
+#define DWT_CTRL_POSTINIT_Msk              (0xFUL << DWT_CTRL_POSTINIT_Pos)            /*!< DWT CTRL: POSTINIT Mask */
+
+#define DWT_CTRL_POSTPRESET_Pos             1U                                         /*!< DWT CTRL: POSTPRESET Position */
+#define DWT_CTRL_POSTPRESET_Msk            (0xFUL << DWT_CTRL_POSTPRESET_Pos)          /*!< DWT CTRL: POSTPRESET Mask */
+
+#define DWT_CTRL_CYCCNTENA_Pos              0U                                         /*!< DWT CTRL: CYCCNTENA Position */
+#define DWT_CTRL_CYCCNTENA_Msk             (1UL /*<< DWT_CTRL_CYCCNTENA_Pos*/)         /*!< DWT CTRL: CYCCNTENA Mask */
+
+/** \brief DWT CPI Count Register Definitions */
+#define DWT_CPICNT_CPICNT_Pos               0U                                         /*!< DWT CPICNT: CPICNT Position */
+#define DWT_CPICNT_CPICNT_Msk              (0xFFUL /*<< DWT_CPICNT_CPICNT_Pos*/)       /*!< DWT CPICNT: CPICNT Mask */
+
+/** \brief DWT Exception Overhead Count Register Definitions */
+#define DWT_EXCCNT_EXCCNT_Pos               0U                                         /*!< DWT EXCCNT: EXCCNT Position */
+#define DWT_EXCCNT_EXCCNT_Msk              (0xFFUL /*<< DWT_EXCCNT_EXCCNT_Pos*/)       /*!< DWT EXCCNT: EXCCNT Mask */
+
+/** \brief DWT Sleep Count Register Definitions */
+#define DWT_SLEEPCNT_SLEEPCNT_Pos           0U                                         /*!< DWT SLEEPCNT: SLEEPCNT Position */
+#define DWT_SLEEPCNT_SLEEPCNT_Msk          (0xFFUL /*<< DWT_SLEEPCNT_SLEEPCNT_Pos*/)   /*!< DWT SLEEPCNT: SLEEPCNT Mask */
+
+/** \brief DWT LSU Count Register Definitions */
+#define DWT_LSUCNT_LSUCNT_Pos               0U                                         /*!< DWT LSUCNT: LSUCNT Position */
+#define DWT_LSUCNT_LSUCNT_Msk              (0xFFUL /*<< DWT_LSUCNT_LSUCNT_Pos*/)       /*!< DWT LSUCNT: LSUCNT Mask */
+
+/** \brief DWT Folded-instruction Count Register Definitions */
+#define DWT_FOLDCNT_FOLDCNT_Pos             0U                                         /*!< DWT FOLDCNT: FOLDCNT Position */
+#define DWT_FOLDCNT_FOLDCNT_Msk            (0xFFUL /*<< DWT_FOLDCNT_FOLDCNT_Pos*/)     /*!< DWT FOLDCNT: FOLDCNT Mask */
+
+/** \brief DWT Comparator Function Register Definitions */
+#define DWT_FUNCTION_ID_Pos                27U                                         /*!< DWT FUNCTION: ID Position */
+#define DWT_FUNCTION_ID_Msk                (0x1FUL << DWT_FUNCTION_ID_Pos)             /*!< DWT FUNCTION: ID Mask */
+
+#define DWT_FUNCTION_MATCHED_Pos           24U                                         /*!< DWT FUNCTION: MATCHED Position */
+#define DWT_FUNCTION_MATCHED_Msk           (1UL << DWT_FUNCTION_MATCHED_Pos)           /*!< DWT FUNCTION: MATCHED Mask */
+
+#define DWT_FUNCTION_DATAVSIZE_Pos         10U                                         /*!< DWT FUNCTION: DATAVSIZE Position */
+#define DWT_FUNCTION_DATAVSIZE_Msk         (0x3UL << DWT_FUNCTION_DATAVSIZE_Pos)       /*!< DWT FUNCTION: DATAVSIZE Mask */
+
+#define DWT_FUNCTION_ACTION_Pos             4U                                         /*!< DWT FUNCTION: ACTION Position */
+#define DWT_FUNCTION_ACTION_Msk            (0x3UL << DWT_FUNCTION_ACTION_Pos)          /*!< DWT FUNCTION: ACTION Mask */
+
+#define DWT_FUNCTION_MATCH_Pos              0U                                         /*!< DWT FUNCTION: MATCH Position */
+#define DWT_FUNCTION_MATCH_Msk             (0xFUL /*<< DWT_FUNCTION_MATCH_Pos*/)       /*!< DWT FUNCTION: MATCH Mask */
+
+/*@}*/ /* end of group CMSIS_DWT */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_TPIU     Trace Port Interface Unit (TPIU)
+  \brief    Type definitions for the Trace Port Interface Unit (TPIU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Trace Port Interface Unit Register (TPIU).
+ */
+typedef struct
+{
+  __IM  uint32_t SSPSR;                  /*!< Offset: 0x000 (R/ )  Supported Parallel Port Size Register */
+  __IOM uint32_t CSPSR;                  /*!< Offset: 0x004 (R/W)  Current Parallel Port Size Register */
+        uint32_t RESERVED0[2U];
+  __IOM uint32_t ACPR;                   /*!< Offset: 0x010 (R/W)  Asynchronous Clock Prescaler Register */
+        uint32_t RESERVED1[55U];
+  __IOM uint32_t SPPR;                   /*!< Offset: 0x0F0 (R/W)  Selected Pin Protocol Register */
+        uint32_t RESERVED2[131U];
+  __IM  uint32_t FFSR;                   /*!< Offset: 0x300 (R/ )  Formatter and Flush Status Register */
+  __IOM uint32_t FFCR;                   /*!< Offset: 0x304 (R/W)  Formatter and Flush Control Register */
+  __IOM uint32_t PSCR;                   /*!< Offset: 0x308 (R/W)  Periodic Synchronization Control Register */
+        uint32_t RESERVED3[759U];
+  __IM  uint32_t TRIGGER;                /*!< Offset: 0xEE8 (R/ )  TRIGGER Register */
+  __IM  uint32_t ITFTTD0;                /*!< Offset: 0xEEC (R/ )  Integration Test FIFO Test Data 0 Register */
+  __IOM uint32_t ITATBCTR2;              /*!< Offset: 0xEF0 (R/W)  Integration Test ATB Control Register 2 */
+        uint32_t RESERVED4[1U];
+  __IM  uint32_t ITATBCTR0;              /*!< Offset: 0xEF8 (R/ )  Integration Test ATB Control Register 0 */
+  __IM  uint32_t ITFTTD1;                /*!< Offset: 0xEFC (R/ )  Integration Test FIFO Test Data 1 Register */
+  __IOM uint32_t ITCTRL;                 /*!< Offset: 0xF00 (R/W)  Integration Mode Control */
+        uint32_t RESERVED5[39U];
+  __IOM uint32_t CLAIMSET;               /*!< Offset: 0xFA0 (R/W)  Claim tag set */
+  __IOM uint32_t CLAIMCLR;               /*!< Offset: 0xFA4 (R/W)  Claim tag clear */
+        uint32_t RESERVED7[8U];
+  __IM  uint32_t DEVID;                  /*!< Offset: 0xFC8 (R/ )  Device Configuration Register */
+  __IM  uint32_t DEVTYPE;                /*!< Offset: 0xFCC (R/ )  Device Type Identifier Register */
+} TPIU_Type;
+
+/** \brief TPIU Asynchronous Clock Prescaler Register Definitions */
+#define TPIU_ACPR_PRESCALER_Pos             0U                                         /*!< TPIU ACPR: PRESCALER Position */
+#define TPIU_ACPR_PRESCALER_Msk            (0x1FFFUL /*<< TPIU_ACPR_PRESCALER_Pos*/)   /*!< TPIU ACPR: PRESCALER Mask */
+
+/** \brief TPIU Selected Pin Protocol Register Definitions */
+#define TPIU_SPPR_TXMODE_Pos                0U                                         /*!< TPIU SPPR: TXMODE Position */
+#define TPIU_SPPR_TXMODE_Msk               (0x3UL /*<< TPIU_SPPR_TXMODE_Pos*/)         /*!< TPIU SPPR: TXMODE Mask */
+
+/** \brief TPIU Formatter and Flush Status Register Definitions */
+#define TPIU_FFSR_FtNonStop_Pos             3U                                         /*!< TPIU FFSR: FtNonStop Position */
+#define TPIU_FFSR_FtNonStop_Msk            (1UL << TPIU_FFSR_FtNonStop_Pos)            /*!< TPIU FFSR: FtNonStop Mask */
+
+#define TPIU_FFSR_TCPresent_Pos             2U                                         /*!< TPIU FFSR: TCPresent Position */
+#define TPIU_FFSR_TCPresent_Msk            (1UL << TPIU_FFSR_TCPresent_Pos)            /*!< TPIU FFSR: TCPresent Mask */
+
+#define TPIU_FFSR_FtStopped_Pos             1U                                         /*!< TPIU FFSR: FtStopped Position */
+#define TPIU_FFSR_FtStopped_Msk            (1UL << TPIU_FFSR_FtStopped_Pos)            /*!< TPIU FFSR: FtStopped Mask */
+
+#define TPIU_FFSR_FlInProg_Pos              0U                                         /*!< TPIU FFSR: FlInProg Position */
+#define TPIU_FFSR_FlInProg_Msk             (1UL /*<< TPIU_FFSR_FlInProg_Pos*/)         /*!< TPIU FFSR: FlInProg Mask */
+
+/** \brief TPIU Formatter and Flush Control Register Definitions */
+#define TPIU_FFCR_TrigIn_Pos                8U                                         /*!< TPIU FFCR: TrigIn Position */
+#define TPIU_FFCR_TrigIn_Msk               (1UL << TPIU_FFCR_TrigIn_Pos)               /*!< TPIU FFCR: TrigIn Mask */
+
+#define TPIU_FFCR_FOnMan_Pos                6U                                         /*!< TPIU FFCR: FOnMan Position */
+#define TPIU_FFCR_FOnMan_Msk               (1UL << TPIU_FFCR_FOnMan_Pos)               /*!< TPIU FFCR: FOnMan Mask */
+
+#define TPIU_FFCR_EnFCont_Pos               1U                                         /*!< TPIU FFCR: EnFCont Position */
+#define TPIU_FFCR_EnFCont_Msk              (1UL << TPIU_FFCR_EnFCont_Pos)              /*!< TPIU FFCR: EnFCont Mask */
+
+/** \brief TPIU Periodic Synchronization Control Register Definitions */
+#define TPIU_PSCR_PSCount_Pos               0U                                         /*!< TPIU PSCR: PSCount Position */
+#define TPIU_PSCR_PSCount_Msk              (0x1FUL /*<< TPIU_PSCR_PSCount_Pos*/)       /*!< TPIU PSCR: TPSCount Mask */
+
+/** \brief TPIU TRIGGER Register Definitions */
+#define TPIU_TRIGGER_TRIGGER_Pos            0U                                         /*!< TPIU TRIGGER: TRIGGER Position */
+#define TPIU_TRIGGER_TRIGGER_Msk           (1UL /*<< TPIU_TRIGGER_TRIGGER_Pos*/)       /*!< TPIU TRIGGER: TRIGGER Mask */
+
+/** \brief TPIU Integration Test FIFO Test Data 0 Register Definitions */
+#define TPIU_ITFTTD0_ATB_IF2_ATVALID_Pos   29U                                         /*!< TPIU ITFTTD0: ATB Interface 2 ATVALIDPosition */
+#define TPIU_ITFTTD0_ATB_IF2_ATVALID_Msk   (0x3UL << TPIU_ITFTTD0_ATB_IF2_ATVALID_Pos) /*!< TPIU ITFTTD0: ATB Interface 2 ATVALID Mask */
+
+#define TPIU_ITFTTD0_ATB_IF2_bytecount_Pos 27U                                         /*!< TPIU ITFTTD0: ATB Interface 2 byte count Position */
+#define TPIU_ITFTTD0_ATB_IF2_bytecount_Msk (0x3UL << TPIU_ITFTTD0_ATB_IF2_bytecount_Pos) /*!< TPIU ITFTTD0: ATB Interface 2 byte count Mask */
+
+#define TPIU_ITFTTD0_ATB_IF1_ATVALID_Pos   26U                                         /*!< TPIU ITFTTD0: ATB Interface 1 ATVALID Position */
+#define TPIU_ITFTTD0_ATB_IF1_ATVALID_Msk   (0x3UL << TPIU_ITFTTD0_ATB_IF1_ATVALID_Pos) /*!< TPIU ITFTTD0: ATB Interface 1 ATVALID Mask */
+
+#define TPIU_ITFTTD0_ATB_IF1_bytecount_Pos 24U                                         /*!< TPIU ITFTTD0: ATB Interface 1 byte count Position */
+#define TPIU_ITFTTD0_ATB_IF1_bytecount_Msk (0x3UL << TPIU_ITFTTD0_ATB_IF1_bytecount_Pos) /*!< TPIU ITFTTD0: ATB Interface 1 byte countt Mask */
+
+#define TPIU_ITFTTD0_ATB_IF1_data2_Pos     16U                                         /*!< TPIU ITFTTD0: ATB Interface 1 data2 Position */
+#define TPIU_ITFTTD0_ATB_IF1_data2_Msk     (0xFFUL << TPIU_ITFTTD0_ATB_IF1_data1_Pos)  /*!< TPIU ITFTTD0: ATB Interface 1 data2 Mask */
+
+#define TPIU_ITFTTD0_ATB_IF1_data1_Pos      8U                                         /*!< TPIU ITFTTD0: ATB Interface 1 data1 Position */
+#define TPIU_ITFTTD0_ATB_IF1_data1_Msk     (0xFFUL << TPIU_ITFTTD0_ATB_IF1_data1_Pos)  /*!< TPIU ITFTTD0: ATB Interface 1 data1 Mask */
+
+#define TPIU_ITFTTD0_ATB_IF1_data0_Pos      0U                                         /*!< TPIU ITFTTD0: ATB Interface 1 data0 Position */
+#define TPIU_ITFTTD0_ATB_IF1_data0_Msk     (0xFFUL /*<< TPIU_ITFTTD0_ATB_IF1_data0_Pos*/) /*!< TPIU ITFTTD0: ATB Interface 1 data0 Mask */
+
+/** \brief TPIU Integration Test ATB Control Register 2 Register Definitions */
+#define TPIU_ITATBCTR2_AFVALID2S_Pos        1U                                         /*!< TPIU ITATBCTR2: AFVALID2S Position */
+#define TPIU_ITATBCTR2_AFVALID2S_Msk       (1UL << TPIU_ITATBCTR2_AFVALID2S_Pos)       /*!< TPIU ITATBCTR2: AFVALID2SS Mask */
+
+#define TPIU_ITATBCTR2_AFVALID1S_Pos        1U                                         /*!< TPIU ITATBCTR2: AFVALID1S Position */
+#define TPIU_ITATBCTR2_AFVALID1S_Msk       (1UL << TPIU_ITATBCTR2_AFVALID1S_Pos)       /*!< TPIU ITATBCTR2: AFVALID1SS Mask */
+
+#define TPIU_ITATBCTR2_ATREADY2S_Pos        0U                                         /*!< TPIU ITATBCTR2: ATREADY2S Position */
+#define TPIU_ITATBCTR2_ATREADY2S_Msk       (1UL /*<< TPIU_ITATBCTR2_ATREADY2S_Pos*/)   /*!< TPIU ITATBCTR2: ATREADY2S Mask */
+
+#define TPIU_ITATBCTR2_ATREADY1S_Pos        0U                                         /*!< TPIU ITATBCTR2: ATREADY1S Position */
+#define TPIU_ITATBCTR2_ATREADY1S_Msk       (1UL /*<< TPIU_ITATBCTR2_ATREADY1S_Pos*/)   /*!< TPIU ITATBCTR2: ATREADY1S Mask */
+
+/** \brief TPIU Integration Test FIFO Test Data 1 Register Definitions */
+#define TPIU_ITFTTD1_ATB_IF2_ATVALID_Pos   29U                                         /*!< TPIU ITFTTD1: ATB Interface 2 ATVALID Position */
+#define TPIU_ITFTTD1_ATB_IF2_ATVALID_Msk   (0x3UL << TPIU_ITFTTD1_ATB_IF2_ATVALID_Pos) /*!< TPIU ITFTTD1: ATB Interface 2 ATVALID Mask */
+
+#define TPIU_ITFTTD1_ATB_IF2_bytecount_Pos 27U                                         /*!< TPIU ITFTTD1: ATB Interface 2 byte count Position */
+#define TPIU_ITFTTD1_ATB_IF2_bytecount_Msk (0x3UL << TPIU_ITFTTD1_ATB_IF2_bytecount_Pos) /*!< TPIU ITFTTD1: ATB Interface 2 byte count Mask */
+
+#define TPIU_ITFTTD1_ATB_IF1_ATVALID_Pos   26U                                         /*!< TPIU ITFTTD1: ATB Interface 1 ATVALID Position */
+#define TPIU_ITFTTD1_ATB_IF1_ATVALID_Msk   (0x3UL << TPIU_ITFTTD1_ATB_IF1_ATVALID_Pos) /*!< TPIU ITFTTD1: ATB Interface 1 ATVALID Mask */
+
+#define TPIU_ITFTTD1_ATB_IF1_bytecount_Pos 24U                                         /*!< TPIU ITFTTD1: ATB Interface 1 byte count Position */
+#define TPIU_ITFTTD1_ATB_IF1_bytecount_Msk (0x3UL << TPIU_ITFTTD1_ATB_IF1_bytecount_Pos) /*!< TPIU ITFTTD1: ATB Interface 1 byte countt Mask */
+
+#define TPIU_ITFTTD1_ATB_IF2_data2_Pos     16U                                         /*!< TPIU ITFTTD1: ATB Interface 2 data2 Position */
+#define TPIU_ITFTTD1_ATB_IF2_data2_Msk     (0xFFUL << TPIU_ITFTTD1_ATB_IF2_data1_Pos)  /*!< TPIU ITFTTD1: ATB Interface 2 data2 Mask */
+
+#define TPIU_ITFTTD1_ATB_IF2_data1_Pos      8U                                         /*!< TPIU ITFTTD1: ATB Interface 2 data1 Position */
+#define TPIU_ITFTTD1_ATB_IF2_data1_Msk     (0xFFUL << TPIU_ITFTTD1_ATB_IF2_data1_Pos)  /*!< TPIU ITFTTD1: ATB Interface 2 data1 Mask */
+
+#define TPIU_ITFTTD1_ATB_IF2_data0_Pos      0U                                         /*!< TPIU ITFTTD1: ATB Interface 2 data0 Position */
+#define TPIU_ITFTTD1_ATB_IF2_data0_Msk     (0xFFUL /*<< TPIU_ITFTTD1_ATB_IF2_data0_Pos*/) /*!< TPIU ITFTTD1: ATB Interface 2 data0 Mask */
+
+/** \brief TPIU Integration Test ATB Control Register 0 Definitions */
+#define TPIU_ITATBCTR0_AFVALID2S_Pos        1U                                         /*!< TPIU ITATBCTR0: AFVALID2S Position */
+#define TPIU_ITATBCTR0_AFVALID2S_Msk       (1UL << TPIU_ITATBCTR0_AFVALID2S_Pos)       /*!< TPIU ITATBCTR0: AFVALID2SS Mask */
+
+#define TPIU_ITATBCTR0_AFVALID1S_Pos        1U                                         /*!< TPIU ITATBCTR0: AFVALID1S Position */
+#define TPIU_ITATBCTR0_AFVALID1S_Msk       (1UL << TPIU_ITATBCTR0_AFVALID1S_Pos)       /*!< TPIU ITATBCTR0: AFVALID1SS Mask */
+
+#define TPIU_ITATBCTR0_ATREADY2S_Pos        0U                                         /*!< TPIU ITATBCTR0: ATREADY2S Position */
+#define TPIU_ITATBCTR0_ATREADY2S_Msk       (1UL /*<< TPIU_ITATBCTR0_ATREADY2S_Pos*/)   /*!< TPIU ITATBCTR0: ATREADY2S Mask */
+
+#define TPIU_ITATBCTR0_ATREADY1S_Pos        0U                                         /*!< TPIU ITATBCTR0: ATREADY1S Position */
+#define TPIU_ITATBCTR0_ATREADY1S_Msk       (1UL /*<< TPIU_ITATBCTR0_ATREADY1S_Pos*/)   /*!< TPIU ITATBCTR0: ATREADY1S Mask */
+
+/** \brief TPIU Integration Mode Control Register Definitions */
+#define TPIU_ITCTRL_Mode_Pos                0U                                         /*!< TPIU ITCTRL: Mode Position */
+#define TPIU_ITCTRL_Mode_Msk               (0x3UL /*<< TPIU_ITCTRL_Mode_Pos*/)         /*!< TPIU ITCTRL: Mode Mask */
+
+/** \brief TPIU DEVID Register Definitions */
+#define TPIU_DEVID_NRZVALID_Pos            11U                                         /*!< TPIU DEVID: NRZVALID Position */
+#define TPIU_DEVID_NRZVALID_Msk            (1UL << TPIU_DEVID_NRZVALID_Pos)            /*!< TPIU DEVID: NRZVALID Mask */
+
+#define TPIU_DEVID_MANCVALID_Pos           10U                                         /*!< TPIU DEVID: MANCVALID Position */
+#define TPIU_DEVID_MANCVALID_Msk           (1UL << TPIU_DEVID_MANCVALID_Pos)           /*!< TPIU DEVID: MANCVALID Mask */
+
+#define TPIU_DEVID_PTINVALID_Pos            9U                                         /*!< TPIU DEVID: PTINVALID Position */
+#define TPIU_DEVID_PTINVALID_Msk           (1UL << TPIU_DEVID_PTINVALID_Pos)           /*!< TPIU DEVID: PTINVALID Mask */
+
+#define TPIU_DEVID_FIFOSZ_Pos               6U                                         /*!< TPIU DEVID: FIFOSZ Position */
+#define TPIU_DEVID_FIFOSZ_Msk              (0x7UL << TPIU_DEVID_FIFOSZ_Pos)            /*!< TPIU DEVID: FIFOSZ Mask */
+
+#define TPIU_DEVID_NrTraceInput_Pos         0U                                         /*!< TPIU DEVID: NrTraceInput Position */
+#define TPIU_DEVID_NrTraceInput_Msk        (0x3FUL /*<< TPIU_DEVID_NrTraceInput_Pos*/) /*!< TPIU DEVID: NrTraceInput Mask */
+
+/** \brief TPIU DEVTYPE Register Definitions */
+#define TPIU_DEVTYPE_SubType_Pos            4U                                         /*!< TPIU DEVTYPE: SubType Position */
+#define TPIU_DEVTYPE_SubType_Msk           (0xFUL /*<< TPIU_DEVTYPE_SubType_Pos*/)     /*!< TPIU DEVTYPE: SubType Mask */
+
+#define TPIU_DEVTYPE_MajorType_Pos          0U                                         /*!< TPIU DEVTYPE: MajorType Position */
+#define TPIU_DEVTYPE_MajorType_Msk         (0xFUL << TPIU_DEVTYPE_MajorType_Pos)       /*!< TPIU DEVTYPE: MajorType Mask */
+
+/*@}*/ /* end of group CMSIS_TPIU */
+
+
+#if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_MPU     Memory Protection Unit (MPU)
+  \brief    Type definitions for the Memory Protection Unit (MPU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Memory Protection Unit (MPU).
+ */
+typedef struct
+{
+  __IM  uint32_t TYPE;                   /*!< Offset: 0x000 (R/ )  MPU Type Register */
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x004 (R/W)  MPU Control Register */
+  __IOM uint32_t RNR;                    /*!< Offset: 0x008 (R/W)  MPU Region Number Register */
+  __IOM uint32_t RBAR;                   /*!< Offset: 0x00C (R/W)  MPU Region Base Address Register */
+  __IOM uint32_t RLAR;                   /*!< Offset: 0x010 (R/W)  MPU Region Limit Address Register */
+  __IOM uint32_t RBAR_A1;                /*!< Offset: 0x014 (R/W)  MPU Region Base Address Register Alias 1 */
+  __IOM uint32_t RLAR_A1;                /*!< Offset: 0x018 (R/W)  MPU Region Limit Address Register Alias 1 */
+  __IOM uint32_t RBAR_A2;                /*!< Offset: 0x01C (R/W)  MPU Region Base Address Register Alias 2 */
+  __IOM uint32_t RLAR_A2;                /*!< Offset: 0x020 (R/W)  MPU Region Limit Address Register Alias 2 */
+  __IOM uint32_t RBAR_A3;                /*!< Offset: 0x024 (R/W)  MPU Region Base Address Register Alias 3 */
+  __IOM uint32_t RLAR_A3;                /*!< Offset: 0x028 (R/W)  MPU Region Limit Address Register Alias 3 */
+        uint32_t RESERVED0[1];
+  union {
+  __IOM uint32_t MAIR[2];
+  struct {
+  __IOM uint32_t MAIR0;                  /*!< Offset: 0x030 (R/W)  MPU Memory Attribute Indirection Register 0 */
+  __IOM uint32_t MAIR1;                  /*!< Offset: 0x034 (R/W)  MPU Memory Attribute Indirection Register 1 */
+  };
+  };
+} MPU_Type;
+
+#define MPU_TYPE_RALIASES                  4U
+
+/** \brief MPU Type Register Definitions */
+#define MPU_TYPE_IREGION_Pos               16U                                            /*!< MPU TYPE: IREGION Position */
+#define MPU_TYPE_IREGION_Msk               (0xFFUL << MPU_TYPE_IREGION_Pos)               /*!< MPU TYPE: IREGION Mask */
+
+#define MPU_TYPE_DREGION_Pos                8U                                            /*!< MPU TYPE: DREGION Position */
+#define MPU_TYPE_DREGION_Msk               (0xFFUL << MPU_TYPE_DREGION_Pos)               /*!< MPU TYPE: DREGION Mask */
+
+#define MPU_TYPE_SEPARATE_Pos               0U                                            /*!< MPU TYPE: SEPARATE Position */
+#define MPU_TYPE_SEPARATE_Msk              (1UL /*<< MPU_TYPE_SEPARATE_Pos*/)             /*!< MPU TYPE: SEPARATE Mask */
+
+/** \brief MPU Control Register Definitions */
+#define MPU_CTRL_PRIVDEFENA_Pos             2U                                            /*!< MPU CTRL: PRIVDEFENA Position */
+#define MPU_CTRL_PRIVDEFENA_Msk            (1UL << MPU_CTRL_PRIVDEFENA_Pos)               /*!< MPU CTRL: PRIVDEFENA Mask */
+
+#define MPU_CTRL_HFNMIENA_Pos               1U                                            /*!< MPU CTRL: HFNMIENA Position */
+#define MPU_CTRL_HFNMIENA_Msk              (1UL << MPU_CTRL_HFNMIENA_Pos)                 /*!< MPU CTRL: HFNMIENA Mask */
+
+#define MPU_CTRL_ENABLE_Pos                 0U                                            /*!< MPU CTRL: ENABLE Position */
+#define MPU_CTRL_ENABLE_Msk                (1UL /*<< MPU_CTRL_ENABLE_Pos*/)               /*!< MPU CTRL: ENABLE Mask */
+
+/** \brief MPU Region Number Register Definitions */
+#define MPU_RNR_REGION_Pos                  0U                                            /*!< MPU RNR: REGION Position */
+#define MPU_RNR_REGION_Msk                 (0xFFUL /*<< MPU_RNR_REGION_Pos*/)             /*!< MPU RNR: REGION Mask */
+
+/** \brief MPU Region Base Address Register Definitions */
+#define MPU_RBAR_BASE_Pos                   5U                                            /*!< MPU RBAR: BASE Position */
+#define MPU_RBAR_BASE_Msk                  (0x7FFFFFFUL << MPU_RBAR_BASE_Pos)             /*!< MPU RBAR: BASE Mask */
+
+#define MPU_RBAR_SH_Pos                     3U                                            /*!< MPU RBAR: SH Position */
+#define MPU_RBAR_SH_Msk                    (0x3UL << MPU_RBAR_SH_Pos)                     /*!< MPU RBAR: SH Mask */
+
+#define MPU_RBAR_AP_Pos                     1U                                            /*!< MPU RBAR: AP Position */
+#define MPU_RBAR_AP_Msk                    (0x3UL << MPU_RBAR_AP_Pos)                     /*!< MPU RBAR: AP Mask */
+
+#define MPU_RBAR_XN_Pos                     0U                                            /*!< MPU RBAR: XN Position */
+#define MPU_RBAR_XN_Msk                    (01UL /*<< MPU_RBAR_XN_Pos*/)                  /*!< MPU RBAR: XN Mask */
+
+/** \brief MPU Region Limit Address Register Definitions */
+#define MPU_RLAR_LIMIT_Pos                  5U                                            /*!< MPU RLAR: LIMIT Position */
+#define MPU_RLAR_LIMIT_Msk                 (0x7FFFFFFUL << MPU_RLAR_LIMIT_Pos)            /*!< MPU RLAR: LIMIT Mask */
+
+#define MPU_RLAR_PXN_Pos                    4U                                            /*!< MPU RLAR: PXN Position */
+#define MPU_RLAR_PXN_Msk                   (1UL << MPU_RLAR_PXN_Pos)                      /*!< MPU RLAR: PXN Mask */
+
+#define MPU_RLAR_AttrIndx_Pos               1U                                            /*!< MPU RLAR: AttrIndx Position */
+#define MPU_RLAR_AttrIndx_Msk              (0x7UL << MPU_RLAR_AttrIndx_Pos)               /*!< MPU RLAR: AttrIndx Mask */
+
+#define MPU_RLAR_EN_Pos                     0U                                            /*!< MPU RLAR: Region enable bit Position */
+#define MPU_RLAR_EN_Msk                    (1UL /*<< MPU_RLAR_EN_Pos*/)                   /*!< MPU RLAR: Region enable bit Mask */
+
+/** \brief MPU Memory Attribute Indirection Register 0 Definitions */
+#define MPU_MAIR0_Attr3_Pos                24U                                            /*!< MPU MAIR0: Attr3 Position */
+#define MPU_MAIR0_Attr3_Msk                (0xFFUL << MPU_MAIR0_Attr3_Pos)                /*!< MPU MAIR0: Attr3 Mask */
+
+#define MPU_MAIR0_Attr2_Pos                16U                                            /*!< MPU MAIR0: Attr2 Position */
+#define MPU_MAIR0_Attr2_Msk                (0xFFUL << MPU_MAIR0_Attr2_Pos)                /*!< MPU MAIR0: Attr2 Mask */
+
+#define MPU_MAIR0_Attr1_Pos                 8U                                            /*!< MPU MAIR0: Attr1 Position */
+#define MPU_MAIR0_Attr1_Msk                (0xFFUL << MPU_MAIR0_Attr1_Pos)                /*!< MPU MAIR0: Attr1 Mask */
+
+#define MPU_MAIR0_Attr0_Pos                 0U                                            /*!< MPU MAIR0: Attr0 Position */
+#define MPU_MAIR0_Attr0_Msk                (0xFFUL /*<< MPU_MAIR0_Attr0_Pos*/)            /*!< MPU MAIR0: Attr0 Mask */
+
+/** \brief MPU Memory Attribute Indirection Register 1 Definitions */
+#define MPU_MAIR1_Attr7_Pos                24U                                            /*!< MPU MAIR1: Attr7 Position */
+#define MPU_MAIR1_Attr7_Msk                (0xFFUL << MPU_MAIR1_Attr7_Pos)                /*!< MPU MAIR1: Attr7 Mask */
+
+#define MPU_MAIR1_Attr6_Pos                16U                                            /*!< MPU MAIR1: Attr6 Position */
+#define MPU_MAIR1_Attr6_Msk                (0xFFUL << MPU_MAIR1_Attr6_Pos)                /*!< MPU MAIR1: Attr6 Mask */
+
+#define MPU_MAIR1_Attr5_Pos                 8U                                            /*!< MPU MAIR1: Attr5 Position */
+#define MPU_MAIR1_Attr5_Msk                (0xFFUL << MPU_MAIR1_Attr5_Pos)                /*!< MPU MAIR1: Attr5 Mask */
+
+#define MPU_MAIR1_Attr4_Pos                 0U                                            /*!< MPU MAIR1: Attr4 Position */
+#define MPU_MAIR1_Attr4_Msk                (0xFFUL /*<< MPU_MAIR1_Attr4_Pos*/)            /*!< MPU MAIR1: Attr4 Mask */
+
+/*@} end of group CMSIS_MPU */
+#endif
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SAU     Security Attribution Unit (SAU)
+  \brief    Type definitions for the Security Attribution Unit (SAU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Security Attribution Unit (SAU).
+ */
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  SAU Control Register */
+  __IM  uint32_t TYPE;                   /*!< Offset: 0x004 (R/ )  SAU Type Register */
+#if defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U)
+  __IOM uint32_t RNR;                    /*!< Offset: 0x008 (R/W)  SAU Region Number Register */
+  __IOM uint32_t RBAR;                   /*!< Offset: 0x00C (R/W)  SAU Region Base Address Register */
+  __IOM uint32_t RLAR;                   /*!< Offset: 0x010 (R/W)  SAU Region Limit Address Register */
+#else
+        uint32_t RESERVED0[3];
+#endif
+  __IOM uint32_t SFSR;                   /*!< Offset: 0x014 (R/W)  Secure Fault Status Register */
+  __IOM uint32_t SFAR;                   /*!< Offset: 0x018 (R/W)  Secure Fault Address Register */
+} SAU_Type;
+
+/** \brief SAU Control Register Definitions */
+#define SAU_CTRL_ALLNS_Pos                  1U                                            /*!< SAU CTRL: ALLNS Position */
+#define SAU_CTRL_ALLNS_Msk                 (1UL << SAU_CTRL_ALLNS_Pos)                    /*!< SAU CTRL: ALLNS Mask */
+
+#define SAU_CTRL_ENABLE_Pos                 0U                                            /*!< SAU CTRL: ENABLE Position */
+#define SAU_CTRL_ENABLE_Msk                (1UL /*<< SAU_CTRL_ENABLE_Pos*/)               /*!< SAU CTRL: ENABLE Mask */
+
+/** \brief SAU Type Register Definitions */
+#define SAU_TYPE_SREGION_Pos                0U                                            /*!< SAU TYPE: SREGION Position */
+#define SAU_TYPE_SREGION_Msk               (0xFFUL /*<< SAU_TYPE_SREGION_Pos*/)           /*!< SAU TYPE: SREGION Mask */
+
+#if defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U)
+/** \brief SAU Region Number Register Definitions */
+#define SAU_RNR_REGION_Pos                  0U                                            /*!< SAU RNR: REGION Position */
+#define SAU_RNR_REGION_Msk                 (0xFFUL /*<< SAU_RNR_REGION_Pos*/)             /*!< SAU RNR: REGION Mask */
+
+/** \brief SAU Region Base Address Register Definitions */
+#define SAU_RBAR_BADDR_Pos                  5U                                            /*!< SAU RBAR: BADDR Position */
+#define SAU_RBAR_BADDR_Msk                 (0x7FFFFFFUL << SAU_RBAR_BADDR_Pos)            /*!< SAU RBAR: BADDR Mask */
+
+/** \brief SAU Region Limit Address Register Definitions */
+#define SAU_RLAR_LADDR_Pos                  5U                                            /*!< SAU RLAR: LADDR Position */
+#define SAU_RLAR_LADDR_Msk                 (0x7FFFFFFUL << SAU_RLAR_LADDR_Pos)            /*!< SAU RLAR: LADDR Mask */
+
+#define SAU_RLAR_NSC_Pos                    1U                                            /*!< SAU RLAR: NSC Position */
+#define SAU_RLAR_NSC_Msk                   (1UL << SAU_RLAR_NSC_Pos)                      /*!< SAU RLAR: NSC Mask */
+
+#define SAU_RLAR_ENABLE_Pos                 0U                                            /*!< SAU RLAR: ENABLE Position */
+#define SAU_RLAR_ENABLE_Msk                (1UL /*<< SAU_RLAR_ENABLE_Pos*/)               /*!< SAU RLAR: ENABLE Mask */
+
+#endif /* defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U) */
+
+/** \brief SAU Secure Fault Status Register Definitions */
+#define SAU_SFSR_LSERR_Pos                  7U                                            /*!< SAU SFSR: LSERR Position */
+#define SAU_SFSR_LSERR_Msk                 (1UL << SAU_SFSR_LSERR_Pos)                    /*!< SAU SFSR: LSERR Mask */
+
+#define SAU_SFSR_SFARVALID_Pos              6U                                            /*!< SAU SFSR: SFARVALID Position */
+#define SAU_SFSR_SFARVALID_Msk             (1UL << SAU_SFSR_SFARVALID_Pos)                /*!< SAU SFSR: SFARVALID Mask */
+
+#define SAU_SFSR_LSPERR_Pos                 5U                                            /*!< SAU SFSR: LSPERR Position */
+#define SAU_SFSR_LSPERR_Msk                (1UL << SAU_SFSR_LSPERR_Pos)                   /*!< SAU SFSR: LSPERR Mask */
+
+#define SAU_SFSR_INVTRAN_Pos                4U                                            /*!< SAU SFSR: INVTRAN Position */
+#define SAU_SFSR_INVTRAN_Msk               (1UL << SAU_SFSR_INVTRAN_Pos)                  /*!< SAU SFSR: INVTRAN Mask */
+
+#define SAU_SFSR_AUVIOL_Pos                 3U                                            /*!< SAU SFSR: AUVIOL Position */
+#define SAU_SFSR_AUVIOL_Msk                (1UL << SAU_SFSR_AUVIOL_Pos)                   /*!< SAU SFSR: AUVIOL Mask */
+
+#define SAU_SFSR_INVER_Pos                  2U                                            /*!< SAU SFSR: INVER Position */
+#define SAU_SFSR_INVER_Msk                 (1UL << SAU_SFSR_INVER_Pos)                    /*!< SAU SFSR: INVER Mask */
+
+#define SAU_SFSR_INVIS_Pos                  1U                                            /*!< SAU SFSR: INVIS Position */
+#define SAU_SFSR_INVIS_Msk                 (1UL << SAU_SFSR_INVIS_Pos)                    /*!< SAU SFSR: INVIS Mask */
+
+#define SAU_SFSR_INVEP_Pos                  0U                                            /*!< SAU SFSR: INVEP Position */
+#define SAU_SFSR_INVEP_Msk                 (1UL /*<< SAU_SFSR_INVEP_Pos*/)                /*!< SAU SFSR: INVEP Mask */
+
+/*@} end of group CMSIS_SAU */
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_FPU     Floating Point Unit (FPU)
+  \brief    Type definitions for the Floating Point Unit (FPU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Floating Point Unit (FPU).
+ */
+typedef struct
+{
+        uint32_t RESERVED0[1U];
+  __IOM uint32_t FPCCR;                  /*!< Offset: 0x004 (R/W)  Floating-Point Context Control Register */
+  __IOM uint32_t FPCAR;                  /*!< Offset: 0x008 (R/W)  Floating-Point Context Address Register */
+  __IOM uint32_t FPDSCR;                 /*!< Offset: 0x00C (R/W)  Floating-Point Default Status Control Register */
+  __IM  uint32_t MVFR0;                  /*!< Offset: 0x010 (R/ )  Media and VFP Feature Register 0 */
+  __IM  uint32_t MVFR1;                  /*!< Offset: 0x014 (R/ )  Media and VFP Feature Register 1 */
+  __IM  uint32_t MVFR2;                  /*!< Offset: 0x018 (R/ )  Media and VFP Feature Register 2 */
+} FPU_Type;
+
+/** \brief FPU Floating-Point Context Control Register Definitions */
+#define FPU_FPCCR_ASPEN_Pos                31U                                            /*!< FPCCR: ASPEN bit Position */
+#define FPU_FPCCR_ASPEN_Msk                (1UL << FPU_FPCCR_ASPEN_Pos)                   /*!< FPCCR: ASPEN bit Mask */
+
+#define FPU_FPCCR_LSPEN_Pos                30U                                            /*!< FPCCR: LSPEN Position */
+#define FPU_FPCCR_LSPEN_Msk                (1UL << FPU_FPCCR_LSPEN_Pos)                   /*!< FPCCR: LSPEN bit Mask */
+
+#define FPU_FPCCR_LSPENS_Pos               29U                                            /*!< FPCCR: LSPENS Position */
+#define FPU_FPCCR_LSPENS_Msk               (1UL << FPU_FPCCR_LSPENS_Pos)                  /*!< FPCCR: LSPENS bit Mask */
+
+#define FPU_FPCCR_CLRONRET_Pos             28U                                            /*!< FPCCR: CLRONRET Position */
+#define FPU_FPCCR_CLRONRET_Msk             (1UL << FPU_FPCCR_CLRONRET_Pos)                /*!< FPCCR: CLRONRET bit Mask */
+
+#define FPU_FPCCR_CLRONRETS_Pos            27U                                            /*!< FPCCR: CLRONRETS Position */
+#define FPU_FPCCR_CLRONRETS_Msk            (1UL << FPU_FPCCR_CLRONRETS_Pos)               /*!< FPCCR: CLRONRETS bit Mask */
+
+#define FPU_FPCCR_TS_Pos                   26U                                            /*!< FPCCR: TS Position */
+#define FPU_FPCCR_TS_Msk                   (1UL << FPU_FPCCR_TS_Pos)                      /*!< FPCCR: TS bit Mask */
+
+#define FPU_FPCCR_UFRDY_Pos                10U                                            /*!< FPCCR: UFRDY Position */
+#define FPU_FPCCR_UFRDY_Msk                (1UL << FPU_FPCCR_UFRDY_Pos)                   /*!< FPCCR: UFRDY bit Mask */
+
+#define FPU_FPCCR_SPLIMVIOL_Pos             9U                                            /*!< FPCCR: SPLIMVIOL Position */
+#define FPU_FPCCR_SPLIMVIOL_Msk            (1UL << FPU_FPCCR_SPLIMVIOL_Pos)               /*!< FPCCR: SPLIMVIOL bit Mask */
+
+#define FPU_FPCCR_MONRDY_Pos                8U                                            /*!< FPCCR: MONRDY Position */
+#define FPU_FPCCR_MONRDY_Msk               (1UL << FPU_FPCCR_MONRDY_Pos)                  /*!< FPCCR: MONRDY bit Mask */
+
+#define FPU_FPCCR_SFRDY_Pos                 7U                                            /*!< FPCCR: SFRDY Position */
+#define FPU_FPCCR_SFRDY_Msk                (1UL << FPU_FPCCR_SFRDY_Pos)                   /*!< FPCCR: SFRDY bit Mask */
+
+#define FPU_FPCCR_BFRDY_Pos                 6U                                            /*!< FPCCR: BFRDY Position */
+#define FPU_FPCCR_BFRDY_Msk                (1UL << FPU_FPCCR_BFRDY_Pos)                   /*!< FPCCR: BFRDY bit Mask */
+
+#define FPU_FPCCR_MMRDY_Pos                 5U                                            /*!< FPCCR: MMRDY Position */
+#define FPU_FPCCR_MMRDY_Msk                (1UL << FPU_FPCCR_MMRDY_Pos)                   /*!< FPCCR: MMRDY bit Mask */
+
+#define FPU_FPCCR_HFRDY_Pos                 4U                                            /*!< FPCCR: HFRDY Position */
+#define FPU_FPCCR_HFRDY_Msk                (1UL << FPU_FPCCR_HFRDY_Pos)                   /*!< FPCCR: HFRDY bit Mask */
+
+#define FPU_FPCCR_THREAD_Pos                3U                                            /*!< FPCCR: processor mode bit Position */
+#define FPU_FPCCR_THREAD_Msk               (1UL << FPU_FPCCR_THREAD_Pos)                  /*!< FPCCR: processor mode active bit Mask */
+
+#define FPU_FPCCR_S_Pos                     2U                                            /*!< FPCCR: Security status of the FP context bit Position */
+#define FPU_FPCCR_S_Msk                    (1UL << FPU_FPCCR_S_Pos)                       /*!< FPCCR: Security status of the FP context bit Mask */
+
+#define FPU_FPCCR_USER_Pos                  1U                                            /*!< FPCCR: privilege level bit Position */
+#define FPU_FPCCR_USER_Msk                 (1UL << FPU_FPCCR_USER_Pos)                    /*!< FPCCR: privilege level bit Mask */
+
+#define FPU_FPCCR_LSPACT_Pos                0U                                            /*!< FPCCR: Lazy state preservation active bit Position */
+#define FPU_FPCCR_LSPACT_Msk               (1UL /*<< FPU_FPCCR_LSPACT_Pos*/)              /*!< FPCCR: Lazy state preservation active bit Mask */
+
+/** \brief FPU Floating-Point Context Address Register Definitions */
+#define FPU_FPCAR_ADDRESS_Pos               3U                                            /*!< FPCAR: ADDRESS bit Position */
+#define FPU_FPCAR_ADDRESS_Msk              (0x1FFFFFFFUL << FPU_FPCAR_ADDRESS_Pos)        /*!< FPCAR: ADDRESS bit Mask */
+
+/** \brief FPU Floating-Point Default Status Control Register Definitions */
+#define FPU_FPDSCR_AHP_Pos                 26U                                            /*!< FPDSCR: AHP bit Position */
+#define FPU_FPDSCR_AHP_Msk                 (1UL << FPU_FPDSCR_AHP_Pos)                    /*!< FPDSCR: AHP bit Mask */
+
+#define FPU_FPDSCR_DN_Pos                  25U                                            /*!< FPDSCR: DN bit Position */
+#define FPU_FPDSCR_DN_Msk                  (1UL << FPU_FPDSCR_DN_Pos)                     /*!< FPDSCR: DN bit Mask */
+
+#define FPU_FPDSCR_FZ_Pos                  24U                                            /*!< FPDSCR: FZ bit Position */
+#define FPU_FPDSCR_FZ_Msk                  (1UL << FPU_FPDSCR_FZ_Pos)                     /*!< FPDSCR: FZ bit Mask */
+
+#define FPU_FPDSCR_RMode_Pos               22U                                            /*!< FPDSCR: RMode bit Position */
+#define FPU_FPDSCR_RMode_Msk               (3UL << FPU_FPDSCR_RMode_Pos)                  /*!< FPDSCR: RMode bit Mask */
+
+/** \brief FPU Media and VFP Feature Register 0 Definitions */
+#define FPU_MVFR0_FPRound_Pos              28U                                            /*!< MVFR0: Rounding modes bits Position */
+#define FPU_MVFR0_FPRound_Msk              (0xFUL << FPU_MVFR0_FPRound_Pos)               /*!< MVFR0: Rounding modes bits Mask */
+
+#define FPU_MVFR0_FPShortvec_Pos           24U                                            /*!< MVFR0: Short vectors bits Position */
+#define FPU_MVFR0_FPShortvec_Msk          (0xFUL << FPU_MVFR0_FPShortvec_Pos)             /*!< MVFR0: Short vectors bits Mask */
+
+#define FPU_MVFR0_FPSqrt_Pos               20U                                            /*!< MVFR0: Square root bits Position */
+#define FPU_MVFR0_FPSqrt_Msk               (0xFUL << FPU_MVFR0_FPSqrt_Pos)                /*!< MVFR0: Square root bits Mask */
+
+#define FPU_MVFR0_FPDivide_Pos             16U                                            /*!< MVFR0: Divide bits Position */
+#define FPU_MVFR0_FPDivide_Msk             (0xFUL << FPU_MVFR0_FPDivide_Pos)              /*!< MVFR0: Divide bits Mask */
+
+#define FPU_MVFR0_FPExceptrap_Pos    12U                                                  /*!< MVFR0: Exception trapping bits Position */
+#define FPU_MVFR0_FPExceptrap_Msk    (0xFUL << FPU_MVFR0_FPExceptrap_Pos)                 /*!< MVFR0: Exception trapping bits Mask */
+
+#define FPU_MVFR0_FPDP_Pos                  8U                                            /*!< MVFR0: Double-precision bits Position */
+#define FPU_MVFR0_FPDP_Msk                 (0xFUL << FPU_MVFR0_FPDP_Pos)                  /*!< MVFR0: Double-precision bits Mask */
+
+#define FPU_MVFR0_FPSP_Pos                  4U                                            /*!< MVFR0: Single-precision bits Position */
+#define FPU_MVFR0_FPSP_Msk                 (0xFUL << FPU_MVFR0_FPSP_Pos)                  /*!< MVFR0: Single-precision bits Mask */
+
+#define FPU_MVFR0_SIMDReg_Pos               0U                                            /*!< MVFR0: SIMD registers bits Position */
+#define FPU_MVFR0_SIMDReg_Msk              (0xFUL /*<< FPU_MVFR0_SIMDReg_Pos*/)           /*!< MVFR0: SIMD registers bits Mask */
+
+/** \brief FPU Media and VFP Feature Register 1 Definitions */
+#define FPU_MVFR1_FMAC_Pos                 28U                                            /*!< MVFR1: Fused MAC bits Position */
+#define FPU_MVFR1_FMAC_Msk                 (0xFUL << FPU_MVFR1_FMAC_Pos)                  /*!< MVFR1: Fused MAC bits Mask */
+
+#define FPU_MVFR1_FPHP_Pos                 24U                                            /*!< MVFR1: FP HPFP bits Position */
+#define FPU_MVFR1_FPHP_Msk                 (0xFUL << FPU_MVFR1_FPHP_Pos)                  /*!< MVFR1: FP HPFP bits Mask */
+
+#define FPU_MVFR1_FPDNaN_Pos                4U                                            /*!< MVFR1: D_NaN mode bits Position */
+#define FPU_MVFR1_FPDNaN_Msk               (0xFUL << FPU_MVFR1_FPDNaN_Pos)                /*!< MVFR1: D_NaN mode bits Mask */
+
+#define FPU_MVFR1_FPFtZ_Pos                 0U                                            /*!< MVFR1: FtZ mode bits Position */
+#define FPU_MVFR1_FPFtZ_Msk                (0xFUL /*<< FPU_MVFR1_FPFtZ_Pos*/)             /*!< MVFR1: FtZ mode bits Mask */
+
+/** \brief FPU Media and VFP Feature Register 2 Definitions */
+#define FPU_MVFR2_FPMisc_Pos                4U                                            /*!< MVFR2: VFP Misc bits Position */
+#define FPU_MVFR2_FPMisc_Msk               (0xFUL << FPU_MVFR2_FPMisc_Pos)                /*!< MVFR2: VFP Misc bits Mask */
+
+/*@} end of group CMSIS_FPU */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_DCB       Debug Control Block
+  \brief    Type definitions for the Debug Control Block Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Debug Control Block Registers (DCB).
+ */
+typedef struct
+{
+  __IOM uint32_t DHCSR;                  /*!< Offset: 0x000 (R/W)  Debug Halting Control and Status Register */
+  __OM  uint32_t DCRSR;                  /*!< Offset: 0x004 ( /W)  Debug Core Register Selector Register */
+  __IOM uint32_t DCRDR;                  /*!< Offset: 0x008 (R/W)  Debug Core Register Data Register */
+  __IOM uint32_t DEMCR;                  /*!< Offset: 0x00C (R/W)  Debug Exception and Monitor Control Register */
+        uint32_t RESERVED0[1U];
+  __IOM uint32_t DAUTHCTRL;              /*!< Offset: 0x014 (R/W)  Debug Authentication Control Register */
+  __IOM uint32_t DSCSR;                  /*!< Offset: 0x018 (R/W)  Debug Security Control and Status Register */
+} DCB_Type;
+
+/** \brief DCB Debug Halting Control and Status Register Definitions */
+#define DCB_DHCSR_DBGKEY_Pos               16U                                            /*!< DCB DHCSR: Debug key Position */
+#define DCB_DHCSR_DBGKEY_Msk               (0xFFFFUL << DCB_DHCSR_DBGKEY_Pos)             /*!< DCB DHCSR: Debug key Mask */
+
+#define DCB_DHCSR_S_RESTART_ST_Pos         26U                                            /*!< DCB DHCSR: Restart sticky status Position */
+#define DCB_DHCSR_S_RESTART_ST_Msk         (1UL << DCB_DHCSR_S_RESTART_ST_Pos)            /*!< DCB DHCSR: Restart sticky status Mask */
+
+#define DCB_DHCSR_S_RESET_ST_Pos           25U                                            /*!< DCB DHCSR: Reset sticky status Position */
+#define DCB_DHCSR_S_RESET_ST_Msk           (1UL << DCB_DHCSR_S_RESET_ST_Pos)              /*!< DCB DHCSR: Reset sticky status Mask */
+
+#define DCB_DHCSR_S_RETIRE_ST_Pos          24U                                            /*!< DCB DHCSR: Retire sticky status Position */
+#define DCB_DHCSR_S_RETIRE_ST_Msk          (1UL << DCB_DHCSR_S_RETIRE_ST_Pos)             /*!< DCB DHCSR: Retire sticky status Mask */
+
+#define DCB_DHCSR_S_SDE_Pos                20U                                            /*!< DCB DHCSR: Secure debug enabled Position */
+#define DCB_DHCSR_S_SDE_Msk                (1UL << DCB_DHCSR_S_SDE_Pos)                   /*!< DCB DHCSR: Secure debug enabled Mask */
+
+#define DCB_DHCSR_S_LOCKUP_Pos             19U                                            /*!< DCB DHCSR: Lockup status Position */
+#define DCB_DHCSR_S_LOCKUP_Msk             (1UL << DCB_DHCSR_S_LOCKUP_Pos)                /*!< DCB DHCSR: Lockup status Mask */
+
+#define DCB_DHCSR_S_SLEEP_Pos              18U                                            /*!< DCB DHCSR: Sleeping status Position */
+#define DCB_DHCSR_S_SLEEP_Msk              (1UL << DCB_DHCSR_S_SLEEP_Pos)                 /*!< DCB DHCSR: Sleeping status Mask */
+
+#define DCB_DHCSR_S_HALT_Pos               17U                                            /*!< DCB DHCSR: Halted status Position */
+#define DCB_DHCSR_S_HALT_Msk               (1UL << DCB_DHCSR_S_HALT_Pos)                  /*!< DCB DHCSR: Halted status Mask */
+
+#define DCB_DHCSR_S_REGRDY_Pos             16U                                            /*!< DCB DHCSR: Register ready status Position */
+#define DCB_DHCSR_S_REGRDY_Msk             (1UL << DCB_DHCSR_S_REGRDY_Pos)                /*!< DCB DHCSR: Register ready status Mask */
+
+#define DCB_DHCSR_C_SNAPSTALL_Pos           5U                                            /*!< DCB DHCSR: Snap stall control Position */
+#define DCB_DHCSR_C_SNAPSTALL_Msk          (1UL << DCB_DHCSR_C_SNAPSTALL_Pos)             /*!< DCB DHCSR: Snap stall control Mask */
+
+#define DCB_DHCSR_C_MASKINTS_Pos            3U                                            /*!< DCB DHCSR: Mask interrupts control Position */
+#define DCB_DHCSR_C_MASKINTS_Msk           (1UL << DCB_DHCSR_C_MASKINTS_Pos)              /*!< DCB DHCSR: Mask interrupts control Mask */
+
+#define DCB_DHCSR_C_STEP_Pos                2U                                            /*!< DCB DHCSR: Step control Position */
+#define DCB_DHCSR_C_STEP_Msk               (1UL << DCB_DHCSR_C_STEP_Pos)                  /*!< DCB DHCSR: Step control Mask */
+
+#define DCB_DHCSR_C_HALT_Pos                1U                                            /*!< DCB DHCSR: Halt control Position */
+#define DCB_DHCSR_C_HALT_Msk               (1UL << DCB_DHCSR_C_HALT_Pos)                  /*!< DCB DHCSR: Halt control Mask */
+
+#define DCB_DHCSR_C_DEBUGEN_Pos             0U                                            /*!< DCB DHCSR: Debug enable control Position */
+#define DCB_DHCSR_C_DEBUGEN_Msk            (1UL /*<< DCB_DHCSR_C_DEBUGEN_Pos*/)           /*!< DCB DHCSR: Debug enable control Mask */
+
+/** \brief DCB Debug Core Register Selector Register Definitions */
+#define DCB_DCRSR_REGWnR_Pos               16U                                            /*!< DCB DCRSR: Register write/not-read Position */
+#define DCB_DCRSR_REGWnR_Msk               (1UL << DCB_DCRSR_REGWnR_Pos)                  /*!< DCB DCRSR: Register write/not-read Mask */
+
+#define DCB_DCRSR_REGSEL_Pos                0U                                            /*!< DCB DCRSR: Register selector Position */
+#define DCB_DCRSR_REGSEL_Msk               (0x7FUL /*<< DCB_DCRSR_REGSEL_Pos*/)           /*!< DCB DCRSR: Register selector Mask */
+
+/** \brief DCB Debug Core Register Data Register Definitions */
+#define DCB_DCRDR_DBGTMP_Pos                0U                                            /*!< DCB DCRDR: Data temporary buffer Position */
+#define DCB_DCRDR_DBGTMP_Msk               (0xFFFFFFFFUL /*<< DCB_DCRDR_DBGTMP_Pos*/)     /*!< DCB DCRDR: Data temporary buffer Mask */
+
+/** \brief DCB Debug Exception and Monitor Control Register Definitions */
+#define DCB_DEMCR_TRCENA_Pos               24U                                            /*!< DCB DEMCR: Trace enable Position */
+#define DCB_DEMCR_TRCENA_Msk               (1UL << DCB_DEMCR_TRCENA_Pos)                  /*!< DCB DEMCR: Trace enable Mask */
+
+#define DCB_DEMCR_MONPRKEY_Pos             23U                                            /*!< DCB DEMCR: Monitor pend req key Position */
+#define DCB_DEMCR_MONPRKEY_Msk             (1UL << DCB_DEMCR_MONPRKEY_Pos)                /*!< DCB DEMCR: Monitor pend req key Mask */
+
+#define DCB_DEMCR_UMON_EN_Pos              21U                                            /*!< DCB DEMCR: Unprivileged monitor enable Position */
+#define DCB_DEMCR_UMON_EN_Msk              (1UL << DCB_DEMCR_UMON_EN_Pos)                 /*!< DCB DEMCR: Unprivileged monitor enable Mask */
+
+#define DCB_DEMCR_SDME_Pos                 20U                                            /*!< DCB DEMCR: Secure DebugMonitor enable Position */
+#define DCB_DEMCR_SDME_Msk                 (1UL << DCB_DEMCR_SDME_Pos)                    /*!< DCB DEMCR: Secure DebugMonitor enable Mask */
+
+#define DCB_DEMCR_MON_REQ_Pos              19U                                            /*!< DCB DEMCR: Monitor request Position */
+#define DCB_DEMCR_MON_REQ_Msk              (1UL << DCB_DEMCR_MON_REQ_Pos)                 /*!< DCB DEMCR: Monitor request Mask */
+
+#define DCB_DEMCR_MON_STEP_Pos             18U                                            /*!< DCB DEMCR: Monitor step Position */
+#define DCB_DEMCR_MON_STEP_Msk             (1UL << DCB_DEMCR_MON_STEP_Pos)                /*!< DCB DEMCR: Monitor step Mask */
+
+#define DCB_DEMCR_MON_PEND_Pos             17U                                            /*!< DCB DEMCR: Monitor pend Position */
+#define DCB_DEMCR_MON_PEND_Msk             (1UL << DCB_DEMCR_MON_PEND_Pos)                /*!< DCB DEMCR: Monitor pend Mask */
+
+#define DCB_DEMCR_MON_EN_Pos               16U                                            /*!< DCB DEMCR: Monitor enable Position */
+#define DCB_DEMCR_MON_EN_Msk               (1UL << DCB_DEMCR_MON_EN_Pos)                  /*!< DCB DEMCR: Monitor enable Mask */
+
+#define DCB_DEMCR_VC_SFERR_Pos             11U                                            /*!< DCB DEMCR: Vector Catch SecureFault Position */
+#define DCB_DEMCR_VC_SFERR_Msk             (1UL << DCB_DEMCR_VC_SFERR_Pos)                /*!< DCB DEMCR: Vector Catch SecureFault Mask */
+
+#define DCB_DEMCR_VC_HARDERR_Pos           10U                                            /*!< DCB DEMCR: Vector Catch HardFault errors Position */
+#define DCB_DEMCR_VC_HARDERR_Msk           (1UL << DCB_DEMCR_VC_HARDERR_Pos)              /*!< DCB DEMCR: Vector Catch HardFault errors Mask */
+
+#define DCB_DEMCR_VC_INTERR_Pos             9U                                            /*!< DCB DEMCR: Vector Catch interrupt errors Position */
+#define DCB_DEMCR_VC_INTERR_Msk            (1UL << DCB_DEMCR_VC_INTERR_Pos)               /*!< DCB DEMCR: Vector Catch interrupt errors Mask */
+
+#define DCB_DEMCR_VC_BUSERR_Pos             8U                                            /*!< DCB DEMCR: Vector Catch BusFault errors Position */
+#define DCB_DEMCR_VC_BUSERR_Msk            (1UL << DCB_DEMCR_VC_BUSERR_Pos)               /*!< DCB DEMCR: Vector Catch BusFault errors Mask */
+
+#define DCB_DEMCR_VC_STATERR_Pos            7U                                            /*!< DCB DEMCR: Vector Catch state errors Position */
+#define DCB_DEMCR_VC_STATERR_Msk           (1UL << DCB_DEMCR_VC_STATERR_Pos)              /*!< DCB DEMCR: Vector Catch state errors Mask */
+
+#define DCB_DEMCR_VC_CHKERR_Pos             6U                                            /*!< DCB DEMCR: Vector Catch check errors Position */
+#define DCB_DEMCR_VC_CHKERR_Msk            (1UL << DCB_DEMCR_VC_CHKERR_Pos)               /*!< DCB DEMCR: Vector Catch check errors Mask */
+
+#define DCB_DEMCR_VC_NOCPERR_Pos            5U                                            /*!< DCB DEMCR: Vector Catch NOCP errors Position */
+#define DCB_DEMCR_VC_NOCPERR_Msk           (1UL << DCB_DEMCR_VC_NOCPERR_Pos)              /*!< DCB DEMCR: Vector Catch NOCP errors Mask */
+
+#define DCB_DEMCR_VC_MMERR_Pos              4U                                            /*!< DCB DEMCR: Vector Catch MemManage errors Position */
+#define DCB_DEMCR_VC_MMERR_Msk             (1UL << DCB_DEMCR_VC_MMERR_Pos)                /*!< DCB DEMCR: Vector Catch MemManage errors Mask */
+
+#define DCB_DEMCR_VC_CORERESET_Pos          0U                                            /*!< DCB DEMCR: Vector Catch Core reset Position */
+#define DCB_DEMCR_VC_CORERESET_Msk         (1UL /*<< DCB_DEMCR_VC_CORERESET_Pos*/)        /*!< DCB DEMCR: Vector Catch Core reset Mask */
+
+/** \brief DCB Debug Authentication Control Register Definitions */
+#define DCB_DAUTHCTRL_INTSPNIDEN_Pos        3U                                            /*!< DCB DAUTHCTRL: Internal Secure non-invasive debug enable Position */
+#define DCB_DAUTHCTRL_INTSPNIDEN_Msk       (1UL << DCB_DAUTHCTRL_INTSPNIDEN_Pos)          /*!< DCB DAUTHCTRL: Internal Secure non-invasive debug enable Mask */
+
+#define DCB_DAUTHCTRL_SPNIDENSEL_Pos        2U                                            /*!< DCB DAUTHCTRL: Secure non-invasive debug enable select Position */
+#define DCB_DAUTHCTRL_SPNIDENSEL_Msk       (1UL << DCB_DAUTHCTRL_SPNIDENSEL_Pos)          /*!< DCB DAUTHCTRL: Secure non-invasive debug enable select Mask */
+
+#define DCB_DAUTHCTRL_INTSPIDEN_Pos         1U                                            /*!< DCB DAUTHCTRL: Internal Secure invasive debug enable Position */
+#define DCB_DAUTHCTRL_INTSPIDEN_Msk        (1UL << DCB_DAUTHCTRL_INTSPIDEN_Pos)           /*!< DCB DAUTHCTRL: Internal Secure invasive debug enable Mask */
+
+#define DCB_DAUTHCTRL_SPIDENSEL_Pos         0U                                            /*!< DCB DAUTHCTRL: Secure invasive debug enable select Position */
+#define DCB_DAUTHCTRL_SPIDENSEL_Msk        (1UL /*<< DCB_DAUTHCTRL_SPIDENSEL_Pos*/)       /*!< DCB DAUTHCTRL: Secure invasive debug enable select Mask */
+
+/** \brief DCB Debug Security Control and Status Register Definitions */
+#define DCB_DSCSR_CDSKEY_Pos               17U                                            /*!< DCB DSCSR: CDS write-enable key Position */
+#define DCB_DSCSR_CDSKEY_Msk               (1UL << DCB_DSCSR_CDSKEY_Pos)                  /*!< DCB DSCSR: CDS write-enable key Mask */
+
+#define DCB_DSCSR_CDS_Pos                  16U                                            /*!< DCB DSCSR: Current domain Secure Position */
+#define DCB_DSCSR_CDS_Msk                  (1UL << DCB_DSCSR_CDS_Pos)                     /*!< DCB DSCSR: Current domain Secure Mask */
+
+#define DCB_DSCSR_SBRSEL_Pos                1U                                            /*!< DCB DSCSR: Secure banked register select Position */
+#define DCB_DSCSR_SBRSEL_Msk               (1UL << DCB_DSCSR_SBRSEL_Pos)                  /*!< DCB DSCSR: Secure banked register select Mask */
+
+#define DCB_DSCSR_SBRSELEN_Pos              0U                                            /*!< DCB DSCSR: Secure banked register select enable Position */
+#define DCB_DSCSR_SBRSELEN_Msk             (1UL /*<< DCB_DSCSR_SBRSELEN_Pos*/)            /*!< DCB DSCSR: Secure banked register select enable Mask */
+
+/*@} end of group CMSIS_DCB */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_DIB       Debug Identification Block
+  \brief    Type definitions for the Debug Identification Block Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Debug Identification Block Registers (DIB).
+ */
+typedef struct
+{
+  __OM  uint32_t DLAR;                   /*!< Offset: 0x000 ( /W)  SCS Software Lock Access Register */
+  __IM  uint32_t DLSR;                   /*!< Offset: 0x004 (R/ )  SCS Software Lock Status Register */
+  __IM  uint32_t DAUTHSTATUS;            /*!< Offset: 0x008 (R/ )  Debug Authentication Status Register */
+  __IM  uint32_t DDEVARCH;               /*!< Offset: 0x00C (R/ )  SCS Device Architecture Register */
+  __IM  uint32_t DDEVTYPE;               /*!< Offset: 0x010 (R/ )  SCS Device Type Register */
+} DIB_Type;
+
+/** \brief DIB SCS Software Lock Access Register Definitions */
+#define DIB_DLAR_KEY_Pos                    0U                                            /*!< DIB DLAR: KEY Position */
+#define DIB_DLAR_KEY_Msk                   (0xFFFFFFFFUL /*<< DIB_DLAR_KEY_Pos */)        /*!< DIB DLAR: KEY Mask */
+
+/** \brief DIB SCS Software Lock Status Register Definitions */
+#define DIB_DLSR_nTT_Pos                    2U                                            /*!< DIB DLSR: Not thirty-two bit Position */
+#define DIB_DLSR_nTT_Msk                   (1UL << DIB_DLSR_nTT_Pos )                     /*!< DIB DLSR: Not thirty-two bit Mask */
+
+#define DIB_DLSR_SLK_Pos                    1U                                            /*!< DIB DLSR: Software Lock status Position */
+#define DIB_DLSR_SLK_Msk                   (1UL << DIB_DLSR_SLK_Pos )                     /*!< DIB DLSR: Software Lock status Mask */
+
+#define DIB_DLSR_SLI_Pos                    0U                                            /*!< DIB DLSR: Software Lock implemented Position */
+#define DIB_DLSR_SLI_Msk                   (1UL /*<< DIB_DLSR_SLI_Pos*/)                  /*!< DIB DLSR: Software Lock implemented Mask */
+
+/** \brief DIB Debug Authentication Status Register Definitions */
+#define DIB_DAUTHSTATUS_SNID_Pos            6U                                            /*!< DIB DAUTHSTATUS: Secure Non-invasive Debug Position */
+#define DIB_DAUTHSTATUS_SNID_Msk           (0x3UL << DIB_DAUTHSTATUS_SNID_Pos )           /*!< DIB DAUTHSTATUS: Secure Non-invasive Debug Mask */
+
+#define DIB_DAUTHSTATUS_SID_Pos             4U                                            /*!< DIB DAUTHSTATUS: Secure Invasive Debug Position */
+#define DIB_DAUTHSTATUS_SID_Msk            (0x3UL << DIB_DAUTHSTATUS_SID_Pos )            /*!< DIB DAUTHSTATUS: Secure Invasive Debug Mask */
+
+#define DIB_DAUTHSTATUS_NSNID_Pos           2U                                            /*!< DIB DAUTHSTATUS: Non-secure Non-invasive Debug Position */
+#define DIB_DAUTHSTATUS_NSNID_Msk          (0x3UL << DIB_DAUTHSTATUS_NSNID_Pos )          /*!< DIB DAUTHSTATUS: Non-secure Non-invasive Debug Mask */
+
+#define DIB_DAUTHSTATUS_NSID_Pos            0U                                            /*!< DIB DAUTHSTATUS: Non-secure Invasive Debug Position */
+#define DIB_DAUTHSTATUS_NSID_Msk           (0x3UL /*<< DIB_DAUTHSTATUS_NSID_Pos*/)        /*!< DIB DAUTHSTATUS: Non-secure Invasive Debug Mask */
+
+/** \brief DIB SCS Device Architecture Register Definitions */
+#define DIB_DDEVARCH_ARCHITECT_Pos         21U                                            /*!< DIB DDEVARCH: Architect Position */
+#define DIB_DDEVARCH_ARCHITECT_Msk         (0x7FFUL << DIB_DDEVARCH_ARCHITECT_Pos )       /*!< DIB DDEVARCH: Architect Mask */
+
+#define DIB_DDEVARCH_PRESENT_Pos           20U                                            /*!< DIB DDEVARCH: DEVARCH Present Position */
+#define DIB_DDEVARCH_PRESENT_Msk           (0x1FUL << DIB_DDEVARCH_PRESENT_Pos )          /*!< DIB DDEVARCH: DEVARCH Present Mask */
+
+#define DIB_DDEVARCH_REVISION_Pos          16U                                            /*!< DIB DDEVARCH: Revision Position */
+#define DIB_DDEVARCH_REVISION_Msk          (0xFUL << DIB_DDEVARCH_REVISION_Pos )          /*!< DIB DDEVARCH: Revision Mask */
+
+#define DIB_DDEVARCH_ARCHVER_Pos           12U                                            /*!< DIB DDEVARCH: Architecture Version Position */
+#define DIB_DDEVARCH_ARCHVER_Msk           (0xFUL << DIB_DDEVARCH_ARCHVER_Pos )           /*!< DIB DDEVARCH: Architecture Version Mask */
+
+#define DIB_DDEVARCH_ARCHPART_Pos           0U                                            /*!< DIB DDEVARCH: Architecture Part Position */
+#define DIB_DDEVARCH_ARCHPART_Msk          (0xFFFUL /*<< DIB_DDEVARCH_ARCHPART_Pos*/)     /*!< DIB DDEVARCH: Architecture Part Mask */
+
+/** \brief DIB SCS Device Type Register Definitions */
+#define DIB_DDEVTYPE_SUB_Pos                4U                                            /*!< DIB DDEVTYPE: Sub-type Position */
+#define DIB_DDEVTYPE_SUB_Msk               (0xFUL << DIB_DDEVTYPE_SUB_Pos )               /*!< DIB DDEVTYPE: Sub-type Mask */
+
+#define DIB_DDEVTYPE_MAJOR_Pos              0U                                            /*!< DIB DDEVTYPE: Major type Position */
+#define DIB_DDEVTYPE_MAJOR_Msk             (0xFUL /*<< DIB_DDEVTYPE_MAJOR_Pos*/)          /*!< DIB DDEVTYPE: Major type Mask */
+
+/*@} end of group CMSIS_DIB */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_core_bitfield     Core register bit field macros
+  \brief      Macros for use with bit field definitions (xxx_Pos, xxx_Msk).
+  @{
+ */
+
+/**
+  \brief   Mask and shift a bit field value for use in a register bit range.
+  \param[in] field  Name of the register bit field.
+  \param[in] value  Value of the bit field. This parameter is interpreted as an uint32_t type.
+  \return           Masked and shifted value.
+*/
+#define _VAL2FLD(field, value)    (((uint32_t)(value) << field ## _Pos) & field ## _Msk)
+
+/**
+  \brief     Mask and shift a register value to extract a bit filed value.
+  \param[in] field  Name of the register bit field.
+  \param[in] value  Value of register. This parameter is interpreted as an uint32_t type.
+  \return           Masked and shifted bit field value.
+*/
+#define _FLD2VAL(field, value)    (((uint32_t)(value) & field ## _Msk) >> field ## _Pos)
+
+/*@} end of group CMSIS_core_bitfield */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_core_base     Core Definitions
+  \brief      Definitions for base addresses, unions, and structures.
+  @{
+ */
+
+/* Memory mapping of Core Hardware */
+  #define SCS_BASE            (0xE000E000UL)                             /*!< System Control Space Base Address */
+  #define ITM_BASE            (0xE0000000UL)                             /*!< ITM Base Address */
+  #define DWT_BASE            (0xE0001000UL)                             /*!< DWT Base Address */
+  #define TPIU_BASE           (0xE0040000UL)                             /*!< TPIU Base Address */
+  #define DCB_BASE            (0xE000EDF0UL)                             /*!< DCB Base Address */
+  #define DIB_BASE            (0xE000EFB0UL)                             /*!< DIB Base Address */
+  #define SysTick_BASE        (SCS_BASE +  0x0010UL)                     /*!< SysTick Base Address */
+  #define NVIC_BASE           (SCS_BASE +  0x0100UL)                     /*!< NVIC Base Address */
+  #define SCB_BASE            (SCS_BASE +  0x0D00UL)                     /*!< System Control Block Base Address */
+
+  #define SCnSCB              ((SCnSCB_Type    *)     SCS_BASE         ) /*!< System control Register not in SCB */
+  #define SCB                 ((SCB_Type       *)     SCB_BASE         ) /*!< SCB configuration struct */
+  #define SysTick             ((SysTick_Type   *)     SysTick_BASE     ) /*!< SysTick configuration struct */
+  #define NVIC                ((NVIC_Type      *)     NVIC_BASE        ) /*!< NVIC configuration struct */
+  #define ITM                 ((ITM_Type       *)     ITM_BASE         ) /*!< ITM configuration struct */
+  #define DWT                 ((DWT_Type       *)     DWT_BASE         ) /*!< DWT configuration struct */
+  #define TPIU                ((TPIU_Type      *)     TPIU_BASE        ) /*!< TPIU configuration struct */
+  #define DCB                 ((DCB_Type       *)     DCB_BASE         ) /*!< DCB configuration struct */
+  #define DIB                 ((DIB_Type       *)     DIB_BASE         ) /*!< DIB configuration struct */
+
+  #if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+    #define MPU_BASE          (SCS_BASE +  0x0D90UL)                     /*!< Memory Protection Unit */
+    #define MPU               ((MPU_Type       *)     MPU_BASE         ) /*!< Memory Protection Unit */
+  #endif
+
+  #if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+    #define SAU_BASE          (SCS_BASE +  0x0DD0UL)                     /*!< Security Attribution Unit */
+    #define SAU               ((SAU_Type       *)     SAU_BASE         ) /*!< Security Attribution Unit */
+  #endif
+
+  #define FPU_BASE            (SCS_BASE +  0x0F30UL)                     /*!< Floating Point Unit */
+  #define FPU                 ((FPU_Type       *)     FPU_BASE         ) /*!< Floating Point Unit */
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  #define SCS_BASE_NS         (0xE002E000UL)                             /*!< System Control Space Base Address (non-secure address space) */
+  #define DCB_BASE_NS         (0xE002EDF0UL)                             /*!< DCB Base Address                  (non-secure address space) */
+  #define DIB_BASE_NS         (0xE002EFB0UL)                             /*!< DIB Base Address                  (non-secure address space) */
+  #define SysTick_BASE_NS     (SCS_BASE_NS +  0x0010UL)                  /*!< SysTick Base Address              (non-secure address space) */
+  #define NVIC_BASE_NS        (SCS_BASE_NS +  0x0100UL)                  /*!< NVIC Base Address                 (non-secure address space) */
+  #define SCB_BASE_NS         (SCS_BASE_NS +  0x0D00UL)                  /*!< System Control Block Base Address (non-secure address space) */
+
+  #define SCnSCB_NS           ((SCnSCB_Type    *)     SCS_BASE_NS      ) /*!< System control Register not in SCB(non-secure address space) */
+  #define SCB_NS              ((SCB_Type       *)     SCB_BASE_NS      ) /*!< SCB configuration struct          (non-secure address space) */
+  #define SysTick_NS          ((SysTick_Type   *)     SysTick_BASE_NS  ) /*!< SysTick configuration struct      (non-secure address space) */
+  #define NVIC_NS             ((NVIC_Type      *)     NVIC_BASE_NS     ) /*!< NVIC configuration struct         (non-secure address space) */
+  #define DCB_NS              ((DCB_Type       *)     DCB_BASE_NS      ) /*!< DCB configuration struct          (non-secure address space) */
+  #define DIB_NS              ((DIB_Type       *)     DIB_BASE_NS      ) /*!< DIB configuration struct          (non-secure address space) */
+
+  #if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+    #define MPU_BASE_NS       (SCS_BASE_NS +  0x0D90UL)                  /*!< Memory Protection Unit            (non-secure address space) */
+    #define MPU_NS            ((MPU_Type       *)     MPU_BASE_NS      ) /*!< Memory Protection Unit            (non-secure address space) */
+  #endif
+
+  #define FPU_BASE_NS         (SCS_BASE_NS +  0x0F30UL)                  /*!< Floating Point Unit               (non-secure address space) */
+  #define FPU_NS              ((FPU_Type       *)     FPU_BASE_NS      ) /*!< Floating Point Unit               (non-secure address space) */
+
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+/*@} */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_register_aliases     Backwards Compatibility Aliases
+  \brief      Register alias definitions for backwards compatibility.
+  @{
+ */
+
+/*@} */
+
+
+/*******************************************************************************
+ *                Hardware Abstraction Layer
+  Core Function Interface contains:
+  - Core NVIC Functions
+  - Core SysTick Functions
+  - Core Debug Functions
+  - Core Register Access Functions
+ ******************************************************************************/
+/**
+  \defgroup CMSIS_Core_FunctionInterface Functions and Instructions Reference
+*/
+
+
+
+/* ##########################   NVIC functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_NVICFunctions NVIC Functions
+  \brief    Functions that manage interrupts and exceptions via the NVIC.
+  @{
+ */
+
+#ifdef CMSIS_NVIC_VIRTUAL
+  #ifndef CMSIS_NVIC_VIRTUAL_HEADER_FILE
+    #define CMSIS_NVIC_VIRTUAL_HEADER_FILE "cmsis_nvic_virtual.h"
+  #endif
+  #include CMSIS_NVIC_VIRTUAL_HEADER_FILE
+#else
+  #define NVIC_SetPriorityGrouping    __NVIC_SetPriorityGrouping
+  #define NVIC_GetPriorityGrouping    __NVIC_GetPriorityGrouping
+  #define NVIC_EnableIRQ              __NVIC_EnableIRQ
+  #define NVIC_GetEnableIRQ           __NVIC_GetEnableIRQ
+  #define NVIC_DisableIRQ             __NVIC_DisableIRQ
+  #define NVIC_GetPendingIRQ          __NVIC_GetPendingIRQ
+  #define NVIC_SetPendingIRQ          __NVIC_SetPendingIRQ
+  #define NVIC_ClearPendingIRQ        __NVIC_ClearPendingIRQ
+  #define NVIC_GetActive              __NVIC_GetActive
+  #define NVIC_SetPriority            __NVIC_SetPriority
+  #define NVIC_GetPriority            __NVIC_GetPriority
+  #define NVIC_SystemReset            __NVIC_SystemReset
+#endif /* CMSIS_NVIC_VIRTUAL */
+
+#ifdef CMSIS_VECTAB_VIRTUAL
+  #ifndef CMSIS_VECTAB_VIRTUAL_HEADER_FILE
+    #define CMSIS_VECTAB_VIRTUAL_HEADER_FILE "cmsis_vectab_virtual.h"
+  #endif
+  #include CMSIS_VECTAB_VIRTUAL_HEADER_FILE
+#else
+  #define NVIC_SetVector              __NVIC_SetVector
+  #define NVIC_GetVector              __NVIC_GetVector
+#endif  /* (CMSIS_VECTAB_VIRTUAL) */
+
+#define NVIC_USER_IRQ_OFFSET          16
+
+
+/* Special LR values for Secure/Non-Secure call handling and exception handling                                               */
+
+/* Function Return Payload (from ARMv8-M Architecture Reference Manual) LR value on entry from Secure BLXNS                   */
+#define FNC_RETURN                 (0xFEFFFFFFUL)     /* bit [0] ignored when processing a branch                             */
+
+/* The following EXC_RETURN mask values are used to evaluate the LR on exception entry */
+#define EXC_RETURN_PREFIX          (0xFF000000UL)     /* bits [31:24] set to indicate an EXC_RETURN value                     */
+#define EXC_RETURN_S               (0x00000040UL)     /* bit [6] stack used to push registers: 0=Non-secure 1=Secure          */
+#define EXC_RETURN_DCRS            (0x00000020UL)     /* bit [5] stacking rules for called registers: 0=skipped 1=saved       */
+#define EXC_RETURN_FTYPE           (0x00000010UL)     /* bit [4] allocate stack for floating-point context: 0=done 1=skipped  */
+#define EXC_RETURN_MODE            (0x00000008UL)     /* bit [3] processor mode for return: 0=Handler mode 1=Thread mode      */
+#define EXC_RETURN_SPSEL           (0x00000004UL)     /* bit [2] stack pointer used to restore context: 0=MSP 1=PSP           */
+#define EXC_RETURN_ES              (0x00000001UL)     /* bit [0] security state exception was taken to: 0=Non-secure 1=Secure */
+
+/* Integrity Signature (from ARMv8-M Architecture Reference Manual) for exception context stacking                            */
+#if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)  /* Value for processors with floating-point extension:                  */
+#define EXC_INTEGRITY_SIGNATURE     (0xFEFA125AUL)     /* bit [0] SFTC must match LR bit[4] EXC_RETURN_FTYPE                   */
+#else
+#define EXC_INTEGRITY_SIGNATURE     (0xFEFA125BUL)     /* Value for processors without floating-point extension                */
+#endif
+
+
+/**
+  \brief   Set Priority Grouping
+  \details Sets the priority grouping field using the required unlock sequence.
+           The parameter PriorityGroup is assigned to the field SCB->AIRCR [10:8] PRIGROUP field.
+           Only values from 0..7 are used.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+  \param [in]      PriorityGroup  Priority grouping field.
+ */
+__STATIC_INLINE void __NVIC_SetPriorityGrouping(uint32_t PriorityGroup)
+{
+  uint32_t reg_value;
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);             /* only values 0..7 are used          */
+
+  reg_value  =  SCB->AIRCR;                                                   /* read old register configuration    */
+  reg_value &= ~((uint32_t)(SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk)); /* clear bits to change               */
+  reg_value  =  (reg_value                                   |
+                ((uint32_t)0x5FAUL << SCB_AIRCR_VECTKEY_Pos) |
+                (PriorityGroupTmp << SCB_AIRCR_PRIGROUP_Pos)  );              /* Insert write key and priority group */
+  SCB->AIRCR =  reg_value;
+}
+
+
+/**
+  \brief   Get Priority Grouping
+  \details Reads the priority grouping field from the NVIC Interrupt Controller.
+  \return                Priority grouping field (SCB->AIRCR [10:8] PRIGROUP field).
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPriorityGrouping(void)
+{
+  return ((uint32_t)((SCB->AIRCR & SCB_AIRCR_PRIGROUP_Msk) >> SCB_AIRCR_PRIGROUP_Pos));
+}
+
+
+/**
+  \brief   Enable Interrupt
+  \details Enables a device specific interrupt in the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_EnableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    __COMPILER_BARRIER();
+    NVIC->ISER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+    __COMPILER_BARRIER();
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Enable status
+  \details Returns a device specific interrupt enable status from the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt is not enabled.
+  \return             1  Interrupt is enabled.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetEnableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ISER[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Disable Interrupt
+  \details Disables a device specific interrupt in the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_DisableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ICER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+    __DSB();
+    __ISB();
+  }
+}
+
+
+/**
+  \brief   Get Pending Interrupt
+  \details Reads the NVIC pending register and returns the pending bit for the specified device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not pending.
+  \return             1  Interrupt status is pending.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ISPR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Pending Interrupt
+  \details Sets the pending bit of a device specific interrupt in the NVIC pending register.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_SetPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ISPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Clear Pending Interrupt
+  \details Clears the pending bit of a device specific interrupt in the NVIC pending register.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_ClearPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ICPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Active Interrupt
+  \details Reads the active register in the NVIC and returns the active bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not active.
+  \return             1  Interrupt status is active.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetActive(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->IABR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   Get Interrupt Target State
+  \details Reads the interrupt target field in the NVIC and returns the interrupt target bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  if interrupt is assigned to Secure
+  \return             1  if interrupt is assigned to Non Secure
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t NVIC_GetTargetState(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Interrupt Target State
+  \details Sets the interrupt target field in the NVIC and returns the interrupt target bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  if interrupt is assigned to Secure
+                      1  if interrupt is assigned to Non Secure
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t NVIC_SetTargetState(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] |=  ((uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL)));
+    return((uint32_t)(((NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Clear Interrupt Target State
+  \details Clears the interrupt target field in the NVIC and returns the interrupt target bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  if interrupt is assigned to Secure
+                      1  if interrupt is assigned to Non Secure
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t NVIC_ClearTargetState(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] &= ~((uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL)));
+    return((uint32_t)(((NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+
+/**
+  \brief   Set Interrupt Priority
+  \details Sets the priority of a device specific interrupt or a processor exception.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]      IRQn  Interrupt number.
+  \param [in]  priority  Priority to set.
+  \note    The priority cannot be set for every processor exception.
+ */
+__STATIC_INLINE void __NVIC_SetPriority(IRQn_Type IRQn, uint32_t priority)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->IPR[((uint32_t)IRQn)]               = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+  else
+  {
+    SCB->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Priority
+  \details Reads the priority of a device specific interrupt or a processor exception.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn  Interrupt number.
+  \return             Interrupt Priority.
+                      Value is aligned automatically to the implemented priority bits of the microcontroller.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPriority(IRQn_Type IRQn)
+{
+
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return(((uint32_t)NVIC->IPR[((uint32_t)IRQn)]               >> (8U - __NVIC_PRIO_BITS)));
+  }
+  else
+  {
+    return(((uint32_t)SCB->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] >> (8U - __NVIC_PRIO_BITS)));
+  }
+}
+
+
+/**
+  \brief   Encode Priority
+  \details Encodes the priority for an interrupt with the given priority group,
+           preemptive priority value, and subpriority value.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+  \param [in]     PriorityGroup  Used priority group.
+  \param [in]   PreemptPriority  Preemptive priority value (starting from 0).
+  \param [in]       SubPriority  Subpriority value (starting from 0).
+  \return                        Encoded priority. Value can be used in the function \ref NVIC_SetPriority().
+ */
+__STATIC_INLINE uint32_t NVIC_EncodePriority (uint32_t PriorityGroup, uint32_t PreemptPriority, uint32_t SubPriority)
+{
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);   /* only values 0..7 are used          */
+  uint32_t PreemptPriorityBits;
+  uint32_t SubPriorityBits;
+
+  PreemptPriorityBits = ((7UL - PriorityGroupTmp) > (uint32_t)(__NVIC_PRIO_BITS)) ? (uint32_t)(__NVIC_PRIO_BITS) : (uint32_t)(7UL - PriorityGroupTmp);
+  SubPriorityBits     = ((PriorityGroupTmp + (uint32_t)(__NVIC_PRIO_BITS)) < (uint32_t)7UL) ? (uint32_t)0UL : (uint32_t)((PriorityGroupTmp - 7UL) + (uint32_t)(__NVIC_PRIO_BITS));
+
+  return (
+           ((PreemptPriority & (uint32_t)((1UL << (PreemptPriorityBits)) - 1UL)) << SubPriorityBits) |
+           ((SubPriority     & (uint32_t)((1UL << (SubPriorityBits    )) - 1UL)))
+         );
+}
+
+
+/**
+  \brief   Decode Priority
+  \details Decodes an interrupt priority value with a given priority group to
+           preemptive priority value and subpriority value.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS) the smallest possible priority group is set.
+  \param [in]         Priority   Priority value, which can be retrieved with the function \ref NVIC_GetPriority().
+  \param [in]     PriorityGroup  Used priority group.
+  \param [out] pPreemptPriority  Preemptive priority value (starting from 0).
+  \param [out]     pSubPriority  Subpriority value (starting from 0).
+ */
+__STATIC_INLINE void NVIC_DecodePriority (uint32_t Priority, uint32_t PriorityGroup, uint32_t* const pPreemptPriority, uint32_t* const pSubPriority)
+{
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);   /* only values 0..7 are used          */
+  uint32_t PreemptPriorityBits;
+  uint32_t SubPriorityBits;
+
+  PreemptPriorityBits = ((7UL - PriorityGroupTmp) > (uint32_t)(__NVIC_PRIO_BITS)) ? (uint32_t)(__NVIC_PRIO_BITS) : (uint32_t)(7UL - PriorityGroupTmp);
+  SubPriorityBits     = ((PriorityGroupTmp + (uint32_t)(__NVIC_PRIO_BITS)) < (uint32_t)7UL) ? (uint32_t)0UL : (uint32_t)((PriorityGroupTmp - 7UL) + (uint32_t)(__NVIC_PRIO_BITS));
+
+  *pPreemptPriority = (Priority >> SubPriorityBits) & (uint32_t)((1UL << (PreemptPriorityBits)) - 1UL);
+  *pSubPriority     = (Priority                   ) & (uint32_t)((1UL << (SubPriorityBits    )) - 1UL);
+}
+
+
+/**
+  \brief   Set Interrupt Vector
+  \details Sets an interrupt vector in SRAM based interrupt vector table.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+           VTOR must been relocated to SRAM before.
+  \param [in]   IRQn      Interrupt number
+  \param [in]   vector    Address of interrupt handler function
+ */
+__STATIC_INLINE void __NVIC_SetVector(IRQn_Type IRQn, uint32_t vector)
+{
+  uint32_t *vectors = (uint32_t *) ((uintptr_t) SCB->VTOR);
+  vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET] = vector;
+  __DSB();
+}
+
+
+/**
+  \brief   Get Interrupt Vector
+  \details Reads an interrupt vector from interrupt vector table.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn      Interrupt number.
+  \return                 Address of interrupt handler function
+ */
+__STATIC_INLINE uint32_t __NVIC_GetVector(IRQn_Type IRQn)
+{
+  uint32_t *vectors = (uint32_t *) ((uintptr_t) SCB->VTOR);
+  return vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET];
+}
+
+
+/**
+  \brief   System Reset
+  \details Initiates a system reset request to reset the MCU.
+ */
+__NO_RETURN __STATIC_INLINE void __NVIC_SystemReset(void)
+{
+  __DSB();                                                          /* Ensure all outstanding memory accesses included
+                                                                       buffered write are completed before reset */
+  SCB->AIRCR  = (uint32_t)((0x5FAUL << SCB_AIRCR_VECTKEY_Pos)    |
+                           (SCB->AIRCR & SCB_AIRCR_PRIGROUP_Msk) |
+                            SCB_AIRCR_SYSRESETREQ_Msk    );         /* Keep priority group unchanged */
+  __DSB();                                                          /* Ensure completion of memory access */
+
+  for(;;)                                                           /* wait until reset */
+  {
+    __NOP();
+  }
+}
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   Set Priority Grouping (non-secure)
+  \details Sets the non-secure priority grouping field when in secure state using the required unlock sequence.
+           The parameter PriorityGroup is assigned to the field SCB->AIRCR [10:8] PRIGROUP field.
+           Only values from 0..7 are used.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+  \param [in]      PriorityGroup  Priority grouping field.
+ */
+__STATIC_INLINE void TZ_NVIC_SetPriorityGrouping_NS(uint32_t PriorityGroup)
+{
+  uint32_t reg_value;
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);             /* only values 0..7 are used          */
+
+  reg_value  =  SCB_NS->AIRCR;                                                /* read old register configuration    */
+  reg_value &= ~((uint32_t)(SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk)); /* clear bits to change               */
+  reg_value  =  (reg_value                                   |
+                ((uint32_t)0x5FAUL << SCB_AIRCR_VECTKEY_Pos) |
+                (PriorityGroupTmp << SCB_AIRCR_PRIGROUP_Pos)  );              /* Insert write key and priority group */
+  SCB_NS->AIRCR =  reg_value;
+}
+
+
+/**
+  \brief   Get Priority Grouping (non-secure)
+  \details Reads the priority grouping field from the non-secure NVIC when in secure state.
+  \return                Priority grouping field (SCB->AIRCR [10:8] PRIGROUP field).
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetPriorityGrouping_NS(void)
+{
+  return ((uint32_t)((SCB_NS->AIRCR & SCB_AIRCR_PRIGROUP_Msk) >> SCB_AIRCR_PRIGROUP_Pos));
+}
+
+
+/**
+  \brief   Enable Interrupt (non-secure)
+  \details Enables a device specific interrupt in the non-secure NVIC interrupt controller when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void TZ_NVIC_EnableIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->ISER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Enable status (non-secure)
+  \details Returns a device specific interrupt enable status from the non-secure NVIC interrupt controller when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt is not enabled.
+  \return             1  Interrupt is enabled.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetEnableIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC_NS->ISER[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Disable Interrupt (non-secure)
+  \details Disables a device specific interrupt in the non-secure NVIC interrupt controller when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void TZ_NVIC_DisableIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->ICER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Pending Interrupt (non-secure)
+  \details Reads the NVIC pending register in the non-secure NVIC when in secure state and returns the pending bit for the specified device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not pending.
+  \return             1  Interrupt status is pending.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetPendingIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC_NS->ISPR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Pending Interrupt (non-secure)
+  \details Sets the pending bit of a device specific interrupt in the non-secure NVIC pending register when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void TZ_NVIC_SetPendingIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->ISPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Clear Pending Interrupt (non-secure)
+  \details Clears the pending bit of a device specific interrupt in the non-secure NVIC pending register when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void TZ_NVIC_ClearPendingIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->ICPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Active Interrupt (non-secure)
+  \details Reads the active register in non-secure NVIC when in secure state and returns the active bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not active.
+  \return             1  Interrupt status is active.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetActive_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC_NS->IABR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Interrupt Priority (non-secure)
+  \details Sets the priority of a non-secure device specific interrupt or a non-secure processor exception when in secure state.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]      IRQn  Interrupt number.
+  \param [in]  priority  Priority to set.
+  \note    The priority cannot be set for every non-secure processor exception.
+ */
+__STATIC_INLINE void TZ_NVIC_SetPriority_NS(IRQn_Type IRQn, uint32_t priority)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->IPR[((uint32_t)IRQn)]               = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+  else
+  {
+    SCB_NS->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Priority (non-secure)
+  \details Reads the priority of a non-secure device specific interrupt or a non-secure processor exception when in secure state.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn  Interrupt number.
+  \return             Interrupt Priority. Value is aligned automatically to the implemented priority bits of the microcontroller.
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetPriority_NS(IRQn_Type IRQn)
+{
+
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return(((uint32_t)NVIC_NS->IPR[((uint32_t)IRQn)]               >> (8U - __NVIC_PRIO_BITS)));
+  }
+  else
+  {
+    return(((uint32_t)SCB_NS->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] >> (8U - __NVIC_PRIO_BITS)));
+  }
+}
+#endif /*  defined (__ARM_FEATURE_CMSE) &&(__ARM_FEATURE_CMSE == 3U) */
+
+/*@} end of CMSIS_Core_NVICFunctions */
+
+/* ##########################  MPU functions  #################################### */
+
+#if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+
+  #include "m-profile/armv8m_mpu.h"
+
+#endif
+
+
+/* ##########################  FPU functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_FpuFunctions FPU Functions
+  \brief    Function that provides FPU type.
+  @{
+ */
+
+/**
+  \brief   get FPU type
+  \details returns the FPU type
+  \returns
+   - \b  0: No FPU
+   - \b  1: Single precision FPU
+   - \b  2: Double + Single precision FPU
+ */
+__STATIC_INLINE uint32_t SCB_GetFPUType(void)
+{
+  uint32_t mvfr0;
+
+  mvfr0 = FPU->MVFR0;
+  if      ((mvfr0 & (FPU_MVFR0_FPSP_Msk | FPU_MVFR0_FPDP_Msk)) == 0x220U)
+  {
+    return 2U;           /* Double + Single precision FPU */
+  }
+  else if ((mvfr0 & (FPU_MVFR0_FPSP_Msk | FPU_MVFR0_FPDP_Msk)) == 0x020U)
+  {
+    return 1U;           /* Single precision FPU */
+  }
+  else
+  {
+    return 0U;           /* No FPU */
+  }
+}
+
+/*@} end of CMSIS_Core_FpuFunctions */
+
+
+
+/* ##########################   SAU functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_SAUFunctions SAU Functions
+  \brief    Functions that configure the SAU.
+  @{
+ */
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+
+/**
+  \brief   Enable SAU
+  \details Enables the Security Attribution Unit (SAU).
+ */
+__STATIC_INLINE void TZ_SAU_Enable(void)
+{
+    SAU->CTRL |=  (SAU_CTRL_ENABLE_Msk);
+}
+
+
+
+/**
+  \brief   Disable SAU
+  \details Disables the Security Attribution Unit (SAU).
+ */
+__STATIC_INLINE void TZ_SAU_Disable(void)
+{
+    SAU->CTRL &= ~(SAU_CTRL_ENABLE_Msk);
+}
+
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+/*@} end of CMSIS_Core_SAUFunctions */
+
+
+
+
+/* ##################################    Debug Control function  ############################################ */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_DCBFunctions Debug Control Functions
+  \brief    Functions that access the Debug Control Block.
+  @{
+ */
+
+
+/**
+  \brief   Set Debug Authentication Control Register
+  \details writes to Debug Authentication Control register.
+  \param [in]  value  value to be writen.
+ */
+__STATIC_INLINE void DCB_SetAuthCtrl(uint32_t value)
+{
+    __DSB();
+    __ISB();
+    DCB->DAUTHCTRL = value;
+    __DSB();
+    __ISB();
+}
+
+
+/**
+  \brief   Get Debug Authentication Control Register
+  \details Reads Debug Authentication Control register.
+  \return             Debug Authentication Control Register.
+ */
+__STATIC_INLINE uint32_t DCB_GetAuthCtrl(void)
+{
+    return (DCB->DAUTHCTRL);
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   Set Debug Authentication Control Register (non-secure)
+  \details writes to non-secure Debug Authentication Control register when in secure state.
+  \param [in]  value  value to be writen
+ */
+__STATIC_INLINE void TZ_DCB_SetAuthCtrl_NS(uint32_t value)
+{
+    __DSB();
+    __ISB();
+    DCB_NS->DAUTHCTRL = value;
+    __DSB();
+    __ISB();
+}
+
+
+/**
+  \brief   Get Debug Authentication Control Register (non-secure)
+  \details Reads non-secure Debug Authentication Control register when in secure state.
+  \return             Debug Authentication Control Register.
+ */
+__STATIC_INLINE uint32_t TZ_DCB_GetAuthCtrl_NS(void)
+{
+    return (DCB_NS->DAUTHCTRL);
+}
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+/*@} end of CMSIS_Core_DCBFunctions */
+
+
+
+
+/* ##################################    Debug Identification function  ############################################ */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_DIBFunctions Debug Identification Functions
+  \brief    Functions that access the Debug Identification Block.
+  @{
+ */
+
+
+/**
+  \brief   Get Debug Authentication Status Register
+  \details Reads Debug Authentication Status register.
+  \return             Debug Authentication Status Register.
+ */
+__STATIC_INLINE uint32_t DIB_GetAuthStatus(void)
+{
+    return (DIB->DAUTHSTATUS);
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   Get Debug Authentication Status Register (non-secure)
+  \details Reads non-secure Debug Authentication Status register when in secure state.
+  \return             Debug Authentication Status Register.
+ */
+__STATIC_INLINE uint32_t TZ_DIB_GetAuthStatus_NS(void)
+{
+    return (DIB_NS->DAUTHSTATUS);
+}
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+/*@} end of CMSIS_Core_DCBFunctions */
+
+
+
+
+/* ##################################    SysTick function  ############################################ */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_SysTickFunctions SysTick Functions
+  \brief    Functions that configure the System.
+  @{
+ */
+
+#if defined (__Vendor_SysTickConfig) && (__Vendor_SysTickConfig == 0U)
+
+/**
+  \brief   System Tick Configuration
+  \details Initializes the System Timer and its interrupt, and starts the System Tick Timer.
+           Counter is in free running mode to generate periodic interrupts.
+  \param [in]  ticks  Number of ticks between two interrupts.
+  \return          0  Function succeeded.
+  \return          1  Function failed.
+  \note    When the variable <b>__Vendor_SysTickConfig</b> is set to 1, then the
+           function <b>SysTick_Config</b> is not included. In this case, the file <b><i>device</i>.h</b>
+           must contain a vendor-specific implementation of this function.
+ */
+__STATIC_INLINE uint32_t SysTick_Config(uint32_t ticks)
+{
+  if ((ticks - 1UL) > SysTick_LOAD_RELOAD_Msk)
+  {
+    return (1UL);                                                   /* Reload value impossible */
+  }
+
+  SysTick->LOAD  = (uint32_t)(ticks - 1UL);                         /* set reload register */
+  NVIC_SetPriority (SysTick_IRQn, (1UL << __NVIC_PRIO_BITS) - 1UL); /* set Priority for Systick Interrupt */
+  SysTick->VAL   = 0UL;                                             /* Load the SysTick Counter Value */
+  SysTick->CTRL  = SysTick_CTRL_CLKSOURCE_Msk |
+                   SysTick_CTRL_TICKINT_Msk   |
+                   SysTick_CTRL_ENABLE_Msk;                         /* Enable SysTick IRQ and SysTick Timer */
+  return (0UL);                                                     /* Function successful */
+}
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   System Tick Configuration (non-secure)
+  \details Initializes the non-secure System Timer and its interrupt when in secure state, and starts the System Tick Timer.
+           Counter is in free running mode to generate periodic interrupts.
+  \param [in]  ticks  Number of ticks between two interrupts.
+  \return          0  Function succeeded.
+  \return          1  Function failed.
+  \note    When the variable <b>__Vendor_SysTickConfig</b> is set to 1, then the
+           function <b>TZ_SysTick_Config_NS</b> is not included. In this case, the file <b><i>device</i>.h</b>
+           must contain a vendor-specific implementation of this function.
+
+ */
+__STATIC_INLINE uint32_t TZ_SysTick_Config_NS(uint32_t ticks)
+{
+  if ((ticks - 1UL) > SysTick_LOAD_RELOAD_Msk)
+  {
+    return (1UL);                                                         /* Reload value impossible */
+  }
+
+  SysTick_NS->LOAD  = (uint32_t)(ticks - 1UL);                            /* set reload register */
+  TZ_NVIC_SetPriority_NS (SysTick_IRQn, (1UL << __NVIC_PRIO_BITS) - 1UL); /* set Priority for Systick Interrupt */
+  SysTick_NS->VAL   = 0UL;                                                /* Load the SysTick Counter Value */
+  SysTick_NS->CTRL  = SysTick_CTRL_CLKSOURCE_Msk |
+                      SysTick_CTRL_TICKINT_Msk   |
+                      SysTick_CTRL_ENABLE_Msk;                            /* Enable SysTick IRQ and SysTick Timer */
+  return (0UL);                                                           /* Function successful */
+}
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+#endif
+
+/*@} end of CMSIS_Core_SysTickFunctions */
+
+
+
+/* ##################################### Debug In/Output function ########################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_core_DebugFunctions ITM Functions
+  \brief    Functions that access the ITM debug interface.
+  @{
+ */
+
+extern volatile int32_t ITM_RxBuffer;                              /*!< External variable to receive characters. */
+#define                 ITM_RXBUFFER_EMPTY  ((int32_t)0x5AA55AA5U) /*!< Value identifying \ref ITM_RxBuffer is ready for next character. */
+
+
+/**
+  \brief   ITM Send Character
+  \details Transmits a character via the ITM channel 0, and
+           \li Just returns when no debugger is connected that has booked the output.
+           \li Is blocking when a debugger is connected, but the previous character sent has not been transmitted.
+  \param [in]     ch  Character to transmit.
+  \returns            Character to transmit.
+ */
+__STATIC_INLINE uint32_t ITM_SendChar (uint32_t ch)
+{
+  if (((ITM->TCR & ITM_TCR_ITMENA_Msk) != 0UL) &&      /* ITM enabled */
+      ((ITM->TER & 1UL               ) != 0UL)   )     /* ITM Port #0 enabled */
+  {
+    while (ITM->PORT[0U].u32 == 0UL)
+    {
+      __NOP();
+    }
+    ITM->PORT[0U].u8 = (uint8_t)ch;
+  }
+  return (ch);
+}
+
+
+/**
+  \brief   ITM Receive Character
+  \details Inputs a character via the external variable \ref ITM_RxBuffer.
+  \return             Received character.
+  \return         -1  No character pending.
+ */
+__STATIC_INLINE int32_t ITM_ReceiveChar (void)
+{
+  int32_t ch = -1;                           /* no character available */
+
+  if (ITM_RxBuffer != ITM_RXBUFFER_EMPTY)
+  {
+    ch = ITM_RxBuffer;
+    ITM_RxBuffer = ITM_RXBUFFER_EMPTY;       /* ready for next character */
+  }
+
+  return (ch);
+}
+
+
+/**
+  \brief   ITM Check Character
+  \details Checks whether a character is pending for reading in the variable \ref ITM_RxBuffer.
+  \return          0  No character available.
+  \return          1  Character available.
+ */
+__STATIC_INLINE int32_t ITM_CheckChar (void)
+{
+
+  if (ITM_RxBuffer == ITM_RXBUFFER_EMPTY)
+  {
+    return (0);                              /* no character available */
+  }
+  else
+  {
+    return (1);                              /*    character available */
+  }
+}
+
+/*@} end of CMSIS_core_DebugFunctions */
+
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_CM35P_H_DEPENDANT */
+
+#endif /* __CMSIS_GENERIC */

--- a/platform/ext/cmsis/CMSIS/Core/Include/core_cm4.h
+++ b/platform/ext/cmsis/CMSIS/Core/Include/core_cm4.h
@@ -1,0 +1,2136 @@
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS Cortex-M4 Core Peripheral Access Layer Header File
+ */
+
+#if   defined ( __ICCARM__ )
+  #pragma system_include                        /* treat file as system include file for MISRA check */
+#elif defined (__clang__)
+  #pragma clang system_header                   /* treat file as system include file */
+#elif defined ( __GNUC__ )
+  #pragma GCC diagnostic ignored "-Wpedantic"   /* disable pedantic warning due to unnamed structs/unions */
+#endif
+
+#ifndef __CORE_CM4_H_GENERIC
+#define __CORE_CM4_H_GENERIC
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/**
+  \page CMSIS_MISRA_Exceptions  MISRA-C:2004 Compliance Exceptions
+  CMSIS violates the following MISRA-C:2004 rules:
+
+   \li Required Rule 8.5, object/function definition in header file.<br>
+     Function definitions in header files are used to allow 'inlining'.
+
+   \li Required Rule 18.4, declaration of union type or object of union type: '{...}'.<br>
+     Unions are used for effective representation of core registers.
+
+   \li Advisory Rule 19.7, Function-like macro defined.<br>
+     Function-like macros are used to allow more efficient code.
+ */
+
+
+/*******************************************************************************
+ *                 CMSIS definitions
+ ******************************************************************************/
+/**
+  \ingroup Cortex_M4
+  @{
+ */
+
+#include "cmsis_version.h"
+
+/* CMSIS CM4 definitions */
+
+#define __CORTEX_M                (4U)                                /*!< Cortex-M Core */
+
+/** __FPU_USED indicates whether an FPU is used or not.
+    For this, __FPU_PRESENT has to be checked prior to making use of FPU specific registers and functions.
+*/
+#if defined ( __CC_ARM )
+  #if defined (__TARGET_FPU_VFP)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #if defined (__ARM_FP)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#elif defined (__ti__)
+  #if defined (__ARM_FP)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#elif defined ( __GNUC__ )
+  #if defined (__VFP_FP__) && !defined(__SOFTFP__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#elif defined ( __ICCARM__ )
+  #if defined (__ARMVFP__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#elif defined ( __TI_ARM__ )
+  #if defined (__TI_VFP_SUPPORT__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#elif defined ( __TASKING__ )
+  #if defined (__FPU_VFP__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#elif defined ( __CSMC__ )
+  #if ( __CSMC__ & 0x400U)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#endif
+
+#include "cmsis_compiler.h"               /* CMSIS compiler specific defines */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_CM4_H_GENERIC */
+
+#ifndef __CMSIS_GENERIC
+
+#ifndef __CORE_CM4_H_DEPENDANT
+#define __CORE_CM4_H_DEPENDANT
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* check device defines and use defaults */
+#if defined __CHECK_DEVICE_DEFINES
+  #ifndef __CM4_REV
+    #define __CM4_REV               0x0000U
+    #warning "__CM4_REV not defined in device header file; using default!"
+  #endif
+
+  #ifndef __FPU_PRESENT
+    #define __FPU_PRESENT             0U
+    #warning "__FPU_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __MPU_PRESENT
+    #define __MPU_PRESENT             0U
+    #warning "__MPU_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __VTOR_PRESENT
+    #define __VTOR_PRESENT            1U
+    #warning "__VTOR_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __NVIC_PRIO_BITS
+    #define __NVIC_PRIO_BITS          3U
+    #warning "__NVIC_PRIO_BITS not defined in device header file; using default!"
+  #endif
+
+  #ifndef __Vendor_SysTickConfig
+    #define __Vendor_SysTickConfig    0U
+    #warning "__Vendor_SysTickConfig not defined in device header file; using default!"
+  #endif
+#endif
+
+/* IO definitions (access restrictions to peripheral registers) */
+/**
+    \defgroup CMSIS_glob_defs CMSIS Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+*/
+#ifdef __cplusplus
+  #define   __I     volatile             /*!< Defines 'read only' permissions */
+#else
+  #define   __I     volatile const       /*!< Defines 'read only' permissions */
+#endif
+#define     __O     volatile             /*!< Defines 'write only' permissions */
+#define     __IO    volatile             /*!< Defines 'read / write' permissions */
+
+/* following defines should be used for structure members */
+#define     __IM     volatile const      /*! Defines 'read only' structure member permissions */
+#define     __OM     volatile            /*! Defines 'write only' structure member permissions */
+#define     __IOM    volatile            /*! Defines 'read / write' structure member permissions */
+
+/*@} end of group Cortex_M4 */
+
+
+
+/*******************************************************************************
+ *                 Register Abstraction
+  Core Register contain:
+  - Core Register
+  - Core NVIC Register
+  - Core SCB Register
+  - Core SysTick Register
+  - Core Debug Register
+  - Core MPU Register
+  - Core FPU Register
+ ******************************************************************************/
+/**
+  \defgroup CMSIS_core_register Defines and Type Definitions
+  \brief Type definitions and defines for Cortex-M processor based devices.
+*/
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_CORE  Status and Control Registers
+  \brief      Core Register type definitions.
+  @{
+ */
+
+/**
+  \brief  Union type to access the Application Program Status Register (APSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t _reserved0:16;              /*!< bit:  0..15  Reserved */
+    uint32_t GE:4;                       /*!< bit: 16..19  Greater than or Equal flags */
+    uint32_t _reserved1:7;               /*!< bit: 20..26  Reserved */
+    uint32_t Q:1;                        /*!< bit:     27  Saturation condition flag */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} APSR_Type;
+
+/** \brief APSR Register Definitions */
+#define APSR_N_Pos                         31U                                            /*!< APSR: N Position */
+#define APSR_N_Msk                         (1UL << APSR_N_Pos)                            /*!< APSR: N Mask */
+
+#define APSR_Z_Pos                         30U                                            /*!< APSR: Z Position */
+#define APSR_Z_Msk                         (1UL << APSR_Z_Pos)                            /*!< APSR: Z Mask */
+
+#define APSR_C_Pos                         29U                                            /*!< APSR: C Position */
+#define APSR_C_Msk                         (1UL << APSR_C_Pos)                            /*!< APSR: C Mask */
+
+#define APSR_V_Pos                         28U                                            /*!< APSR: V Position */
+#define APSR_V_Msk                         (1UL << APSR_V_Pos)                            /*!< APSR: V Mask */
+
+#define APSR_Q_Pos                         27U                                            /*!< APSR: Q Position */
+#define APSR_Q_Msk                         (1UL << APSR_Q_Pos)                            /*!< APSR: Q Mask */
+
+#define APSR_GE_Pos                        16U                                            /*!< APSR: GE Position */
+#define APSR_GE_Msk                        (0xFUL << APSR_GE_Pos)                         /*!< APSR: GE Mask */
+
+
+/**
+  \brief  Union type to access the Interrupt Program Status Register (IPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number */
+    uint32_t _reserved0:23;              /*!< bit:  9..31  Reserved */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} IPSR_Type;
+
+/** \brief IPSR Register Definitions */
+#define IPSR_ISR_Pos                        0U                                            /*!< IPSR: ISR Position */
+#define IPSR_ISR_Msk                       (0x1FFUL /*<< IPSR_ISR_Pos*/)                  /*!< IPSR: ISR Mask */
+
+
+/**
+  \brief  Union type to access the Special-Purpose Program Status Registers (xPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number */
+    uint32_t _reserved0:1;               /*!< bit:      9  Reserved */
+    uint32_t ICI_IT_1:6;                 /*!< bit: 10..15  ICI/IT part 1 */
+    uint32_t GE:4;                       /*!< bit: 16..19  Greater than or Equal flags */
+    uint32_t _reserved1:4;               /*!< bit: 20..23  Reserved */
+    uint32_t T:1;                        /*!< bit:     24  Thumb bit */
+    uint32_t ICI_IT_2:2;                 /*!< bit: 25..26  ICI/IT part 2 */
+    uint32_t Q:1;                        /*!< bit:     27  Saturation condition flag */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} xPSR_Type;
+
+/** \brief xPSR Register Definitions */
+#define xPSR_N_Pos                         31U                                            /*!< xPSR: N Position */
+#define xPSR_N_Msk                         (1UL << xPSR_N_Pos)                            /*!< xPSR: N Mask */
+
+#define xPSR_Z_Pos                         30U                                            /*!< xPSR: Z Position */
+#define xPSR_Z_Msk                         (1UL << xPSR_Z_Pos)                            /*!< xPSR: Z Mask */
+
+#define xPSR_C_Pos                         29U                                            /*!< xPSR: C Position */
+#define xPSR_C_Msk                         (1UL << xPSR_C_Pos)                            /*!< xPSR: C Mask */
+
+#define xPSR_V_Pos                         28U                                            /*!< xPSR: V Position */
+#define xPSR_V_Msk                         (1UL << xPSR_V_Pos)                            /*!< xPSR: V Mask */
+
+#define xPSR_Q_Pos                         27U                                            /*!< xPSR: Q Position */
+#define xPSR_Q_Msk                         (1UL << xPSR_Q_Pos)                            /*!< xPSR: Q Mask */
+
+#define xPSR_ICI_IT_2_Pos                  25U                                            /*!< xPSR: ICI/IT part 2 Position */
+#define xPSR_ICI_IT_2_Msk                  (3UL << xPSR_ICI_IT_2_Pos)                     /*!< xPSR: ICI/IT part 2 Mask */
+
+#define xPSR_T_Pos                         24U                                            /*!< xPSR: T Position */
+#define xPSR_T_Msk                         (1UL << xPSR_T_Pos)                            /*!< xPSR: T Mask */
+
+#define xPSR_GE_Pos                        16U                                            /*!< xPSR: GE Position */
+#define xPSR_GE_Msk                        (0xFUL << xPSR_GE_Pos)                         /*!< xPSR: GE Mask */
+
+#define xPSR_ICI_IT_1_Pos                  10U                                            /*!< xPSR: ICI/IT part 1 Position */
+#define xPSR_ICI_IT_1_Msk                  (0x3FUL << xPSR_ICI_IT_1_Pos)                  /*!< xPSR: ICI/IT part 1 Mask */
+
+#define xPSR_ISR_Pos                        0U                                            /*!< xPSR: ISR Position */
+#define xPSR_ISR_Msk                       (0x1FFUL /*<< xPSR_ISR_Pos*/)                  /*!< xPSR: ISR Mask */
+
+
+/**
+  \brief  Union type to access the Control Registers (CONTROL).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t nPRIV:1;                    /*!< bit:      0  Execution privilege in Thread mode */
+    uint32_t SPSEL:1;                    /*!< bit:      1  Stack to be used */
+    uint32_t FPCA:1;                     /*!< bit:      2  FP extension active flag */
+    uint32_t _reserved0:29;              /*!< bit:  3..31  Reserved */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} CONTROL_Type;
+
+/** \brief CONTROL Register Definitions */
+#define CONTROL_FPCA_Pos                    2U                                            /*!< CONTROL: FPCA Position */
+#define CONTROL_FPCA_Msk                   (1UL << CONTROL_FPCA_Pos)                      /*!< CONTROL: FPCA Mask */
+
+#define CONTROL_SPSEL_Pos                   1U                                            /*!< CONTROL: SPSEL Position */
+#define CONTROL_SPSEL_Msk                  (1UL << CONTROL_SPSEL_Pos)                     /*!< CONTROL: SPSEL Mask */
+
+#define CONTROL_nPRIV_Pos                   0U                                            /*!< CONTROL: nPRIV Position */
+#define CONTROL_nPRIV_Msk                  (1UL /*<< CONTROL_nPRIV_Pos*/)                 /*!< CONTROL: nPRIV Mask */
+
+/*@} end of group CMSIS_CORE */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_NVIC  Nested Vectored Interrupt Controller (NVIC)
+  \brief      Type definitions for the NVIC Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Nested Vectored Interrupt Controller (NVIC).
+ */
+typedef struct
+{
+  __IOM uint32_t ISER[8U];               /*!< Offset: 0x000 (R/W)  Interrupt Set Enable Register */
+        uint32_t RESERVED0[24U];
+  __IOM uint32_t ICER[8U];               /*!< Offset: 0x080 (R/W)  Interrupt Clear Enable Register */
+        uint32_t RESERVED1[24U];
+  __IOM uint32_t ISPR[8U];               /*!< Offset: 0x100 (R/W)  Interrupt Set Pending Register */
+        uint32_t RESERVED2[24U];
+  __IOM uint32_t ICPR[8U];               /*!< Offset: 0x180 (R/W)  Interrupt Clear Pending Register */
+        uint32_t RESERVED3[24U];
+  __IOM uint32_t IABR[8U];               /*!< Offset: 0x200 (R/W)  Interrupt Active bit Register */
+        uint32_t RESERVED4[56U];
+  __IOM uint8_t  IPR[240U];              /*!< Offset: 0x300 (R/W)  Interrupt Priority Register (8Bit wide) */
+        uint32_t RESERVED5[644U];
+  __OM  uint32_t STIR;                   /*!< Offset: 0xE00 ( /W)  Software Trigger Interrupt Register */
+}  NVIC_Type;
+
+/** \brief NVIC Software Triggered Interrupt Register Definitions */
+#define NVIC_STIR_INTID_Pos                 0U                                         /*!< STIR: INTLINESNUM Position */
+#define NVIC_STIR_INTID_Msk                (0x1FFUL /*<< NVIC_STIR_INTID_Pos*/)        /*!< STIR: INTLINESNUM Mask */
+
+/*@} end of group CMSIS_NVIC */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SCB     System Control Block (SCB)
+  \brief    Type definitions for the System Control Block Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Control Block (SCB).
+ */
+typedef struct
+{
+  __IM  uint32_t CPUID;                  /*!< Offset: 0x000 (R/ )  CPUID Base Register */
+  __IOM uint32_t ICSR;                   /*!< Offset: 0x004 (R/W)  Interrupt Control and State Register */
+  __IOM uint32_t VTOR;                   /*!< Offset: 0x008 (R/W)  Vector Table Offset Register */
+  __IOM uint32_t AIRCR;                  /*!< Offset: 0x00C (R/W)  Application Interrupt and Reset Control Register */
+  __IOM uint32_t SCR;                    /*!< Offset: 0x010 (R/W)  System Control Register */
+  __IOM uint32_t CCR;                    /*!< Offset: 0x014 (R/W)  Configuration Control Register */
+  __IOM uint8_t  SHPR[12U];              /*!< Offset: 0x018 (R/W)  System Handlers Priority Registers (4-7, 8-11, 12-15) */
+  __IOM uint32_t SHCSR;                  /*!< Offset: 0x024 (R/W)  System Handler Control and State Register */
+  __IOM uint32_t CFSR;                   /*!< Offset: 0x028 (R/W)  Configurable Fault Status Register */
+  __IOM uint32_t HFSR;                   /*!< Offset: 0x02C (R/W)  HardFault Status Register */
+  __IOM uint32_t DFSR;                   /*!< Offset: 0x030 (R/W)  Debug Fault Status Register */
+  __IOM uint32_t MMFAR;                  /*!< Offset: 0x034 (R/W)  MemManage Fault Address Register */
+  __IOM uint32_t BFAR;                   /*!< Offset: 0x038 (R/W)  BusFault Address Register */
+  __IOM uint32_t AFSR;                   /*!< Offset: 0x03C (R/W)  Auxiliary Fault Status Register */
+  __IM  uint32_t ID_PFR[2U];             /*!< Offset: 0x040 (R/ )  Processor Feature Register */
+  __IM  uint32_t ID_DFR;                 /*!< Offset: 0x048 (R/ )  Debug Feature Register */
+  __IM  uint32_t ID_AFR;                 /*!< Offset: 0x04C (R/ )  Auxiliary Feature Register */
+  __IM  uint32_t ID_MMFR[4U];            /*!< Offset: 0x050 (R/ )  Memory Model Feature Register */
+  __IM  uint32_t ID_ISAR[5U];            /*!< Offset: 0x060 (R/ )  Instruction Set Attributes Register */
+        uint32_t RESERVED0[5U];
+  __IOM uint32_t CPACR;                  /*!< Offset: 0x088 (R/W)  Coprocessor Access Control Register */
+        uint32_t RESERVED3[93U];
+  __OM  uint32_t STIR;                   /*!< Offset: 0x200 ( /W)  Software Triggered Interrupt Register */
+} SCB_Type;
+
+/** \brief SCB CPUID Register Definitions */
+#define SCB_CPUID_IMPLEMENTER_Pos          24U                                            /*!< SCB CPUID: IMPLEMENTER Position */
+#define SCB_CPUID_IMPLEMENTER_Msk          (0xFFUL << SCB_CPUID_IMPLEMENTER_Pos)          /*!< SCB CPUID: IMPLEMENTER Mask */
+
+#define SCB_CPUID_VARIANT_Pos              20U                                            /*!< SCB CPUID: VARIANT Position */
+#define SCB_CPUID_VARIANT_Msk              (0xFUL << SCB_CPUID_VARIANT_Pos)               /*!< SCB CPUID: VARIANT Mask */
+
+#define SCB_CPUID_ARCHITECTURE_Pos         16U                                            /*!< SCB CPUID: ARCHITECTURE Position */
+#define SCB_CPUID_ARCHITECTURE_Msk         (0xFUL << SCB_CPUID_ARCHITECTURE_Pos)          /*!< SCB CPUID: ARCHITECTURE Mask */
+
+#define SCB_CPUID_PARTNO_Pos                4U                                            /*!< SCB CPUID: PARTNO Position */
+#define SCB_CPUID_PARTNO_Msk               (0xFFFUL << SCB_CPUID_PARTNO_Pos)              /*!< SCB CPUID: PARTNO Mask */
+
+#define SCB_CPUID_REVISION_Pos              0U                                            /*!< SCB CPUID: REVISION Position */
+#define SCB_CPUID_REVISION_Msk             (0xFUL /*<< SCB_CPUID_REVISION_Pos*/)          /*!< SCB CPUID: REVISION Mask */
+
+/** \brief SCB Interrupt Control State Register Definitions */
+#define SCB_ICSR_NMIPENDSET_Pos            31U                                            /*!< SCB ICSR: NMIPENDSET Position */
+#define SCB_ICSR_NMIPENDSET_Msk            (1UL << SCB_ICSR_NMIPENDSET_Pos)               /*!< SCB ICSR: NMIPENDSET Mask */
+
+#define SCB_ICSR_PENDSVSET_Pos             28U                                            /*!< SCB ICSR: PENDSVSET Position */
+#define SCB_ICSR_PENDSVSET_Msk             (1UL << SCB_ICSR_PENDSVSET_Pos)                /*!< SCB ICSR: PENDSVSET Mask */
+
+#define SCB_ICSR_PENDSVCLR_Pos             27U                                            /*!< SCB ICSR: PENDSVCLR Position */
+#define SCB_ICSR_PENDSVCLR_Msk             (1UL << SCB_ICSR_PENDSVCLR_Pos)                /*!< SCB ICSR: PENDSVCLR Mask */
+
+#define SCB_ICSR_PENDSTSET_Pos             26U                                            /*!< SCB ICSR: PENDSTSET Position */
+#define SCB_ICSR_PENDSTSET_Msk             (1UL << SCB_ICSR_PENDSTSET_Pos)                /*!< SCB ICSR: PENDSTSET Mask */
+
+#define SCB_ICSR_PENDSTCLR_Pos             25U                                            /*!< SCB ICSR: PENDSTCLR Position */
+#define SCB_ICSR_PENDSTCLR_Msk             (1UL << SCB_ICSR_PENDSTCLR_Pos)                /*!< SCB ICSR: PENDSTCLR Mask */
+
+#define SCB_ICSR_ISRPREEMPT_Pos            23U                                            /*!< SCB ICSR: ISRPREEMPT Position */
+#define SCB_ICSR_ISRPREEMPT_Msk            (1UL << SCB_ICSR_ISRPREEMPT_Pos)               /*!< SCB ICSR: ISRPREEMPT Mask */
+
+#define SCB_ICSR_ISRPENDING_Pos            22U                                            /*!< SCB ICSR: ISRPENDING Position */
+#define SCB_ICSR_ISRPENDING_Msk            (1UL << SCB_ICSR_ISRPENDING_Pos)               /*!< SCB ICSR: ISRPENDING Mask */
+
+#define SCB_ICSR_VECTPENDING_Pos           12U                                            /*!< SCB ICSR: VECTPENDING Position */
+#define SCB_ICSR_VECTPENDING_Msk           (0x1FFUL << SCB_ICSR_VECTPENDING_Pos)          /*!< SCB ICSR: VECTPENDING Mask */
+
+#define SCB_ICSR_RETTOBASE_Pos             11U                                            /*!< SCB ICSR: RETTOBASE Position */
+#define SCB_ICSR_RETTOBASE_Msk             (1UL << SCB_ICSR_RETTOBASE_Pos)                /*!< SCB ICSR: RETTOBASE Mask */
+
+#define SCB_ICSR_VECTACTIVE_Pos             0U                                            /*!< SCB ICSR: VECTACTIVE Position */
+#define SCB_ICSR_VECTACTIVE_Msk            (0x1FFUL /*<< SCB_ICSR_VECTACTIVE_Pos*/)       /*!< SCB ICSR: VECTACTIVE Mask */
+
+/** \brief SCB Vector Table Offset Register Definitions */
+#define SCB_VTOR_TBLOFF_Pos                 7U                                            /*!< SCB VTOR: TBLOFF Position */
+#define SCB_VTOR_TBLOFF_Msk                (0x1FFFFFFUL << SCB_VTOR_TBLOFF_Pos)           /*!< SCB VTOR: TBLOFF Mask */
+
+/** \brief SCB Application Interrupt and Reset Control Register Definitions */
+#define SCB_AIRCR_VECTKEY_Pos              16U                                            /*!< SCB AIRCR: VECTKEY Position */
+#define SCB_AIRCR_VECTKEY_Msk              (0xFFFFUL << SCB_AIRCR_VECTKEY_Pos)            /*!< SCB AIRCR: VECTKEY Mask */
+
+#define SCB_AIRCR_VECTKEYSTAT_Pos          16U                                            /*!< SCB AIRCR: VECTKEYSTAT Position */
+#define SCB_AIRCR_VECTKEYSTAT_Msk          (0xFFFFUL << SCB_AIRCR_VECTKEYSTAT_Pos)        /*!< SCB AIRCR: VECTKEYSTAT Mask */
+
+#define SCB_AIRCR_ENDIANESS_Pos            15U                                            /*!< SCB AIRCR: ENDIANESS Position */
+#define SCB_AIRCR_ENDIANESS_Msk            (1UL << SCB_AIRCR_ENDIANESS_Pos)               /*!< SCB AIRCR: ENDIANESS Mask */
+
+#define SCB_AIRCR_PRIGROUP_Pos              8U                                            /*!< SCB AIRCR: PRIGROUP Position */
+#define SCB_AIRCR_PRIGROUP_Msk             (7UL << SCB_AIRCR_PRIGROUP_Pos)                /*!< SCB AIRCR: PRIGROUP Mask */
+
+#define SCB_AIRCR_SYSRESETREQ_Pos           2U                                            /*!< SCB AIRCR: SYSRESETREQ Position */
+#define SCB_AIRCR_SYSRESETREQ_Msk          (1UL << SCB_AIRCR_SYSRESETREQ_Pos)             /*!< SCB AIRCR: SYSRESETREQ Mask */
+
+#define SCB_AIRCR_VECTCLRACTIVE_Pos         1U                                            /*!< SCB AIRCR: VECTCLRACTIVE Position */
+#define SCB_AIRCR_VECTCLRACTIVE_Msk        (1UL << SCB_AIRCR_VECTCLRACTIVE_Pos)           /*!< SCB AIRCR: VECTCLRACTIVE Mask */
+
+#define SCB_AIRCR_VECTRESET_Pos             0U                                            /*!< SCB AIRCR: VECTRESET Position */
+#define SCB_AIRCR_VECTRESET_Msk            (1UL /*<< SCB_AIRCR_VECTRESET_Pos*/)           /*!< SCB AIRCR: VECTRESET Mask */
+
+/** \brief SCB System Control Register Definitions */
+#define SCB_SCR_SEVONPEND_Pos               4U                                            /*!< SCB SCR: SEVONPEND Position */
+#define SCB_SCR_SEVONPEND_Msk              (1UL << SCB_SCR_SEVONPEND_Pos)                 /*!< SCB SCR: SEVONPEND Mask */
+
+#define SCB_SCR_SLEEPDEEP_Pos               2U                                            /*!< SCB SCR: SLEEPDEEP Position */
+#define SCB_SCR_SLEEPDEEP_Msk              (1UL << SCB_SCR_SLEEPDEEP_Pos)                 /*!< SCB SCR: SLEEPDEEP Mask */
+
+#define SCB_SCR_SLEEPONEXIT_Pos             1U                                            /*!< SCB SCR: SLEEPONEXIT Position */
+#define SCB_SCR_SLEEPONEXIT_Msk            (1UL << SCB_SCR_SLEEPONEXIT_Pos)               /*!< SCB SCR: SLEEPONEXIT Mask */
+
+/** \brief SCB Configuration Control Register Definitions */
+#define SCB_CCR_STKALIGN_Pos                9U                                            /*!< SCB CCR: STKALIGN Position */
+#define SCB_CCR_STKALIGN_Msk               (1UL << SCB_CCR_STKALIGN_Pos)                  /*!< SCB CCR: STKALIGN Mask */
+
+#define SCB_CCR_BFHFNMIGN_Pos               8U                                            /*!< SCB CCR: BFHFNMIGN Position */
+#define SCB_CCR_BFHFNMIGN_Msk              (1UL << SCB_CCR_BFHFNMIGN_Pos)                 /*!< SCB CCR: BFHFNMIGN Mask */
+
+#define SCB_CCR_DIV_0_TRP_Pos               4U                                            /*!< SCB CCR: DIV_0_TRP Position */
+#define SCB_CCR_DIV_0_TRP_Msk              (1UL << SCB_CCR_DIV_0_TRP_Pos)                 /*!< SCB CCR: DIV_0_TRP Mask */
+
+#define SCB_CCR_UNALIGN_TRP_Pos             3U                                            /*!< SCB CCR: UNALIGN_TRP Position */
+#define SCB_CCR_UNALIGN_TRP_Msk            (1UL << SCB_CCR_UNALIGN_TRP_Pos)               /*!< SCB CCR: UNALIGN_TRP Mask */
+
+#define SCB_CCR_USERSETMPEND_Pos            1U                                            /*!< SCB CCR: USERSETMPEND Position */
+#define SCB_CCR_USERSETMPEND_Msk           (1UL << SCB_CCR_USERSETMPEND_Pos)              /*!< SCB CCR: USERSETMPEND Mask */
+
+#define SCB_CCR_NONBASETHRDENA_Pos          0U                                            /*!< SCB CCR: NONBASETHRDENA Position */
+#define SCB_CCR_NONBASETHRDENA_Msk         (1UL /*<< SCB_CCR_NONBASETHRDENA_Pos*/)        /*!< SCB CCR: NONBASETHRDENA Mask */
+
+/** \brief SCB System Handler Control and State Register Definitions */
+#define SCB_SHCSR_USGFAULTENA_Pos          18U                                            /*!< SCB SHCSR: USGFAULTENA Position */
+#define SCB_SHCSR_USGFAULTENA_Msk          (1UL << SCB_SHCSR_USGFAULTENA_Pos)             /*!< SCB SHCSR: USGFAULTENA Mask */
+
+#define SCB_SHCSR_BUSFAULTENA_Pos          17U                                            /*!< SCB SHCSR: BUSFAULTENA Position */
+#define SCB_SHCSR_BUSFAULTENA_Msk          (1UL << SCB_SHCSR_BUSFAULTENA_Pos)             /*!< SCB SHCSR: BUSFAULTENA Mask */
+
+#define SCB_SHCSR_MEMFAULTENA_Pos          16U                                            /*!< SCB SHCSR: MEMFAULTENA Position */
+#define SCB_SHCSR_MEMFAULTENA_Msk          (1UL << SCB_SHCSR_MEMFAULTENA_Pos)             /*!< SCB SHCSR: MEMFAULTENA Mask */
+
+#define SCB_SHCSR_SVCALLPENDED_Pos         15U                                            /*!< SCB SHCSR: SVCALLPENDED Position */
+#define SCB_SHCSR_SVCALLPENDED_Msk         (1UL << SCB_SHCSR_SVCALLPENDED_Pos)            /*!< SCB SHCSR: SVCALLPENDED Mask */
+
+#define SCB_SHCSR_BUSFAULTPENDED_Pos       14U                                            /*!< SCB SHCSR: BUSFAULTPENDED Position */
+#define SCB_SHCSR_BUSFAULTPENDED_Msk       (1UL << SCB_SHCSR_BUSFAULTPENDED_Pos)          /*!< SCB SHCSR: BUSFAULTPENDED Mask */
+
+#define SCB_SHCSR_MEMFAULTPENDED_Pos       13U                                            /*!< SCB SHCSR: MEMFAULTPENDED Position */
+#define SCB_SHCSR_MEMFAULTPENDED_Msk       (1UL << SCB_SHCSR_MEMFAULTPENDED_Pos)          /*!< SCB SHCSR: MEMFAULTPENDED Mask */
+
+#define SCB_SHCSR_USGFAULTPENDED_Pos       12U                                            /*!< SCB SHCSR: USGFAULTPENDED Position */
+#define SCB_SHCSR_USGFAULTPENDED_Msk       (1UL << SCB_SHCSR_USGFAULTPENDED_Pos)          /*!< SCB SHCSR: USGFAULTPENDED Mask */
+
+#define SCB_SHCSR_SYSTICKACT_Pos           11U                                            /*!< SCB SHCSR: SYSTICKACT Position */
+#define SCB_SHCSR_SYSTICKACT_Msk           (1UL << SCB_SHCSR_SYSTICKACT_Pos)              /*!< SCB SHCSR: SYSTICKACT Mask */
+
+#define SCB_SHCSR_PENDSVACT_Pos            10U                                            /*!< SCB SHCSR: PENDSVACT Position */
+#define SCB_SHCSR_PENDSVACT_Msk            (1UL << SCB_SHCSR_PENDSVACT_Pos)               /*!< SCB SHCSR: PENDSVACT Mask */
+
+#define SCB_SHCSR_MONITORACT_Pos            8U                                            /*!< SCB SHCSR: MONITORACT Position */
+#define SCB_SHCSR_MONITORACT_Msk           (1UL << SCB_SHCSR_MONITORACT_Pos)              /*!< SCB SHCSR: MONITORACT Mask */
+
+#define SCB_SHCSR_SVCALLACT_Pos             7U                                            /*!< SCB SHCSR: SVCALLACT Position */
+#define SCB_SHCSR_SVCALLACT_Msk            (1UL << SCB_SHCSR_SVCALLACT_Pos)               /*!< SCB SHCSR: SVCALLACT Mask */
+
+#define SCB_SHCSR_USGFAULTACT_Pos           3U                                            /*!< SCB SHCSR: USGFAULTACT Position */
+#define SCB_SHCSR_USGFAULTACT_Msk          (1UL << SCB_SHCSR_USGFAULTACT_Pos)             /*!< SCB SHCSR: USGFAULTACT Mask */
+
+#define SCB_SHCSR_BUSFAULTACT_Pos           1U                                            /*!< SCB SHCSR: BUSFAULTACT Position */
+#define SCB_SHCSR_BUSFAULTACT_Msk          (1UL << SCB_SHCSR_BUSFAULTACT_Pos)             /*!< SCB SHCSR: BUSFAULTACT Mask */
+
+#define SCB_SHCSR_MEMFAULTACT_Pos           0U                                            /*!< SCB SHCSR: MEMFAULTACT Position */
+#define SCB_SHCSR_MEMFAULTACT_Msk          (1UL /*<< SCB_SHCSR_MEMFAULTACT_Pos*/)         /*!< SCB SHCSR: MEMFAULTACT Mask */
+
+/** \brief SCB Configurable Fault Status Register Definitions */
+#define SCB_CFSR_USGFAULTSR_Pos            16U                                            /*!< SCB CFSR: Usage Fault Status Register Position */
+#define SCB_CFSR_USGFAULTSR_Msk            (0xFFFFUL << SCB_CFSR_USGFAULTSR_Pos)          /*!< SCB CFSR: Usage Fault Status Register Mask */
+
+#define SCB_CFSR_BUSFAULTSR_Pos             8U                                            /*!< SCB CFSR: Bus Fault Status Register Position */
+#define SCB_CFSR_BUSFAULTSR_Msk            (0xFFUL << SCB_CFSR_BUSFAULTSR_Pos)            /*!< SCB CFSR: Bus Fault Status Register Mask */
+
+#define SCB_CFSR_MEMFAULTSR_Pos             0U                                            /*!< SCB CFSR: Memory Manage Fault Status Register Position */
+#define SCB_CFSR_MEMFAULTSR_Msk            (0xFFUL /*<< SCB_CFSR_MEMFAULTSR_Pos*/)        /*!< SCB CFSR: Memory Manage Fault Status Register Mask */
+
+/** \brief SCB MemManage Fault Status Register Definitions (part of SCB Configurable Fault Status Register) */
+#define SCB_CFSR_MMARVALID_Pos             (SCB_CFSR_MEMFAULTSR_Pos + 7U)                 /*!< SCB CFSR (MMFSR): MMARVALID Position */
+#define SCB_CFSR_MMARVALID_Msk             (1UL << SCB_CFSR_MMARVALID_Pos)                /*!< SCB CFSR (MMFSR): MMARVALID Mask */
+
+#define SCB_CFSR_MLSPERR_Pos               (SCB_CFSR_MEMFAULTSR_Pos + 5U)                 /*!< SCB CFSR (MMFSR): MLSPERR Position */
+#define SCB_CFSR_MLSPERR_Msk               (1UL << SCB_CFSR_MLSPERR_Pos)                  /*!< SCB CFSR (MMFSR): MLSPERR Mask */
+
+#define SCB_CFSR_MSTKERR_Pos               (SCB_CFSR_MEMFAULTSR_Pos + 4U)                 /*!< SCB CFSR (MMFSR): MSTKERR Position */
+#define SCB_CFSR_MSTKERR_Msk               (1UL << SCB_CFSR_MSTKERR_Pos)                  /*!< SCB CFSR (MMFSR): MSTKERR Mask */
+
+#define SCB_CFSR_MUNSTKERR_Pos             (SCB_CFSR_MEMFAULTSR_Pos + 3U)                 /*!< SCB CFSR (MMFSR): MUNSTKERR Position */
+#define SCB_CFSR_MUNSTKERR_Msk             (1UL << SCB_CFSR_MUNSTKERR_Pos)                /*!< SCB CFSR (MMFSR): MUNSTKERR Mask */
+
+#define SCB_CFSR_DACCVIOL_Pos              (SCB_CFSR_MEMFAULTSR_Pos + 1U)                 /*!< SCB CFSR (MMFSR): DACCVIOL Position */
+#define SCB_CFSR_DACCVIOL_Msk              (1UL << SCB_CFSR_DACCVIOL_Pos)                 /*!< SCB CFSR (MMFSR): DACCVIOL Mask */
+
+#define SCB_CFSR_IACCVIOL_Pos              (SCB_CFSR_MEMFAULTSR_Pos + 0U)                 /*!< SCB CFSR (MMFSR): IACCVIOL Position */
+#define SCB_CFSR_IACCVIOL_Msk              (1UL /*<< SCB_CFSR_IACCVIOL_Pos*/)             /*!< SCB CFSR (MMFSR): IACCVIOL Mask */
+
+/** \brief SCB BusFault Status Register Definitions (part of SCB Configurable Fault Status Register) */
+#define SCB_CFSR_BFARVALID_Pos            (SCB_CFSR_BUSFAULTSR_Pos + 7U)                  /*!< SCB CFSR (BFSR): BFARVALID Position */
+#define SCB_CFSR_BFARVALID_Msk            (1UL << SCB_CFSR_BFARVALID_Pos)                 /*!< SCB CFSR (BFSR): BFARVALID Mask */
+
+#define SCB_CFSR_LSPERR_Pos               (SCB_CFSR_BUSFAULTSR_Pos + 5U)                  /*!< SCB CFSR (BFSR): LSPERR Position */
+#define SCB_CFSR_LSPERR_Msk               (1UL << SCB_CFSR_LSPERR_Pos)                    /*!< SCB CFSR (BFSR): LSPERR Mask */
+
+#define SCB_CFSR_STKERR_Pos               (SCB_CFSR_BUSFAULTSR_Pos + 4U)                  /*!< SCB CFSR (BFSR): STKERR Position */
+#define SCB_CFSR_STKERR_Msk               (1UL << SCB_CFSR_STKERR_Pos)                    /*!< SCB CFSR (BFSR): STKERR Mask */
+
+#define SCB_CFSR_UNSTKERR_Pos             (SCB_CFSR_BUSFAULTSR_Pos + 3U)                  /*!< SCB CFSR (BFSR): UNSTKERR Position */
+#define SCB_CFSR_UNSTKERR_Msk             (1UL << SCB_CFSR_UNSTKERR_Pos)                  /*!< SCB CFSR (BFSR): UNSTKERR Mask */
+
+#define SCB_CFSR_IMPRECISERR_Pos          (SCB_CFSR_BUSFAULTSR_Pos + 2U)                  /*!< SCB CFSR (BFSR): IMPRECISERR Position */
+#define SCB_CFSR_IMPRECISERR_Msk          (1UL << SCB_CFSR_IMPRECISERR_Pos)               /*!< SCB CFSR (BFSR): IMPRECISERR Mask */
+
+#define SCB_CFSR_PRECISERR_Pos            (SCB_CFSR_BUSFAULTSR_Pos + 1U)                  /*!< SCB CFSR (BFSR): PRECISERR Position */
+#define SCB_CFSR_PRECISERR_Msk            (1UL << SCB_CFSR_PRECISERR_Pos)                 /*!< SCB CFSR (BFSR): PRECISERR Mask */
+
+#define SCB_CFSR_IBUSERR_Pos              (SCB_CFSR_BUSFAULTSR_Pos + 0U)                  /*!< SCB CFSR (BFSR): IBUSERR Position */
+#define SCB_CFSR_IBUSERR_Msk              (1UL << SCB_CFSR_IBUSERR_Pos)                   /*!< SCB CFSR (BFSR): IBUSERR Mask */
+
+/** \brief SCB UsageFault Status Register Definitions (part of SCB Configurable Fault Status Register) */
+#define SCB_CFSR_DIVBYZERO_Pos            (SCB_CFSR_USGFAULTSR_Pos + 9U)                  /*!< SCB CFSR (UFSR): DIVBYZERO Position */
+#define SCB_CFSR_DIVBYZERO_Msk            (1UL << SCB_CFSR_DIVBYZERO_Pos)                 /*!< SCB CFSR (UFSR): DIVBYZERO Mask */
+
+#define SCB_CFSR_UNALIGNED_Pos            (SCB_CFSR_USGFAULTSR_Pos + 8U)                  /*!< SCB CFSR (UFSR): UNALIGNED Position */
+#define SCB_CFSR_UNALIGNED_Msk            (1UL << SCB_CFSR_UNALIGNED_Pos)                 /*!< SCB CFSR (UFSR): UNALIGNED Mask */
+
+#define SCB_CFSR_NOCP_Pos                 (SCB_CFSR_USGFAULTSR_Pos + 3U)                  /*!< SCB CFSR (UFSR): NOCP Position */
+#define SCB_CFSR_NOCP_Msk                 (1UL << SCB_CFSR_NOCP_Pos)                      /*!< SCB CFSR (UFSR): NOCP Mask */
+
+#define SCB_CFSR_INVPC_Pos                (SCB_CFSR_USGFAULTSR_Pos + 2U)                  /*!< SCB CFSR (UFSR): INVPC Position */
+#define SCB_CFSR_INVPC_Msk                (1UL << SCB_CFSR_INVPC_Pos)                     /*!< SCB CFSR (UFSR): INVPC Mask */
+
+#define SCB_CFSR_INVSTATE_Pos             (SCB_CFSR_USGFAULTSR_Pos + 1U)                  /*!< SCB CFSR (UFSR): INVSTATE Position */
+#define SCB_CFSR_INVSTATE_Msk             (1UL << SCB_CFSR_INVSTATE_Pos)                  /*!< SCB CFSR (UFSR): INVSTATE Mask */
+
+#define SCB_CFSR_UNDEFINSTR_Pos           (SCB_CFSR_USGFAULTSR_Pos + 0U)                  /*!< SCB CFSR (UFSR): UNDEFINSTR Position */
+#define SCB_CFSR_UNDEFINSTR_Msk           (1UL << SCB_CFSR_UNDEFINSTR_Pos)                /*!< SCB CFSR (UFSR): UNDEFINSTR Mask */
+
+/** \brief SCB Hard Fault Status Register Definitions */
+#define SCB_HFSR_DEBUGEVT_Pos              31U                                            /*!< SCB HFSR: DEBUGEVT Position */
+#define SCB_HFSR_DEBUGEVT_Msk              (1UL << SCB_HFSR_DEBUGEVT_Pos)                 /*!< SCB HFSR: DEBUGEVT Mask */
+
+#define SCB_HFSR_FORCED_Pos                30U                                            /*!< SCB HFSR: FORCED Position */
+#define SCB_HFSR_FORCED_Msk                (1UL << SCB_HFSR_FORCED_Pos)                   /*!< SCB HFSR: FORCED Mask */
+
+#define SCB_HFSR_VECTTBL_Pos                1U                                            /*!< SCB HFSR: VECTTBL Position */
+#define SCB_HFSR_VECTTBL_Msk               (1UL << SCB_HFSR_VECTTBL_Pos)                  /*!< SCB HFSR: VECTTBL Mask */
+
+/** \brief SCB Debug Fault Status Register Definitions */
+#define SCB_DFSR_EXTERNAL_Pos               4U                                            /*!< SCB DFSR: EXTERNAL Position */
+#define SCB_DFSR_EXTERNAL_Msk              (1UL << SCB_DFSR_EXTERNAL_Pos)                 /*!< SCB DFSR: EXTERNAL Mask */
+
+#define SCB_DFSR_VCATCH_Pos                 3U                                            /*!< SCB DFSR: VCATCH Position */
+#define SCB_DFSR_VCATCH_Msk                (1UL << SCB_DFSR_VCATCH_Pos)                   /*!< SCB DFSR: VCATCH Mask */
+
+#define SCB_DFSR_DWTTRAP_Pos                2U                                            /*!< SCB DFSR: DWTTRAP Position */
+#define SCB_DFSR_DWTTRAP_Msk               (1UL << SCB_DFSR_DWTTRAP_Pos)                  /*!< SCB DFSR: DWTTRAP Mask */
+
+#define SCB_DFSR_BKPT_Pos                   1U                                            /*!< SCB DFSR: BKPT Position */
+#define SCB_DFSR_BKPT_Msk                  (1UL << SCB_DFSR_BKPT_Pos)                     /*!< SCB DFSR: BKPT Mask */
+
+#define SCB_DFSR_HALTED_Pos                 0U                                            /*!< SCB DFSR: HALTED Position */
+#define SCB_DFSR_HALTED_Msk                (1UL /*<< SCB_DFSR_HALTED_Pos*/)               /*!< SCB DFSR: HALTED Mask */
+
+/*@} end of group CMSIS_SCB */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SCnSCB System Controls not in SCB (SCnSCB)
+  \brief    Type definitions for the System Control and ID Register not in the SCB
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Control and ID Register not in the SCB.
+ */
+typedef struct
+{
+        uint32_t RESERVED0[1U];
+  __IM  uint32_t ICTR;                   /*!< Offset: 0x004 (R/ )  Interrupt Controller Type Register */
+  __IOM uint32_t ACTLR;                  /*!< Offset: 0x008 (R/W)  Auxiliary Control Register */
+} SCnSCB_Type;
+
+/** \brief SCnSCB Interrupt Controller Type Register Definitions */
+#define SCnSCB_ICTR_INTLINESNUM_Pos         0U                                         /*!< ICTR: INTLINESNUM Position */
+#define SCnSCB_ICTR_INTLINESNUM_Msk        (0xFUL /*<< SCnSCB_ICTR_INTLINESNUM_Pos*/)  /*!< ICTR: INTLINESNUM Mask */
+
+/** \brief SCnSCB Auxiliary Control Register Definitions */
+#define SCnSCB_ACTLR_DISOOFP_Pos            9U                                         /*!< ACTLR: DISOOFP Position */
+#define SCnSCB_ACTLR_DISOOFP_Msk           (1UL << SCnSCB_ACTLR_DISOOFP_Pos)           /*!< ACTLR: DISOOFP Mask */
+
+#define SCnSCB_ACTLR_DISFPCA_Pos            8U                                         /*!< ACTLR: DISFPCA Position */
+#define SCnSCB_ACTLR_DISFPCA_Msk           (1UL << SCnSCB_ACTLR_DISFPCA_Pos)           /*!< ACTLR: DISFPCA Mask */
+
+#define SCnSCB_ACTLR_DISFOLD_Pos            2U                                         /*!< ACTLR: DISFOLD Position */
+#define SCnSCB_ACTLR_DISFOLD_Msk           (1UL << SCnSCB_ACTLR_DISFOLD_Pos)           /*!< ACTLR: DISFOLD Mask */
+
+#define SCnSCB_ACTLR_DISDEFWBUF_Pos         1U                                         /*!< ACTLR: DISDEFWBUF Position */
+#define SCnSCB_ACTLR_DISDEFWBUF_Msk        (1UL << SCnSCB_ACTLR_DISDEFWBUF_Pos)        /*!< ACTLR: DISDEFWBUF Mask */
+
+#define SCnSCB_ACTLR_DISMCYCINT_Pos         0U                                         /*!< ACTLR: DISMCYCINT Position */
+#define SCnSCB_ACTLR_DISMCYCINT_Msk        (1UL /*<< SCnSCB_ACTLR_DISMCYCINT_Pos*/)    /*!< ACTLR: DISMCYCINT Mask */
+
+/*@} end of group CMSIS_SCnotSCB */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SysTick     System Tick Timer (SysTick)
+  \brief    Type definitions for the System Timer Registers.
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Timer (SysTick).
+ */
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  SysTick Control and Status Register */
+  __IOM uint32_t LOAD;                   /*!< Offset: 0x004 (R/W)  SysTick Reload Value Register */
+  __IOM uint32_t VAL;                    /*!< Offset: 0x008 (R/W)  SysTick Current Value Register */
+  __IM  uint32_t CALIB;                  /*!< Offset: 0x00C (R/ )  SysTick Calibration Register */
+} SysTick_Type;
+
+/** \brief SysTick Control / Status Register Definitions */
+#define SysTick_CTRL_COUNTFLAG_Pos         16U                                            /*!< SysTick CTRL: COUNTFLAG Position */
+#define SysTick_CTRL_COUNTFLAG_Msk         (1UL << SysTick_CTRL_COUNTFLAG_Pos)            /*!< SysTick CTRL: COUNTFLAG Mask */
+
+#define SysTick_CTRL_CLKSOURCE_Pos          2U                                            /*!< SysTick CTRL: CLKSOURCE Position */
+#define SysTick_CTRL_CLKSOURCE_Msk         (1UL << SysTick_CTRL_CLKSOURCE_Pos)            /*!< SysTick CTRL: CLKSOURCE Mask */
+
+#define SysTick_CTRL_TICKINT_Pos            1U                                            /*!< SysTick CTRL: TICKINT Position */
+#define SysTick_CTRL_TICKINT_Msk           (1UL << SysTick_CTRL_TICKINT_Pos)              /*!< SysTick CTRL: TICKINT Mask */
+
+#define SysTick_CTRL_ENABLE_Pos             0U                                            /*!< SysTick CTRL: ENABLE Position */
+#define SysTick_CTRL_ENABLE_Msk            (1UL /*<< SysTick_CTRL_ENABLE_Pos*/)           /*!< SysTick CTRL: ENABLE Mask */
+
+/** \brief SysTick Reload Register Definitions */
+#define SysTick_LOAD_RELOAD_Pos             0U                                            /*!< SysTick LOAD: RELOAD Position */
+#define SysTick_LOAD_RELOAD_Msk            (0xFFFFFFUL /*<< SysTick_LOAD_RELOAD_Pos*/)    /*!< SysTick LOAD: RELOAD Mask */
+
+/** \brief SysTick Current Register Definitions */
+#define SysTick_VAL_CURRENT_Pos             0U                                            /*!< SysTick VAL: CURRENT Position */
+#define SysTick_VAL_CURRENT_Msk            (0xFFFFFFUL /*<< SysTick_VAL_CURRENT_Pos*/)    /*!< SysTick VAL: CURRENT Mask */
+
+/** \brief SysTick Calibration Register Definitions */
+#define SysTick_CALIB_NOREF_Pos            31U                                            /*!< SysTick CALIB: NOREF Position */
+#define SysTick_CALIB_NOREF_Msk            (1UL << SysTick_CALIB_NOREF_Pos)               /*!< SysTick CALIB: NOREF Mask */
+
+#define SysTick_CALIB_SKEW_Pos             30U                                            /*!< SysTick CALIB: SKEW Position */
+#define SysTick_CALIB_SKEW_Msk             (1UL << SysTick_CALIB_SKEW_Pos)                /*!< SysTick CALIB: SKEW Mask */
+
+#define SysTick_CALIB_TENMS_Pos             0U                                            /*!< SysTick CALIB: TENMS Position */
+#define SysTick_CALIB_TENMS_Msk            (0xFFFFFFUL /*<< SysTick_CALIB_TENMS_Pos*/)    /*!< SysTick CALIB: TENMS Mask */
+
+/*@} end of group CMSIS_SysTick */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_ITM     Instrumentation Trace Macrocell (ITM)
+  \brief    Type definitions for the Instrumentation Trace Macrocell (ITM)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Instrumentation Trace Macrocell Register (ITM).
+ */
+typedef struct
+{
+  __OM  union
+  {
+    __OM  uint8_t    u8;                 /*!< Offset: 0x000 ( /W)  Stimulus Port 8-bit */
+    __OM  uint16_t   u16;                /*!< Offset: 0x000 ( /W)  Stimulus Port 16-bit */
+    __OM  uint32_t   u32;                /*!< Offset: 0x000 ( /W)  Stimulus Port 32-bit */
+  }  PORT [32U];                         /*!< Offset: 0x000 ( /W)  Stimulus Port Registers */
+        uint32_t RESERVED0[864U];
+  __IOM uint32_t TER;                    /*!< Offset: 0xE00 (R/W)  Trace Enable Register */
+        uint32_t RESERVED1[15U];
+  __IOM uint32_t TPR;                    /*!< Offset: 0xE40 (R/W)  Trace Privilege Register */
+        uint32_t RESERVED2[15U];
+  __IOM uint32_t TCR;                    /*!< Offset: 0xE80 (R/W)  Trace Control Register */
+        uint32_t RESERVED3[32U];
+        uint32_t RESERVED4[43U];
+  __OM  uint32_t LAR;                    /*!< Offset: 0xFB0 ( /W)  Lock Access Register */
+  __IM  uint32_t LSR;                    /*!< Offset: 0xFB4 (R/ )  Lock Status Register */
+} ITM_Type;
+
+/** \brief ITM Trace Privilege Register Definitions */
+#define ITM_TPR_PRIVMASK_Pos                0U                                            /*!< ITM TPR: PRIVMASK Position */
+#define ITM_TPR_PRIVMASK_Msk               (0xFFFFFFFFUL /*<< ITM_TPR_PRIVMASK_Pos*/)     /*!< ITM TPR: PRIVMASK Mask */
+
+/** \brief ITM Trace Control Register Definitions */
+#define ITM_TCR_BUSY_Pos                   23U                                            /*!< ITM TCR: BUSY Position */
+#define ITM_TCR_BUSY_Msk                   (1UL << ITM_TCR_BUSY_Pos)                      /*!< ITM TCR: BUSY Mask */
+
+#define ITM_TCR_TRACEBUSID_Pos             16U                                            /*!< ITM TCR: ATBID Position */
+#define ITM_TCR_TRACEBUSID_Msk             (0x7FUL << ITM_TCR_TRACEBUSID_Pos)             /*!< ITM TCR: ATBID Mask */
+
+#define ITM_TCR_GTSFREQ_Pos                10U                                            /*!< ITM TCR: Global timestamp frequency Position */
+#define ITM_TCR_GTSFREQ_Msk                (3UL << ITM_TCR_GTSFREQ_Pos)                   /*!< ITM TCR: Global timestamp frequency Mask */
+
+#define ITM_TCR_TSPRESCALE_Pos              8U                                            /*!< ITM TCR: TSPrescale Position */
+#define ITM_TCR_TSPRESCALE_Msk             (3UL << ITM_TCR_TSPRESCALE_Pos)                /*!< ITM TCR: TSPrescale Mask */
+
+#define ITM_TCR_SWOENA_Pos                  4U                                            /*!< ITM TCR: SWOENA Position */
+#define ITM_TCR_SWOENA_Msk                 (1UL << ITM_TCR_SWOENA_Pos)                    /*!< ITM TCR: SWOENA Mask */
+
+#define ITM_TCR_DWTENA_Pos                  3U                                            /*!< ITM TCR: DWTENA Position */
+#define ITM_TCR_DWTENA_Msk                 (1UL << ITM_TCR_DWTENA_Pos)                    /*!< ITM TCR: DWTENA Mask */
+
+#define ITM_TCR_SYNCENA_Pos                 2U                                            /*!< ITM TCR: SYNCENA Position */
+#define ITM_TCR_SYNCENA_Msk                (1UL << ITM_TCR_SYNCENA_Pos)                   /*!< ITM TCR: SYNCENA Mask */
+
+#define ITM_TCR_TSENA_Pos                   1U                                            /*!< ITM TCR: TSENA Position */
+#define ITM_TCR_TSENA_Msk                  (1UL << ITM_TCR_TSENA_Pos)                     /*!< ITM TCR: TSENA Mask */
+
+#define ITM_TCR_ITMENA_Pos                  0U                                            /*!< ITM TCR: ITM Enable bit Position */
+#define ITM_TCR_ITMENA_Msk                 (1UL /*<< ITM_TCR_ITMENA_Pos*/)                /*!< ITM TCR: ITM Enable bit Mask */
+
+/** \brief ITM Lock Status Register Definitions */
+#define ITM_LSR_BYTEACC_Pos                 2U                                            /*!< ITM LSR: ByteAcc Position */
+#define ITM_LSR_BYTEACC_Msk                (1UL << ITM_LSR_BYTEACC_Pos)                   /*!< ITM LSR: ByteAcc Mask */
+
+#define ITM_LSR_ACCESS_Pos                  1U                                            /*!< ITM LSR: Access Position */
+#define ITM_LSR_ACCESS_Msk                 (1UL << ITM_LSR_ACCESS_Pos)                    /*!< ITM LSR: Access Mask */
+
+#define ITM_LSR_PRESENT_Pos                 0U                                            /*!< ITM LSR: Present Position */
+#define ITM_LSR_PRESENT_Msk                (1UL /*<< ITM_LSR_PRESENT_Pos*/)               /*!< ITM LSR: Present Mask */
+
+/*@}*/ /* end of group CMSIS_ITM */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_DWT     Data Watchpoint and Trace (DWT)
+  \brief    Type definitions for the Data Watchpoint and Trace (DWT)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Data Watchpoint and Trace Register (DWT).
+ */
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  Control Register */
+  __IOM uint32_t CYCCNT;                 /*!< Offset: 0x004 (R/W)  Cycle Count Register */
+  __IOM uint32_t CPICNT;                 /*!< Offset: 0x008 (R/W)  CPI Count Register */
+  __IOM uint32_t EXCCNT;                 /*!< Offset: 0x00C (R/W)  Exception Overhead Count Register */
+  __IOM uint32_t SLEEPCNT;               /*!< Offset: 0x010 (R/W)  Sleep Count Register */
+  __IOM uint32_t LSUCNT;                 /*!< Offset: 0x014 (R/W)  LSU Count Register */
+  __IOM uint32_t FOLDCNT;                /*!< Offset: 0x018 (R/W)  Folded-instruction Count Register */
+  __IM  uint32_t PCSR;                   /*!< Offset: 0x01C (R/ )  Program Counter Sample Register */
+  __IOM uint32_t COMP0;                  /*!< Offset: 0x020 (R/W)  Comparator Register 0 */
+  __IOM uint32_t MASK0;                  /*!< Offset: 0x024 (R/W)  Mask Register 0 */
+  __IOM uint32_t FUNCTION0;              /*!< Offset: 0x028 (R/W)  Function Register 0 */
+        uint32_t RESERVED0[1U];
+  __IOM uint32_t COMP1;                  /*!< Offset: 0x030 (R/W)  Comparator Register 1 */
+  __IOM uint32_t MASK1;                  /*!< Offset: 0x034 (R/W)  Mask Register 1 */
+  __IOM uint32_t FUNCTION1;              /*!< Offset: 0x038 (R/W)  Function Register 1 */
+        uint32_t RESERVED1[1U];
+  __IOM uint32_t COMP2;                  /*!< Offset: 0x040 (R/W)  Comparator Register 2 */
+  __IOM uint32_t MASK2;                  /*!< Offset: 0x044 (R/W)  Mask Register 2 */
+  __IOM uint32_t FUNCTION2;              /*!< Offset: 0x048 (R/W)  Function Register 2 */
+        uint32_t RESERVED2[1U];
+  __IOM uint32_t COMP3;                  /*!< Offset: 0x050 (R/W)  Comparator Register 3 */
+  __IOM uint32_t MASK3;                  /*!< Offset: 0x054 (R/W)  Mask Register 3 */
+  __IOM uint32_t FUNCTION3;              /*!< Offset: 0x058 (R/W)  Function Register 3 */
+} DWT_Type;
+
+/** \brief DWT Control Register Definitions */
+#define DWT_CTRL_NUMCOMP_Pos               28U                                         /*!< DWT CTRL: NUMCOMP Position */
+#define DWT_CTRL_NUMCOMP_Msk               (0xFUL << DWT_CTRL_NUMCOMP_Pos)             /*!< DWT CTRL: NUMCOMP Mask */
+
+#define DWT_CTRL_NOTRCPKT_Pos              27U                                         /*!< DWT CTRL: NOTRCPKT Position */
+#define DWT_CTRL_NOTRCPKT_Msk              (1UL << DWT_CTRL_NOTRCPKT_Pos)              /*!< DWT CTRL: NOTRCPKT Mask */
+
+#define DWT_CTRL_NOEXTTRIG_Pos             26U                                         /*!< DWT CTRL: NOEXTTRIG Position */
+#define DWT_CTRL_NOEXTTRIG_Msk             (1UL << DWT_CTRL_NOEXTTRIG_Pos)             /*!< DWT CTRL: NOEXTTRIG Mask */
+
+#define DWT_CTRL_NOCYCCNT_Pos              25U                                         /*!< DWT CTRL: NOCYCCNT Position */
+#define DWT_CTRL_NOCYCCNT_Msk              (1UL << DWT_CTRL_NOCYCCNT_Pos)              /*!< DWT CTRL: NOCYCCNT Mask */
+
+#define DWT_CTRL_NOPRFCNT_Pos              24U                                         /*!< DWT CTRL: NOPRFCNT Position */
+#define DWT_CTRL_NOPRFCNT_Msk              (1UL << DWT_CTRL_NOPRFCNT_Pos)              /*!< DWT CTRL: NOPRFCNT Mask */
+
+#define DWT_CTRL_CYCEVTENA_Pos             22U                                         /*!< DWT CTRL: CYCEVTENA Position */
+#define DWT_CTRL_CYCEVTENA_Msk             (1UL << DWT_CTRL_CYCEVTENA_Pos)             /*!< DWT CTRL: CYCEVTENA Mask */
+
+#define DWT_CTRL_FOLDEVTENA_Pos            21U                                         /*!< DWT CTRL: FOLDEVTENA Position */
+#define DWT_CTRL_FOLDEVTENA_Msk            (1UL << DWT_CTRL_FOLDEVTENA_Pos)            /*!< DWT CTRL: FOLDEVTENA Mask */
+
+#define DWT_CTRL_LSUEVTENA_Pos             20U                                         /*!< DWT CTRL: LSUEVTENA Position */
+#define DWT_CTRL_LSUEVTENA_Msk             (1UL << DWT_CTRL_LSUEVTENA_Pos)             /*!< DWT CTRL: LSUEVTENA Mask */
+
+#define DWT_CTRL_SLEEPEVTENA_Pos           19U                                         /*!< DWT CTRL: SLEEPEVTENA Position */
+#define DWT_CTRL_SLEEPEVTENA_Msk           (1UL << DWT_CTRL_SLEEPEVTENA_Pos)           /*!< DWT CTRL: SLEEPEVTENA Mask */
+
+#define DWT_CTRL_EXCEVTENA_Pos             18U                                         /*!< DWT CTRL: EXCEVTENA Position */
+#define DWT_CTRL_EXCEVTENA_Msk             (1UL << DWT_CTRL_EXCEVTENA_Pos)             /*!< DWT CTRL: EXCEVTENA Mask */
+
+#define DWT_CTRL_CPIEVTENA_Pos             17U                                         /*!< DWT CTRL: CPIEVTENA Position */
+#define DWT_CTRL_CPIEVTENA_Msk             (1UL << DWT_CTRL_CPIEVTENA_Pos)             /*!< DWT CTRL: CPIEVTENA Mask */
+
+#define DWT_CTRL_EXCTRCENA_Pos             16U                                         /*!< DWT CTRL: EXCTRCENA Position */
+#define DWT_CTRL_EXCTRCENA_Msk             (1UL << DWT_CTRL_EXCTRCENA_Pos)             /*!< DWT CTRL: EXCTRCENA Mask */
+
+#define DWT_CTRL_PCSAMPLENA_Pos            12U                                         /*!< DWT CTRL: PCSAMPLENA Position */
+#define DWT_CTRL_PCSAMPLENA_Msk            (1UL << DWT_CTRL_PCSAMPLENA_Pos)            /*!< DWT CTRL: PCSAMPLENA Mask */
+
+#define DWT_CTRL_SYNCTAP_Pos               10U                                         /*!< DWT CTRL: SYNCTAP Position */
+#define DWT_CTRL_SYNCTAP_Msk               (0x3UL << DWT_CTRL_SYNCTAP_Pos)             /*!< DWT CTRL: SYNCTAP Mask */
+
+#define DWT_CTRL_CYCTAP_Pos                 9U                                         /*!< DWT CTRL: CYCTAP Position */
+#define DWT_CTRL_CYCTAP_Msk                (1UL << DWT_CTRL_CYCTAP_Pos)                /*!< DWT CTRL: CYCTAP Mask */
+
+#define DWT_CTRL_POSTINIT_Pos               5U                                         /*!< DWT CTRL: POSTINIT Position */
+#define DWT_CTRL_POSTINIT_Msk              (0xFUL << DWT_CTRL_POSTINIT_Pos)            /*!< DWT CTRL: POSTINIT Mask */
+
+#define DWT_CTRL_POSTPRESET_Pos             1U                                         /*!< DWT CTRL: POSTPRESET Position */
+#define DWT_CTRL_POSTPRESET_Msk            (0xFUL << DWT_CTRL_POSTPRESET_Pos)          /*!< DWT CTRL: POSTPRESET Mask */
+
+#define DWT_CTRL_CYCCNTENA_Pos              0U                                         /*!< DWT CTRL: CYCCNTENA Position */
+#define DWT_CTRL_CYCCNTENA_Msk             (1UL /*<< DWT_CTRL_CYCCNTENA_Pos*/)         /*!< DWT CTRL: CYCCNTENA Mask */
+
+/** \brief DWT CPI Count Register Definitions */
+#define DWT_CPICNT_CPICNT_Pos               0U                                         /*!< DWT CPICNT: CPICNT Position */
+#define DWT_CPICNT_CPICNT_Msk              (0xFFUL /*<< DWT_CPICNT_CPICNT_Pos*/)       /*!< DWT CPICNT: CPICNT Mask */
+
+/** \brief DWT Exception Overhead Count Register Definitions */
+#define DWT_EXCCNT_EXCCNT_Pos               0U                                         /*!< DWT EXCCNT: EXCCNT Position */
+#define DWT_EXCCNT_EXCCNT_Msk              (0xFFUL /*<< DWT_EXCCNT_EXCCNT_Pos*/)       /*!< DWT EXCCNT: EXCCNT Mask */
+
+/** \brief DWT Sleep Count Register Definitions */
+#define DWT_SLEEPCNT_SLEEPCNT_Pos           0U                                         /*!< DWT SLEEPCNT: SLEEPCNT Position */
+#define DWT_SLEEPCNT_SLEEPCNT_Msk          (0xFFUL /*<< DWT_SLEEPCNT_SLEEPCNT_Pos*/)   /*!< DWT SLEEPCNT: SLEEPCNT Mask */
+
+/** \brief DWT LSU Count Register Definitions */
+#define DWT_LSUCNT_LSUCNT_Pos               0U                                         /*!< DWT LSUCNT: LSUCNT Position */
+#define DWT_LSUCNT_LSUCNT_Msk              (0xFFUL /*<< DWT_LSUCNT_LSUCNT_Pos*/)       /*!< DWT LSUCNT: LSUCNT Mask */
+
+/** \brief DWT Folded-instruction Count Register Definitions */
+#define DWT_FOLDCNT_FOLDCNT_Pos             0U                                         /*!< DWT FOLDCNT: FOLDCNT Position */
+#define DWT_FOLDCNT_FOLDCNT_Msk            (0xFFUL /*<< DWT_FOLDCNT_FOLDCNT_Pos*/)     /*!< DWT FOLDCNT: FOLDCNT Mask */
+
+/** \brief DWT Comparator Mask Register Definitions */
+#define DWT_MASK_MASK_Pos                   0U                                         /*!< DWT MASK: MASK Position */
+#define DWT_MASK_MASK_Msk                  (0x1FUL /*<< DWT_MASK_MASK_Pos*/)           /*!< DWT MASK: MASK Mask */
+
+/** \brief DWT Comparator Function Register Definitions */
+#define DWT_FUNCTION_MATCHED_Pos           24U                                         /*!< DWT FUNCTION: MATCHED Position */
+#define DWT_FUNCTION_MATCHED_Msk           (1UL << DWT_FUNCTION_MATCHED_Pos)           /*!< DWT FUNCTION: MATCHED Mask */
+
+#define DWT_FUNCTION_DATAVADDR1_Pos        16U                                         /*!< DWT FUNCTION: DATAVADDR1 Position */
+#define DWT_FUNCTION_DATAVADDR1_Msk        (0xFUL << DWT_FUNCTION_DATAVADDR1_Pos)      /*!< DWT FUNCTION: DATAVADDR1 Mask */
+
+#define DWT_FUNCTION_DATAVADDR0_Pos        12U                                         /*!< DWT FUNCTION: DATAVADDR0 Position */
+#define DWT_FUNCTION_DATAVADDR0_Msk        (0xFUL << DWT_FUNCTION_DATAVADDR0_Pos)      /*!< DWT FUNCTION: DATAVADDR0 Mask */
+
+#define DWT_FUNCTION_DATAVSIZE_Pos         10U                                         /*!< DWT FUNCTION: DATAVSIZE Position */
+#define DWT_FUNCTION_DATAVSIZE_Msk         (0x3UL << DWT_FUNCTION_DATAVSIZE_Pos)       /*!< DWT FUNCTION: DATAVSIZE Mask */
+
+#define DWT_FUNCTION_LNK1ENA_Pos            9U                                         /*!< DWT FUNCTION: LNK1ENA Position */
+#define DWT_FUNCTION_LNK1ENA_Msk           (1UL << DWT_FUNCTION_LNK1ENA_Pos)           /*!< DWT FUNCTION: LNK1ENA Mask */
+
+#define DWT_FUNCTION_DATAVMATCH_Pos         8U                                         /*!< DWT FUNCTION: DATAVMATCH Position */
+#define DWT_FUNCTION_DATAVMATCH_Msk        (1UL << DWT_FUNCTION_DATAVMATCH_Pos)        /*!< DWT FUNCTION: DATAVMATCH Mask */
+
+#define DWT_FUNCTION_CYCMATCH_Pos           7U                                         /*!< DWT FUNCTION: CYCMATCH Position */
+#define DWT_FUNCTION_CYCMATCH_Msk          (1UL << DWT_FUNCTION_CYCMATCH_Pos)          /*!< DWT FUNCTION: CYCMATCH Mask */
+
+#define DWT_FUNCTION_EMITRANGE_Pos          5U                                         /*!< DWT FUNCTION: EMITRANGE Position */
+#define DWT_FUNCTION_EMITRANGE_Msk         (1UL << DWT_FUNCTION_EMITRANGE_Pos)         /*!< DWT FUNCTION: EMITRANGE Mask */
+
+#define DWT_FUNCTION_FUNCTION_Pos           0U                                         /*!< DWT FUNCTION: FUNCTION Position */
+#define DWT_FUNCTION_FUNCTION_Msk          (0xFUL /*<< DWT_FUNCTION_FUNCTION_Pos*/)    /*!< DWT FUNCTION: FUNCTION Mask */
+
+/*@}*/ /* end of group CMSIS_DWT */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_TPIU    Trace Port Interface Unit (TPIU)
+  \brief    Type definitions for the Trace Port Interface Unit (TPIU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Trace Port Interface Unit Register (TPIU).
+ */
+typedef struct
+{
+  __IM  uint32_t SSPSR;                  /*!< Offset: 0x000 (R/ )  Supported Parallel Port Size Register */
+  __IOM uint32_t CSPSR;                  /*!< Offset: 0x004 (R/W)  Current Parallel Port Size Register */
+        uint32_t RESERVED0[2U];
+  __IOM uint32_t ACPR;                   /*!< Offset: 0x010 (R/W)  Asynchronous Clock Prescaler Register */
+        uint32_t RESERVED1[55U];
+  __IOM uint32_t SPPR;                   /*!< Offset: 0x0F0 (R/W)  Selected Pin Protocol Register */
+        uint32_t RESERVED2[131U];
+  __IM  uint32_t FFSR;                   /*!< Offset: 0x300 (R/ )  Formatter and Flush Status Register */
+  __IOM uint32_t FFCR;                   /*!< Offset: 0x304 (R/W)  Formatter and Flush Control Register */
+  __IM  uint32_t FSCR;                   /*!< Offset: 0x308 (R/ )  Formatter Synchronization Counter Register */
+        uint32_t RESERVED3[759U];
+  __IM  uint32_t TRIGGER;                /*!< Offset: 0xEE8 (R/ )  TRIGGER Register */
+  __IM  uint32_t FIFO0;                  /*!< Offset: 0xEEC (R/ )  Integration ETM Data */
+  __IM  uint32_t ITATBCTR2;              /*!< Offset: 0xEF0 (R/ )  ITATBCTR2 */
+        uint32_t RESERVED4[1U];
+  __IM  uint32_t ITATBCTR0;              /*!< Offset: 0xEF8 (R/ )  ITATBCTR0 */
+  __IM  uint32_t FIFO1;                  /*!< Offset: 0xEFC (R/ )  Integration ITM Data */
+  __IOM uint32_t ITCTRL;                 /*!< Offset: 0xF00 (R/W)  Integration Mode Control */
+        uint32_t RESERVED5[39U];
+  __IOM uint32_t CLAIMSET;               /*!< Offset: 0xFA0 (R/W)  Claim tag set */
+  __IOM uint32_t CLAIMCLR;               /*!< Offset: 0xFA4 (R/W)  Claim tag clear */
+        uint32_t RESERVED7[8U];
+  __IM  uint32_t DEVID;                  /*!< Offset: 0xFC8 (R/ )  Device Configuration Register */
+  __IM  uint32_t DEVTYPE;                /*!< Offset: 0xFCC (R/ )  Device Type Identifier Register */
+} TPIU_Type;
+
+/** \brief TPIU Asynchronous Clock Prescaler Register Definitions */
+#define TPIU_ACPR_PRESCALER_Pos             0U                                         /*!< TPIU ACPR: PRESCALER Position */
+#define TPIU_ACPR_PRESCALER_Msk            (0x1FFFUL /*<< TPIU_ACPR_PRESCALER_Pos*/)   /*!< TPIU ACPR: PRESCALER Mask */
+
+/** \brief TPIU Selected Pin Protocol Register Definitions */
+#define TPIU_SPPR_TXMODE_Pos                0U                                         /*!< TPIU SPPR: TXMODE Position */
+#define TPIU_SPPR_TXMODE_Msk               (0x3UL /*<< TPIU_SPPR_TXMODE_Pos*/)         /*!< TPIU SPPR: TXMODE Mask */
+
+/** \brief TPIU Formatter and Flush Status Register Definitions */
+#define TPIU_FFSR_FtNonStop_Pos             3U                                         /*!< TPIU FFSR: FtNonStop Position */
+#define TPIU_FFSR_FtNonStop_Msk            (1UL << TPIU_FFSR_FtNonStop_Pos)            /*!< TPIU FFSR: FtNonStop Mask */
+
+#define TPIU_FFSR_TCPresent_Pos             2U                                         /*!< TPIU FFSR: TCPresent Position */
+#define TPIU_FFSR_TCPresent_Msk            (1UL << TPIU_FFSR_TCPresent_Pos)            /*!< TPIU FFSR: TCPresent Mask */
+
+#define TPIU_FFSR_FtStopped_Pos             1U                                         /*!< TPIU FFSR: FtStopped Position */
+#define TPIU_FFSR_FtStopped_Msk            (1UL << TPIU_FFSR_FtStopped_Pos)            /*!< TPIU FFSR: FtStopped Mask */
+
+#define TPIU_FFSR_FlInProg_Pos              0U                                         /*!< TPIU FFSR: FlInProg Position */
+#define TPIU_FFSR_FlInProg_Msk             (1UL /*<< TPIU_FFSR_FlInProg_Pos*/)         /*!< TPIU FFSR: FlInProg Mask */
+
+/** \brief TPIU Formatter and Flush Control Register Definitions */
+#define TPIU_FFCR_TrigIn_Pos                8U                                         /*!< TPIU FFCR: TrigIn Position */
+#define TPIU_FFCR_TrigIn_Msk               (1UL << TPIU_FFCR_TrigIn_Pos)               /*!< TPIU FFCR: TrigIn Mask */
+
+#define TPIU_FFCR_EnFCont_Pos               1U                                         /*!< TPIU FFCR: EnFCont Position */
+#define TPIU_FFCR_EnFCont_Msk              (1UL << TPIU_FFCR_EnFCont_Pos)              /*!< TPIU FFCR: EnFCont Mask */
+
+/** \brief TPIU TRIGGER Register Definitions */
+#define TPIU_TRIGGER_TRIGGER_Pos            0U                                         /*!< TPIU TRIGGER: TRIGGER Position */
+#define TPIU_TRIGGER_TRIGGER_Msk           (1UL /*<< TPIU_TRIGGER_TRIGGER_Pos*/)       /*!< TPIU TRIGGER: TRIGGER Mask */
+
+/** \brief TPIU Integration ETM Data Register Definitions (FIFO0) */
+#define TPIU_FIFO0_ITM_ATVALID_Pos         29U                                         /*!< TPIU FIFO0: ITM_ATVALID Position */
+#define TPIU_FIFO0_ITM_ATVALID_Msk         (1UL << TPIU_FIFO0_ITM_ATVALID_Pos)         /*!< TPIU FIFO0: ITM_ATVALID Mask */
+
+#define TPIU_FIFO0_ITM_bytecount_Pos       27U                                         /*!< TPIU FIFO0: ITM_bytecount Position */
+#define TPIU_FIFO0_ITM_bytecount_Msk       (0x3UL << TPIU_FIFO0_ITM_bytecount_Pos)     /*!< TPIU FIFO0: ITM_bytecount Mask */
+
+#define TPIU_FIFO0_ETM_ATVALID_Pos         26U                                         /*!< TPIU FIFO0: ETM_ATVALID Position */
+#define TPIU_FIFO0_ETM_ATVALID_Msk         (1UL << TPIU_FIFO0_ETM_ATVALID_Pos)         /*!< TPIU FIFO0: ETM_ATVALID Mask */
+
+#define TPIU_FIFO0_ETM_bytecount_Pos       24U                                         /*!< TPIU FIFO0: ETM_bytecount Position */
+#define TPIU_FIFO0_ETM_bytecount_Msk       (0x3UL << TPIU_FIFO0_ETM_bytecount_Pos)     /*!< TPIU FIFO0: ETM_bytecount Mask */
+
+#define TPIU_FIFO0_ETM2_Pos                16U                                         /*!< TPIU FIFO0: ETM2 Position */
+#define TPIU_FIFO0_ETM2_Msk                (0xFFUL << TPIU_FIFO0_ETM2_Pos)             /*!< TPIU FIFO0: ETM2 Mask */
+
+#define TPIU_FIFO0_ETM1_Pos                 8U                                         /*!< TPIU FIFO0: ETM1 Position */
+#define TPIU_FIFO0_ETM1_Msk                (0xFFUL << TPIU_FIFO0_ETM1_Pos)             /*!< TPIU FIFO0: ETM1 Mask */
+
+#define TPIU_FIFO0_ETM0_Pos                 0U                                         /*!< TPIU FIFO0: ETM0 Position */
+#define TPIU_FIFO0_ETM0_Msk                (0xFFUL /*<< TPIU_FIFO0_ETM0_Pos*/)         /*!< TPIU FIFO0: ETM0 Mask */
+
+/** \brief TPIU ITATBCTR2 Register Definitions */
+#define TPIU_ITATBCTR2_ATREADY2_Pos         0U                                         /*!< TPIU ITATBCTR2: ATREADY2 Position */
+#define TPIU_ITATBCTR2_ATREADY2_Msk        (1UL /*<< TPIU_ITATBCTR2_ATREADY2_Pos*/)    /*!< TPIU ITATBCTR2: ATREADY2 Mask */
+
+#define TPIU_ITATBCTR2_ATREADY1_Pos         0U                                         /*!< TPIU ITATBCTR2: ATREADY1 Position */
+#define TPIU_ITATBCTR2_ATREADY1_Msk        (1UL /*<< TPIU_ITATBCTR2_ATREADY1_Pos*/)    /*!< TPIU ITATBCTR2: ATREADY1 Mask */
+
+/** \brief TPIU Integration ITM Data Register Definitions (FIFO1) */
+#define TPIU_FIFO1_ITM_ATVALID_Pos         29U                                         /*!< TPIU FIFO1: ITM_ATVALID Position */
+#define TPIU_FIFO1_ITM_ATVALID_Msk         (1UL << TPIU_FIFO1_ITM_ATVALID_Pos)         /*!< TPIU FIFO1: ITM_ATVALID Mask */
+
+#define TPIU_FIFO1_ITM_bytecount_Pos       27U                                         /*!< TPIU FIFO1: ITM_bytecount Position */
+#define TPIU_FIFO1_ITM_bytecount_Msk       (0x3UL << TPIU_FIFO1_ITM_bytecount_Pos)     /*!< TPIU FIFO1: ITM_bytecount Mask */
+
+#define TPIU_FIFO1_ETM_ATVALID_Pos         26U                                         /*!< TPIU FIFO1: ETM_ATVALID Position */
+#define TPIU_FIFO1_ETM_ATVALID_Msk         (1UL << TPIU_FIFO1_ETM_ATVALID_Pos)         /*!< TPIU FIFO1: ETM_ATVALID Mask */
+
+#define TPIU_FIFO1_ETM_bytecount_Pos       24U                                         /*!< TPIU FIFO1: ETM_bytecount Position */
+#define TPIU_FIFO1_ETM_bytecount_Msk       (0x3UL << TPIU_FIFO1_ETM_bytecount_Pos)     /*!< TPIU FIFO1: ETM_bytecount Mask */
+
+#define TPIU_FIFO1_ITM2_Pos                16U                                         /*!< TPIU FIFO1: ITM2 Position */
+#define TPIU_FIFO1_ITM2_Msk                (0xFFUL << TPIU_FIFO1_ITM2_Pos)             /*!< TPIU FIFO1: ITM2 Mask */
+
+#define TPIU_FIFO1_ITM1_Pos                 8U                                         /*!< TPIU FIFO1: ITM1 Position */
+#define TPIU_FIFO1_ITM1_Msk                (0xFFUL << TPIU_FIFO1_ITM1_Pos)             /*!< TPIU FIFO1: ITM1 Mask */
+
+#define TPIU_FIFO1_ITM0_Pos                 0U                                         /*!< TPIU FIFO1: ITM0 Position */
+#define TPIU_FIFO1_ITM0_Msk                (0xFFUL /*<< TPIU_FIFO1_ITM0_Pos*/)         /*!< TPIU FIFO1: ITM0 Mask */
+
+/** \brief TPIU ITATBCTR0 Register Definitions */
+#define TPIU_ITATBCTR0_ATREADY2_Pos         0U                                         /*!< TPIU ITATBCTR0: ATREADY2 Position */
+#define TPIU_ITATBCTR0_ATREADY2_Msk        (1UL /*<< TPIU_ITATBCTR0_ATREADY2_Pos*/)    /*!< TPIU ITATBCTR0: ATREADY2 Mask */
+
+#define TPIU_ITATBCTR0_ATREADY1_Pos         0U                                         /*!< TPIU ITATBCTR0: ATREADY1 Position */
+#define TPIU_ITATBCTR0_ATREADY1_Msk        (1UL /*<< TPIU_ITATBCTR0_ATREADY1_Pos*/)    /*!< TPIU ITATBCTR0: ATREADY1 Mask */
+
+/** \brief TPIU Integration Mode Control Register Definitions */
+#define TPIU_ITCTRL_Mode_Pos                0U                                         /*!< TPIU ITCTRL: Mode Position */
+#define TPIU_ITCTRL_Mode_Msk               (0x3UL /*<< TPIU_ITCTRL_Mode_Pos*/)         /*!< TPIU ITCTRL: Mode Mask */
+
+/** \brief TPIU DEVID Register Definitions */
+#define TPIU_DEVID_NRZVALID_Pos            11U                                         /*!< TPIU DEVID: NRZVALID Position */
+#define TPIU_DEVID_NRZVALID_Msk            (1UL << TPIU_DEVID_NRZVALID_Pos)            /*!< TPIU DEVID: NRZVALID Mask */
+
+#define TPIU_DEVID_MANCVALID_Pos           10U                                         /*!< TPIU DEVID: MANCVALID Position */
+#define TPIU_DEVID_MANCVALID_Msk           (1UL << TPIU_DEVID_MANCVALID_Pos)           /*!< TPIU DEVID: MANCVALID Mask */
+
+#define TPIU_DEVID_PTINVALID_Pos            9U                                         /*!< TPIU DEVID: PTINVALID Position */
+#define TPIU_DEVID_PTINVALID_Msk           (1UL << TPIU_DEVID_PTINVALID_Pos)           /*!< TPIU DEVID: PTINVALID Mask */
+
+#define TPIU_DEVID_MinBufSz_Pos             6U                                         /*!< TPIU DEVID: MinBufSz Position */
+#define TPIU_DEVID_MinBufSz_Msk            (0x7UL << TPIU_DEVID_MinBufSz_Pos)          /*!< TPIU DEVID: MinBufSz Mask */
+
+#define TPIU_DEVID_AsynClkIn_Pos            5U                                         /*!< TPIU DEVID: AsynClkIn Position */
+#define TPIU_DEVID_AsynClkIn_Msk           (1UL << TPIU_DEVID_AsynClkIn_Pos)           /*!< TPIU DEVID: AsynClkIn Mask */
+
+#define TPIU_DEVID_NrTraceInput_Pos         0U                                         /*!< TPIU DEVID: NrTraceInput Position */
+#define TPIU_DEVID_NrTraceInput_Msk        (0x3FUL /*<< TPIU_DEVID_NrTraceInput_Pos*/) /*!< TPIU DEVID: NrTraceInput Mask */
+
+/** \brief TPIU DEVTYPE Register Definitions */
+#define TPIU_DEVTYPE_SubType_Pos            4U                                         /*!< TPIU DEVTYPE: SubType Position */
+#define TPIU_DEVTYPE_SubType_Msk           (0xFUL /*<< TPIU_DEVTYPE_SubType_Pos*/)     /*!< TPIU DEVTYPE: SubType Mask */
+
+#define TPIU_DEVTYPE_MajorType_Pos          0U                                         /*!< TPIU DEVTYPE: MajorType Position */
+#define TPIU_DEVTYPE_MajorType_Msk         (0xFUL << TPIU_DEVTYPE_MajorType_Pos)       /*!< TPIU DEVTYPE: MajorType Mask */
+
+/*@}*/ /* end of group CMSIS_TPIU */
+
+
+#if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_MPU     Memory Protection Unit (MPU)
+  \brief    Type definitions for the Memory Protection Unit (MPU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Memory Protection Unit (MPU).
+ */
+typedef struct
+{
+  __IM  uint32_t TYPE;                   /*!< Offset: 0x000 (R/ )  MPU Type Register */
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x004 (R/W)  MPU Control Register */
+  __IOM uint32_t RNR;                    /*!< Offset: 0x008 (R/W)  MPU Region Number Register */
+  __IOM uint32_t RBAR;                   /*!< Offset: 0x00C (R/W)  MPU Region Base Address Register */
+  __IOM uint32_t RASR;                   /*!< Offset: 0x010 (R/W)  MPU Region Attribute and Size Register */
+  __IOM uint32_t RBAR_A1;                /*!< Offset: 0x014 (R/W)  MPU Alias 1 Region Base Address Register */
+  __IOM uint32_t RASR_A1;                /*!< Offset: 0x018 (R/W)  MPU Alias 1 Region Attribute and Size Register */
+  __IOM uint32_t RBAR_A2;                /*!< Offset: 0x01C (R/W)  MPU Alias 2 Region Base Address Register */
+  __IOM uint32_t RASR_A2;                /*!< Offset: 0x020 (R/W)  MPU Alias 2 Region Attribute and Size Register */
+  __IOM uint32_t RBAR_A3;                /*!< Offset: 0x024 (R/W)  MPU Alias 3 Region Base Address Register */
+  __IOM uint32_t RASR_A3;                /*!< Offset: 0x028 (R/W)  MPU Alias 3 Region Attribute and Size Register */
+} MPU_Type;
+
+#define MPU_TYPE_RALIASES                  4U
+
+/** \brief MPU Type Register Definitions */
+#define MPU_TYPE_IREGION_Pos               16U                                            /*!< MPU TYPE: IREGION Position */
+#define MPU_TYPE_IREGION_Msk               (0xFFUL << MPU_TYPE_IREGION_Pos)               /*!< MPU TYPE: IREGION Mask */
+
+#define MPU_TYPE_DREGION_Pos                8U                                            /*!< MPU TYPE: DREGION Position */
+#define MPU_TYPE_DREGION_Msk               (0xFFUL << MPU_TYPE_DREGION_Pos)               /*!< MPU TYPE: DREGION Mask */
+
+#define MPU_TYPE_SEPARATE_Pos               0U                                            /*!< MPU TYPE: SEPARATE Position */
+#define MPU_TYPE_SEPARATE_Msk              (1UL /*<< MPU_TYPE_SEPARATE_Pos*/)             /*!< MPU TYPE: SEPARATE Mask */
+
+/** \brief MPU Control Register Definitions */
+#define MPU_CTRL_PRIVDEFENA_Pos             2U                                            /*!< MPU CTRL: PRIVDEFENA Position */
+#define MPU_CTRL_PRIVDEFENA_Msk            (1UL << MPU_CTRL_PRIVDEFENA_Pos)               /*!< MPU CTRL: PRIVDEFENA Mask */
+
+#define MPU_CTRL_HFNMIENA_Pos               1U                                            /*!< MPU CTRL: HFNMIENA Position */
+#define MPU_CTRL_HFNMIENA_Msk              (1UL << MPU_CTRL_HFNMIENA_Pos)                 /*!< MPU CTRL: HFNMIENA Mask */
+
+#define MPU_CTRL_ENABLE_Pos                 0U                                            /*!< MPU CTRL: ENABLE Position */
+#define MPU_CTRL_ENABLE_Msk                (1UL /*<< MPU_CTRL_ENABLE_Pos*/)               /*!< MPU CTRL: ENABLE Mask */
+
+/** \brief MPU Region Number Register Definitions */
+#define MPU_RNR_REGION_Pos                  0U                                            /*!< MPU RNR: REGION Position */
+#define MPU_RNR_REGION_Msk                 (0xFFUL /*<< MPU_RNR_REGION_Pos*/)             /*!< MPU RNR: REGION Mask */
+
+/** \brief MPU Region Base Address Register Definitions */
+#define MPU_RBAR_ADDR_Pos                   5U                                            /*!< MPU RBAR: ADDR Position */
+#define MPU_RBAR_ADDR_Msk                  (0x7FFFFFFUL << MPU_RBAR_ADDR_Pos)             /*!< MPU RBAR: ADDR Mask */
+
+#define MPU_RBAR_VALID_Pos                  4U                                            /*!< MPU RBAR: VALID Position */
+#define MPU_RBAR_VALID_Msk                 (1UL << MPU_RBAR_VALID_Pos)                    /*!< MPU RBAR: VALID Mask */
+
+#define MPU_RBAR_REGION_Pos                 0U                                            /*!< MPU RBAR: REGION Position */
+#define MPU_RBAR_REGION_Msk                (0xFUL /*<< MPU_RBAR_REGION_Pos*/)             /*!< MPU RBAR: REGION Mask */
+
+/** \brief MPU Region Attribute and Size Register Definitions */
+#define MPU_RASR_ATTRS_Pos                 16U                                            /*!< MPU RASR: MPU Region Attribute field Position */
+#define MPU_RASR_ATTRS_Msk                 (0xFFFFUL << MPU_RASR_ATTRS_Pos)               /*!< MPU RASR: MPU Region Attribute field Mask */
+
+#define MPU_RASR_XN_Pos                    28U                                            /*!< MPU RASR: ATTRS.XN Position */
+#define MPU_RASR_XN_Msk                    (1UL << MPU_RASR_XN_Pos)                       /*!< MPU RASR: ATTRS.XN Mask */
+
+#define MPU_RASR_AP_Pos                    24U                                            /*!< MPU RASR: ATTRS.AP Position */
+#define MPU_RASR_AP_Msk                    (0x7UL << MPU_RASR_AP_Pos)                     /*!< MPU RASR: ATTRS.AP Mask */
+
+#define MPU_RASR_TEX_Pos                   19U                                            /*!< MPU RASR: ATTRS.TEX Position */
+#define MPU_RASR_TEX_Msk                   (0x7UL << MPU_RASR_TEX_Pos)                    /*!< MPU RASR: ATTRS.TEX Mask */
+
+#define MPU_RASR_S_Pos                     18U                                            /*!< MPU RASR: ATTRS.S Position */
+#define MPU_RASR_S_Msk                     (1UL << MPU_RASR_S_Pos)                        /*!< MPU RASR: ATTRS.S Mask */
+
+#define MPU_RASR_C_Pos                     17U                                            /*!< MPU RASR: ATTRS.C Position */
+#define MPU_RASR_C_Msk                     (1UL << MPU_RASR_C_Pos)                        /*!< MPU RASR: ATTRS.C Mask */
+
+#define MPU_RASR_B_Pos                     16U                                            /*!< MPU RASR: ATTRS.B Position */
+#define MPU_RASR_B_Msk                     (1UL << MPU_RASR_B_Pos)                        /*!< MPU RASR: ATTRS.B Mask */
+
+#define MPU_RASR_SRD_Pos                    8U                                            /*!< MPU RASR: Sub-Region Disable Position */
+#define MPU_RASR_SRD_Msk                   (0xFFUL << MPU_RASR_SRD_Pos)                   /*!< MPU RASR: Sub-Region Disable Mask */
+
+#define MPU_RASR_SIZE_Pos                   1U                                            /*!< MPU RASR: Region Size Field Position */
+#define MPU_RASR_SIZE_Msk                  (0x1FUL << MPU_RASR_SIZE_Pos)                  /*!< MPU RASR: Region Size Field Mask */
+
+#define MPU_RASR_ENABLE_Pos                 0U                                            /*!< MPU RASR: Region enable bit Position */
+#define MPU_RASR_ENABLE_Msk                (1UL /*<< MPU_RASR_ENABLE_Pos*/)               /*!< MPU RASR: Region enable bit Disable Mask */
+
+/*@} end of group CMSIS_MPU */
+#endif /* defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U) */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_FPU     Floating Point Unit (FPU)
+  \brief    Type definitions for the Floating Point Unit (FPU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Floating Point Unit (FPU).
+ */
+typedef struct
+{
+        uint32_t RESERVED0[1U];
+  __IOM uint32_t FPCCR;                  /*!< Offset: 0x004 (R/W)  Floating-Point Context Control Register */
+  __IOM uint32_t FPCAR;                  /*!< Offset: 0x008 (R/W)  Floating-Point Context Address Register */
+  __IOM uint32_t FPDSCR;                 /*!< Offset: 0x00C (R/W)  Floating-Point Default Status Control Register */
+  __IM  uint32_t MVFR0;                  /*!< Offset: 0x010 (R/ )  Media and VFP Feature Register 0 */
+  __IM  uint32_t MVFR1;                  /*!< Offset: 0x014 (R/ )  Media and VFP Feature Register 1 */
+  __IM  uint32_t MVFR2;                  /*!< Offset: 0x018 (R/ )  Media and VFP Feature Register 2 */
+} FPU_Type;
+
+/** \brief FPU Floating-Point Context Control Register Definitions */
+#define FPU_FPCCR_ASPEN_Pos                31U                                            /*!< FPCCR: ASPEN bit Position */
+#define FPU_FPCCR_ASPEN_Msk                (1UL << FPU_FPCCR_ASPEN_Pos)                   /*!< FPCCR: ASPEN bit Mask */
+
+#define FPU_FPCCR_LSPEN_Pos                30U                                            /*!< FPCCR: LSPEN Position */
+#define FPU_FPCCR_LSPEN_Msk                (1UL << FPU_FPCCR_LSPEN_Pos)                   /*!< FPCCR: LSPEN bit Mask */
+
+#define FPU_FPCCR_MONRDY_Pos                8U                                            /*!< FPCCR: MONRDY Position */
+#define FPU_FPCCR_MONRDY_Msk               (1UL << FPU_FPCCR_MONRDY_Pos)                  /*!< FPCCR: MONRDY bit Mask */
+
+#define FPU_FPCCR_BFRDY_Pos                 6U                                            /*!< FPCCR: BFRDY Position */
+#define FPU_FPCCR_BFRDY_Msk                (1UL << FPU_FPCCR_BFRDY_Pos)                   /*!< FPCCR: BFRDY bit Mask */
+
+#define FPU_FPCCR_MMRDY_Pos                 5U                                            /*!< FPCCR: MMRDY Position */
+#define FPU_FPCCR_MMRDY_Msk                (1UL << FPU_FPCCR_MMRDY_Pos)                   /*!< FPCCR: MMRDY bit Mask */
+
+#define FPU_FPCCR_HFRDY_Pos                 4U                                            /*!< FPCCR: HFRDY Position */
+#define FPU_FPCCR_HFRDY_Msk                (1UL << FPU_FPCCR_HFRDY_Pos)                   /*!< FPCCR: HFRDY bit Mask */
+
+#define FPU_FPCCR_THREAD_Pos                3U                                            /*!< FPCCR: processor mode bit Position */
+#define FPU_FPCCR_THREAD_Msk               (1UL << FPU_FPCCR_THREAD_Pos)                  /*!< FPCCR: processor mode active bit Mask */
+
+#define FPU_FPCCR_USER_Pos                  1U                                            /*!< FPCCR: privilege level bit Position */
+#define FPU_FPCCR_USER_Msk                 (1UL << FPU_FPCCR_USER_Pos)                    /*!< FPCCR: privilege level bit Mask */
+
+#define FPU_FPCCR_LSPACT_Pos                0U                                            /*!< FPCCR: Lazy state preservation active bit Position */
+#define FPU_FPCCR_LSPACT_Msk               (1UL /*<< FPU_FPCCR_LSPACT_Pos*/)              /*!< FPCCR: Lazy state preservation active bit Mask */
+
+/** \brief FPU Floating-Point Context Address Register Definitions */
+#define FPU_FPCAR_ADDRESS_Pos               3U                                            /*!< FPCAR: ADDRESS bit Position */
+#define FPU_FPCAR_ADDRESS_Msk              (0x1FFFFFFFUL << FPU_FPCAR_ADDRESS_Pos)        /*!< FPCAR: ADDRESS bit Mask */
+
+/** \brief FPU Floating-Point Default Status Control Register Definitions */
+#define FPU_FPDSCR_AHP_Pos                 26U                                            /*!< FPDSCR: AHP bit Position */
+#define FPU_FPDSCR_AHP_Msk                 (1UL << FPU_FPDSCR_AHP_Pos)                    /*!< FPDSCR: AHP bit Mask */
+
+#define FPU_FPDSCR_DN_Pos                  25U                                            /*!< FPDSCR: DN bit Position */
+#define FPU_FPDSCR_DN_Msk                  (1UL << FPU_FPDSCR_DN_Pos)                     /*!< FPDSCR: DN bit Mask */
+
+#define FPU_FPDSCR_FZ_Pos                  24U                                            /*!< FPDSCR: FZ bit Position */
+#define FPU_FPDSCR_FZ_Msk                  (1UL << FPU_FPDSCR_FZ_Pos)                     /*!< FPDSCR: FZ bit Mask */
+
+#define FPU_FPDSCR_RMode_Pos               22U                                            /*!< FPDSCR: RMode bit Position */
+#define FPU_FPDSCR_RMode_Msk               (3UL << FPU_FPDSCR_RMode_Pos)                  /*!< FPDSCR: RMode bit Mask */
+
+/** \brief FPU Media and VFP Feature Register 0 Definitions */
+#define FPU_MVFR0_FPRound_Pos              28U                                            /*!< MVFR0: Rounding modes bits Position */
+#define FPU_MVFR0_FPRound_Msk              (0xFUL << FPU_MVFR0_FPRound_Pos)               /*!< MVFR0: Rounding modes bits Mask */
+
+#define FPU_MVFR0_FPShortvec_Pos           24U                                            /*!< MVFR0: Short vectors bits Position */
+#define FPU_MVFR0_FPShortvec_Msk          (0xFUL << FPU_MVFR0_FPShortvec_Pos)             /*!< MVFR0: Short vectors bits Mask */
+
+#define FPU_MVFR0_FPSqrt_Pos               20U                                            /*!< MVFR0: Square root bits Position */
+#define FPU_MVFR0_FPSqrt_Msk               (0xFUL << FPU_MVFR0_FPSqrt_Pos)                /*!< MVFR0: Square root bits Mask */
+
+#define FPU_MVFR0_FPDivide_Pos             16U                                            /*!< MVFR0: Divide bits Position */
+#define FPU_MVFR0_FPDivide_Msk             (0xFUL << FPU_MVFR0_FPDivide_Pos)              /*!< MVFR0: Divide bits Mask */
+
+#define FPU_MVFR0_FPExceptrap_Pos    12U                                                  /*!< MVFR0: Exception trapping bits Position */
+#define FPU_MVFR0_FPExceptrap_Msk    (0xFUL << FPU_MVFR0_FPExceptrap_Pos)                 /*!< MVFR0: Exception trapping bits Mask */
+
+#define FPU_MVFR0_FPDP_Pos                  8U                                            /*!< MVFR0: Double-precision bits Position */
+#define FPU_MVFR0_FPDP_Msk                 (0xFUL << FPU_MVFR0_FPDP_Pos)                  /*!< MVFR0: Double-precision bits Mask */
+
+#define FPU_MVFR0_FPSP_Pos                  4U                                            /*!< MVFR0: Single-precision bits Position */
+#define FPU_MVFR0_FPSP_Msk                 (0xFUL << FPU_MVFR0_FPSP_Pos)                  /*!< MVFR0: Single-precision bits Mask */
+
+#define FPU_MVFR0_SIMDReg_Pos               0U                                            /*!< MVFR0: SIMD registers bits Position */
+#define FPU_MVFR0_SIMDReg_Msk              (0xFUL /*<< FPU_MVFR0_SIMDReg_Pos*/)           /*!< MVFR0: SIMD registers bits Mask */
+
+/** \brief FPU Media and VFP Feature Register 1 Definitions */
+#define FPU_MVFR1_FMAC_Pos                 28U                                            /*!< MVFR1: Fused MAC bits Position */
+#define FPU_MVFR1_FMAC_Msk                 (0xFUL << FPU_MVFR1_FMAC_Pos)                  /*!< MVFR1: Fused MAC bits Mask */
+
+#define FPU_MVFR1_FPHP_Pos                 24U                                            /*!< MVFR1: FP HPFP bits Position */
+#define FPU_MVFR1_FPHP_Msk                 (0xFUL << FPU_MVFR1_FPHP_Pos)                  /*!< MVFR1: FP HPFP bits Mask */
+
+#define FPU_MVFR1_FPDNaN_Pos                4U                                            /*!< MVFR1: D_NaN mode bits Position */
+#define FPU_MVFR1_FPDNaN_Msk               (0xFUL << FPU_MVFR1_FPDNaN_Pos)                /*!< MVFR1: D_NaN mode bits Mask */
+
+#define FPU_MVFR1_FPFtZ_Pos                 0U                                            /*!< MVFR1: FtZ mode bits Position */
+#define FPU_MVFR1_FPFtZ_Msk                (0xFUL /*<< FPU_MVFR1_FPFtZ_Pos*/)             /*!< MVFR1: FtZ mode bits Mask */
+
+/** \brief FPU Media and VFP Feature Register 2 Definitions */
+#define FPU_MVFR2_FPMisc_Pos                4U                                            /*!< MVFR2: VFP Misc bits Position */
+#define FPU_MVFR2_FPMisc_Msk               (0xFUL << FPU_MVFR2_FPMisc_Pos)                /*!< MVFR2: VFP Misc bits Mask */
+
+/*@} end of group CMSIS_FPU */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_DCB       Debug Control Block
+  \brief    Type definitions for the Debug Control Block Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Debug Control Block Registers (DCB).
+ */
+typedef struct
+{
+  __IOM uint32_t DHCSR;                  /*!< Offset: 0x000 (R/W)  Debug Halting Control and Status Register */
+  __OM  uint32_t DCRSR;                  /*!< Offset: 0x004 ( /W)  Debug Core Register Selector Register */
+  __IOM uint32_t DCRDR;                  /*!< Offset: 0x008 (R/W)  Debug Core Register Data Register */
+  __IOM uint32_t DEMCR;                  /*!< Offset: 0x00C (R/W)  Debug Exception and Monitor Control Register */
+} DCB_Type;
+
+/** \brief DCB Debug Halting Control and Status Register Definitions */
+#define DCB_DHCSR_DBGKEY_Pos               16U                                            /*!< DCB DHCSR: Debug key Position */
+#define DCB_DHCSR_DBGKEY_Msk               (0xFFFFUL << DCB_DHCSR_DBGKEY_Pos)             /*!< DCB DHCSR: Debug key Mask */
+
+#define DCB_DHCSR_S_RESET_ST_Pos           25U                                            /*!< DCB DHCSR: Reset sticky status Position */
+#define DCB_DHCSR_S_RESET_ST_Msk           (1UL << DCB_DHCSR_S_RESET_ST_Pos)              /*!< DCB DHCSR: Reset sticky status Mask */
+
+#define DCB_DHCSR_S_RETIRE_ST_Pos          24U                                            /*!< DCB DHCSR: Retire sticky status Position */
+#define DCB_DHCSR_S_RETIRE_ST_Msk          (1UL << DCB_DHCSR_S_RETIRE_ST_Pos)             /*!< DCB DHCSR: Retire sticky status Mask */
+
+#define DCB_DHCSR_S_LOCKUP_Pos             19U                                            /*!< DCB DHCSR: Lockup status Position */
+#define DCB_DHCSR_S_LOCKUP_Msk             (1UL << DCB_DHCSR_S_LOCKUP_Pos)                /*!< DCB DHCSR: Lockup status Mask */
+
+#define DCB_DHCSR_S_SLEEP_Pos              18U                                            /*!< DCB DHCSR: Sleeping status Position */
+#define DCB_DHCSR_S_SLEEP_Msk              (1UL << DCB_DHCSR_S_SLEEP_Pos)                 /*!< DCB DHCSR: Sleeping status Mask */
+
+#define DCB_DHCSR_S_HALT_Pos               17U                                            /*!< DCB DHCSR: Halted status Position */
+#define DCB_DHCSR_S_HALT_Msk               (1UL << DCB_DHCSR_S_HALT_Pos)                  /*!< DCB DHCSR: Halted status Mask */
+
+#define DCB_DHCSR_S_REGRDY_Pos             16U                                            /*!< DCB DHCSR: Register ready status Position */
+#define DCB_DHCSR_S_REGRDY_Msk             (1UL << DCB_DHCSR_S_REGRDY_Pos)                /*!< DCB DHCSR: Register ready status Mask */
+
+#define DCB_DHCSR_C_SNAPSTALL_Pos           5U                                            /*!< DCB DHCSR: Snap stall control Position */
+#define DCB_DHCSR_C_SNAPSTALL_Msk          (1UL << DCB_DHCSR_C_SNAPSTALL_Pos)             /*!< DCB DHCSR: Snap stall control Mask */
+
+#define DCB_DHCSR_C_MASKINTS_Pos            3U                                            /*!< DCB DHCSR: Mask interrupts control Position */
+#define DCB_DHCSR_C_MASKINTS_Msk           (1UL << DCB_DHCSR_C_MASKINTS_Pos)              /*!< DCB DHCSR: Mask interrupts control Mask */
+
+#define DCB_DHCSR_C_STEP_Pos                2U                                            /*!< DCB DHCSR: Step control Position */
+#define DCB_DHCSR_C_STEP_Msk               (1UL << DCB_DHCSR_C_STEP_Pos)                  /*!< DCB DHCSR: Step control Mask */
+
+#define DCB_DHCSR_C_HALT_Pos                1U                                            /*!< DCB DHCSR: Halt control Position */
+#define DCB_DHCSR_C_HALT_Msk               (1UL << DCB_DHCSR_C_HALT_Pos)                  /*!< DCB DHCSR: Halt control Mask */
+
+#define DCB_DHCSR_C_DEBUGEN_Pos             0U                                            /*!< DCB DHCSR: Debug enable control Position */
+#define DCB_DHCSR_C_DEBUGEN_Msk            (1UL /*<< DCB_DHCSR_C_DEBUGEN_Pos*/)           /*!< DCB DHCSR: Debug enable control Mask */
+
+/** \brief DCB Debug Core Register Selector Register Definitions */
+#define DCB_DCRSR_REGWnR_Pos               16U                                            /*!< DCB DCRSR: Register write/not-read Position */
+#define DCB_DCRSR_REGWnR_Msk               (1UL << DCB_DCRSR_REGWnR_Pos)                  /*!< DCB DCRSR: Register write/not-read Mask */
+
+#define DCB_DCRSR_REGSEL_Pos                0U                                            /*!< DCB DCRSR: Register selector Position */
+#define DCB_DCRSR_REGSEL_Msk               (0x7FUL /*<< DCB_DCRSR_REGSEL_Pos*/)           /*!< DCB DCRSR: Register selector Mask */
+
+/** \brief DCB Debug Core Register Data Register Definitions */
+#define DCB_DCRDR_DBGTMP_Pos                0U                                            /*!< DCB DCRDR: Data temporary buffer Position */
+#define DCB_DCRDR_DBGTMP_Msk               (0xFFFFFFFFUL /*<< DCB_DCRDR_DBGTMP_Pos*/)     /*!< DCB DCRDR: Data temporary buffer Mask */
+
+/** \brief DCB Debug Exception and Monitor Control Register Definitions */
+#define DCB_DEMCR_TRCENA_Pos               24U                                            /*!< DCB DEMCR: Trace enable Position */
+#define DCB_DEMCR_TRCENA_Msk               (1UL << DCB_DEMCR_TRCENA_Pos)                  /*!< DCB DEMCR: Trace enable Mask */
+
+#define DCB_DEMCR_MON_REQ_Pos              19U                                            /*!< DCB DEMCR: Monitor request Position */
+#define DCB_DEMCR_MON_REQ_Msk              (1UL << DCB_DEMCR_MON_REQ_Pos)                 /*!< DCB DEMCR: Monitor request Mask */
+
+#define DCB_DEMCR_MON_STEP_Pos             18U                                            /*!< DCB DEMCR: Monitor step Position */
+#define DCB_DEMCR_MON_STEP_Msk             (1UL << DCB_DEMCR_MON_STEP_Pos)                /*!< DCB DEMCR: Monitor step Mask */
+
+#define DCB_DEMCR_MON_PEND_Pos             17U                                            /*!< DCB DEMCR: Monitor pend Position */
+#define DCB_DEMCR_MON_PEND_Msk             (1UL << DCB_DEMCR_MON_PEND_Pos)                /*!< DCB DEMCR: Monitor pend Mask */
+
+#define DCB_DEMCR_MON_EN_Pos               16U                                            /*!< DCB DEMCR: Monitor enable Position */
+#define DCB_DEMCR_MON_EN_Msk               (1UL << DCB_DEMCR_MON_EN_Pos)                  /*!< DCB DEMCR: Monitor enable Mask */
+
+#define DCB_DEMCR_VC_HARDERR_Pos           10U                                            /*!< DCB DEMCR: Vector Catch HardFault errors Position */
+#define DCB_DEMCR_VC_HARDERR_Msk           (1UL << DCB_DEMCR_VC_HARDERR_Pos)              /*!< DCB DEMCR: Vector Catch HardFault errors Mask */
+
+#define DCB_DEMCR_VC_INTERR_Pos             9U                                            /*!< DCB DEMCR: Vector Catch interrupt errors Position */
+#define DCB_DEMCR_VC_INTERR_Msk            (1UL << DCB_DEMCR_VC_INTERR_Pos)               /*!< DCB DEMCR: Vector Catch interrupt errors Mask */
+
+#define DCB_DEMCR_VC_BUSERR_Pos             8U                                            /*!< DCB DEMCR: Vector Catch BusFault errors Position */
+#define DCB_DEMCR_VC_BUSERR_Msk            (1UL << DCB_DEMCR_VC_BUSERR_Pos)               /*!< DCB DEMCR: Vector Catch BusFault errors Mask */
+
+#define DCB_DEMCR_VC_STATERR_Pos            7U                                            /*!< DCB DEMCR: Vector Catch state errors Position */
+#define DCB_DEMCR_VC_STATERR_Msk           (1UL << DCB_DEMCR_VC_STATERR_Pos)              /*!< DCB DEMCR: Vector Catch state errors Mask */
+
+#define DCB_DEMCR_VC_CHKERR_Pos             6U                                            /*!< DCB DEMCR: Vector Catch check errors Position */
+#define DCB_DEMCR_VC_CHKERR_Msk            (1UL << DCB_DEMCR_VC_CHKERR_Pos)               /*!< DCB DEMCR: Vector Catch check errors Mask */
+
+#define DCB_DEMCR_VC_NOCPERR_Pos            5U                                            /*!< DCB DEMCR: Vector Catch NOCP errors Position */
+#define DCB_DEMCR_VC_NOCPERR_Msk           (1UL << DCB_DEMCR_VC_NOCPERR_Pos)              /*!< DCB DEMCR: Vector Catch NOCP errors Mask */
+
+#define DCB_DEMCR_VC_MMERR_Pos              4U                                            /*!< DCB DEMCR: Vector Catch MemManage errors Position */
+#define DCB_DEMCR_VC_MMERR_Msk             (1UL << DCB_DEMCR_VC_MMERR_Pos)                /*!< DCB DEMCR: Vector Catch MemManage errors Mask */
+
+#define DCB_DEMCR_VC_CORERESET_Pos          0U                                            /*!< DCB DEMCR: Vector Catch Core reset Position */
+#define DCB_DEMCR_VC_CORERESET_Msk         (1UL /*<< DCB_DEMCR_VC_CORERESET_Pos*/)        /*!< DCB DEMCR: Vector Catch Core reset Mask */
+
+/*@} end of group CMSIS_DCB */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_core_bitfield     Core register bit field macros
+  \brief      Macros for use with bit field definitions (xxx_Pos, xxx_Msk).
+  @{
+ */
+
+/**
+  \brief   Mask and shift a bit field value for use in a register bit range.
+  \param[in] field  Name of the register bit field.
+  \param[in] value  Value of the bit field. This parameter is interpreted as an uint32_t type.
+  \return           Masked and shifted value.
+*/
+#define _VAL2FLD(field, value)    (((uint32_t)(value) << field ## _Pos) & field ## _Msk)
+
+/**
+  \brief     Mask and shift a register value to extract a bit filed value.
+  \param[in] field  Name of the register bit field.
+  \param[in] value  Value of register. This parameter is interpreted as an uint32_t type.
+  \return           Masked and shifted bit field value.
+*/
+#define _FLD2VAL(field, value)    (((uint32_t)(value) & field ## _Msk) >> field ## _Pos)
+
+/*@} end of group CMSIS_core_bitfield */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_core_base     Core Definitions
+  \brief      Definitions for base addresses, unions, and structures.
+  @{
+ */
+
+/* Memory mapping of Core Hardware */
+#define SCS_BASE            (0xE000E000UL)                            /*!< System Control Space Base Address */
+#define ITM_BASE            (0xE0000000UL)                            /*!< ITM Base Address */
+#define DWT_BASE            (0xE0001000UL)                            /*!< DWT Base Address */
+#define TPIU_BASE           (0xE0040000UL)                            /*!< TPIU Base Address */
+#define DCB_BASE            (0xE000EDF0UL)                            /*!< Core Debug Base Address */
+#define SysTick_BASE        (SCS_BASE +  0x0010UL)                    /*!< SysTick Base Address */
+#define NVIC_BASE           (SCS_BASE +  0x0100UL)                    /*!< NVIC Base Address */
+#define SCB_BASE            (SCS_BASE +  0x0D00UL)                    /*!< System Control Block Base Address */
+
+#define SCnSCB              ((SCnSCB_Type    *)     SCS_BASE      )   /*!< System control Register not in SCB */
+#define SCB                 ((SCB_Type       *)     SCB_BASE      )   /*!< SCB configuration struct */
+#define SysTick             ((SysTick_Type   *)     SysTick_BASE  )   /*!< SysTick configuration struct */
+#define NVIC                ((NVIC_Type      *)     NVIC_BASE     )   /*!< NVIC configuration struct */
+#define ITM                 ((ITM_Type       *)     ITM_BASE      )   /*!< ITM configuration struct */
+#define DWT                 ((DWT_Type       *)     DWT_BASE      )   /*!< DWT configuration struct */
+#define TPIU                ((TPIU_Type      *)     TPIU_BASE     )   /*!< TPIU configuration struct */
+#define DCB                 ((DCB_Type       *)     DCB_BASE      )   /*!< DCB configuration struct */
+
+#if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+  #define MPU_BASE          (SCS_BASE +  0x0D90UL)                    /*!< Memory Protection Unit */
+  #define MPU               ((MPU_Type       *)     MPU_BASE      )   /*!< Memory Protection Unit */
+#endif
+
+#define FPU_BASE            (SCS_BASE +  0x0F30UL)                    /*!< Floating Point Unit */
+#define FPU                 ((FPU_Type       *)     FPU_BASE      )   /*!< Floating Point Unit */
+
+/*@} */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_register_aliases     Backwards Compatibility Aliases
+  \brief      Register alias definitions for backwards compatibility.
+  @{
+ */
+
+/*@} */
+
+
+/*******************************************************************************
+ *                Hardware Abstraction Layer
+  Core Function Interface contains:
+  - Core NVIC Functions
+  - Core SysTick Functions
+  - Core Debug Functions
+  - Core Register Access Functions
+ ******************************************************************************/
+/**
+  \defgroup CMSIS_Core_FunctionInterface Functions and Instructions Reference
+*/
+
+
+
+/* ##########################   NVIC functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_NVICFunctions NVIC Functions
+  \brief    Functions that manage interrupts and exceptions via the NVIC.
+  @{
+ */
+
+#ifdef CMSIS_NVIC_VIRTUAL
+  #ifndef CMSIS_NVIC_VIRTUAL_HEADER_FILE
+    #define CMSIS_NVIC_VIRTUAL_HEADER_FILE "cmsis_nvic_virtual.h"
+  #endif
+  #include CMSIS_NVIC_VIRTUAL_HEADER_FILE
+#else
+  #define NVIC_SetPriorityGrouping    __NVIC_SetPriorityGrouping
+  #define NVIC_GetPriorityGrouping    __NVIC_GetPriorityGrouping
+  #define NVIC_EnableIRQ              __NVIC_EnableIRQ
+  #define NVIC_GetEnableIRQ           __NVIC_GetEnableIRQ
+  #define NVIC_DisableIRQ             __NVIC_DisableIRQ
+  #define NVIC_GetPendingIRQ          __NVIC_GetPendingIRQ
+  #define NVIC_SetPendingIRQ          __NVIC_SetPendingIRQ
+  #define NVIC_ClearPendingIRQ        __NVIC_ClearPendingIRQ
+  #define NVIC_GetActive              __NVIC_GetActive
+  #define NVIC_SetPriority            __NVIC_SetPriority
+  #define NVIC_GetPriority            __NVIC_GetPriority
+  #define NVIC_SystemReset            __NVIC_SystemReset
+#endif /* CMSIS_NVIC_VIRTUAL */
+
+#ifdef CMSIS_VECTAB_VIRTUAL
+  #ifndef CMSIS_VECTAB_VIRTUAL_HEADER_FILE
+    #define CMSIS_VECTAB_VIRTUAL_HEADER_FILE "cmsis_vectab_virtual.h"
+  #endif
+  #include CMSIS_VECTAB_VIRTUAL_HEADER_FILE
+#else
+  #define NVIC_SetVector              __NVIC_SetVector
+  #define NVIC_GetVector              __NVIC_GetVector
+#endif  /* (CMSIS_VECTAB_VIRTUAL) */
+
+#define NVIC_USER_IRQ_OFFSET          16
+
+
+/* The following EXC_RETURN values are saved the LR on exception entry */
+#define EXC_RETURN_HANDLER         (0xFFFFFFF1UL)     /* return to Handler mode, uses MSP after return                               */
+#define EXC_RETURN_THREAD_MSP      (0xFFFFFFF9UL)     /* return to Thread mode, uses MSP after return                                */
+#define EXC_RETURN_THREAD_PSP      (0xFFFFFFFDUL)     /* return to Thread mode, uses PSP after return                                */
+#define EXC_RETURN_HANDLER_FPU     (0xFFFFFFE1UL)     /* return to Handler mode, uses MSP after return, restore floating-point state */
+#define EXC_RETURN_THREAD_MSP_FPU  (0xFFFFFFE9UL)     /* return to Thread mode, uses MSP after return, restore floating-point state  */
+#define EXC_RETURN_THREAD_PSP_FPU  (0xFFFFFFEDUL)     /* return to Thread mode, uses PSP after return, restore floating-point state  */
+
+
+/**
+  \brief   Set Priority Grouping
+  \details Sets the priority grouping field using the required unlock sequence.
+           The parameter PriorityGroup is assigned to the field SCB->AIRCR [10:8] PRIGROUP field.
+           Only values from 0..7 are used.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+  \param [in]      PriorityGroup  Priority grouping field.
+ */
+__STATIC_INLINE void __NVIC_SetPriorityGrouping(uint32_t PriorityGroup)
+{
+  uint32_t reg_value;
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);             /* only values 0..7 are used          */
+
+  reg_value  =  SCB->AIRCR;                                                   /* read old register configuration    */
+  reg_value &= ~((uint32_t)(SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk)); /* clear bits to change               */
+  reg_value  =  (reg_value                                   |
+                ((uint32_t)0x5FAUL << SCB_AIRCR_VECTKEY_Pos) |
+                (PriorityGroupTmp << SCB_AIRCR_PRIGROUP_Pos)  );              /* Insert write key and priority group */
+  SCB->AIRCR =  reg_value;
+}
+
+
+/**
+  \brief   Get Priority Grouping
+  \details Reads the priority grouping field from the NVIC Interrupt Controller.
+  \return                Priority grouping field (SCB->AIRCR [10:8] PRIGROUP field).
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPriorityGrouping(void)
+{
+  return ((uint32_t)((SCB->AIRCR & SCB_AIRCR_PRIGROUP_Msk) >> SCB_AIRCR_PRIGROUP_Pos));
+}
+
+
+/**
+  \brief   Enable Interrupt
+  \details Enables a device specific interrupt in the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_EnableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    __COMPILER_BARRIER();
+    NVIC->ISER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+    __COMPILER_BARRIER();
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Enable status
+  \details Returns a device specific interrupt enable status from the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt is not enabled.
+  \return             1  Interrupt is enabled.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetEnableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ISER[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Disable Interrupt
+  \details Disables a device specific interrupt in the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_DisableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ICER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+    __DSB();
+    __ISB();
+  }
+}
+
+
+/**
+  \brief   Get Pending Interrupt
+  \details Reads the NVIC pending register and returns the pending bit for the specified device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not pending.
+  \return             1  Interrupt status is pending.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ISPR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Pending Interrupt
+  \details Sets the pending bit of a device specific interrupt in the NVIC pending register.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_SetPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ISPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Clear Pending Interrupt
+  \details Clears the pending bit of a device specific interrupt in the NVIC pending register.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_ClearPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ICPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Active Interrupt
+  \details Reads the active register in the NVIC and returns the active bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not active.
+  \return             1  Interrupt status is active.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetActive(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->IABR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Interrupt Priority
+  \details Sets the priority of a device specific interrupt or a processor exception.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]      IRQn  Interrupt number.
+  \param [in]  priority  Priority to set.
+  \note    The priority cannot be set for every processor exception.
+ */
+__STATIC_INLINE void __NVIC_SetPriority(IRQn_Type IRQn, uint32_t priority)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->IPR[((uint32_t)IRQn)]               = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+  else
+  {
+    SCB->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Priority
+  \details Reads the priority of a device specific interrupt or a processor exception.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn  Interrupt number.
+  \return             Interrupt Priority.
+                      Value is aligned automatically to the implemented priority bits of the microcontroller.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPriority(IRQn_Type IRQn)
+{
+
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return(((uint32_t)NVIC->IPR[((uint32_t)IRQn)]               >> (8U - __NVIC_PRIO_BITS)));
+  }
+  else
+  {
+    return(((uint32_t)SCB->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] >> (8U - __NVIC_PRIO_BITS)));
+  }
+}
+
+
+/**
+  \brief   Encode Priority
+  \details Encodes the priority for an interrupt with the given priority group,
+           preemptive priority value, and subpriority value.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+  \param [in]     PriorityGroup  Used priority group.
+  \param [in]   PreemptPriority  Preemptive priority value (starting from 0).
+  \param [in]       SubPriority  Subpriority value (starting from 0).
+  \return                        Encoded priority. Value can be used in the function \ref NVIC_SetPriority().
+ */
+__STATIC_INLINE uint32_t NVIC_EncodePriority (uint32_t PriorityGroup, uint32_t PreemptPriority, uint32_t SubPriority)
+{
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);   /* only values 0..7 are used          */
+  uint32_t PreemptPriorityBits;
+  uint32_t SubPriorityBits;
+
+  PreemptPriorityBits = ((7UL - PriorityGroupTmp) > (uint32_t)(__NVIC_PRIO_BITS)) ? (uint32_t)(__NVIC_PRIO_BITS) : (uint32_t)(7UL - PriorityGroupTmp);
+  SubPriorityBits     = ((PriorityGroupTmp + (uint32_t)(__NVIC_PRIO_BITS)) < (uint32_t)7UL) ? (uint32_t)0UL : (uint32_t)((PriorityGroupTmp - 7UL) + (uint32_t)(__NVIC_PRIO_BITS));
+
+  return (
+           ((PreemptPriority & (uint32_t)((1UL << (PreemptPriorityBits)) - 1UL)) << SubPriorityBits) |
+           ((SubPriority     & (uint32_t)((1UL << (SubPriorityBits    )) - 1UL)))
+         );
+}
+
+
+/**
+  \brief   Decode Priority
+  \details Decodes an interrupt priority value with a given priority group to
+           preemptive priority value and subpriority value.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS) the smallest possible priority group is set.
+  \param [in]         Priority   Priority value, which can be retrieved with the function \ref NVIC_GetPriority().
+  \param [in]     PriorityGroup  Used priority group.
+  \param [out] pPreemptPriority  Preemptive priority value (starting from 0).
+  \param [out]     pSubPriority  Subpriority value (starting from 0).
+ */
+__STATIC_INLINE void NVIC_DecodePriority (uint32_t Priority, uint32_t PriorityGroup, uint32_t* const pPreemptPriority, uint32_t* const pSubPriority)
+{
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);   /* only values 0..7 are used          */
+  uint32_t PreemptPriorityBits;
+  uint32_t SubPriorityBits;
+
+  PreemptPriorityBits = ((7UL - PriorityGroupTmp) > (uint32_t)(__NVIC_PRIO_BITS)) ? (uint32_t)(__NVIC_PRIO_BITS) : (uint32_t)(7UL - PriorityGroupTmp);
+  SubPriorityBits     = ((PriorityGroupTmp + (uint32_t)(__NVIC_PRIO_BITS)) < (uint32_t)7UL) ? (uint32_t)0UL : (uint32_t)((PriorityGroupTmp - 7UL) + (uint32_t)(__NVIC_PRIO_BITS));
+
+  *pPreemptPriority = (Priority >> SubPriorityBits) & (uint32_t)((1UL << (PreemptPriorityBits)) - 1UL);
+  *pSubPriority     = (Priority                   ) & (uint32_t)((1UL << (SubPriorityBits    )) - 1UL);
+}
+
+
+/**
+  \brief   Set Interrupt Vector
+  \details Sets an interrupt vector in SRAM based interrupt vector table.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+           VTOR must been relocated to SRAM before.
+  \param [in]   IRQn      Interrupt number
+  \param [in]   vector    Address of interrupt handler function
+ */
+__STATIC_INLINE void __NVIC_SetVector(IRQn_Type IRQn, uint32_t vector)
+{
+  uint32_t *vectors = (uint32_t *) ((uintptr_t) SCB->VTOR);
+  vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET] = vector;
+  /* ARM Application Note 321 states that the M4 does not require the architectural barrier */
+}
+
+
+/**
+  \brief   Get Interrupt Vector
+  \details Reads an interrupt vector from interrupt vector table.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn      Interrupt number.
+  \return                 Address of interrupt handler function
+ */
+__STATIC_INLINE uint32_t __NVIC_GetVector(IRQn_Type IRQn)
+{
+  uint32_t *vectors = (uint32_t *) ((uintptr_t) SCB->VTOR);
+  return vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET];
+}
+
+
+/**
+  \brief   System Reset
+  \details Initiates a system reset request to reset the MCU.
+ */
+__NO_RETURN __STATIC_INLINE void __NVIC_SystemReset(void)
+{
+  __DSB();                                                          /* Ensure all outstanding memory accesses included
+                                                                       buffered write are completed before reset */
+  SCB->AIRCR  = (uint32_t)((0x5FAUL << SCB_AIRCR_VECTKEY_Pos)    |
+                           (SCB->AIRCR & SCB_AIRCR_PRIGROUP_Msk) |
+                            SCB_AIRCR_SYSRESETREQ_Msk    );         /* Keep priority group unchanged */
+  __DSB();                                                          /* Ensure completion of memory access */
+
+  for(;;)                                                           /* wait until reset */
+  {
+    __NOP();
+  }
+}
+
+/*@} end of CMSIS_Core_NVICFunctions */
+
+
+/* ##########################  MPU functions  #################################### */
+
+#if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+
+#include "m-profile/armv7m_mpu.h"
+
+#endif
+
+
+/* ##########################  FPU functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_FpuFunctions FPU Functions
+  \brief    Function that provides FPU type.
+  @{
+ */
+
+/**
+  \brief   get FPU type
+  \details returns the FPU type
+  \returns
+   - \b  0: No FPU
+   - \b  1: Single precision FPU
+   - \b  2: Double + Single precision FPU
+ */
+__STATIC_INLINE uint32_t SCB_GetFPUType(void)
+{
+  uint32_t mvfr0;
+
+  mvfr0 = FPU->MVFR0;
+  if      ((mvfr0 & (FPU_MVFR0_FPSP_Msk | FPU_MVFR0_FPDP_Msk)) == 0x020U)
+  {
+    return 1U;           /* Single precision FPU */
+  }
+  else
+  {
+    return 0U;           /* No FPU */
+  }
+}
+
+/*@} end of CMSIS_Core_FpuFunctions */
+
+
+/* ##################################    SysTick function  ############################################ */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_SysTickFunctions SysTick Functions
+  \brief    Functions that configure the System.
+  @{
+ */
+
+#if defined (__Vendor_SysTickConfig) && (__Vendor_SysTickConfig == 0U)
+
+/**
+  \brief   System Tick Configuration
+  \details Initializes the System Timer and its interrupt, and starts the System Tick Timer.
+           Counter is in free running mode to generate periodic interrupts.
+  \param [in]  ticks  Number of ticks between two interrupts.
+  \return          0  Function succeeded.
+  \return          1  Function failed.
+  \note    When the variable <b>__Vendor_SysTickConfig</b> is set to 1, then the
+           function <b>SysTick_Config</b> is not included. In this case, the file <b><i>device</i>.h</b>
+           must contain a vendor-specific implementation of this function.
+ */
+__STATIC_INLINE uint32_t SysTick_Config(uint32_t ticks)
+{
+  if ((ticks - 1UL) > SysTick_LOAD_RELOAD_Msk)
+  {
+    return (1UL);                                                   /* Reload value impossible */
+  }
+
+  SysTick->LOAD  = (uint32_t)(ticks - 1UL);                         /* set reload register */
+  NVIC_SetPriority (SysTick_IRQn, (1UL << __NVIC_PRIO_BITS) - 1UL); /* set Priority for Systick Interrupt */
+  SysTick->VAL   = 0UL;                                             /* Load the SysTick Counter Value */
+  SysTick->CTRL  = SysTick_CTRL_CLKSOURCE_Msk |
+                   SysTick_CTRL_TICKINT_Msk   |
+                   SysTick_CTRL_ENABLE_Msk;                         /* Enable SysTick IRQ and SysTick Timer */
+  return (0UL);                                                     /* Function successful */
+}
+
+#endif
+
+/*@} end of CMSIS_Core_SysTickFunctions */
+
+
+
+/* ##################################### Debug In/Output function ########################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_core_DebugFunctions ITM Functions
+  \brief    Functions that access the ITM debug interface.
+  @{
+ */
+
+extern volatile int32_t ITM_RxBuffer;                              /*!< External variable to receive characters. */
+#define                 ITM_RXBUFFER_EMPTY  ((int32_t)0x5AA55AA5U) /*!< Value identifying \ref ITM_RxBuffer is ready for next character. */
+
+
+/**
+  \brief   ITM Send Character
+  \details Transmits a character via the ITM channel 0, and
+           \li Just returns when no debugger is connected that has booked the output.
+           \li Is blocking when a debugger is connected, but the previous character sent has not been transmitted.
+  \param [in]     ch  Character to transmit.
+  \returns            Character to transmit.
+ */
+__STATIC_INLINE uint32_t ITM_SendChar (uint32_t ch)
+{
+  if (((ITM->TCR & ITM_TCR_ITMENA_Msk) != 0UL) &&      /* ITM enabled */
+      ((ITM->TER & 1UL               ) != 0UL)   )     /* ITM Port #0 enabled */
+  {
+    while (ITM->PORT[0U].u32 == 0UL)
+    {
+      __NOP();
+    }
+    ITM->PORT[0U].u8 = (uint8_t)ch;
+  }
+  return (ch);
+}
+
+
+/**
+  \brief   ITM Receive Character
+  \details Inputs a character via the external variable \ref ITM_RxBuffer.
+  \return             Received character.
+  \return         -1  No character pending.
+ */
+__STATIC_INLINE int32_t ITM_ReceiveChar (void)
+{
+  int32_t ch = -1;                           /* no character available */
+
+  if (ITM_RxBuffer != ITM_RXBUFFER_EMPTY)
+  {
+    ch = ITM_RxBuffer;
+    ITM_RxBuffer = ITM_RXBUFFER_EMPTY;       /* ready for next character */
+  }
+
+  return (ch);
+}
+
+
+/**
+  \brief   ITM Check Character
+  \details Checks whether a character is pending for reading in the variable \ref ITM_RxBuffer.
+  \return          0  No character available.
+  \return          1  Character available.
+ */
+__STATIC_INLINE int32_t ITM_CheckChar (void)
+{
+
+  if (ITM_RxBuffer == ITM_RXBUFFER_EMPTY)
+  {
+    return (0);                              /* no character available */
+  }
+  else
+  {
+    return (1);                              /*    character available */
+  }
+}
+
+/*@} end of CMSIS_core_DebugFunctions */
+
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_CM4_H_DEPENDANT */
+
+#endif /* __CMSIS_GENERIC */

--- a/platform/ext/cmsis/CMSIS/Core/Include/core_cm52.h
+++ b/platform/ext/cmsis/CMSIS/Core/Include/core_cm52.h
@@ -1,0 +1,4777 @@
+/*
+ * Copyright (c) 2018-2023 Arm Limited. Copyright (c) 2024 Arm Technology (China) Co., Ltd. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS Cortex-M52 Core Peripheral Access Layer Header File
+ */
+
+#if   defined ( __ICCARM__ )
+  #pragma system_include                        /* treat file as system include file for MISRA check */
+#elif defined (__clang__)
+  #pragma clang system_header                   /* treat file as system include file */
+#elif defined ( __GNUC__ )
+  #pragma GCC diagnostic ignored "-Wpedantic"   /* disable pedantic warning due to unnamed structs/unions */
+#endif
+
+#ifndef __CORE_CM52_H_GENERIC
+#define __CORE_CM52_H_GENERIC
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/**
+  \page CMSIS_MISRA_Exceptions  MISRA-C:2004 Compliance Exceptions
+  CMSIS violates the following MISRA-C:2004 rules:
+
+   \li Required Rule 8.5, object/function definition in header file.<br>
+     Function definitions in header files are used to allow 'inlining'.
+
+   \li Required Rule 18.4, declaration of union type or object of union type: '{...}'.<br>
+     Unions are used for effective representation of core registers.
+
+   \li Advisory Rule 19.7, Function-like macro defined.<br>
+     Function-like macros are used to allow more efficient code.
+ */
+
+
+/*******************************************************************************
+ *                 CMSIS definitions
+ ******************************************************************************/
+/**
+  \ingroup Cortex_M52
+  @{
+ */
+
+#include "cmsis_version.h"
+
+/* CMSIS CM52 definitions */
+
+#define __CORTEX_M                (52U)                               /*!< Cortex-M Core */
+
+#if defined ( __CC_ARM )
+  #error Legacy Arm Compiler does not support Armv8.1-M target architecture.
+#elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #if defined (__ARM_FP)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+  #if defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1U)
+    #if defined (__DSP_PRESENT) && (__DSP_PRESENT == 1U)
+      #define __DSP_USED       1U
+    #else
+      #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
+      #define __DSP_USED       0U
+    #endif
+  #else
+    #define __DSP_USED         0U
+  #endif
+
+#elif defined (__ti__)
+  #if defined (__ARM_FP)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+  #if defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1U)
+    #if defined (__DSP_PRESENT) && (__DSP_PRESENT == 1U)
+      #define __DSP_USED       1U
+    #else
+      #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
+      #define __DSP_USED       0U
+    #endif
+  #else
+    #define __DSP_USED         0U
+  #endif
+
+#elif defined ( __GNUC__ )
+  #if defined (__VFP_FP__) && !defined(__SOFTFP__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+  #if defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1U)
+    #if defined (__DSP_PRESENT) && (__DSP_PRESENT == 1U)
+      #define __DSP_USED       1U
+    #else
+      #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
+      #define __DSP_USED         0U
+    #endif
+  #else
+    #define __DSP_USED         0U
+  #endif
+
+#elif defined ( __ICCARM__ )
+  #if defined (__ARMVFP__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+  #if defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1U)
+    #if defined (__DSP_PRESENT) && (__DSP_PRESENT == 1U)
+      #define __DSP_USED       1U
+    #else
+      #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
+      #define __DSP_USED         0U
+    #endif
+  #else
+    #define __DSP_USED         0U
+  #endif
+
+#elif defined ( __TI_ARM__ )
+  #if defined (__TI_VFP_SUPPORT__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#elif defined ( __TASKING__ )
+  #if defined (__FPU_VFP__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#elif defined ( __CSMC__ )
+  #if ( __CSMC__ & 0x400U)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#endif
+
+#include "cmsis_compiler.h"               /* CMSIS compiler specific defines */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_CM52_H_GENERIC */
+
+#ifndef __CMSIS_GENERIC
+
+#ifndef __CORE_CM52_H_DEPENDANT
+#define __CORE_CM52_H_DEPENDANT
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* check device defines and use defaults */
+#if defined __CHECK_DEVICE_DEFINES
+  #ifndef __CM52_REV
+    #define __CM52_REV               0x0002U
+    #warning "__CM52_REV not defined in device header file; using default!"
+  #endif
+
+  #ifndef __FPU_PRESENT
+    #define __FPU_PRESENT             0U
+    #warning "__FPU_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #if __FPU_PRESENT != 0U
+    #ifndef __FPU_DP
+      #define __FPU_DP             0U
+      #warning "__FPU_DP not defined in device header file; using default!"
+    #endif
+  #endif
+
+  #ifndef __MPU_PRESENT
+    #define __MPU_PRESENT             0U
+    #warning "__MPU_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __ICACHE_PRESENT
+    #define __ICACHE_PRESENT          0U
+    #warning "__ICACHE_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __DCACHE_PRESENT
+    #define __DCACHE_PRESENT          0U
+    #warning "__DCACHE_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __UCACHE_PRESENT
+    #define __UCACHE_PRESENT          0U
+    #warning "__UCACHE_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __VTOR_PRESENT
+    #define __VTOR_PRESENT             1U
+    #warning "__VTOR_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __PMU_PRESENT
+    #define __PMU_PRESENT             0U
+    #warning "__PMU_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #if __PMU_PRESENT != 0U
+    #ifndef __PMU_NUM_EVENTCNT
+      #define __PMU_NUM_EVENTCNT      8U
+      #warning "__PMU_NUM_EVENTCNT not defined in device header file; using default!"
+    #elif (__PMU_NUM_EVENTCNT > 8 || __PMU_NUM_EVENTCNT < 2)
+    #error "__PMU_NUM_EVENTCNT is out of range in device header file!" */
+    #endif
+  #endif
+
+  #ifndef __SAUREGION_PRESENT
+    #define __SAUREGION_PRESENT       0U
+    #warning "__SAUREGION_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __DSP_PRESENT
+    #define __DSP_PRESENT             0U
+    #warning "__DSP_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __NVIC_PRIO_BITS
+    #define __NVIC_PRIO_BITS          3U
+    #warning "__NVIC_PRIO_BITS not defined in device header file; using default!"
+  #endif
+
+  #ifndef __Vendor_SysTickConfig
+    #define __Vendor_SysTickConfig    0U
+    #warning "__Vendor_SysTickConfig not defined in device header file; using default!"
+  #endif
+#endif
+
+/* IO definitions (access restrictions to peripheral registers) */
+/**
+    \defgroup CMSIS_glob_defs CMSIS Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+*/
+#ifdef __cplusplus
+  #define   __I     volatile             /*!< Defines 'read only' permissions */
+#else
+  #define   __I     volatile const       /*!< Defines 'read only' permissions */
+#endif
+#define     __O     volatile             /*!< Defines 'write only' permissions */
+#define     __IO    volatile             /*!< Defines 'read / write' permissions */
+
+/* following defines should be used for structure members */
+#define     __IM     volatile const      /*! Defines 'read only' structure member permissions */
+#define     __OM     volatile            /*! Defines 'write only' structure member permissions */
+#define     __IOM    volatile            /*! Defines 'read / write' structure member permissions */
+
+/*@} end of group Cortex_M52 */
+
+
+
+/*******************************************************************************
+ *                 Register Abstraction
+  Core Register contain:
+  - Core Register
+  - Core NVIC Register
+  - Core EWIC Register
+  - Core EWIC Interrupt Status Access Register
+  - Core SCB Register
+  - Core SysTick Register
+  - Core Debug Register
+  - Core PMU Register
+  - Core MPU Register
+  - Core SAU Register
+  - Core FPU Register
+ ******************************************************************************/
+/**
+  \defgroup CMSIS_core_register Defines and Type Definitions
+  \brief Type definitions and defines for Cortex-M processor based devices.
+*/
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_CORE  Status and Control Registers
+  \brief      Core Register type definitions.
+  @{
+ */
+
+/**
+  \brief  Union type to access the Application Program Status Register (APSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t _reserved0:16;              /*!< bit:  0..15  Reserved */
+    uint32_t GE:4;                       /*!< bit: 16..19  Greater than or Equal flags */
+    uint32_t _reserved1:7;               /*!< bit: 20..26  Reserved */
+    uint32_t Q:1;                        /*!< bit:     27  Saturation condition flag */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} APSR_Type;
+
+/** \brief APSR Register Definitions */
+#define APSR_N_Pos                         31U                                            /*!< APSR: N Position */
+#define APSR_N_Msk                         (1UL << APSR_N_Pos)                            /*!< APSR: N Mask */
+
+#define APSR_Z_Pos                         30U                                            /*!< APSR: Z Position */
+#define APSR_Z_Msk                         (1UL << APSR_Z_Pos)                            /*!< APSR: Z Mask */
+
+#define APSR_C_Pos                         29U                                            /*!< APSR: C Position */
+#define APSR_C_Msk                         (1UL << APSR_C_Pos)                            /*!< APSR: C Mask */
+
+#define APSR_V_Pos                         28U                                            /*!< APSR: V Position */
+#define APSR_V_Msk                         (1UL << APSR_V_Pos)                            /*!< APSR: V Mask */
+
+#define APSR_Q_Pos                         27U                                            /*!< APSR: Q Position */
+#define APSR_Q_Msk                         (1UL << APSR_Q_Pos)                            /*!< APSR: Q Mask */
+
+#define APSR_GE_Pos                        16U                                            /*!< APSR: GE Position */
+#define APSR_GE_Msk                        (0xFUL << APSR_GE_Pos)                         /*!< APSR: GE Mask */
+
+
+/**
+  \brief  Union type to access the Interrupt Program Status Register (IPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number */
+    uint32_t _reserved0:23;              /*!< bit:  9..31  Reserved */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} IPSR_Type;
+
+/** \brief IPSR Register Definitions */
+#define IPSR_ISR_Pos                        0U                                            /*!< IPSR: ISR Position */
+#define IPSR_ISR_Msk                       (0x1FFUL /*<< IPSR_ISR_Pos*/)                  /*!< IPSR: ISR Mask */
+
+
+/**
+  \brief  Union type to access the Special-Purpose Program Status Registers (xPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number */
+    uint32_t _reserved0:7;               /*!< bit:  9..15  Reserved */
+    uint32_t GE:4;                       /*!< bit: 16..19  Greater than or Equal flags */
+    uint32_t _reserved1:1;               /*!< bit:     20  Reserved */
+    uint32_t B:1;                        /*!< bit:     21  BTI active       (read 0) */
+    uint32_t _reserved2:2;               /*!< bit: 22..23  Reserved */
+    uint32_t T:1;                        /*!< bit:     24  Thumb bit        (read 0) */
+    uint32_t IT:2;                       /*!< bit: 25..26  saved IT state   (read 0) */
+    uint32_t Q:1;                        /*!< bit:     27  Saturation condition flag */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} xPSR_Type;
+
+/** \brief xPSR Register Definitions */
+#define xPSR_N_Pos                         31U                                            /*!< xPSR: N Position */
+#define xPSR_N_Msk                         (1UL << xPSR_N_Pos)                            /*!< xPSR: N Mask */
+
+#define xPSR_Z_Pos                         30U                                            /*!< xPSR: Z Position */
+#define xPSR_Z_Msk                         (1UL << xPSR_Z_Pos)                            /*!< xPSR: Z Mask */
+
+#define xPSR_C_Pos                         29U                                            /*!< xPSR: C Position */
+#define xPSR_C_Msk                         (1UL << xPSR_C_Pos)                            /*!< xPSR: C Mask */
+
+#define xPSR_V_Pos                         28U                                            /*!< xPSR: V Position */
+#define xPSR_V_Msk                         (1UL << xPSR_V_Pos)                            /*!< xPSR: V Mask */
+
+#define xPSR_Q_Pos                         27U                                            /*!< xPSR: Q Position */
+#define xPSR_Q_Msk                         (1UL << xPSR_Q_Pos)                            /*!< xPSR: Q Mask */
+
+#define xPSR_IT_Pos                        25U                                            /*!< xPSR: IT Position */
+#define xPSR_IT_Msk                        (3UL << xPSR_IT_Pos)                           /*!< xPSR: IT Mask */
+
+#define xPSR_T_Pos                         24U                                            /*!< xPSR: T Position */
+#define xPSR_T_Msk                         (1UL << xPSR_T_Pos)                            /*!< xPSR: T Mask */
+
+#define xPSR_B_Pos                         21U                                            /*!< xPSR: B Position */
+#define xPSR_B_Msk                         (1UL << xPSR_B_Pos)                            /*!< xPSR: B Mask */
+
+#define xPSR_GE_Pos                        16U                                            /*!< xPSR: GE Position */
+#define xPSR_GE_Msk                        (0xFUL << xPSR_GE_Pos)                         /*!< xPSR: GE Mask */
+
+#define xPSR_ISR_Pos                        0U                                            /*!< xPSR: ISR Position */
+#define xPSR_ISR_Msk                       (0x1FFUL /*<< xPSR_ISR_Pos*/)                  /*!< xPSR: ISR Mask */
+
+
+/**
+  \brief  Union type to access the Control Registers (CONTROL).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t nPRIV:1;                    /*!< bit:      0  Execution privilege in Thread mode */
+    uint32_t SPSEL:1;                    /*!< bit:      1  Stack-pointer select */
+    uint32_t FPCA:1;                     /*!< bit:      2  Floating-point context active */
+    uint32_t SFPA:1;                     /*!< bit:      3  Secure floating-point active */
+    uint32_t BTI_EN:1;                   /*!< bit:      4  Privileged branch target identification enable */
+    uint32_t UBTI_EN:1;                  /*!< bit:      5  Unprivileged branch target identification enable */
+    uint32_t PAC_EN:1;                   /*!< bit:      6  Privileged pointer authentication enable */
+    uint32_t UPAC_EN:1;                  /*!< bit:      7  Unprivileged pointer authentication enable */
+    uint32_t _reserved1:24;              /*!< bit:  8..31  Reserved */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} CONTROL_Type;
+
+/** \brief CONTROL Register Definitions */
+#define CONTROL_UPAC_EN_Pos                 7U                                            /*!< CONTROL: UPAC_EN Position */
+#define CONTROL_UPAC_EN_Msk                (1UL << CONTROL_UPAC_EN_Pos)                   /*!< CONTROL: UPAC_EN Mask */
+
+#define CONTROL_PAC_EN_Pos                  6U                                            /*!< CONTROL: PAC_EN Position */
+#define CONTROL_PAC_EN_Msk                 (1UL << CONTROL_PAC_EN_Pos)                    /*!< CONTROL: PAC_EN Mask */
+
+#define CONTROL_UBTI_EN_Pos                 5U                                            /*!< CONTROL: UBTI_EN Position */
+#define CONTROL_UBTI_EN_Msk                (1UL << CONTROL_UBTI_EN_Pos)                   /*!< CONTROL: UBTI_EN Mask */
+
+#define CONTROL_BTI_EN_Pos                  4U                                            /*!< CONTROL: BTI_EN Position */
+#define CONTROL_BTI_EN_Msk                 (1UL << CONTROL_BTI_EN_Pos)                    /*!< CONTROL: BTI_EN Mask */
+
+#define CONTROL_SFPA_Pos                    3U                                            /*!< CONTROL: SFPA Position */
+#define CONTROL_SFPA_Msk                   (1UL << CONTROL_SFPA_Pos)                      /*!< CONTROL: SFPA Mask */
+
+#define CONTROL_FPCA_Pos                    2U                                            /*!< CONTROL: FPCA Position */
+#define CONTROL_FPCA_Msk                   (1UL << CONTROL_FPCA_Pos)                      /*!< CONTROL: FPCA Mask */
+
+#define CONTROL_SPSEL_Pos                   1U                                            /*!< CONTROL: SPSEL Position */
+#define CONTROL_SPSEL_Msk                  (1UL << CONTROL_SPSEL_Pos)                     /*!< CONTROL: SPSEL Mask */
+
+#define CONTROL_nPRIV_Pos                   0U                                            /*!< CONTROL: nPRIV Position */
+#define CONTROL_nPRIV_Msk                  (1UL /*<< CONTROL_nPRIV_Pos*/)                 /*!< CONTROL: nPRIV Mask */
+
+/*@} end of group CMSIS_CORE */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_NVIC  Nested Vectored Interrupt Controller (NVIC)
+  \brief      Type definitions for the NVIC Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Nested Vectored Interrupt Controller (NVIC).
+ */
+typedef struct
+{
+  __IOM uint32_t ISER[16U];              /*!< Offset: 0x000 (R/W)  Interrupt Set Enable Register */
+        uint32_t RESERVED0[16U];
+  __IOM uint32_t ICER[16U];              /*!< Offset: 0x080 (R/W)  Interrupt Clear Enable Register */
+        uint32_t RESERVED1[16U];
+  __IOM uint32_t ISPR[16U];              /*!< Offset: 0x100 (R/W)  Interrupt Set Pending Register */
+        uint32_t RESERVED2[16U];
+  __IOM uint32_t ICPR[16U];              /*!< Offset: 0x180 (R/W)  Interrupt Clear Pending Register */
+        uint32_t RESERVED3[16U];
+  __IOM uint32_t IABR[16U];              /*!< Offset: 0x200 (R/W)  Interrupt Active bit Register */
+        uint32_t RESERVED4[16U];
+  __IOM uint32_t ITNS[16U];              /*!< Offset: 0x280 (R/W)  Interrupt Non-Secure State Register */
+        uint32_t RESERVED5[16U];
+  __IOM uint8_t  IPR[496U];              /*!< Offset: 0x300 (R/W)  Interrupt Priority Register (8Bit wide) */
+        uint32_t RESERVED6[580U];
+  __OM  uint32_t STIR;                   /*!< Offset: 0xE00 ( /W)  Software Trigger Interrupt Register */
+}  NVIC_Type;
+
+/** \brief NVIC Software Triggered Interrupt Register Definitions */
+#define NVIC_STIR_INTID_Pos                 0U                                         /*!< STIR: INTLINESNUM Position */
+#define NVIC_STIR_INTID_Msk                (0x1FFUL /*<< NVIC_STIR_INTID_Pos*/)        /*!< STIR: INTLINESNUM Mask */
+
+/*@} end of group CMSIS_NVIC */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SCB     System Control Block (SCB)
+  \brief    Type definitions for the System Control Block Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Control Block (SCB).
+ */
+typedef struct
+{
+  __IM  uint32_t CPUID;                  /*!< Offset: 0x000 (R/ )  CPUID Base Register */
+  __IOM uint32_t ICSR;                   /*!< Offset: 0x004 (R/W)  Interrupt Control and State Register */
+  __IOM uint32_t VTOR;                   /*!< Offset: 0x008 (R/W)  Vector Table Offset Register */
+  __IOM uint32_t AIRCR;                  /*!< Offset: 0x00C (R/W)  Application Interrupt and Reset Control Register */
+  __IOM uint32_t SCR;                    /*!< Offset: 0x010 (R/W)  System Control Register */
+  __IOM uint32_t CCR;                    /*!< Offset: 0x014 (R/W)  Configuration Control Register */
+  __IOM uint8_t  SHPR[12U];              /*!< Offset: 0x018 (R/W)  System Handlers Priority Registers (4-7, 8-11, 12-15) */
+  __IOM uint32_t SHCSR;                  /*!< Offset: 0x024 (R/W)  System Handler Control and State Register */
+  __IOM uint32_t CFSR;                   /*!< Offset: 0x028 (R/W)  Configurable Fault Status Register */
+  __IOM uint32_t HFSR;                   /*!< Offset: 0x02C (R/W)  HardFault Status Register */
+  __IOM uint32_t DFSR;                   /*!< Offset: 0x030 (R/W)  Debug Fault Status Register */
+  __IOM uint32_t MMFAR;                  /*!< Offset: 0x034 (R/W)  MemManage Fault Address Register */
+  __IOM uint32_t BFAR;                   /*!< Offset: 0x038 (R/W)  BusFault Address Register */
+  __IOM uint32_t AFSR;                   /*!< Offset: 0x03C (R/W)  Auxiliary Fault Status Register */
+  __IM  uint32_t ID_PFR[2U];             /*!< Offset: 0x040 (R/ )  Processor Feature Register */
+  __IM  uint32_t ID_DFR;                 /*!< Offset: 0x048 (R/ )  Debug Feature Register */
+  __IM  uint32_t ID_AFR;                 /*!< Offset: 0x04C (R/ )  Auxiliary Feature Register */
+  __IM  uint32_t ID_MMFR[4U];            /*!< Offset: 0x050 (R/ )  Memory Model Feature Register */
+  __IM  uint32_t ID_ISAR[6U];            /*!< Offset: 0x060 (R/ )  Instruction Set Attributes Register */
+  __IM  uint32_t CLIDR;                  /*!< Offset: 0x078 (R/ )  Cache Level ID register */
+  __IM  uint32_t CTR;                    /*!< Offset: 0x07C (R/ )  Cache Type register */
+  __IM  uint32_t CCSIDR;                 /*!< Offset: 0x080 (R/ )  Cache Size ID Register */
+  __IOM uint32_t CSSELR;                 /*!< Offset: 0x084 (R/W)  Cache Size Selection Register */
+  __IOM uint32_t CPACR;                  /*!< Offset: 0x088 (R/W)  Coprocessor Access Control Register */
+  __IOM uint32_t NSACR;                  /*!< Offset: 0x08C (R/W)  Non-Secure Access Control Register */
+        uint32_t RESERVED0[21U];
+  __IOM uint32_t SFSR;                   /*!< Offset: 0x0E4 (R/W)  Secure Fault Status Register */
+  __IOM uint32_t SFAR;                   /*!< Offset: 0x0E8 (R/W)  Secure Fault Address Register */
+        uint32_t RESERVED1[69U];
+  __OM  uint32_t STIR;                   /*!< Offset: 0x200 ( /W)  Software Triggered Interrupt Register */
+  __IOM uint32_t RFSR;                   /*!< Offset: 0x204 (R/W)  RAS Fault Status Register */
+        uint32_t RESERVED2[14U];
+  __IM  uint32_t MVFR0;                  /*!< Offset: 0x240 (R/ )  Media and VFP Feature Register 0 */
+  __IM  uint32_t MVFR1;                  /*!< Offset: 0x244 (R/ )  Media and VFP Feature Register 1 */
+  __IM  uint32_t MVFR2;                  /*!< Offset: 0x248 (R/ )  Media and VFP Feature Register 2 */
+        uint32_t RESERVED3[1U];
+  __OM  uint32_t ICIALLU;                /*!< Offset: 0x250 ( /W)  I-Cache Invalidate All to PoU */
+        uint32_t RESERVED4[1U];
+  __OM  uint32_t ICIMVAU;                /*!< Offset: 0x258 ( /W)  I-Cache Invalidate by MVA to PoU */
+  __OM  uint32_t DCIMVAC;                /*!< Offset: 0x25C ( /W)  D-Cache Invalidate by MVA to PoC */
+  __OM  uint32_t DCISW;                  /*!< Offset: 0x260 ( /W)  D-Cache Invalidate by Set-way */
+  __OM  uint32_t DCCMVAU;                /*!< Offset: 0x264 ( /W)  D-Cache Clean by MVA to PoU */
+  __OM  uint32_t DCCMVAC;                /*!< Offset: 0x268 ( /W)  D-Cache Clean by MVA to PoC */
+  __OM  uint32_t DCCSW;                  /*!< Offset: 0x26C ( /W)  D-Cache Clean by Set-way */
+  __OM  uint32_t DCCIMVAC;               /*!< Offset: 0x270 ( /W)  D-Cache Clean and Invalidate by MVA to PoC */
+  __OM  uint32_t DCCISW;                 /*!< Offset: 0x274 ( /W)  D-Cache Clean and Invalidate by Set-way */
+  __OM  uint32_t BPIALL;                 /*!< Offset: 0x278 ( /W)  Branch Predictor Invalidate All */
+} SCB_Type;
+
+/** \brief SCB CPUID Register Definitions */
+#define SCB_CPUID_IMPLEMENTER_Pos          24U                                            /*!< SCB CPUID: IMPLEMENTER Position */
+#define SCB_CPUID_IMPLEMENTER_Msk          (0xFFUL << SCB_CPUID_IMPLEMENTER_Pos)          /*!< SCB CPUID: IMPLEMENTER Mask */
+
+#define SCB_CPUID_VARIANT_Pos              20U                                            /*!< SCB CPUID: VARIANT Position */
+#define SCB_CPUID_VARIANT_Msk              (0xFUL << SCB_CPUID_VARIANT_Pos)               /*!< SCB CPUID: VARIANT Mask */
+
+#define SCB_CPUID_ARCHITECTURE_Pos         16U                                            /*!< SCB CPUID: ARCHITECTURE Position */
+#define SCB_CPUID_ARCHITECTURE_Msk         (0xFUL << SCB_CPUID_ARCHITECTURE_Pos)          /*!< SCB CPUID: ARCHITECTURE Mask */
+
+#define SCB_CPUID_PARTNO_Pos                4U                                            /*!< SCB CPUID: PARTNO Position */
+#define SCB_CPUID_PARTNO_Msk               (0xFFFUL << SCB_CPUID_PARTNO_Pos)              /*!< SCB CPUID: PARTNO Mask */
+
+#define SCB_CPUID_REVISION_Pos              0U                                            /*!< SCB CPUID: REVISION Position */
+#define SCB_CPUID_REVISION_Msk             (0xFUL /*<< SCB_CPUID_REVISION_Pos*/)          /*!< SCB CPUID: REVISION Mask */
+
+/** \brief SCB Interrupt Control State Register Definitions */
+#define SCB_ICSR_PENDNMISET_Pos            31U                                            /*!< SCB ICSR: PENDNMISET Position */
+#define SCB_ICSR_PENDNMISET_Msk            (1UL << SCB_ICSR_PENDNMISET_Pos)               /*!< SCB ICSR: PENDNMISET Mask */
+
+#define SCB_ICSR_PENDNMICLR_Pos            30U                                            /*!< SCB ICSR: PENDNMICLR Position */
+#define SCB_ICSR_PENDNMICLR_Msk            (1UL << SCB_ICSR_PENDNMICLR_Pos)               /*!< SCB ICSR: PENDNMICLR Mask */
+
+#define SCB_ICSR_PENDSVSET_Pos             28U                                            /*!< SCB ICSR: PENDSVSET Position */
+#define SCB_ICSR_PENDSVSET_Msk             (1UL << SCB_ICSR_PENDSVSET_Pos)                /*!< SCB ICSR: PENDSVSET Mask */
+
+#define SCB_ICSR_PENDSVCLR_Pos             27U                                            /*!< SCB ICSR: PENDSVCLR Position */
+#define SCB_ICSR_PENDSVCLR_Msk             (1UL << SCB_ICSR_PENDSVCLR_Pos)                /*!< SCB ICSR: PENDSVCLR Mask */
+
+#define SCB_ICSR_PENDSTSET_Pos             26U                                            /*!< SCB ICSR: PENDSTSET Position */
+#define SCB_ICSR_PENDSTSET_Msk             (1UL << SCB_ICSR_PENDSTSET_Pos)                /*!< SCB ICSR: PENDSTSET Mask */
+
+#define SCB_ICSR_PENDSTCLR_Pos             25U                                            /*!< SCB ICSR: PENDSTCLR Position */
+#define SCB_ICSR_PENDSTCLR_Msk             (1UL << SCB_ICSR_PENDSTCLR_Pos)                /*!< SCB ICSR: PENDSTCLR Mask */
+
+#define SCB_ICSR_STTNS_Pos                 24U                                            /*!< SCB ICSR: STTNS Position (Security Extension) */
+#define SCB_ICSR_STTNS_Msk                 (1UL << SCB_ICSR_STTNS_Pos)                    /*!< SCB ICSR: STTNS Mask (Security Extension) */
+
+#define SCB_ICSR_ISRPREEMPT_Pos            23U                                            /*!< SCB ICSR: ISRPREEMPT Position */
+#define SCB_ICSR_ISRPREEMPT_Msk            (1UL << SCB_ICSR_ISRPREEMPT_Pos)               /*!< SCB ICSR: ISRPREEMPT Mask */
+
+#define SCB_ICSR_ISRPENDING_Pos            22U                                            /*!< SCB ICSR: ISRPENDING Position */
+#define SCB_ICSR_ISRPENDING_Msk            (1UL << SCB_ICSR_ISRPENDING_Pos)               /*!< SCB ICSR: ISRPENDING Mask */
+
+#define SCB_ICSR_VECTPENDING_Pos           12U                                            /*!< SCB ICSR: VECTPENDING Position */
+#define SCB_ICSR_VECTPENDING_Msk           (0x1FFUL << SCB_ICSR_VECTPENDING_Pos)          /*!< SCB ICSR: VECTPENDING Mask */
+
+#define SCB_ICSR_RETTOBASE_Pos             11U                                            /*!< SCB ICSR: RETTOBASE Position */
+#define SCB_ICSR_RETTOBASE_Msk             (1UL << SCB_ICSR_RETTOBASE_Pos)                /*!< SCB ICSR: RETTOBASE Mask */
+
+#define SCB_ICSR_VECTACTIVE_Pos             0U                                            /*!< SCB ICSR: VECTACTIVE Position */
+#define SCB_ICSR_VECTACTIVE_Msk            (0x1FFUL /*<< SCB_ICSR_VECTACTIVE_Pos*/)       /*!< SCB ICSR: VECTACTIVE Mask */
+
+/** \brief SCB Vector Table Offset Register Definitions */
+#define SCB_VTOR_TBLOFF_Pos                 7U                                            /*!< SCB VTOR: TBLOFF Position */
+#define SCB_VTOR_TBLOFF_Msk                (0x1FFFFFFUL << SCB_VTOR_TBLOFF_Pos)           /*!< SCB VTOR: TBLOFF Mask */
+
+/** \brief SCB Application Interrupt and Reset Control Register Definitions */
+#define SCB_AIRCR_VECTKEY_Pos              16U                                            /*!< SCB AIRCR: VECTKEY Position */
+#define SCB_AIRCR_VECTKEY_Msk              (0xFFFFUL << SCB_AIRCR_VECTKEY_Pos)            /*!< SCB AIRCR: VECTKEY Mask */
+
+#define SCB_AIRCR_VECTKEYSTAT_Pos          16U                                            /*!< SCB AIRCR: VECTKEYSTAT Position */
+#define SCB_AIRCR_VECTKEYSTAT_Msk          (0xFFFFUL << SCB_AIRCR_VECTKEYSTAT_Pos)        /*!< SCB AIRCR: VECTKEYSTAT Mask */
+
+#define SCB_AIRCR_ENDIANESS_Pos            15U                                            /*!< SCB AIRCR: ENDIANESS Position */
+#define SCB_AIRCR_ENDIANESS_Msk            (1UL << SCB_AIRCR_ENDIANESS_Pos)               /*!< SCB AIRCR: ENDIANESS Mask */
+
+#define SCB_AIRCR_PRIS_Pos                 14U                                            /*!< SCB AIRCR: PRIS Position */
+#define SCB_AIRCR_PRIS_Msk                 (1UL << SCB_AIRCR_PRIS_Pos)                    /*!< SCB AIRCR: PRIS Mask */
+
+#define SCB_AIRCR_BFHFNMINS_Pos            13U                                            /*!< SCB AIRCR: BFHFNMINS Position */
+#define SCB_AIRCR_BFHFNMINS_Msk            (1UL << SCB_AIRCR_BFHFNMINS_Pos)               /*!< SCB AIRCR: BFHFNMINS Mask */
+
+#define SCB_AIRCR_PRIGROUP_Pos              8U                                            /*!< SCB AIRCR: PRIGROUP Position */
+#define SCB_AIRCR_PRIGROUP_Msk             (7UL << SCB_AIRCR_PRIGROUP_Pos)                /*!< SCB AIRCR: PRIGROUP Mask */
+
+#define SCB_AIRCR_IESB_Pos                  5U                                            /*!< SCB AIRCR: Implicit ESB Enable Position */
+#define SCB_AIRCR_IESB_Msk                 (1UL << SCB_AIRCR_IESB_Pos)                    /*!< SCB AIRCR: Implicit ESB Enable Mask */
+
+#define SCB_AIRCR_DIT_Pos                   4U                                            /*!< SCB AIRCR: Data Independent Timing Position */
+#define SCB_AIRCR_DIT_Msk                  (1UL << SCB_AIRCR_DIT_Pos)                     /*!< SCB AIRCR: Data Independent Timing Mask */
+
+#define SCB_AIRCR_SYSRESETREQS_Pos          3U                                            /*!< SCB AIRCR: SYSRESETREQS Position */
+#define SCB_AIRCR_SYSRESETREQS_Msk         (1UL << SCB_AIRCR_SYSRESETREQS_Pos)            /*!< SCB AIRCR: SYSRESETREQS Mask */
+
+#define SCB_AIRCR_SYSRESETREQ_Pos           2U                                            /*!< SCB AIRCR: SYSRESETREQ Position */
+#define SCB_AIRCR_SYSRESETREQ_Msk          (1UL << SCB_AIRCR_SYSRESETREQ_Pos)             /*!< SCB AIRCR: SYSRESETREQ Mask */
+
+#define SCB_AIRCR_VECTCLRACTIVE_Pos         1U                                            /*!< SCB AIRCR: VECTCLRACTIVE Position */
+#define SCB_AIRCR_VECTCLRACTIVE_Msk        (1UL << SCB_AIRCR_VECTCLRACTIVE_Pos)           /*!< SCB AIRCR: VECTCLRACTIVE Mask */
+
+/** \brief SCB System Control Register Definitions */
+#define SCB_SCR_SEVONPEND_Pos               4U                                            /*!< SCB SCR: SEVONPEND Position */
+#define SCB_SCR_SEVONPEND_Msk              (1UL << SCB_SCR_SEVONPEND_Pos)                 /*!< SCB SCR: SEVONPEND Mask */
+
+#define SCB_SCR_SLEEPDEEPS_Pos              3U                                            /*!< SCB SCR: SLEEPDEEPS Position */
+#define SCB_SCR_SLEEPDEEPS_Msk             (1UL << SCB_SCR_SLEEPDEEPS_Pos)                /*!< SCB SCR: SLEEPDEEPS Mask */
+
+#define SCB_SCR_SLEEPDEEP_Pos               2U                                            /*!< SCB SCR: SLEEPDEEP Position */
+#define SCB_SCR_SLEEPDEEP_Msk              (1UL << SCB_SCR_SLEEPDEEP_Pos)                 /*!< SCB SCR: SLEEPDEEP Mask */
+
+#define SCB_SCR_SLEEPONEXIT_Pos             1U                                            /*!< SCB SCR: SLEEPONEXIT Position */
+#define SCB_SCR_SLEEPONEXIT_Msk            (1UL << SCB_SCR_SLEEPONEXIT_Pos)               /*!< SCB SCR: SLEEPONEXIT Mask */
+
+/** \brief SCB Configuration Control Register Definitions */
+#define SCB_CCR_TRD_Pos                    20U                                            /*!< SCB CCR: TRD Position */
+#define SCB_CCR_TRD_Msk                    (1UL << SCB_CCR_TRD_Pos)                       /*!< SCB CCR: TRD Mask */
+
+#define SCB_CCR_LOB_Pos                    19U                                            /*!< SCB CCR: LOB Position */
+#define SCB_CCR_LOB_Msk                    (1UL << SCB_CCR_LOB_Pos)                       /*!< SCB CCR: LOB Mask */
+
+#define SCB_CCR_BP_Pos                     18U                                            /*!< SCB CCR: BP Position */
+#define SCB_CCR_BP_Msk                     (1UL << SCB_CCR_BP_Pos)                        /*!< SCB CCR: BP Mask */
+
+#define SCB_CCR_IC_Pos                     17U                                            /*!< SCB CCR: IC Position */
+#define SCB_CCR_IC_Msk                     (1UL << SCB_CCR_IC_Pos)                        /*!< SCB CCR: IC Mask */
+
+#define SCB_CCR_DC_Pos                     16U                                            /*!< SCB CCR: DC Position */
+#define SCB_CCR_DC_Msk                     (1UL << SCB_CCR_DC_Pos)                        /*!< SCB CCR: DC Mask */
+
+#define SCB_CCR_STKOFHFNMIGN_Pos           10U                                            /*!< SCB CCR: STKOFHFNMIGN Position */
+#define SCB_CCR_STKOFHFNMIGN_Msk           (1UL << SCB_CCR_STKOFHFNMIGN_Pos)              /*!< SCB CCR: STKOFHFNMIGN Mask */
+
+#define SCB_CCR_BFHFNMIGN_Pos               8U                                            /*!< SCB CCR: BFHFNMIGN Position */
+#define SCB_CCR_BFHFNMIGN_Msk              (1UL << SCB_CCR_BFHFNMIGN_Pos)                 /*!< SCB CCR: BFHFNMIGN Mask */
+
+#define SCB_CCR_DIV_0_TRP_Pos               4U                                            /*!< SCB CCR: DIV_0_TRP Position */
+#define SCB_CCR_DIV_0_TRP_Msk              (1UL << SCB_CCR_DIV_0_TRP_Pos)                 /*!< SCB CCR: DIV_0_TRP Mask */
+
+#define SCB_CCR_UNALIGN_TRP_Pos             3U                                            /*!< SCB CCR: UNALIGN_TRP Position */
+#define SCB_CCR_UNALIGN_TRP_Msk            (1UL << SCB_CCR_UNALIGN_TRP_Pos)               /*!< SCB CCR: UNALIGN_TRP Mask */
+
+#define SCB_CCR_USERSETMPEND_Pos            1U                                            /*!< SCB CCR: USERSETMPEND Position */
+#define SCB_CCR_USERSETMPEND_Msk           (1UL << SCB_CCR_USERSETMPEND_Pos)              /*!< SCB CCR: USERSETMPEND Mask */
+
+/** \brief SCB System Handler Control and State Register Definitions */
+#define SCB_SHCSR_HARDFAULTPENDED_Pos      21U                                            /*!< SCB SHCSR: HARDFAULTPENDED Position */
+#define SCB_SHCSR_HARDFAULTPENDED_Msk      (1UL << SCB_SHCSR_HARDFAULTPENDED_Pos)         /*!< SCB SHCSR: HARDFAULTPENDED Mask */
+
+#define SCB_SHCSR_SECUREFAULTPENDED_Pos    20U                                            /*!< SCB SHCSR: SECUREFAULTPENDED Position */
+#define SCB_SHCSR_SECUREFAULTPENDED_Msk    (1UL << SCB_SHCSR_SECUREFAULTPENDED_Pos)       /*!< SCB SHCSR: SECUREFAULTPENDED Mask */
+
+#define SCB_SHCSR_SECUREFAULTENA_Pos       19U                                            /*!< SCB SHCSR: SECUREFAULTENA Position */
+#define SCB_SHCSR_SECUREFAULTENA_Msk       (1UL << SCB_SHCSR_SECUREFAULTENA_Pos)          /*!< SCB SHCSR: SECUREFAULTENA Mask */
+
+#define SCB_SHCSR_USGFAULTENA_Pos          18U                                            /*!< SCB SHCSR: USGFAULTENA Position */
+#define SCB_SHCSR_USGFAULTENA_Msk          (1UL << SCB_SHCSR_USGFAULTENA_Pos)             /*!< SCB SHCSR: USGFAULTENA Mask */
+
+#define SCB_SHCSR_BUSFAULTENA_Pos          17U                                            /*!< SCB SHCSR: BUSFAULTENA Position */
+#define SCB_SHCSR_BUSFAULTENA_Msk          (1UL << SCB_SHCSR_BUSFAULTENA_Pos)             /*!< SCB SHCSR: BUSFAULTENA Mask */
+
+#define SCB_SHCSR_MEMFAULTENA_Pos          16U                                            /*!< SCB SHCSR: MEMFAULTENA Position */
+#define SCB_SHCSR_MEMFAULTENA_Msk          (1UL << SCB_SHCSR_MEMFAULTENA_Pos)             /*!< SCB SHCSR: MEMFAULTENA Mask */
+
+#define SCB_SHCSR_SVCALLPENDED_Pos         15U                                            /*!< SCB SHCSR: SVCALLPENDED Position */
+#define SCB_SHCSR_SVCALLPENDED_Msk         (1UL << SCB_SHCSR_SVCALLPENDED_Pos)            /*!< SCB SHCSR: SVCALLPENDED Mask */
+
+#define SCB_SHCSR_BUSFAULTPENDED_Pos       14U                                            /*!< SCB SHCSR: BUSFAULTPENDED Position */
+#define SCB_SHCSR_BUSFAULTPENDED_Msk       (1UL << SCB_SHCSR_BUSFAULTPENDED_Pos)          /*!< SCB SHCSR: BUSFAULTPENDED Mask */
+
+#define SCB_SHCSR_MEMFAULTPENDED_Pos       13U                                            /*!< SCB SHCSR: MEMFAULTPENDED Position */
+#define SCB_SHCSR_MEMFAULTPENDED_Msk       (1UL << SCB_SHCSR_MEMFAULTPENDED_Pos)          /*!< SCB SHCSR: MEMFAULTPENDED Mask */
+
+#define SCB_SHCSR_USGFAULTPENDED_Pos       12U                                            /*!< SCB SHCSR: USGFAULTPENDED Position */
+#define SCB_SHCSR_USGFAULTPENDED_Msk       (1UL << SCB_SHCSR_USGFAULTPENDED_Pos)          /*!< SCB SHCSR: USGFAULTPENDED Mask */
+
+#define SCB_SHCSR_SYSTICKACT_Pos           11U                                            /*!< SCB SHCSR: SYSTICKACT Position */
+#define SCB_SHCSR_SYSTICKACT_Msk           (1UL << SCB_SHCSR_SYSTICKACT_Pos)              /*!< SCB SHCSR: SYSTICKACT Mask */
+
+#define SCB_SHCSR_PENDSVACT_Pos            10U                                            /*!< SCB SHCSR: PENDSVACT Position */
+#define SCB_SHCSR_PENDSVACT_Msk            (1UL << SCB_SHCSR_PENDSVACT_Pos)               /*!< SCB SHCSR: PENDSVACT Mask */
+
+#define SCB_SHCSR_MONITORACT_Pos            8U                                            /*!< SCB SHCSR: MONITORACT Position */
+#define SCB_SHCSR_MONITORACT_Msk           (1UL << SCB_SHCSR_MONITORACT_Pos)              /*!< SCB SHCSR: MONITORACT Mask */
+
+#define SCB_SHCSR_SVCALLACT_Pos             7U                                            /*!< SCB SHCSR: SVCALLACT Position */
+#define SCB_SHCSR_SVCALLACT_Msk            (1UL << SCB_SHCSR_SVCALLACT_Pos)               /*!< SCB SHCSR: SVCALLACT Mask */
+
+#define SCB_SHCSR_NMIACT_Pos                5U                                            /*!< SCB SHCSR: NMIACT Position */
+#define SCB_SHCSR_NMIACT_Msk               (1UL << SCB_SHCSR_NMIACT_Pos)                  /*!< SCB SHCSR: NMIACT Mask */
+
+#define SCB_SHCSR_SECUREFAULTACT_Pos        4U                                            /*!< SCB SHCSR: SECUREFAULTACT Position */
+#define SCB_SHCSR_SECUREFAULTACT_Msk       (1UL << SCB_SHCSR_SECUREFAULTACT_Pos)          /*!< SCB SHCSR: SECUREFAULTACT Mask */
+
+#define SCB_SHCSR_USGFAULTACT_Pos           3U                                            /*!< SCB SHCSR: USGFAULTACT Position */
+#define SCB_SHCSR_USGFAULTACT_Msk          (1UL << SCB_SHCSR_USGFAULTACT_Pos)             /*!< SCB SHCSR: USGFAULTACT Mask */
+
+#define SCB_SHCSR_HARDFAULTACT_Pos          2U                                            /*!< SCB SHCSR: HARDFAULTACT Position */
+#define SCB_SHCSR_HARDFAULTACT_Msk         (1UL << SCB_SHCSR_HARDFAULTACT_Pos)            /*!< SCB SHCSR: HARDFAULTACT Mask */
+
+#define SCB_SHCSR_BUSFAULTACT_Pos           1U                                            /*!< SCB SHCSR: BUSFAULTACT Position */
+#define SCB_SHCSR_BUSFAULTACT_Msk          (1UL << SCB_SHCSR_BUSFAULTACT_Pos)             /*!< SCB SHCSR: BUSFAULTACT Mask */
+
+#define SCB_SHCSR_MEMFAULTACT_Pos           0U                                            /*!< SCB SHCSR: MEMFAULTACT Position */
+#define SCB_SHCSR_MEMFAULTACT_Msk          (1UL /*<< SCB_SHCSR_MEMFAULTACT_Pos*/)         /*!< SCB SHCSR: MEMFAULTACT Mask */
+
+/** \brief SCB Configurable Fault Status Register Definitions */
+#define SCB_CFSR_USGFAULTSR_Pos            16U                                            /*!< SCB CFSR: Usage Fault Status Register Position */
+#define SCB_CFSR_USGFAULTSR_Msk            (0xFFFFUL << SCB_CFSR_USGFAULTSR_Pos)          /*!< SCB CFSR: Usage Fault Status Register Mask */
+
+#define SCB_CFSR_BUSFAULTSR_Pos             8U                                            /*!< SCB CFSR: Bus Fault Status Register Position */
+#define SCB_CFSR_BUSFAULTSR_Msk            (0xFFUL << SCB_CFSR_BUSFAULTSR_Pos)            /*!< SCB CFSR: Bus Fault Status Register Mask */
+
+#define SCB_CFSR_MEMFAULTSR_Pos             0U                                            /*!< SCB CFSR: Memory Manage Fault Status Register Position */
+#define SCB_CFSR_MEMFAULTSR_Msk            (0xFFUL /*<< SCB_CFSR_MEMFAULTSR_Pos*/)        /*!< SCB CFSR: Memory Manage Fault Status Register Mask */
+
+/** \brief SCB MemManage Fault Status Register Definitions (part of SCB Configurable Fault Status Register) */
+#define SCB_CFSR_MMARVALID_Pos             (SCB_CFSR_MEMFAULTSR_Pos + 7U)                 /*!< SCB CFSR (MMFSR): MMARVALID Position */
+#define SCB_CFSR_MMARVALID_Msk             (1UL << SCB_CFSR_MMARVALID_Pos)                /*!< SCB CFSR (MMFSR): MMARVALID Mask */
+
+#define SCB_CFSR_MLSPERR_Pos               (SCB_CFSR_MEMFAULTSR_Pos + 5U)                 /*!< SCB CFSR (MMFSR): MLSPERR Position */
+#define SCB_CFSR_MLSPERR_Msk               (1UL << SCB_CFSR_MLSPERR_Pos)                  /*!< SCB CFSR (MMFSR): MLSPERR Mask */
+
+#define SCB_CFSR_MSTKERR_Pos               (SCB_CFSR_MEMFAULTSR_Pos + 4U)                 /*!< SCB CFSR (MMFSR): MSTKERR Position */
+#define SCB_CFSR_MSTKERR_Msk               (1UL << SCB_CFSR_MSTKERR_Pos)                  /*!< SCB CFSR (MMFSR): MSTKERR Mask */
+
+#define SCB_CFSR_MUNSTKERR_Pos             (SCB_CFSR_MEMFAULTSR_Pos + 3U)                 /*!< SCB CFSR (MMFSR): MUNSTKERR Position */
+#define SCB_CFSR_MUNSTKERR_Msk             (1UL << SCB_CFSR_MUNSTKERR_Pos)                /*!< SCB CFSR (MMFSR): MUNSTKERR Mask */
+
+#define SCB_CFSR_DACCVIOL_Pos              (SCB_CFSR_MEMFAULTSR_Pos + 1U)                 /*!< SCB CFSR (MMFSR): DACCVIOL Position */
+#define SCB_CFSR_DACCVIOL_Msk              (1UL << SCB_CFSR_DACCVIOL_Pos)                 /*!< SCB CFSR (MMFSR): DACCVIOL Mask */
+
+#define SCB_CFSR_IACCVIOL_Pos              (SCB_CFSR_MEMFAULTSR_Pos + 0U)                 /*!< SCB CFSR (MMFSR): IACCVIOL Position */
+#define SCB_CFSR_IACCVIOL_Msk              (1UL /*<< SCB_CFSR_IACCVIOL_Pos*/)             /*!< SCB CFSR (MMFSR): IACCVIOL Mask */
+
+/** \brief SCB BusFault Status Register Definitions (part of SCB Configurable Fault Status Register) */
+#define SCB_CFSR_BFARVALID_Pos            (SCB_CFSR_BUSFAULTSR_Pos + 7U)                  /*!< SCB CFSR (BFSR): BFARVALID Position */
+#define SCB_CFSR_BFARVALID_Msk            (1UL << SCB_CFSR_BFARVALID_Pos)                 /*!< SCB CFSR (BFSR): BFARVALID Mask */
+
+#define SCB_CFSR_LSPERR_Pos               (SCB_CFSR_BUSFAULTSR_Pos + 5U)                  /*!< SCB CFSR (BFSR): LSPERR Position */
+#define SCB_CFSR_LSPERR_Msk               (1UL << SCB_CFSR_LSPERR_Pos)                    /*!< SCB CFSR (BFSR): LSPERR Mask */
+
+#define SCB_CFSR_STKERR_Pos               (SCB_CFSR_BUSFAULTSR_Pos + 4U)                  /*!< SCB CFSR (BFSR): STKERR Position */
+#define SCB_CFSR_STKERR_Msk               (1UL << SCB_CFSR_STKERR_Pos)                    /*!< SCB CFSR (BFSR): STKERR Mask */
+
+#define SCB_CFSR_UNSTKERR_Pos             (SCB_CFSR_BUSFAULTSR_Pos + 3U)                  /*!< SCB CFSR (BFSR): UNSTKERR Position */
+#define SCB_CFSR_UNSTKERR_Msk             (1UL << SCB_CFSR_UNSTKERR_Pos)                  /*!< SCB CFSR (BFSR): UNSTKERR Mask */
+
+#define SCB_CFSR_IMPRECISERR_Pos          (SCB_CFSR_BUSFAULTSR_Pos + 2U)                  /*!< SCB CFSR (BFSR): IMPRECISERR Position */
+#define SCB_CFSR_IMPRECISERR_Msk          (1UL << SCB_CFSR_IMPRECISERR_Pos)               /*!< SCB CFSR (BFSR): IMPRECISERR Mask */
+
+#define SCB_CFSR_PRECISERR_Pos            (SCB_CFSR_BUSFAULTSR_Pos + 1U)                  /*!< SCB CFSR (BFSR): PRECISERR Position */
+#define SCB_CFSR_PRECISERR_Msk            (1UL << SCB_CFSR_PRECISERR_Pos)                 /*!< SCB CFSR (BFSR): PRECISERR Mask */
+
+#define SCB_CFSR_IBUSERR_Pos              (SCB_CFSR_BUSFAULTSR_Pos + 0U)                  /*!< SCB CFSR (BFSR): IBUSERR Position */
+#define SCB_CFSR_IBUSERR_Msk              (1UL << SCB_CFSR_IBUSERR_Pos)                   /*!< SCB CFSR (BFSR): IBUSERR Mask */
+
+/** \brief SCB UsageFault Status Register Definitions (part of SCB Configurable Fault Status Register) */
+#define SCB_CFSR_DIVBYZERO_Pos            (SCB_CFSR_USGFAULTSR_Pos + 9U)                  /*!< SCB CFSR (UFSR): DIVBYZERO Position */
+#define SCB_CFSR_DIVBYZERO_Msk            (1UL << SCB_CFSR_DIVBYZERO_Pos)                 /*!< SCB CFSR (UFSR): DIVBYZERO Mask */
+
+#define SCB_CFSR_UNALIGNED_Pos            (SCB_CFSR_USGFAULTSR_Pos + 8U)                  /*!< SCB CFSR (UFSR): UNALIGNED Position */
+#define SCB_CFSR_UNALIGNED_Msk            (1UL << SCB_CFSR_UNALIGNED_Pos)                 /*!< SCB CFSR (UFSR): UNALIGNED Mask */
+
+#define SCB_CFSR_STKOF_Pos                (SCB_CFSR_USGFAULTSR_Pos + 4U)                  /*!< SCB CFSR (UFSR): STKOF Position */
+#define SCB_CFSR_STKOF_Msk                (1UL << SCB_CFSR_STKOF_Pos)                     /*!< SCB CFSR (UFSR): STKOF Mask */
+
+#define SCB_CFSR_NOCP_Pos                 (SCB_CFSR_USGFAULTSR_Pos + 3U)                  /*!< SCB CFSR (UFSR): NOCP Position */
+#define SCB_CFSR_NOCP_Msk                 (1UL << SCB_CFSR_NOCP_Pos)                      /*!< SCB CFSR (UFSR): NOCP Mask */
+
+#define SCB_CFSR_INVPC_Pos                (SCB_CFSR_USGFAULTSR_Pos + 2U)                  /*!< SCB CFSR (UFSR): INVPC Position */
+#define SCB_CFSR_INVPC_Msk                (1UL << SCB_CFSR_INVPC_Pos)                     /*!< SCB CFSR (UFSR): INVPC Mask */
+
+#define SCB_CFSR_INVSTATE_Pos             (SCB_CFSR_USGFAULTSR_Pos + 1U)                  /*!< SCB CFSR (UFSR): INVSTATE Position */
+#define SCB_CFSR_INVSTATE_Msk             (1UL << SCB_CFSR_INVSTATE_Pos)                  /*!< SCB CFSR (UFSR): INVSTATE Mask */
+
+#define SCB_CFSR_UNDEFINSTR_Pos           (SCB_CFSR_USGFAULTSR_Pos + 0U)                  /*!< SCB CFSR (UFSR): UNDEFINSTR Position */
+#define SCB_CFSR_UNDEFINSTR_Msk           (1UL << SCB_CFSR_UNDEFINSTR_Pos)                /*!< SCB CFSR (UFSR): UNDEFINSTR Mask */
+
+/** \brief SCB Hard Fault Status Register Definitions */
+#define SCB_HFSR_DEBUGEVT_Pos              31U                                            /*!< SCB HFSR: DEBUGEVT Position */
+#define SCB_HFSR_DEBUGEVT_Msk              (1UL << SCB_HFSR_DEBUGEVT_Pos)                 /*!< SCB HFSR: DEBUGEVT Mask */
+
+#define SCB_HFSR_FORCED_Pos                30U                                            /*!< SCB HFSR: FORCED Position */
+#define SCB_HFSR_FORCED_Msk                (1UL << SCB_HFSR_FORCED_Pos)                   /*!< SCB HFSR: FORCED Mask */
+
+#define SCB_HFSR_VECTTBL_Pos                1U                                            /*!< SCB HFSR: VECTTBL Position */
+#define SCB_HFSR_VECTTBL_Msk               (1UL << SCB_HFSR_VECTTBL_Pos)                  /*!< SCB HFSR: VECTTBL Mask */
+
+/** \brief SCB Debug Fault Status Register Definitions */
+#define SCB_DFSR_PMU_Pos                    5U                                            /*!< SCB DFSR: PMU Position */
+#define SCB_DFSR_PMU_Msk                   (1UL << SCB_DFSR_PMU_Pos)                      /*!< SCB DFSR: PMU Mask */
+
+#define SCB_DFSR_EXTERNAL_Pos               4U                                            /*!< SCB DFSR: EXTERNAL Position */
+#define SCB_DFSR_EXTERNAL_Msk              (1UL << SCB_DFSR_EXTERNAL_Pos)                 /*!< SCB DFSR: EXTERNAL Mask */
+
+#define SCB_DFSR_VCATCH_Pos                 3U                                            /*!< SCB DFSR: VCATCH Position */
+#define SCB_DFSR_VCATCH_Msk                (1UL << SCB_DFSR_VCATCH_Pos)                   /*!< SCB DFSR: VCATCH Mask */
+
+#define SCB_DFSR_DWTTRAP_Pos                2U                                            /*!< SCB DFSR: DWTTRAP Position */
+#define SCB_DFSR_DWTTRAP_Msk               (1UL << SCB_DFSR_DWTTRAP_Pos)                  /*!< SCB DFSR: DWTTRAP Mask */
+
+#define SCB_DFSR_BKPT_Pos                   1U                                            /*!< SCB DFSR: BKPT Position */
+#define SCB_DFSR_BKPT_Msk                  (1UL << SCB_DFSR_BKPT_Pos)                     /*!< SCB DFSR: BKPT Mask */
+
+#define SCB_DFSR_HALTED_Pos                 0U                                            /*!< SCB DFSR: HALTED Position */
+#define SCB_DFSR_HALTED_Msk                (1UL /*<< SCB_DFSR_HALTED_Pos*/)               /*!< SCB DFSR: HALTED Mask */
+
+/** \brief SCB Non-Secure Access Control Register Definitions */
+#define SCB_NSACR_CP11_Pos                 11U                                            /*!< SCB NSACR: CP11 Position */
+#define SCB_NSACR_CP11_Msk                 (1UL << SCB_NSACR_CP11_Pos)                    /*!< SCB NSACR: CP11 Mask */
+
+#define SCB_NSACR_CP10_Pos                 10U                                            /*!< SCB NSACR: CP10 Position */
+#define SCB_NSACR_CP10_Msk                 (1UL << SCB_NSACR_CP10_Pos)                    /*!< SCB NSACR: CP10 Mask */
+
+#define SCB_NSACR_CP7_Pos                   7U                                            /*!< SCB NSACR: CP7 Position */
+#define SCB_NSACR_CP7_Msk                  (1UL << SCB_NSACR_CP7_Pos)                     /*!< SCB NSACR: CP7 Mask */
+
+#define SCB_NSACR_CP6_Pos                   6U                                            /*!< SCB NSACR: CP6 Position */
+#define SCB_NSACR_CP6_Msk                  (1UL << SCB_NSACR_CP6_Pos)                     /*!< SCB NSACR: CP6 Mask */
+
+#define SCB_NSACR_CP5_Pos                   5U                                            /*!< SCB NSACR: CP5 Position */
+#define SCB_NSACR_CP5_Msk                  (1UL << SCB_NSACR_CP5_Pos)                     /*!< SCB NSACR: CP5 Mask */
+
+#define SCB_NSACR_CP4_Pos                   4U                                            /*!< SCB NSACR: CP4 Position */
+#define SCB_NSACR_CP4_Msk                  (1UL << SCB_NSACR_CP4_Pos)                     /*!< SCB NSACR: CP4 Mask */
+
+#define SCB_NSACR_CP3_Pos                   3U                                            /*!< SCB NSACR: CP3 Position */
+#define SCB_NSACR_CP3_Msk                  (1UL << SCB_NSACR_CP3_Pos)                     /*!< SCB NSACR: CP3 Mask */
+
+#define SCB_NSACR_CP2_Pos                   2U                                            /*!< SCB NSACR: CP2 Position */
+#define SCB_NSACR_CP2_Msk                  (1UL << SCB_NSACR_CP2_Pos)                     /*!< SCB NSACR: CP2 Mask */
+
+#define SCB_NSACR_CP1_Pos                   1U                                            /*!< SCB NSACR: CP1 Position */
+#define SCB_NSACR_CP1_Msk                  (1UL << SCB_NSACR_CP1_Pos)                     /*!< SCB NSACR: CP1 Mask */
+
+#define SCB_NSACR_CP0_Pos                   0U                                            /*!< SCB NSACR: CP0 Position */
+#define SCB_NSACR_CP0_Msk                  (1UL /*<< SCB_NSACR_CP0_Pos*/)                 /*!< SCB NSACR: CP0 Mask */
+
+/** \brief SCB Debug Feature Register 0 Definitions */
+#define SCB_ID_DFR_UDE_Pos                 28U                                            /*!< SCB ID_DFR: UDE Position */
+#define SCB_ID_DFR_UDE_Msk                 (0xFUL << SCB_ID_DFR_UDE_Pos)                  /*!< SCB ID_DFR: UDE Mask */
+
+#define SCB_ID_DFR_MProfDbg_Pos            20U                                            /*!< SCB ID_DFR: MProfDbg Position */
+#define SCB_ID_DFR_MProfDbg_Msk            (0xFUL << SCB_ID_DFR_MProfDbg_Pos)             /*!< SCB ID_DFR: MProfDbg Mask */
+
+/** \brief SCB Cache Level ID Register Definitions */
+#define SCB_CLIDR_LOUU_Pos                 27U                                            /*!< SCB CLIDR: LoUU Position */
+#define SCB_CLIDR_LOUU_Msk                 (7UL << SCB_CLIDR_LOUU_Pos)                    /*!< SCB CLIDR: LoUU Mask */
+
+#define SCB_CLIDR_LOC_Pos                  24U                                            /*!< SCB CLIDR: LoC Position */
+#define SCB_CLIDR_LOC_Msk                  (7UL << SCB_CLIDR_LOC_Pos)                     /*!< SCB CLIDR: LoC Mask */
+
+#define SCB_CLIDR_CTYPE1_Pos               0U
+#define SCB_CLIDR_CTYPE1_Msk               (7UL << SCB_CLIDR_CTYPE1_Pos)
+
+/** \brief SCB Cache Type Register Definitions */
+#define SCB_CTR_FORMAT_Pos                 29U                                            /*!< SCB CTR: Format Position */
+#define SCB_CTR_FORMAT_Msk                 (7UL << SCB_CTR_FORMAT_Pos)                    /*!< SCB CTR: Format Mask */
+
+#define SCB_CTR_CWG_Pos                    24U                                            /*!< SCB CTR: CWG Position */
+#define SCB_CTR_CWG_Msk                    (0xFUL << SCB_CTR_CWG_Pos)                     /*!< SCB CTR: CWG Mask */
+
+#define SCB_CTR_ERG_Pos                    20U                                            /*!< SCB CTR: ERG Position */
+#define SCB_CTR_ERG_Msk                    (0xFUL << SCB_CTR_ERG_Pos)                     /*!< SCB CTR: ERG Mask */
+
+#define SCB_CTR_DMINLINE_Pos               16U                                            /*!< SCB CTR: DminLine Position */
+#define SCB_CTR_DMINLINE_Msk               (0xFUL << SCB_CTR_DMINLINE_Pos)                /*!< SCB CTR: DminLine Mask */
+
+#define SCB_CTR_IMINLINE_Pos                0U                                            /*!< SCB CTR: ImInLine Position */
+#define SCB_CTR_IMINLINE_Msk               (0xFUL /*<< SCB_CTR_IMINLINE_Pos*/)            /*!< SCB CTR: ImInLine Mask */
+
+/** \brief SCB Cache Size ID Register Definitions */
+#define SCB_CCSIDR_WT_Pos                  31U                                            /*!< SCB CCSIDR: WT Position */
+#define SCB_CCSIDR_WT_Msk                  (1UL << SCB_CCSIDR_WT_Pos)                     /*!< SCB CCSIDR: WT Mask */
+
+#define SCB_CCSIDR_WB_Pos                  30U                                            /*!< SCB CCSIDR: WB Position */
+#define SCB_CCSIDR_WB_Msk                  (1UL << SCB_CCSIDR_WB_Pos)                     /*!< SCB CCSIDR: WB Mask */
+
+#define SCB_CCSIDR_RA_Pos                  29U                                            /*!< SCB CCSIDR: RA Position */
+#define SCB_CCSIDR_RA_Msk                  (1UL << SCB_CCSIDR_RA_Pos)                     /*!< SCB CCSIDR: RA Mask */
+
+#define SCB_CCSIDR_WA_Pos                  28U                                            /*!< SCB CCSIDR: WA Position */
+#define SCB_CCSIDR_WA_Msk                  (1UL << SCB_CCSIDR_WA_Pos)                     /*!< SCB CCSIDR: WA Mask */
+
+#define SCB_CCSIDR_NUMSETS_Pos             13U                                            /*!< SCB CCSIDR: NumSets Position */
+#define SCB_CCSIDR_NUMSETS_Msk             (0x7FFFUL << SCB_CCSIDR_NUMSETS_Pos)           /*!< SCB CCSIDR: NumSets Mask */
+
+#define SCB_CCSIDR_ASSOCIATIVITY_Pos        3U                                            /*!< SCB CCSIDR: Associativity Position */
+#define SCB_CCSIDR_ASSOCIATIVITY_Msk       (0x3FFUL << SCB_CCSIDR_ASSOCIATIVITY_Pos)      /*!< SCB CCSIDR: Associativity Mask */
+
+#define SCB_CCSIDR_LINESIZE_Pos             0U                                            /*!< SCB CCSIDR: LineSize Position */
+#define SCB_CCSIDR_LINESIZE_Msk            (7UL /*<< SCB_CCSIDR_LINESIZE_Pos*/)           /*!< SCB CCSIDR: LineSize Mask */
+
+/** \brief SCB Cache Size Selection Register Definitions */
+#define SCB_CSSELR_LEVEL_Pos                1U                                            /*!< SCB CSSELR: Level Position */
+#define SCB_CSSELR_LEVEL_Msk               (7UL << SCB_CSSELR_LEVEL_Pos)                  /*!< SCB CSSELR: Level Mask */
+
+#define SCB_CSSELR_IND_Pos                  0U                                            /*!< SCB CSSELR: InD Position */
+#define SCB_CSSELR_IND_Msk                 (1UL /*<< SCB_CSSELR_IND_Pos*/)                /*!< SCB CSSELR: InD Mask */
+
+/** \brief SCB Software Triggered Interrupt Register Definitions */
+#define SCB_STIR_INTID_Pos                  0U                                            /*!< SCB STIR: INTID Position */
+#define SCB_STIR_INTID_Msk                 (0x1FFUL /*<< SCB_STIR_INTID_Pos*/)            /*!< SCB STIR: INTID Mask */
+
+/** \brief SCB RAS Fault Status Register Definitions */
+#define SCB_RFSR_V_Pos                     31U                                            /*!< SCB RFSR: V Position */
+#define SCB_RFSR_V_Msk                     (1UL << SCB_RFSR_V_Pos)                        /*!< SCB RFSR: V Mask */
+
+#define SCB_RFSR_IS_Pos                    16U                                            /*!< SCB RFSR: IS Position */
+#define SCB_RFSR_IS_Msk                    (0x7FFFUL << SCB_RFSR_IS_Pos)                  /*!< SCB RFSR: IS Mask */
+
+#define SCB_RFSR_UET_Pos                    0U                                            /*!< SCB RFSR: UET Position */
+#define SCB_RFSR_UET_Msk                   (3UL /*<< SCB_RFSR_UET_Pos*/)                  /*!< SCB RFSR: UET Mask */
+
+/** \brief SCB D-Cache Invalidate by Set-way Register Definitions */
+#define SCB_DCISW_WAY_Pos                  30U                                            /*!< SCB DCISW: Way Position */
+#define SCB_DCISW_WAY_Msk                  (3UL << SCB_DCISW_WAY_Pos)                     /*!< SCB DCISW: Way Mask */
+
+#define SCB_DCISW_SET_Pos                   5U                                            /*!< SCB DCISW: Set Position */
+#define SCB_DCISW_SET_Msk                  (0x1FFUL << SCB_DCISW_SET_Pos)                 /*!< SCB DCISW: Set Mask */
+
+/** \brief SCB D-Cache Clean by Set-way Register Definitions */
+#define SCB_DCCSW_WAY_Pos                  30U                                            /*!< SCB DCCSW: Way Position */
+#define SCB_DCCSW_WAY_Msk                  (3UL << SCB_DCCSW_WAY_Pos)                     /*!< SCB DCCSW: Way Mask */
+
+#define SCB_DCCSW_SET_Pos                   5U                                            /*!< SCB DCCSW: Set Position */
+#define SCB_DCCSW_SET_Msk                  (0x1FFUL << SCB_DCCSW_SET_Pos)                 /*!< SCB DCCSW: Set Mask */
+
+/** \brief SCB D-Cache Clean and Invalidate by Set-way Register Definitions */
+#define SCB_DCCISW_WAY_Pos                 30U                                            /*!< SCB DCCISW: Way Position */
+#define SCB_DCCISW_WAY_Msk                 (3UL << SCB_DCCISW_WAY_Pos)                    /*!< SCB DCCISW: Way Mask */
+
+#define SCB_DCCISW_SET_Pos                  5U                                            /*!< SCB DCCISW: Set Position */
+#define SCB_DCCISW_SET_Msk                 (0x1FFUL << SCB_DCCISW_SET_Pos)                /*!< SCB DCCISW: Set Mask */
+
+
+/** \brief SCB U-Cache Invalidate by Set-way Register Definitions */
+#define SCB_DCISW_UC_WAY_Pos               31U                                            /*!< SCB DCISW: Way Position */
+#define SCB_DCISW_UC_WAY_Msk               (1UL << SCB_DCISW_UC_WAY_Pos)                  /*!< SCB DCISW: Way Mask */
+
+#define SCB_DCISW_UC_SET_Pos               5U                                             /*!< SCB DCISW: Set Position */
+#define SCB_DCISW_UC_SET_Msk               (0x3FFUL << SCB_DCISW_UC_SET_Pos)              /*!< SCB DCISW: Set Mask */
+
+/** \brief SCB U-Cache Clean by Set-way Register Definitions */
+#define SCB_DCCSW_UC_WAY_Pos               31U                                            /*!< SCB DCCSW: Way Position */
+#define SCB_DCCSW_UC_WAY_Msk               (1UL << SCB_DCCSW_UC_WAY_Pos)                  /*!< SCB DCCSW: Way Mask */
+
+#define SCB_DCCSW_UC_SET_Pos               5U                                             /*!< SCB DCCSW: Set Position */
+#define SCB_DCCSW_UC_SET_Msk               (0x3FFUL << SCB_DCCSW_UC_SET_Pos)              /*!< SCB DCCSW: Set Mask */
+
+/** \brief SCB U-Cache Clean and Invalidate by Set-way Register Definitions */
+#define SCB_DCCISW_UC_WAY_Pos              31U                                            /*!< SCB DCCISW: Way Position */
+#define SCB_DCCISW_UC_WAY_Msk              (1UL << SCB_DCCISW_UC_WAY_Pos)                 /*!< SCB DCCISW: Way Mask */
+
+#define SCB_DCCISW_UC_SET_Pos              5U                                             /*!< SCB DCCISW: Set Position */
+#define SCB_DCCISW_UC_SET_Msk              (0x3FFUL << SCB_DCCISW_UC_SET_Pos)             /*!< SCB DCCISW: Set Mask */
+
+
+/*@} end of group CMSIS_SCB */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_ICB Implementation Control Block register (ICB)
+  \brief    Type definitions for the Implementation Control Block Register
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Implementation Control Block (ICB).
+ */
+typedef struct
+{
+        uint32_t RESERVED0[1U];
+  __IM  uint32_t ICTR;                   /*!< Offset: 0x004 (R/ )  Interrupt Controller Type Register */
+  __IOM uint32_t ACTLR;                  /*!< Offset: 0x008 (R/W)  Auxiliary Control Register */
+  __IOM uint32_t CPPWR;                  /*!< Offset: 0x00C (R/W)  Coprocessor Power Control  Register */
+} ICB_Type;
+
+/** \brief ICB Auxiliary Control Register Definitions */
+#define ICB_ACTLR_DISCRITAXIRUW_Pos     27U                                               /*!< ACTLR: DISCRITAXIRUW Position */
+#define ICB_ACTLR_DISCRITAXIRUW_Msk     (1UL << ICB_ACTLR_DISCRITAXIRUW_Pos)              /*!< ACTLR: DISCRITAXIRUW Mask */
+
+#define ICB_ACTLR_DISDI_Pos             16U                                               /*!< ACTLR: DISDI Position */
+#define ICB_ACTLR_DISDI_Msk             (3UL << ICB_ACTLR_DISDI_Pos)                      /*!< ACTLR: DISDI Mask */
+
+#define ICB_ACTLR_DISCRITAXIRUR_Pos     15U                                               /*!< ACTLR: DISCRITAXIRUR Position */
+#define ICB_ACTLR_DISCRITAXIRUR_Msk     (1UL << ICB_ACTLR_DISCRITAXIRUR_Pos)              /*!< ACTLR: DISCRITAXIRUR Mask */
+
+#define ICB_ACTLR_EVENTBUSEN_Pos        14U                                               /*!< ACTLR: EVENTBUSEN Position */
+#define ICB_ACTLR_EVENTBUSEN_Msk        (1UL << ICB_ACTLR_EVENTBUSEN_Pos)                 /*!< ACTLR: EVENTBUSEN Mask */
+
+#define ICB_ACTLR_EVENTBUSEN_S_Pos      13U                                               /*!< ACTLR: EVENTBUSEN_S Position */
+#define ICB_ACTLR_EVENTBUSEN_S_Msk      (1UL << ICB_ACTLR_EVENTBUSEN_S_Pos)               /*!< ACTLR: EVENTBUSEN_S Mask */
+
+#define ICB_ACTLR_DISITMATBFLUSH_Pos    12U                                               /*!< ACTLR: DISITMATBFLUSH Position */
+#define ICB_ACTLR_DISITMATBFLUSH_Msk    (1UL << ICB_ACTLR_DISITMATBFLUSH_Pos)             /*!< ACTLR: DISITMATBFLUSH Mask */
+
+#define ICB_ACTLR_DISNWAMODE_Pos        11U                                               /*!< ACTLR: DISNWAMODE Position */
+#define ICB_ACTLR_DISNWAMODE_Msk        (1UL << ICB_ACTLR_DISNWAMODE_Pos)                 /*!< ACTLR: DISNWAMODE Mask */
+
+#define ICB_ACTLR_FPEXCODIS_Pos         10U                                               /*!< ACTLR: FPEXCODIS Position */
+#define ICB_ACTLR_FPEXCODIS_Msk         (1UL << ICB_ACTLR_FPEXCODIS_Pos)                  /*!< ACTLR: FPEXCODIS Mask */
+
+#define ICB_ACTLR_DISOLAP_Pos            7U                                               /*!< ACTLR: DISOLAP Position */
+#define ICB_ACTLR_DISOLAP_Msk           (1UL << ICB_ACTLR_DISOLAP_Pos)                    /*!< ACTLR: DISOLAP Mask */
+
+#define ICB_ACTLR_DISOLAPS_Pos           6U                                               /*!< ACTLR: DISOLAPS Position */
+#define ICB_ACTLR_DISOLAPS_Msk          (1UL << ICB_ACTLR_DISOLAPS_Pos)                   /*!< ACTLR: DISOLAPS Mask */
+
+#define ICB_ACTLR_DISLOBR_Pos            5U                                               /*!< ACTLR: DISLOBR Position */
+#define ICB_ACTLR_DISLOBR_Msk           (1UL << ICB_ACTLR_DISLOBR_Pos)                    /*!< ACTLR: DISLOBR Mask */
+
+#define ICB_ACTLR_DISLO_Pos              4U                                               /*!< ACTLR: DISLO Position */
+#define ICB_ACTLR_DISLO_Msk             (1UL << ICB_ACTLR_DISLO_Pos)                      /*!< ACTLR: DISLO Mask */
+
+#define ICB_ACTLR_DISLOLEP_Pos           3U                                               /*!< ACTLR: DISLOLEP Position */
+#define ICB_ACTLR_DISLOLEP_Msk          (1UL << ICB_ACTLR_DISLOLEP_Pos)                   /*!< ACTLR: DISLOLEP Mask */
+
+#define ICB_ACTLR_DISFOLD_Pos            2U                                               /*!< ACTLR: DISFOLD Position */
+#define ICB_ACTLR_DISFOLD_Msk           (1UL << ICB_ACTLR_DISFOLD_Pos)                    /*!< ACTLR: DISFOLD Mask */
+
+/** \brief ICB Interrupt Controller Type Register Definitions */
+#define ICB_ICTR_INTLINESNUM_Pos         0U                                               /*!< ICTR: INTLINESNUM Position */
+#define ICB_ICTR_INTLINESNUM_Msk        (0xFUL /*<< ICB_ICTR_INTLINESNUM_Pos*/)           /*!< ICTR: INTLINESNUM Mask */
+
+/*@} end of group CMSIS_ICB */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SysTick     System Tick Timer (SysTick)
+  \brief    Type definitions for the System Timer Registers.
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Timer (SysTick).
+ */
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  SysTick Control and Status Register */
+  __IOM uint32_t LOAD;                   /*!< Offset: 0x004 (R/W)  SysTick Reload Value Register */
+  __IOM uint32_t VAL;                    /*!< Offset: 0x008 (R/W)  SysTick Current Value Register */
+  __IM  uint32_t CALIB;                  /*!< Offset: 0x00C (R/ )  SysTick Calibration Register */
+} SysTick_Type;
+
+/** \brief SysTick Control / Status Register Definitions */
+#define SysTick_CTRL_COUNTFLAG_Pos         16U                                            /*!< SysTick CTRL: COUNTFLAG Position */
+#define SysTick_CTRL_COUNTFLAG_Msk         (1UL << SysTick_CTRL_COUNTFLAG_Pos)            /*!< SysTick CTRL: COUNTFLAG Mask */
+
+#define SysTick_CTRL_CLKSOURCE_Pos          2U                                            /*!< SysTick CTRL: CLKSOURCE Position */
+#define SysTick_CTRL_CLKSOURCE_Msk         (1UL << SysTick_CTRL_CLKSOURCE_Pos)            /*!< SysTick CTRL: CLKSOURCE Mask */
+
+#define SysTick_CTRL_TICKINT_Pos            1U                                            /*!< SysTick CTRL: TICKINT Position */
+#define SysTick_CTRL_TICKINT_Msk           (1UL << SysTick_CTRL_TICKINT_Pos)              /*!< SysTick CTRL: TICKINT Mask */
+
+#define SysTick_CTRL_ENABLE_Pos             0U                                            /*!< SysTick CTRL: ENABLE Position */
+#define SysTick_CTRL_ENABLE_Msk            (1UL /*<< SysTick_CTRL_ENABLE_Pos*/)           /*!< SysTick CTRL: ENABLE Mask */
+
+/** \brief SysTick Reload Register Definitions */
+#define SysTick_LOAD_RELOAD_Pos             0U                                            /*!< SysTick LOAD: RELOAD Position */
+#define SysTick_LOAD_RELOAD_Msk            (0xFFFFFFUL /*<< SysTick_LOAD_RELOAD_Pos*/)    /*!< SysTick LOAD: RELOAD Mask */
+
+/** \brief SysTick Current Register Definitions */
+#define SysTick_VAL_CURRENT_Pos             0U                                            /*!< SysTick VAL: CURRENT Position */
+#define SysTick_VAL_CURRENT_Msk            (0xFFFFFFUL /*<< SysTick_VAL_CURRENT_Pos*/)    /*!< SysTick VAL: CURRENT Mask */
+
+/** \brief SysTick Calibration Register Definitions */
+#define SysTick_CALIB_NOREF_Pos            31U                                            /*!< SysTick CALIB: NOREF Position */
+#define SysTick_CALIB_NOREF_Msk            (1UL << SysTick_CALIB_NOREF_Pos)               /*!< SysTick CALIB: NOREF Mask */
+
+#define SysTick_CALIB_SKEW_Pos             30U                                            /*!< SysTick CALIB: SKEW Position */
+#define SysTick_CALIB_SKEW_Msk             (1UL << SysTick_CALIB_SKEW_Pos)                /*!< SysTick CALIB: SKEW Mask */
+
+#define SysTick_CALIB_TENMS_Pos             0U                                            /*!< SysTick CALIB: TENMS Position */
+#define SysTick_CALIB_TENMS_Msk            (0xFFFFFFUL /*<< SysTick_CALIB_TENMS_Pos*/)    /*!< SysTick CALIB: TENMS Mask */
+
+/*@} end of group CMSIS_SysTick */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_ITM     Instrumentation Trace Macrocell (ITM)
+  \brief    Type definitions for the Instrumentation Trace Macrocell (ITM)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Instrumentation Trace Macrocell Register (ITM).
+ */
+typedef struct
+{
+  __OM  union
+  {
+    __OM  uint8_t    u8;                 /*!< Offset: 0x000 ( /W)  Stimulus Port 8-bit */
+    __OM  uint16_t   u16;                /*!< Offset: 0x000 ( /W)  Stimulus Port 16-bit */
+    __OM  uint32_t   u32;                /*!< Offset: 0x000 ( /W)  Stimulus Port 32-bit */
+  }  PORT [32U];                         /*!< Offset: 0x000 ( /W)  Stimulus Port Registers */
+        uint32_t RESERVED0[864U];
+  __IOM uint32_t TER;                    /*!< Offset: 0xE00 (R/W)  Trace Enable Register */
+        uint32_t RESERVED1[15U];
+  __IOM uint32_t TPR;                    /*!< Offset: 0xE40 (R/W)  Trace Privilege Register */
+        uint32_t RESERVED2[15U];
+  __IOM uint32_t TCR;                    /*!< Offset: 0xE80 (R/W)  Trace Control Register */
+        uint32_t RESERVED3[27U];
+  __IM  uint32_t ITREAD;                 /*!< Offset: 0xEF0 (R/ )  Integration Read Register */
+        uint32_t RESERVED4[1U];
+  __OM  uint32_t ITWRITE;                /*!< Offset: 0xEF8 ( /W)  Integration Write Register */
+        uint32_t RESERVED5[1U];
+  __IOM uint32_t ITCTRL;                 /*!< Offset: 0xF00 (R/W)  Integration Mode Control Register */
+        uint32_t RESERVED6[46U];
+  __IM  uint32_t DEVARCH;                /*!< Offset: 0xFBC (R/ )  Device Architecture Register */
+        uint32_t RESERVED7[3U];
+  __IM  uint32_t DEVTYPE;                /*!< Offset: 0xFCC (R/ )  Device Type Register */
+} ITM_Type;
+
+/** \brief ITM Stimulus Port Register Definitions */
+#define ITM_STIM_DISABLED_Pos               1U                                            /*!< ITM STIM: DISABLED Position */
+#define ITM_STIM_DISABLED_Msk              (1UL << ITM_STIM_DISABLED_Pos)                 /*!< ITM STIM: DISABLED Mask */
+
+#define ITM_STIM_FIFOREADY_Pos              0U                                            /*!< ITM STIM: FIFOREADY Position */
+#define ITM_STIM_FIFOREADY_Msk             (1UL /*<< ITM_STIM_FIFOREADY_Pos*/)            /*!< ITM STIM: FIFOREADY Mask */
+
+/** \brief ITM Trace Privilege Register Definitions */
+#define ITM_TPR_PRIVMASK_Pos                0U                                            /*!< ITM TPR: PRIVMASK Position */
+#define ITM_TPR_PRIVMASK_Msk               (0xFUL /*<< ITM_TPR_PRIVMASK_Pos*/)            /*!< ITM TPR: PRIVMASK Mask */
+
+/** \brief ITM Trace Control Register Definitions */
+#define ITM_TCR_BUSY_Pos                   23U                                            /*!< ITM TCR: BUSY Position */
+#define ITM_TCR_BUSY_Msk                   (1UL << ITM_TCR_BUSY_Pos)                      /*!< ITM TCR: BUSY Mask */
+
+#define ITM_TCR_TRACEBUSID_Pos             16U                                            /*!< ITM TCR: ATBID Position */
+#define ITM_TCR_TRACEBUSID_Msk             (0x7FUL << ITM_TCR_TRACEBUSID_Pos)             /*!< ITM TCR: ATBID Mask */
+
+#define ITM_TCR_GTSFREQ_Pos                10U                                            /*!< ITM TCR: Global timestamp frequency Position */
+#define ITM_TCR_GTSFREQ_Msk                (3UL << ITM_TCR_GTSFREQ_Pos)                   /*!< ITM TCR: Global timestamp frequency Mask */
+
+#define ITM_TCR_TSPRESCALE_Pos              8U                                            /*!< ITM TCR: TSPRESCALE Position */
+#define ITM_TCR_TSPRESCALE_Msk             (3UL << ITM_TCR_TSPRESCALE_Pos)                /*!< ITM TCR: TSPRESCALE Mask */
+
+#define ITM_TCR_STALLENA_Pos                5U                                            /*!< ITM TCR: STALLENA Position */
+#define ITM_TCR_STALLENA_Msk               (1UL << ITM_TCR_STALLENA_Pos)                  /*!< ITM TCR: STALLENA Mask */
+
+#define ITM_TCR_SWOENA_Pos                  4U                                            /*!< ITM TCR: SWOENA Position */
+#define ITM_TCR_SWOENA_Msk                 (1UL << ITM_TCR_SWOENA_Pos)                    /*!< ITM TCR: SWOENA Mask */
+
+#define ITM_TCR_DWTENA_Pos                  3U                                            /*!< ITM TCR: DWTENA Position */
+#define ITM_TCR_DWTENA_Msk                 (1UL << ITM_TCR_DWTENA_Pos)                    /*!< ITM TCR: DWTENA Mask */
+
+#define ITM_TCR_SYNCENA_Pos                 2U                                            /*!< ITM TCR: SYNCENA Position */
+#define ITM_TCR_SYNCENA_Msk                (1UL << ITM_TCR_SYNCENA_Pos)                   /*!< ITM TCR: SYNCENA Mask */
+
+#define ITM_TCR_TSENA_Pos                   1U                                            /*!< ITM TCR: TSENA Position */
+#define ITM_TCR_TSENA_Msk                  (1UL << ITM_TCR_TSENA_Pos)                     /*!< ITM TCR: TSENA Mask */
+
+#define ITM_TCR_ITMENA_Pos                  0U                                            /*!< ITM TCR: ITM Enable bit Position */
+#define ITM_TCR_ITMENA_Msk                 (1UL /*<< ITM_TCR_ITMENA_Pos*/)                /*!< ITM TCR: ITM Enable bit Mask */
+
+/** \brief ITM Integration Read Register Definitions */
+#define ITM_ITREAD_AFVALID_Pos              1U                                            /*!< ITM ITREAD: AFVALID Position */
+#define ITM_ITREAD_AFVALID_Msk             (1UL << ITM_ITREAD_AFVALID_Pos)                /*!< ITM ITREAD: AFVALID Mask */
+
+#define ITM_ITREAD_ATREADY_Pos              0U                                            /*!< ITM ITREAD: ATREADY Position */
+#define ITM_ITREAD_ATREADY_Msk             (1UL /*<< ITM_ITREAD_ATREADY_Pos*/)            /*!< ITM ITREAD: ATREADY Mask */
+
+/** \brief ITM Integration Write Register Definitions */
+#define ITM_ITWRITE_AFVALID_Pos             1U                                            /*!< ITM ITWRITE: AFVALID Position */
+#define ITM_ITWRITE_AFVALID_Msk            (1UL << ITM_ITWRITE_AFVALID_Pos)               /*!< ITM ITWRITE: AFVALID Mask */
+
+#define ITM_ITWRITE_ATREADY_Pos             0U                                            /*!< ITM ITWRITE: ATREADY Position */
+#define ITM_ITWRITE_ATREADY_Msk            (1UL /*<< ITM_ITWRITE_ATREADY_Pos*/)           /*!< ITM ITWRITE: ATREADY Mask */
+
+/** \brief ITM Integration Mode Control Register Definitions */
+#define ITM_ITCTRL_IME_Pos                  0U                                            /*!< ITM ITCTRL: IME Position */
+#define ITM_ITCTRL_IME_Msk                 (1UL /*<< ITM_ITCTRL_IME_Pos*/)                /*!< ITM ITCTRL: IME Mask */
+
+/*@}*/ /* end of group CMSIS_ITM */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_DWT     Data Watchpoint and Trace (DWT)
+  \brief    Type definitions for the Data Watchpoint and Trace (DWT)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Data Watchpoint and Trace Register (DWT).
+ */
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  Control Register */
+  __IOM uint32_t CYCCNT;                 /*!< Offset: 0x004 (R/W)  Cycle Count Register */
+  __IOM uint32_t CPICNT;                 /*!< Offset: 0x008 (R/W)  CPI Count Register */
+  __IOM uint32_t EXCCNT;                 /*!< Offset: 0x00C (R/W)  Exception Overhead Count Register */
+  __IOM uint32_t SLEEPCNT;               /*!< Offset: 0x010 (R/W)  Sleep Count Register */
+  __IOM uint32_t LSUCNT;                 /*!< Offset: 0x014 (R/W)  LSU Count Register */
+  __IOM uint32_t FOLDCNT;                /*!< Offset: 0x018 (R/W)  Folded-instruction Count Register */
+  __IM  uint32_t PCSR;                   /*!< Offset: 0x01C (R/ )  Program Counter Sample Register */
+  __IOM uint32_t COMP0;                  /*!< Offset: 0x020 (R/W)  Comparator Register 0 */
+        uint32_t RESERVED1[1U];
+  __IOM uint32_t FUNCTION0;              /*!< Offset: 0x028 (R/W)  Function Register 0 */
+        uint32_t RESERVED2[1U];
+  __IOM uint32_t COMP1;                  /*!< Offset: 0x030 (R/W)  Comparator Register 1 */
+        uint32_t RESERVED3[1U];
+  __IOM uint32_t FUNCTION1;              /*!< Offset: 0x038 (R/W)  Function Register 1 */
+  __IOM uint32_t VMASK1;                 /*!< Offset: 0x03C (R/W)  Comparator Value Mask 1 */
+  __IOM uint32_t COMP2;                  /*!< Offset: 0x040 (R/W)  Comparator Register 2 */
+        uint32_t RESERVED4[1U];
+  __IOM uint32_t FUNCTION2;              /*!< Offset: 0x048 (R/W)  Function Register 2 */
+        uint32_t RESERVED5[1U];
+  __IOM uint32_t COMP3;                  /*!< Offset: 0x050 (R/W)  Comparator Register 3 */
+        uint32_t RESERVED6[1U];
+  __IOM uint32_t FUNCTION3;              /*!< Offset: 0x058 (R/W)  Function Register 3 */
+  __IOM uint32_t VMASK3;                 /*!< Offset: 0x05C (R/W)  Comparator Value Mask 3 */
+  __IOM uint32_t COMP4;                  /*!< Offset: 0x060 (R/W)  Comparator Register 4 */
+        uint32_t RESERVED7[1U];
+  __IOM uint32_t FUNCTION4;              /*!< Offset: 0x068 (R/W)  Function Register 4 */
+        uint32_t RESERVED8[1U];
+  __IOM uint32_t COMP5;                  /*!< Offset: 0x070 (R/W)  Comparator Register 5 */
+        uint32_t RESERVED9[1U];
+  __IOM uint32_t FUNCTION5;              /*!< Offset: 0x078 (R/W)  Function Register 5 */
+        uint32_t RESERVED10[1U];
+  __IOM uint32_t COMP6;                  /*!< Offset: 0x080 (R/W)  Comparator Register 6 */
+        uint32_t RESERVED11[1U];
+  __IOM uint32_t FUNCTION6;              /*!< Offset: 0x088 (R/W)  Function Register 6 */
+        uint32_t RESERVED12[1U];
+  __IOM uint32_t COMP7;                  /*!< Offset: 0x090 (R/W)  Comparator Register 7 */
+        uint32_t RESERVED13[1U];
+  __IOM uint32_t FUNCTION7;              /*!< Offset: 0x098 (R/W)  Function Register 7 */
+        uint32_t RESERVED14[968U];
+  __IM  uint32_t DEVARCH;                /*!< Offset: 0xFBC (R/ )  Device Type Architecture Register */
+        uint32_t RESERVED15[3U];
+  __IM  uint32_t DEVTYPE;                /*!< Offset: 0xFCC (R/ )  Device Type Identifier Register */
+} DWT_Type;
+
+/** \brief DWT Control Register Definitions */
+#define DWT_CTRL_NUMCOMP_Pos               28U                                         /*!< DWT CTRL: NUMCOMP Position */
+#define DWT_CTRL_NUMCOMP_Msk               (0xFUL << DWT_CTRL_NUMCOMP_Pos)             /*!< DWT CTRL: NUMCOMP Mask */
+
+#define DWT_CTRL_NOTRCPKT_Pos              27U                                         /*!< DWT CTRL: NOTRCPKT Position */
+#define DWT_CTRL_NOTRCPKT_Msk              (1UL << DWT_CTRL_NOTRCPKT_Pos)              /*!< DWT CTRL: NOTRCPKT Mask */
+
+#define DWT_CTRL_NOEXTTRIG_Pos             26U                                         /*!< DWT CTRL: NOEXTTRIG Position */
+#define DWT_CTRL_NOEXTTRIG_Msk             (1UL << DWT_CTRL_NOEXTTRIG_Pos)             /*!< DWT CTRL: NOEXTTRIG Mask */
+
+#define DWT_CTRL_NOCYCCNT_Pos              25U                                         /*!< DWT CTRL: NOCYCCNT Position */
+#define DWT_CTRL_NOCYCCNT_Msk              (1UL << DWT_CTRL_NOCYCCNT_Pos)              /*!< DWT CTRL: NOCYCCNT Mask */
+
+#define DWT_CTRL_NOPRFCNT_Pos              24U                                         /*!< DWT CTRL: NOPRFCNT Position */
+#define DWT_CTRL_NOPRFCNT_Msk              (1UL << DWT_CTRL_NOPRFCNT_Pos)              /*!< DWT CTRL: NOPRFCNT Mask */
+
+#define DWT_CTRL_CYCDISS_Pos               23U                                         /*!< DWT CTRL: CYCDISS Position */
+#define DWT_CTRL_CYCDISS_Msk               (1UL << DWT_CTRL_CYCDISS_Pos)               /*!< DWT CTRL: CYCDISS Mask */
+
+#define DWT_CTRL_CYCEVTENA_Pos             22U                                         /*!< DWT CTRL: CYCEVTENA Position */
+#define DWT_CTRL_CYCEVTENA_Msk             (1UL << DWT_CTRL_CYCEVTENA_Pos)             /*!< DWT CTRL: CYCEVTENA Mask */
+
+#define DWT_CTRL_FOLDEVTENA_Pos            21U                                         /*!< DWT CTRL: FOLDEVTENA Position */
+#define DWT_CTRL_FOLDEVTENA_Msk            (1UL << DWT_CTRL_FOLDEVTENA_Pos)            /*!< DWT CTRL: FOLDEVTENA Mask */
+
+#define DWT_CTRL_LSUEVTENA_Pos             20U                                         /*!< DWT CTRL: LSUEVTENA Position */
+#define DWT_CTRL_LSUEVTENA_Msk             (1UL << DWT_CTRL_LSUEVTENA_Pos)             /*!< DWT CTRL: LSUEVTENA Mask */
+
+#define DWT_CTRL_SLEEPEVTENA_Pos           19U                                         /*!< DWT CTRL: SLEEPEVTENA Position */
+#define DWT_CTRL_SLEEPEVTENA_Msk           (1UL << DWT_CTRL_SLEEPEVTENA_Pos)           /*!< DWT CTRL: SLEEPEVTENA Mask */
+
+#define DWT_CTRL_EXCEVTENA_Pos             18U                                         /*!< DWT CTRL: EXCEVTENA Position */
+#define DWT_CTRL_EXCEVTENA_Msk             (1UL << DWT_CTRL_EXCEVTENA_Pos)             /*!< DWT CTRL: EXCEVTENA Mask */
+
+#define DWT_CTRL_CPIEVTENA_Pos             17U                                         /*!< DWT CTRL: CPIEVTENA Position */
+#define DWT_CTRL_CPIEVTENA_Msk             (1UL << DWT_CTRL_CPIEVTENA_Pos)             /*!< DWT CTRL: CPIEVTENA Mask */
+
+#define DWT_CTRL_EXCTRCENA_Pos             16U                                         /*!< DWT CTRL: EXCTRCENA Position */
+#define DWT_CTRL_EXCTRCENA_Msk             (1UL << DWT_CTRL_EXCTRCENA_Pos)             /*!< DWT CTRL: EXCTRCENA Mask */
+
+#define DWT_CTRL_PCSAMPLENA_Pos            12U                                         /*!< DWT CTRL: PCSAMPLENA Position */
+#define DWT_CTRL_PCSAMPLENA_Msk            (1UL << DWT_CTRL_PCSAMPLENA_Pos)            /*!< DWT CTRL: PCSAMPLENA Mask */
+
+#define DWT_CTRL_SYNCTAP_Pos               10U                                         /*!< DWT CTRL: SYNCTAP Position */
+#define DWT_CTRL_SYNCTAP_Msk               (0x3UL << DWT_CTRL_SYNCTAP_Pos)             /*!< DWT CTRL: SYNCTAP Mask */
+
+#define DWT_CTRL_CYCTAP_Pos                 9U                                         /*!< DWT CTRL: CYCTAP Position */
+#define DWT_CTRL_CYCTAP_Msk                (1UL << DWT_CTRL_CYCTAP_Pos)                /*!< DWT CTRL: CYCTAP Mask */
+
+#define DWT_CTRL_POSTINIT_Pos               5U                                         /*!< DWT CTRL: POSTINIT Position */
+#define DWT_CTRL_POSTINIT_Msk              (0xFUL << DWT_CTRL_POSTINIT_Pos)            /*!< DWT CTRL: POSTINIT Mask */
+
+#define DWT_CTRL_POSTPRESET_Pos             1U                                         /*!< DWT CTRL: POSTPRESET Position */
+#define DWT_CTRL_POSTPRESET_Msk            (0xFUL << DWT_CTRL_POSTPRESET_Pos)          /*!< DWT CTRL: POSTPRESET Mask */
+
+#define DWT_CTRL_CYCCNTENA_Pos              0U                                         /*!< DWT CTRL: CYCCNTENA Position */
+#define DWT_CTRL_CYCCNTENA_Msk             (1UL /*<< DWT_CTRL_CYCCNTENA_Pos*/)         /*!< DWT CTRL: CYCCNTENA Mask */
+
+/** \brief DWT CPI Count Register Definitions */
+#define DWT_CPICNT_CPICNT_Pos               0U                                         /*!< DWT CPICNT: CPICNT Position */
+#define DWT_CPICNT_CPICNT_Msk              (0xFFUL /*<< DWT_CPICNT_CPICNT_Pos*/)       /*!< DWT CPICNT: CPICNT Mask */
+
+/** \brief DWT Exception Overhead Count Register Definitions */
+#define DWT_EXCCNT_EXCCNT_Pos               0U                                         /*!< DWT EXCCNT: EXCCNT Position */
+#define DWT_EXCCNT_EXCCNT_Msk              (0xFFUL /*<< DWT_EXCCNT_EXCCNT_Pos*/)       /*!< DWT EXCCNT: EXCCNT Mask */
+
+/** \brief DWT Sleep Count Register Definitions */
+#define DWT_SLEEPCNT_SLEEPCNT_Pos           0U                                         /*!< DWT SLEEPCNT: SLEEPCNT Position */
+#define DWT_SLEEPCNT_SLEEPCNT_Msk          (0xFFUL /*<< DWT_SLEEPCNT_SLEEPCNT_Pos*/)   /*!< DWT SLEEPCNT: SLEEPCNT Mask */
+
+/** \brief DWT LSU Count Register Definitions */
+#define DWT_LSUCNT_LSUCNT_Pos               0U                                         /*!< DWT LSUCNT: LSUCNT Position */
+#define DWT_LSUCNT_LSUCNT_Msk              (0xFFUL /*<< DWT_LSUCNT_LSUCNT_Pos*/)       /*!< DWT LSUCNT: LSUCNT Mask */
+
+/** \brief DWT Folded-instruction Count Register Definitions */
+#define DWT_FOLDCNT_FOLDCNT_Pos             0U                                         /*!< DWT FOLDCNT: FOLDCNT Position */
+#define DWT_FOLDCNT_FOLDCNT_Msk            (0xFFUL /*<< DWT_FOLDCNT_FOLDCNT_Pos*/)     /*!< DWT FOLDCNT: FOLDCNT Mask */
+
+/** \brief DWT Comparator Function Register Definitions */
+#define DWT_FUNCTION_ID_Pos                27U                                         /*!< DWT FUNCTION: ID Position */
+#define DWT_FUNCTION_ID_Msk                (0x1FUL << DWT_FUNCTION_ID_Pos)             /*!< DWT FUNCTION: ID Mask */
+
+#define DWT_FUNCTION_MATCHED_Pos           24U                                         /*!< DWT FUNCTION: MATCHED Position */
+#define DWT_FUNCTION_MATCHED_Msk           (1UL << DWT_FUNCTION_MATCHED_Pos)           /*!< DWT FUNCTION: MATCHED Mask */
+
+#define DWT_FUNCTION_DATAVSIZE_Pos         10U                                         /*!< DWT FUNCTION: DATAVSIZE Position */
+#define DWT_FUNCTION_DATAVSIZE_Msk         (0x3UL << DWT_FUNCTION_DATAVSIZE_Pos)       /*!< DWT FUNCTION: DATAVSIZE Mask */
+
+#define DWT_FUNCTION_ACTION_Pos             4U                                         /*!< DWT FUNCTION: ACTION Position */
+#define DWT_FUNCTION_ACTION_Msk            (0x3UL << DWT_FUNCTION_ACTION_Pos)          /*!< DWT FUNCTION: ACTION Mask */
+
+#define DWT_FUNCTION_MATCH_Pos              0U                                         /*!< DWT FUNCTION: MATCH Position */
+#define DWT_FUNCTION_MATCH_Msk             (0xFUL /*<< DWT_FUNCTION_MATCH_Pos*/)       /*!< DWT FUNCTION: MATCH Mask */
+
+/*@}*/ /* end of group CMSIS_DWT */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup MemSysCtl_Type     Memory System Control Registers (IMPLEMENTATION DEFINED)
+  \brief    Type definitions for the Memory System Control Registers (MEMSYSCTL)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Memory System Control Registers (MEMSYSCTL).
+ */
+typedef struct
+{
+  __IOM uint32_t MSCR;                   /*!< Offset: 0x000 (R/W)  Memory System Control Register */
+        uint32_t RESERVED1[3U];
+  __IOM uint32_t ITCMCR;                 /*!< Offset: 0x010 (R/W)  ITCM Control Register */
+  __IOM uint32_t DTCMCR;                 /*!< Offset: 0x014 (R/W)  DTCM Control Register */
+  __IOM uint32_t PAHBCR;                 /*!< Offset: 0x018 (R/W)  P-AHB Control Register */
+        uint32_t RESERVED2[313U];
+  __IOM uint32_t ITGU_CTRL;              /*!< Offset: 0x500 (R/W)  ITGU Control Register */
+  __IOM uint32_t ITGU_CFG;               /*!< Offset: 0x504 (R/W)  ITGU Configuration Register */
+        uint32_t RESERVED3[2U];
+  __IOM uint32_t ITGU_LUT[16U];          /*!< Offset: 0x510 (R/W)  ITGU Look Up Table Register */
+        uint32_t RESERVED4[44U];
+  __IOM uint32_t DTGU_CTRL;              /*!< Offset: 0x600 (R/W)  DTGU Control Registers */
+  __IOM uint32_t DTGU_CFG;               /*!< Offset: 0x604 (R/W)  DTGU Configuration Register */
+        uint32_t RESERVED5[2U];
+  __IOM uint32_t DTGU_LUT[16U];          /*!< Offset: 0x610 (R/W)  DTGU Look Up Table Register */
+} MemSysCtl_Type;
+
+/** \brief MemSysCtl Memory System Control Register Definitions */
+#define MEMSYSCTL_MSCR_CPWRDN_Pos          17U                                         /*!< MEMSYSCTL MSCR: CPWRDN Position */
+#define MEMSYSCTL_MSCR_CPWRDN_Msk          (1UL << MEMSYSCTL_MSCR_CPWRDN_Pos)          /*!< MEMSYSCTL MSCR: CPWRDN Mask */
+
+#define MEMSYSCTL_MSCR_DCCLEAN_Pos         16U                                         /*!< MEMSYSCTL MSCR: DCCLEAN Position */
+#define MEMSYSCTL_MSCR_DCCLEAN_Msk         (1UL << MEMSYSCTL_MSCR_DCCLEAN_Pos)         /*!< MEMSYSCTL MSCR: DCCLEAN Mask */
+
+#define MEMSYSCTL_MSCR_ICACTIVE_Pos        13U                                         /*!< MEMSYSCTL MSCR: ICACTIVE Position */
+#define MEMSYSCTL_MSCR_ICACTIVE_Msk        (1UL << MEMSYSCTL_MSCR_ICACTIVE_Pos)        /*!< MEMSYSCTL MSCR: ICACTIVE Mask */
+
+#define MEMSYSCTL_MSCR_DCACTIVE_Pos        12U                                         /*!< MEMSYSCTL MSCR: DCACTIVE Position */
+#define MEMSYSCTL_MSCR_DCACTIVE_Msk        (1UL << MEMSYSCTL_MSCR_DCACTIVE_Pos)        /*!< MEMSYSCTL MSCR: DCACTIVE Mask */
+
+#define MEMSYSCTL_MSCR_TECCCHKDIS_Pos       4U                                         /*!< MEMSYSCTL MSCR: TECCCHKDIS Position */
+#define MEMSYSCTL_MSCR_TECCCHKDIS_Msk      (1UL << MEMSYSCTL_MSCR_TECCCHKDIS_Pos)      /*!< MEMSYSCTL MSCR: TECCCHKDIS Mask */
+
+#define MEMSYSCTL_MSCR_EVECCFAULT_Pos       3U                                         /*!< MEMSYSCTL MSCR: EVECCFAULT Position */
+#define MEMSYSCTL_MSCR_EVECCFAULT_Msk      (1UL << MEMSYSCTL_MSCR_EVECCFAULT_Pos)      /*!< MEMSYSCTL MSCR: EVECCFAULT Mask */
+
+#define MEMSYSCTL_MSCR_FORCEWT_Pos          2U                                         /*!< MEMSYSCTL MSCR: FORCEWT Position */
+#define MEMSYSCTL_MSCR_FORCEWT_Msk         (1UL << MEMSYSCTL_MSCR_FORCEWT_Pos)         /*!< MEMSYSCTL MSCR: FORCEWT Mask */
+
+#define MEMSYSCTL_MSCR_ECCEN_Pos            1U                                         /*!< MEMSYSCTL MSCR: ECCEN Position */
+#define MEMSYSCTL_MSCR_ECCEN_Msk           (1UL << MEMSYSCTL_MSCR_ECCEN_Pos)           /*!< MEMSYSCTL MSCR: ECCEN Mask */
+
+/** \brief MemSysCtl ITCM Control Register Definitions */
+#define MEMSYSCTL_ITCMCR_SZ_Pos             3U                                         /*!< MEMSYSCTL ITCMCR: SZ Position */
+#define MEMSYSCTL_ITCMCR_SZ_Msk            (0xFUL << MEMSYSCTL_ITCMCR_SZ_Pos)          /*!< MEMSYSCTL ITCMCR: SZ Mask */
+
+#define MEMSYSCTL_ITCMCR_EN_Pos             0U                                         /*!< MEMSYSCTL ITCMCR: EN Position */
+#define MEMSYSCTL_ITCMCR_EN_Msk            (1UL /*<< MEMSYSCTL_ITCMCR_EN_Pos*/)        /*!< MEMSYSCTL ITCMCR: EN Mask */
+
+/** \brief MemSysCtl DTCM Control Register Definitions */
+#define MEMSYSCTL_DTCMCR_SZ_Pos             3U                                         /*!< MEMSYSCTL DTCMCR: SZ Position */
+#define MEMSYSCTL_DTCMCR_SZ_Msk            (0xFUL << MEMSYSCTL_DTCMCR_SZ_Pos)          /*!< MEMSYSCTL DTCMCR: SZ Mask */
+
+#define MEMSYSCTL_DTCMCR_EN_Pos             0U                                         /*!< MEMSYSCTL DTCMCR: EN Position */
+#define MEMSYSCTL_DTCMCR_EN_Msk            (1UL /*<< MEMSYSCTL_DTCMCR_EN_Pos*/)        /*!< MEMSYSCTL DTCMCR: EN Mask */
+
+/** \brief MemSysCtl P-AHB Control Register Definitions */
+#define MEMSYSCTL_PAHBCR_SZ_Pos             1U                                         /*!< MEMSYSCTL PAHBCR: SZ Position */
+#define MEMSYSCTL_PAHBCR_SZ_Msk            (0x7UL << MEMSYSCTL_PAHBCR_SZ_Pos)          /*!< MEMSYSCTL PAHBCR: SZ Mask */
+
+#define MEMSYSCTL_PAHBCR_EN_Pos             0U                                         /*!< MEMSYSCTL PAHBCR: EN Position */
+#define MEMSYSCTL_PAHBCR_EN_Msk            (1UL /*<< MEMSYSCTL_PAHBCR_EN_Pos*/)        /*!< MEMSYSCTL PAHBCR: EN Mask */
+
+/** \brief MemSysCtl ITGU Control Register Definitions */
+#define MEMSYSCTL_ITGU_CTRL_DEREN_Pos       1U                                         /*!< MEMSYSCTL ITGU_CTRL: DEREN Position */
+#define MEMSYSCTL_ITGU_CTRL_DEREN_Msk      (1UL << MEMSYSCTL_ITGU_CTRL_DEREN_Pos)      /*!< MEMSYSCTL ITGU_CTRL: DEREN Mask */
+
+#define MEMSYSCTL_ITGU_CTRL_DBFEN_Pos       0U                                         /*!< MEMSYSCTL ITGU_CTRL: DBFEN Position */
+#define MEMSYSCTL_ITGU_CTRL_DBFEN_Msk      (1UL /*<< MEMSYSCTL_ITGU_CTRL_DBFEN_Pos*/)  /*!< MEMSYSCTL ITGU_CTRL: DBFEN Mask */
+
+/** \brief MemSysCtl ITGU Configuration Register Definitions */
+#define MEMSYSCTL_ITGU_CFG_PRESENT_Pos     31U                                         /*!< MEMSYSCTL ITGU_CFG: PRESENT Position */
+#define MEMSYSCTL_ITGU_CFG_PRESENT_Msk     (1UL << MEMSYSCTL_ITGU_CFG_PRESENT_Pos)     /*!< MEMSYSCTL ITGU_CFG: PRESENT Mask */
+
+#define MEMSYSCTL_ITGU_CFG_NUMBLKS_Pos      8U                                         /*!< MEMSYSCTL ITGU_CFG: NUMBLKS Position */
+#define MEMSYSCTL_ITGU_CFG_NUMBLKS_Msk     (0xFUL << MEMSYSCTL_ITGU_CFG_NUMBLKS_Pos)   /*!< MEMSYSCTL ITGU_CFG: NUMBLKS Mask */
+
+#define MEMSYSCTL_ITGU_CFG_BLKSZ_Pos        0U                                         /*!< MEMSYSCTL ITGU_CFG: BLKSZ Position */
+#define MEMSYSCTL_ITGU_CFG_BLKSZ_Msk       (0xFUL /*<< MEMSYSCTL_ITGU_CFG_BLKSZ_Pos*/) /*!< MEMSYSCTL ITGU_CFG: BLKSZ Mask */
+
+/** \brief MemSysCtl DTGU Control Registers Definitions */
+#define MEMSYSCTL_DTGU_CTRL_DEREN_Pos       1U                                         /*!< MEMSYSCTL DTGU_CTRL: DEREN Position */
+#define MEMSYSCTL_DTGU_CTRL_DEREN_Msk      (1UL << MEMSYSCTL_DTGU_CTRL_DEREN_Pos)      /*!< MEMSYSCTL DTGU_CTRL: DEREN Mask */
+
+#define MEMSYSCTL_DTGU_CTRL_DBFEN_Pos       0U                                         /*!< MEMSYSCTL DTGU_CTRL: DBFEN Position */
+#define MEMSYSCTL_DTGU_CTRL_DBFEN_Msk      (1UL /*<< MEMSYSCTL_DTGU_CTRL_DBFEN_Pos*/)  /*!< MEMSYSCTL DTGU_CTRL: DBFEN Mask */
+
+/** \brief MemSysCtl DTGU Configuration Register Definitions */
+#define MEMSYSCTL_DTGU_CFG_PRESENT_Pos     31U                                         /*!< MEMSYSCTL DTGU_CFG: PRESENT Position */
+#define MEMSYSCTL_DTGU_CFG_PRESENT_Msk     (1UL << MEMSYSCTL_DTGU_CFG_PRESENT_Pos)     /*!< MEMSYSCTL DTGU_CFG: PRESENT Mask */
+
+#define MEMSYSCTL_DTGU_CFG_NUMBLKS_Pos      8U                                         /*!< MEMSYSCTL DTGU_CFG: NUMBLKS Position */
+#define MEMSYSCTL_DTGU_CFG_NUMBLKS_Msk     (0xFUL << MEMSYSCTL_DTGU_CFG_NUMBLKS_Pos)   /*!< MEMSYSCTL DTGU_CFG: NUMBLKS Mask */
+
+#define MEMSYSCTL_DTGU_CFG_BLKSZ_Pos        0U                                         /*!< MEMSYSCTL DTGU_CFG: BLKSZ Position */
+#define MEMSYSCTL_DTGU_CFG_BLKSZ_Msk       (0xFUL /*<< MEMSYSCTL_DTGU_CFG_BLKSZ_Pos*/) /*!< MEMSYSCTL DTGU_CFG: BLKSZ Mask */
+
+/*@}*/ /* end of group MemSysCtl_Type */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup DCAR_Type     Direct Cache Access Registers
+  \brief    Type definitions for the Direct Cache Access Registers (DCAR)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Direct Cache Access Registers (DCAR).
+ */
+typedef struct
+{
+  __IM  uint32_t DCADCRR;               /*!< Offset: 0x000 (R/W)  Direct Cache Access Data Cache Read Register */
+  __IM  uint32_t DCAICRR;               /*!< Offset: 0x004 (R/W)  Direct Cache Access Instruction Cache Read Register */
+        uint32_t RESERVED1[2];          
+  __IOM uint32_t DCADCLR;               /*!< Offset: 0x010 (R/W)  Direct Cache Access Data Cache Location Registers */
+  __IOM uint32_t DCAICLR;               /*!< Offset: 0x014 (R/W)  Direct Cache Access Instruction Cache Location Registers */
+} DCAR_Type;
+
+/*@}*/ /* end of group DCAR_Type */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup PwrModCtl_Type     Power Mode Control Registers
+  \brief    Type definitions for the Power Mode Control Registers (PWRMODCTL)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Power Mode Control Registers (PWRMODCTL).
+ */
+typedef struct
+{
+  __IOM uint32_t CPDLPSTATE;             /*!< Offset: 0x000 (R/W)  Core Power Domain Low Power State Register */
+  __IOM uint32_t DPDLPSTATE;             /*!< Offset: 0x004 (R/W)  Debug Power Domain Low Power State Register */
+} PwrModCtl_Type;
+
+/** \brief PwrModCtl Core Power Domain Low Power State Register Definitions */
+#define PWRMODCTL_CPDLPSTATE_RLPSTATE_Pos   8U                                              /*!< PWRMODCTL CPDLPSTATE: RLPSTATE Position */
+#define PWRMODCTL_CPDLPSTATE_RLPSTATE_Msk  (0x3UL << PWRMODCTL_CPDLPSTATE_RLPSTATE_Pos)     /*!< PWRMODCTL CPDLPSTATE: RLPSTATE Mask */
+
+#define PWRMODCTL_CPDLPSTATE_CLPSTATE_Pos   0U                                              /*!< PWRMODCTL CPDLPSTATE: CLPSTATE Position */
+#define PWRMODCTL_CPDLPSTATE_CLPSTATE_Msk  (0x3UL /*<< PWRMODCTL_CPDLPSTATE_CLPSTATE_Pos*/) /*!< PWRMODCTL CPDLPSTATE: CLPSTATE Mask */
+
+/** \brief PwrModCtl Debug Power Domain Low Power State Register Definitions */
+#define PWRMODCTL_DPDLPSTATE_DLPSTATE_Pos   0U                                              /*!< PWRMODCTL DPDLPSTATE: DLPSTATE Position */
+#define PWRMODCTL_DPDLPSTATE_DLPSTATE_Msk  (0x3UL /*<< PWRMODCTL_DPDLPSTATE_DLPSTATE_Pos*/) /*!< PWRMODCTL DPDLPSTATE: DLPSTATE Mask */
+
+/*@}*/ /* end of group PwrModCtl_Type */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup EWIC_Type     External Wakeup Interrupt Controller Registers
+  \brief    Type definitions for the External Wakeup Interrupt Controller Registers (EWIC)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the External Wakeup Interrupt Controller Registers (EWIC).
+ */
+typedef struct
+{
+  __IOM uint32_t EWIC_CR;                /*!< Offset: 0x000 (R/W)  EWIC Control Register */
+  __IOM uint32_t EWIC_ASCR;              /*!< Offset: 0x004 (R/W)  EWIC Automatic Sequence Control Register */
+  __OM  uint32_t EWIC_CLRMASK;           /*!< Offset: 0x008 ( /W)  EWIC Clear Mask Register */
+  __IM  uint32_t EWIC_NUMID;             /*!< Offset: 0x00C (R/ )  EWIC Event Number ID Register */
+        uint32_t RESERVED0[124U];
+  __IOM uint32_t EWIC_MASKA;             /*!< Offset: 0x200 (R/W)  EWIC MaskA Register */
+  __IOM uint32_t EWIC_MASKn[15];         /*!< Offset: 0x204 (R/W)  EWIC Maskn Registers */
+        uint32_t RESERVED1[112U];
+  __IM  uint32_t EWIC_PENDA;             /*!< Offset: 0x400 (R/ )  EWIC PendA Event Register */
+  __IOM uint32_t EWIC_PENDn[15];         /*!< Offset: 0x404 (R/W)  EWIC Pendn Event Registers */
+        uint32_t RESERVED2[112U];
+  __IM  uint32_t EWIC_PSR;               /*!< Offset: 0x600 (R/ )  EWIC Pend Summary Register */
+} EWIC_Type;
+
+/** \brief EWIC Control Register Definitions */
+#define EWIC_EWIC_CR_EN_Pos                 0U                                         /*!< EWIC EWIC_CR: EN Position */
+#define EWIC_EWIC_CR_EN_Msk                (1UL /*<< EWIC_EWIC_CR_EN_Pos*/)            /*!< EWIC EWIC_CR: EN Mask */
+
+/** \brief EWIC Automatic Sequence Control Register Definitions */
+#define EWIC_EWIC_ASCR_ASPU_Pos             1U                                         /*!< EWIC EWIC_ASCR: ASPU Position */
+#define EWIC_EWIC_ASCR_ASPU_Msk            (1UL << EWIC_EWIC_ASCR_ASPU_Pos)            /*!< EWIC EWIC_ASCR: ASPU Mask */
+
+#define EWIC_EWIC_ASCR_ASPD_Pos             0U                                         /*!< EWIC EWIC_ASCR: ASPD Position */
+#define EWIC_EWIC_ASCR_ASPD_Msk            (1UL /*<< EWIC_EWIC_ASCR_ASPD_Pos*/)        /*!< EWIC EWIC_ASCR: ASPD Mask */
+
+/** \brief EWIC Event Number ID Register Definitions */
+#define EWIC_EWIC_NUMID_NUMEVENT_Pos        0U                                         /*!< EWIC_NUMID: NUMEVENT Position */
+#define EWIC_EWIC_NUMID_NUMEVENT_Msk       (0xFFFFUL /*<< EWIC_EWIC_NUMID_NUMEVENT_Pos*/) /*!< EWIC_NUMID: NUMEVENT Mask */
+
+/** \brief EWIC Mask A Register Definitions */
+#define EWIC_EWIC_MASKA_EDBGREQ_Pos         2U                                         /*!< EWIC EWIC_MASKA: EDBGREQ Position */
+#define EWIC_EWIC_MASKA_EDBGREQ_Msk        (1UL << EWIC_EWIC_MASKA_EDBGREQ_Pos)        /*!< EWIC EWIC_MASKA: EDBGREQ Mask */
+
+#define EWIC_EWIC_MASKA_NMI_Pos             1U                                         /*!< EWIC EWIC_MASKA: NMI Position */
+#define EWIC_EWIC_MASKA_NMI_Msk            (1UL << EWIC_EWIC_MASKA_NMI_Pos)            /*!< EWIC EWIC_MASKA: NMI Mask */
+
+#define EWIC_EWIC_MASKA_EVENT_Pos           0U                                         /*!< EWIC EWIC_MASKA: EVENT Position */
+#define EWIC_EWIC_MASKA_EVENT_Msk          (1UL /*<< EWIC_EWIC_MASKA_EVENT_Pos*/)      /*!< EWIC EWIC_MASKA: EVENT Mask */
+
+/** \brief EWIC Mask n Register Definitions */
+#define EWIC_EWIC_MASKn_IRQ_Pos             0U                                         /*!< EWIC EWIC_MASKn: IRQ Position */
+#define EWIC_EWIC_MASKn_IRQ_Msk            (0xFFFFFFFFUL /*<< EWIC_EWIC_MASKn_IRQ_Pos*/) /*!< EWIC EWIC_MASKn: IRQ Mask */
+
+/** \brief EWIC Pend A Register Definitions */
+#define EWIC_EWIC_PENDA_EDBGREQ_Pos         2U                                         /*!< EWIC EWIC_PENDA: EDBGREQ Position */
+#define EWIC_EWIC_PENDA_EDBGREQ_Msk        (1UL << EWIC_EWIC_PENDA_EDBGREQ_Pos)        /*!< EWIC EWIC_PENDA: EDBGREQ Mask */
+
+#define EWIC_EWIC_PENDA_NMI_Pos             1U                                         /*!< EWIC EWIC_PENDA: NMI Position */
+#define EWIC_EWIC_PENDA_NMI_Msk            (1UL << EWIC_EWIC_PENDA_NMI_Pos)            /*!< EWIC EWIC_PENDA: NMI Mask */
+
+#define EWIC_EWIC_PENDA_EVENT_Pos           0U                                         /*!< EWIC EWIC_PENDA: EVENT Position */
+#define EWIC_EWIC_PENDA_EVENT_Msk          (1UL /*<< EWIC_EWIC_PENDA_EVENT_Pos*/)      /*!< EWIC EWIC_PENDA: EVENT Mask */
+
+/** \brief EWIC Pend n Register Definitions */
+#define EWIC_EWIC_PENDn_IRQ_Pos             0U                                         /*!< EWIC EWIC_PENDn: IRQ Position */
+#define EWIC_EWIC_PENDn_IRQ_Msk            (0xFFFFFFFFUL /*<< EWIC_EWIC_PENDn_IRQ_Pos*/) /*!< EWIC EWIC_PENDn: IRQ Mask */
+
+/** \brief EWIC Pend Summary Register Definitions */
+#define EWIC_EWIC_PSR_NZ_Pos                1U                                         /*!< EWIC EWIC_PSR: NZ Position */
+#define EWIC_EWIC_PSR_NZ_Msk               (0x7FFFUL << EWIC_EWIC_PSR_NZ_Pos)          /*!< EWIC EWIC_PSR: NZ Mask */
+
+#define EWIC_EWIC_PSR_NZA_Pos               0U                                         /*!< EWIC EWIC_PSR: NZA Position */
+#define EWIC_EWIC_PSR_NZA_Msk              (1UL /*<< EWIC_EWIC_PSR_NZA_Pos*/)          /*!< EWIC EWIC_PSR: NZA Mask */
+
+/*@}*/ /* end of group EWIC_Type */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup EWIC_ISA_Type     External Wakeup Interrupt Controller (EWIC) interrupt status access registers
+  \brief    Type definitions for the External Wakeup Interrupt Controller interrupt status access registers (EWIC_ISA)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the External Wakeup Interrupt Controller interrupt status access registers (EWIC_ISA).
+ */
+typedef struct
+{
+  __OM  uint32_t EVENTSPR;               /*!< Offset: 0x000 ( /W)  Event Set Pending Register */
+        uint32_t RESERVED0[31U];
+  __IM  uint32_t EVENTMASKA;             /*!< Offset: 0x080 (R/ )  Event Mask A Register */
+  __IM  uint32_t EVENTMASKn[15];         /*!< Offset: 0x084 (R/ )  Event Mask Register */
+} EWIC_ISA_Type;
+
+/** \brief EWIC_ISA Event Set Pending Register Definitions */
+#define EWIC_ISA_EVENTSPR_EDBGREQ_Pos       2U                                         /*!< EWIC_ISA EVENTSPR: EDBGREQ Position */
+#define EWIC_ISA_EVENTSPR_EDBGREQ_Msk      (1UL << EWIC_ISA_EVENTSPR_EDBGREQ_Pos)      /*!< EWIC_ISA EVENTSPR: EDBGREQ Mask */
+
+#define EWIC_ISA_EVENTSPR_NMI_Pos           1U                                         /*!< EWIC_ISA EVENTSPR: NMI Position */
+#define EWIC_ISA_EVENTSPR_NMI_Msk          (1UL << EWIC_ISA_EVENTSPR_NMI_Pos)          /*!< EWIC_ISA EVENTSPR: NMI Mask */
+
+#define EWIC_ISA_EVENTSPR_EVENT_Pos         0U                                         /*!< EWIC_ISA EVENTSPR: EVENT Position */
+#define EWIC_ISA_EVENTSPR_EVENT_Msk        (1UL /*<< EWIC_ISA_EVENTSPR_EVENT_Pos*/)    /*!< EWIC_ISA EVENTSPR: EVENT Mask */
+
+/** \brief EWIC_ISA Event Mask A Register Definitions */
+#define EWIC_ISA_EVENTMASKA_EDBGREQ_Pos     2U                                         /*!< EWIC_ISA EVENTMASKA: EDBGREQ Position */
+#define EWIC_ISA_EVENTMASKA_EDBGREQ_Msk    (1UL << EWIC_ISA_EVENTMASKA_EDBGREQ_Pos)    /*!< EWIC_ISA EVENTMASKA: EDBGREQ Mask */
+
+#define EWIC_ISA_EVENTMASKA_NMI_Pos         1U                                         /*!< EWIC_ISA EVENTMASKA: NMI Position */
+#define EWIC_ISA_EVENTMASKA_NMI_Msk        (1UL << EWIC_ISA_EVENTMASKA_NMI_Pos)        /*!< EWIC_ISA EVENTMASKA: NMI Mask */
+
+#define EWIC_ISA_EVENTMASKA_EVENT_Pos       0U                                         /*!< EWIC_ISA EVENTMASKA: EVENT Position */
+#define EWIC_ISA_EVENTMASKA_EVENT_Msk      (1UL /*<< EWIC_ISA_EVENTMASKA_EVENT_Pos*/)  /*!< EWIC_ISA EVENTMASKA: EVENT Mask */
+
+/** \brief EWIC_ISA Event Mask n Register Definitions */
+#define EWIC_ISA_EVENTMASKn_IRQ_Pos         0U                                         /*!< EWIC_ISA EVENTMASKn: IRQ Position */
+#define EWIC_ISA_EVENTMASKn_IRQ_Msk        (0xFFFFFFFFUL /*<< EWIC_ISA_EVENTMASKn_IRQ_Pos*/) /*!< EWIC_ISA EVENTMASKn: IRQ Mask */
+
+/*@}*/ /* end of group EWIC_ISA_Type */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup ErrBnk_Type     Error Banking Registers (IMPLEMENTATION DEFINED)
+  \brief    Type definitions for the Error Banking Registers (ERRBNK)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Error Banking Registers (ERRBNK).
+ */
+typedef struct
+{
+  __IOM uint32_t IEBR0;                  /*!< Offset: 0x000 (R/W)  Instruction Cache Error Bank Register 0 */
+  __IOM uint32_t IEBR1;                  /*!< Offset: 0x004 (R/W)  Instruction Cache Error Bank Register 1 */
+        uint32_t RESERVED0[2U];
+  __IOM uint32_t DEBR0;                  /*!< Offset: 0x010 (R/W)  Data Cache Error Bank Register 0 */
+  __IOM uint32_t DEBR1;                  /*!< Offset: 0x014 (R/W)  Data Cache Error Bank Register 1 */
+        uint32_t RESERVED1[2U];
+  __IOM uint32_t TEBR0;                  /*!< Offset: 0x020 (R/W)  TCM Error Bank Register 0 */
+  __IM  uint32_t TEBRDATA0;              /*!< Offset: 0x024 (RO)   Storage for corrected data that is associated with an error.*/        
+  __IOM uint32_t TEBR1;                  /*!< Offset: 0x028 (R/W)  TCM Error Bank Register 1 */
+  __IM  uint32_t TEBRDATA1;              /*!< Offset: 0x02c (RO)   Storage for corrected data that is associated with an error.*/
+} ErrBnk_Type;
+
+/** \brief ErrBnk Instruction Cache Error Bank Register 0 Definitions */
+#define ERRBNK_IEBR0_SWDEF_Pos             30U                                         /*!< ERRBNK IEBR0: SWDEF Position */
+#define ERRBNK_IEBR0_SWDEF_Msk             (0x3UL << ERRBNK_IEBR0_SWDEF_Pos)           /*!< ERRBNK IEBR0: SWDEF Mask */
+
+#define ERRBNK_IEBR0_BANK_Pos              16U                                         /*!< ERRBNK IEBR0: BANK Position */
+#define ERRBNK_IEBR0_BANK_Msk              (1UL << ERRBNK_IEBR0_BANK_Pos)              /*!< ERRBNK IEBR0: BANK Mask */
+
+#define ERRBNK_IEBR0_LOCATION_Pos           2U                                         /*!< ERRBNK IEBR0: LOCATION Position */
+#define ERRBNK_IEBR0_LOCATION_Msk          (0x3FFFUL << ERRBNK_IEBR0_LOCATION_Pos)     /*!< ERRBNK IEBR0: LOCATION Mask */
+
+#define ERRBNK_IEBR0_LOCKED_Pos             1U                                         /*!< ERRBNK IEBR0: LOCKED Position */
+#define ERRBNK_IEBR0_LOCKED_Msk            (1UL << ERRBNK_IEBR0_LOCKED_Pos)            /*!< ERRBNK IEBR0: LOCKED Mask */
+
+#define ERRBNK_IEBR0_VALID_Pos              0U                                         /*!< ERRBNK IEBR0: VALID Position */
+#define ERRBNK_IEBR0_VALID_Msk             (1UL << /*ERRBNK_IEBR0_VALID_Pos*/)         /*!< ERRBNK IEBR0: VALID Mask */
+
+/** \brief ErrBnk Instruction Cache Error Bank Register 1 Definitions */
+#define ERRBNK_IEBR1_SWDEF_Pos             30U                                         /*!< ERRBNK IEBR1: SWDEF Position */
+#define ERRBNK_IEBR1_SWDEF_Msk             (0x3UL << ERRBNK_IEBR1_SWDEF_Pos)           /*!< ERRBNK IEBR1: SWDEF Mask */
+
+#define ERRBNK_IEBR1_BANK_Pos              16U                                         /*!< ERRBNK IEBR1: BANK Position */
+#define ERRBNK_IEBR1_BANK_Msk              (1UL << ERRBNK_IEBR1_BANK_Pos)              /*!< ERRBNK IEBR1: BANK Mask */
+
+#define ERRBNK_IEBR1_LOCATION_Pos           2U                                         /*!< ERRBNK IEBR1: LOCATION Position */
+#define ERRBNK_IEBR1_LOCATION_Msk          (0x3FFFUL << ERRBNK_IEBR1_LOCATION_Pos)     /*!< ERRBNK IEBR1: LOCATION Mask */
+
+#define ERRBNK_IEBR1_LOCKED_Pos             1U                                         /*!< ERRBNK IEBR1: LOCKED Position */
+#define ERRBNK_IEBR1_LOCKED_Msk            (1UL << ERRBNK_IEBR1_LOCKED_Pos)            /*!< ERRBNK IEBR1: LOCKED Mask */
+
+#define ERRBNK_IEBR1_VALID_Pos              0U                                         /*!< ERRBNK IEBR1: VALID Position */
+#define ERRBNK_IEBR1_VALID_Msk             (1UL << /*ERRBNK_IEBR1_VALID_Pos*/)         /*!< ERRBNK IEBR1: VALID Mask */
+
+/** \brief ErrBnk Data Cache Error Bank Register 0 Definitions */
+#define ERRBNK_DEBR0_SWDEF_Pos             30U                                         /*!< ERRBNK DEBR0: SWDEF Position */
+#define ERRBNK_DEBR0_SWDEF_Msk             (0x3UL << ERRBNK_DEBR0_SWDEF_Pos)           /*!< ERRBNK DEBR0: SWDEF Mask */
+
+#define ERRBNK_DEBR0_TYPE_Pos              17U                                         /*!< ERRBNK DEBR0: TYPE Position */
+#define ERRBNK_DEBR0_TYPE_Msk              (1UL << ERRBNK_DEBR0_TYPE_Pos)              /*!< ERRBNK DEBR0: TYPE Mask */
+
+#define ERRBNK_DEBR0_BANK_Pos              16U                                         /*!< ERRBNK DEBR0: BANK Position */
+#define ERRBNK_DEBR0_BANK_Msk              (1UL << ERRBNK_DEBR0_BANK_Pos)              /*!< ERRBNK DEBR0: BANK Mask */
+
+#define ERRBNK_DEBR0_LOCATION_Pos           2U                                         /*!< ERRBNK DEBR0: LOCATION Position */
+#define ERRBNK_DEBR0_LOCATION_Msk          (0x3FFFUL << ERRBNK_DEBR0_LOCATION_Pos)     /*!< ERRBNK DEBR0: LOCATION Mask */
+
+#define ERRBNK_DEBR0_LOCKED_Pos             1U                                         /*!< ERRBNK DEBR0: LOCKED Position */
+#define ERRBNK_DEBR0_LOCKED_Msk            (1UL << ERRBNK_DEBR0_LOCKED_Pos)            /*!< ERRBNK DEBR0: LOCKED Mask */
+
+#define ERRBNK_DEBR0_VALID_Pos              0U                                         /*!< ERRBNK DEBR0: VALID Position */
+#define ERRBNK_DEBR0_VALID_Msk             (1UL << /*ERRBNK_DEBR0_VALID_Pos*/)         /*!< ERRBNK DEBR0: VALID Mask */
+
+/** \brief ErrBnk Data Cache Error Bank Register 1 Definitions */
+#define ERRBNK_DEBR1_SWDEF_Pos             30U                                         /*!< ERRBNK DEBR1: SWDEF Position */
+#define ERRBNK_DEBR1_SWDEF_Msk             (0x3UL << ERRBNK_DEBR1_SWDEF_Pos)           /*!< ERRBNK DEBR1: SWDEF Mask */
+
+#define ERRBNK_DEBR1_TYPE_Pos              17U                                         /*!< ERRBNK DEBR1: TYPE Position */
+#define ERRBNK_DEBR1_TYPE_Msk              (1UL << ERRBNK_DEBR1_TYPE_Pos)              /*!< ERRBNK DEBR1: TYPE Mask */
+
+#define ERRBNK_DEBR1_BANK_Pos              16U                                         /*!< ERRBNK DEBR1: BANK Position */
+#define ERRBNK_DEBR1_BANK_Msk              (1UL << ERRBNK_DEBR1_BANK_Pos)              /*!< ERRBNK DEBR1: BANK Mask */
+
+#define ERRBNK_DEBR1_LOCATION_Pos           2U                                         /*!< ERRBNK DEBR1: LOCATION Position */
+#define ERRBNK_DEBR1_LOCATION_Msk          (0x3FFFUL << ERRBNK_DEBR1_LOCATION_Pos)     /*!< ERRBNK DEBR1: LOCATION Mask */
+
+#define ERRBNK_DEBR1_LOCKED_Pos             1U                                         /*!< ERRBNK DEBR1: LOCKED Position */
+#define ERRBNK_DEBR1_LOCKED_Msk            (1UL << ERRBNK_DEBR1_LOCKED_Pos)            /*!< ERRBNK DEBR1: LOCKED Mask */
+
+#define ERRBNK_DEBR1_VALID_Pos              0U                                         /*!< ERRBNK DEBR1: VALID Position */
+#define ERRBNK_DEBR1_VALID_Msk             (1UL << /*ERRBNK_DEBR1_VALID_Pos*/)         /*!< ERRBNK DEBR1: VALID Mask */
+
+/** \brief ErrBnk TCM Error Bank Register 0 Definitions */
+#define ERRBNK_TEBR0_SWDEF_Pos             30U                                         /*!< ERRBNK TEBR0: SWDEF Position */
+#define ERRBNK_TEBR0_SWDEF_Msk             (0x3UL << ERRBNK_TEBR0_SWDEF_Pos)           /*!< ERRBNK TEBR0: SWDEF Mask */
+
+#define ERRBNK_TEBR0_POISON_Pos            27U                                         /*!< ERRBNK TEBR0: POISON Position */
+#define ERRBNK_TEBR0_POISON_Msk            (1UL << ERRBNK_TEBR0_POISON_Pos)            /*!< ERRBNK TEBR0: POISON Mask */
+
+#define ERRBNK_TEBR0_TYPE_Pos              26U                                         /*!< ERRBNK TEBR0: TYPE Position */
+#define ERRBNK_TEBR0_TYPE_Msk              (1UL << ERRBNK_TEBR0_TYPE_Pos)              /*!< ERRBNK TEBR0: TYPE Mask */
+
+#define ERRBNK_TEBR0_BANK_Pos              24U                                         /*!< ERRBNK TEBR0: BANK Position */
+#define ERRBNK_TEBR0_BANK_Msk              (0x3UL << ERRBNK_TEBR0_BANK_Pos)            /*!< ERRBNK TEBR0: BANK Mask */
+
+#define ERRBNK_TEBR0_LOCATION_Pos           2U                                         /*!< ERRBNK TEBR0: LOCATION Position */
+#define ERRBNK_TEBR0_LOCATION_Msk          (0x3FFFFFUL << ERRBNK_TEBR0_LOCATION_Pos)   /*!< ERRBNK TEBR0: LOCATION Mask */
+
+#define ERRBNK_TEBR0_LOCKED_Pos             1U                                         /*!< ERRBNK TEBR0: LOCKED Position */
+#define ERRBNK_TEBR0_LOCKED_Msk            (1UL << ERRBNK_TEBR0_LOCKED_Pos)            /*!< ERRBNK TEBR0: LOCKED Mask */
+
+#define ERRBNK_TEBR0_VALID_Pos              0U                                         /*!< ERRBNK TEBR0: VALID Position */
+#define ERRBNK_TEBR0_VALID_Msk             (1UL << /*ERRBNK_TEBR0_VALID_Pos*/)         /*!< ERRBNK TEBR0: VALID Mask */
+
+/** \brief ErrBnk TCM Error Bank Register 1 Definitions */
+#define ERRBNK_TEBR1_SWDEF_Pos             30U                                         /*!< ERRBNK TEBR1: SWDEF Position */
+#define ERRBNK_TEBR1_SWDEF_Msk             (0x3UL << ERRBNK_TEBR1_SWDEF_Pos)           /*!< ERRBNK TEBR1: SWDEF Mask */
+
+#define ERRBNK_TEBR1_POISON_Pos            27U                                         /*!< ERRBNK TEBR1: POISON Position */
+#define ERRBNK_TEBR1_POISON_Msk            (1UL << ERRBNK_TEBR1_POISON_Pos)            /*!< ERRBNK TEBR1: POISON Mask */
+
+#define ERRBNK_TEBR1_TYPE_Pos              26U                                         /*!< ERRBNK TEBR1: TYPE Position */
+#define ERRBNK_TEBR1_TYPE_Msk              (1UL << ERRBNK_TEBR1_TYPE_Pos)              /*!< ERRBNK TEBR1: TYPE Mask */
+
+#define ERRBNK_TEBR1_BANK_Pos              24U                                         /*!< ERRBNK TEBR1: BANK Position */
+#define ERRBNK_TEBR1_BANK_Msk              (0x3UL << ERRBNK_TEBR1_BANK_Pos)            /*!< ERRBNK TEBR1: BANK Mask */
+
+#define ERRBNK_TEBR1_LOCATION_Pos           2U                                         /*!< ERRBNK TEBR1: LOCATION Position */
+#define ERRBNK_TEBR1_LOCATION_Msk          (0x3FFFFFUL << ERRBNK_TEBR1_LOCATION_Pos)   /*!< ERRBNK TEBR1: LOCATION Mask */
+
+#define ERRBNK_TEBR1_LOCKED_Pos             1U                                         /*!< ERRBNK TEBR1: LOCKED Position */
+#define ERRBNK_TEBR1_LOCKED_Msk            (1UL << ERRBNK_TEBR1_LOCKED_Pos)            /*!< ERRBNK TEBR1: LOCKED Mask */
+
+#define ERRBNK_TEBR1_VALID_Pos              0U                                         /*!< ERRBNK TEBR1: VALID Position */
+#define ERRBNK_TEBR1_VALID_Msk             (1UL << /*ERRBNK_TEBR1_VALID_Pos*/)         /*!< ERRBNK TEBR1: VALID Mask */
+
+/*@}*/ /* end of group ErrBnk_Type */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup PrcCfgInf_Type     Processor Configuration Information Registers (IMPLEMENTATION DEFINED)
+  \brief    Type definitions for the Processor Configuration Information Registerss (PRCCFGINF)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Processor Configuration Information Registerss (PRCCFGINF).
+ */
+typedef struct
+{
+  __OM  uint32_t CFGINFOSEL;             /*!< Offset: 0x000 ( /W)  Processor Configuration Information Selection Register */
+  __IM  uint32_t CFGINFORD;              /*!< Offset: 0x004 (R/ )  Processor Configuration Information Read Data Register */
+} PrcCfgInf_Type;
+
+/** \brief PrcCfgInf Processor Configuration Information Selection Register Definitions */
+
+/** \brief PrcCfgInf Processor Configuration Information Read Data Register Definitions */
+
+/*@}*/ /* end of group PrcCfgInf_Type */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup STL_Type     Software Test Library Observation Registers
+  \brief    Type definitions for the Software Test Library Observation Registerss (STL)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Software Test Library Observation Registerss (STL).
+ */
+typedef struct
+{
+  __IM  uint32_t STLNVICPENDOR;          /*!< Offset: 0x000 (R/ )  NVIC Pending Priority Tree Register */
+  __IM  uint32_t STLNVICACTVOR;          /*!< Offset: 0x004 (R/ )  NVIC Active Priority Tree Register */
+        uint32_t RESERVED0[2U];
+  __IOM uint32_t STLIDMPUSR;             /*!< Offset: 0x010 ( /W)  MPU Sample Register */
+  __IM  uint32_t STLIMPUOR;              /*!< Offset: 0x014 (R/ )  MPU Region Hit Register */
+  __IM  uint32_t STLDMPUOR;              /*!< Offset: 0x018 (R/ )  MPU Memory Attributes Register */
+ 
+} STL_Type;
+
+/** \brief STL NVIC Pending Priority Tree Register Definitions */
+#define STL_STLNVICPENDOR_VALID_Pos        18U                                         /*!< STL STLNVICPENDOR: VALID Position */
+#define STL_STLNVICPENDOR_VALID_Msk        (1UL << STL_STLNVICPENDOR_VALID_Pos)        /*!< STL STLNVICPENDOR: VALID Mask */
+
+#define STL_STLNVICPENDOR_TARGET_Pos       17U                                         /*!< STL STLNVICPENDOR: TARGET Position */
+#define STL_STLNVICPENDOR_TARGET_Msk       (1UL << STL_STLNVICPENDOR_TARGET_Pos)       /*!< STL STLNVICPENDOR: TARGET Mask */
+
+#define STL_STLNVICPENDOR_PRIORITY_Pos      9U                                         /*!< STL STLNVICPENDOR: PRIORITY Position */
+#define STL_STLNVICPENDOR_PRIORITY_Msk     (0xFFUL << STL_STLNVICPENDOR_PRIORITY_Pos)  /*!< STL STLNVICPENDOR: PRIORITY Mask */
+
+#define STL_STLNVICPENDOR_INTNUM_Pos        0U                                         /*!< STL STLNVICPENDOR: INTNUM Position */
+#define STL_STLNVICPENDOR_INTNUM_Msk       (0x1FFUL /*<< STL_STLNVICPENDOR_INTNUM_Pos*/) /*!< STL STLNVICPENDOR: INTNUM Mask */
+
+/** \brief STL NVIC Active Priority Tree Register Definitions */
+#define STL_STLNVICACTVOR_VALID_Pos        18U                                         /*!< STL STLNVICACTVOR: VALID Position */
+#define STL_STLNVICACTVOR_VALID_Msk        (1UL << STL_STLNVICACTVOR_VALID_Pos)        /*!< STL STLNVICACTVOR: VALID Mask */
+
+#define STL_STLNVICACTVOR_TARGET_Pos       17U                                         /*!< STL STLNVICACTVOR: TARGET Position */
+#define STL_STLNVICACTVOR_TARGET_Msk       (1UL << STL_STLNVICACTVOR_TARGET_Pos)       /*!< STL STLNVICACTVOR: TARGET Mask */
+
+#define STL_STLNVICACTVOR_PRIORITY_Pos      9U                                         /*!< STL STLNVICACTVOR: PRIORITY Position */
+#define STL_STLNVICACTVOR_PRIORITY_Msk     (0xFFUL << STL_STLNVICACTVOR_PRIORITY_Pos)  /*!< STL STLNVICACTVOR: PRIORITY Mask */
+
+#define STL_STLNVICACTVOR_INTNUM_Pos        0U                                         /*!< STL STLNVICACTVOR: INTNUM Position */
+#define STL_STLNVICACTVOR_INTNUM_Msk       (0x1FFUL /*<< STL_STLNVICACTVOR_INTNUM_Pos*/) /*!< STL STLNVICACTVOR: INTNUM Mask */
+
+/** \brief STL MPU Sample Register Definitions */
+#define STL_STLIDMPUSR_ADDR_Pos             5U                                         /*!< STL STLIDMPUSR: ADDR Position */
+#define STL_STLIDMPUSR_ADDR_Msk            (0x7FFFFFFUL << STL_STLIDMPUSR_ADDR_Pos)    /*!< STL STLIDMPUSR: ADDR Mask */
+
+#define STL_STLIDMPUSR_INSTR_Pos            2U                                         /*!< STL STLIDMPUSR: INSTR Position */
+#define STL_STLIDMPUSR_INSTR_Msk           (1UL << STL_STLIDMPUSR_INSTR_Pos)           /*!< STL STLIDMPUSR: INSTR Mask */
+
+#define STL_STLIDMPUSR_DATA_Pos             1U                                         /*!< STL STLIDMPUSR: DATA Position */
+#define STL_STLIDMPUSR_DATA_Msk            (1UL << STL_STLIDMPUSR_DATA_Pos)            /*!< STL STLIDMPUSR: DATA Mask */
+
+/** \brief STL MPU Region Hit Register Definitions */
+#define STL_STLIMPUOR_HITREGION_Pos         9U                                         /*!< STL STLIMPUOR: HITREGION Position */
+#define STL_STLIMPUOR_HITREGION_Msk        (0xFFUL << STL_STLIMPUOR_HITREGION_Pos)     /*!< STL STLIMPUOR: HITREGION Mask */
+ 
+#define STL_STLIMPUOR_ATTR_Pos              0U                                         /*!< STL STLIMPUOR: ATTR Position */
+#define STL_STLIMPUOR_ATTR_Msk             (0x1FFUL /*<< STL_STLIMPUOR_ATTR_Pos*/)     /*!< STL STLIMPUOR: ATTR Mask */
+ 
+/** \brief STL MPU Memory Attributes Register Definitions */
+#define STL_STLDMPUOR_HITREGION_Pos        9U                                         /*!< STL STLDMPUOR: HITREGION Position */
+#define STL_STLDMPUOR_HITREGION_Msk       (0xFFUL << STL_STLDMPUOR_HITREGION_Pos)     /*!< STL STLDMPUOR: HITREGION Mask */
+ 
+#define STL_STLDMPUOR_ATTR_Pos             0U                                         /*!< STL STLDMPUOR: ATTR Position */
+#define STL_STLDMPUOR_ATTR_Msk            (0x1FFUL /*<< STL_STLDMPUOR_ATTR_Pos*/)     /*!< STL STLDMPUOR: ATTR Mask */
+ 
+/*@}*/ /* end of group STL_Type */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_TPIU    Trace Port Interface Unit (TPIU)
+  \brief    Type definitions for the Trace Port Interface Unit (TPIU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Trace Port Interface Unit Register (TPIU).
+ */
+typedef struct
+{
+  __IM  uint32_t SSPSR;                  /*!< Offset: 0x000 (R/ )  Supported Parallel Port Size Register */
+  __IOM uint32_t CSPSR;                  /*!< Offset: 0x004 (R/W)  Current Parallel Port Size Register */
+        uint32_t RESERVED0[2U];
+  __IOM uint32_t ACPR;                   /*!< Offset: 0x010 (R/W)  Asynchronous Clock Prescaler Register */
+        uint32_t RESERVED1[55U];
+  __IOM uint32_t SPPR;                   /*!< Offset: 0x0F0 (R/W)  Selected Pin Protocol Register */
+        uint32_t RESERVED2[131U];
+  __IM  uint32_t FFSR;                   /*!< Offset: 0x300 (R/ )  Formatter and Flush Status Register */
+  __IOM uint32_t FFCR;                   /*!< Offset: 0x304 (R/W)  Formatter and Flush Control Register */
+  __IOM uint32_t PSCR;                   /*!< Offset: 0x308 (R/W)  Periodic Synchronization Control Register */
+        uint32_t RESERVED3[759U];
+  __IM  uint32_t TRIGGER;                /*!< Offset: 0xEE8 (R/ )  TRIGGER Register */
+  __IM  uint32_t ITFTTD0;                /*!< Offset: 0xEEC (R/ )  Integration Test FIFO Test Data 0 Register */
+  __IOM uint32_t ITATBCTR2;              /*!< Offset: 0xEF0 (R/W)  Integration Test ATB Control Register 2 */
+        uint32_t RESERVED4[1U];
+  __IM  uint32_t ITATBCTR0;              /*!< Offset: 0xEF8 (R/ )  Integration Test ATB Control Register 0 */
+  __IM  uint32_t ITFTTD1;                /*!< Offset: 0xEFC (R/ )  Integration Test FIFO Test Data 1 Register */
+  __IOM uint32_t ITCTRL;                 /*!< Offset: 0xF00 (R/W)  Integration Mode Control */
+        uint32_t RESERVED5[39U];
+  __IOM uint32_t CLAIMSET;               /*!< Offset: 0xFA0 (R/W)  Claim tag set */
+  __IOM uint32_t CLAIMCLR;               /*!< Offset: 0xFA4 (R/W)  Claim tag clear */
+        uint32_t RESERVED7[8U];
+  __IM  uint32_t DEVID;                  /*!< Offset: 0xFC8 (R/ )  Device Configuration Register */
+  __IM  uint32_t DEVTYPE;                /*!< Offset: 0xFCC (R/ )  Device Type Identifier Register */
+} TPIU_Type;
+
+/** \brief TPIU Asynchronous Clock Prescaler Register Definitions */
+#define TPIU_ACPR_PRESCALER_Pos             0U                                         /*!< TPIU ACPR: PRESCALER Position */
+#define TPIU_ACPR_PRESCALER_Msk            (0x1FFFUL /*<< TPIU_ACPR_PRESCALER_Pos*/)   /*!< TPIU ACPR: PRESCALER Mask */
+
+/** \brief TPIU Selected Pin Protocol Register Definitions */
+#define TPIU_SPPR_TXMODE_Pos                0U                                         /*!< TPIU SPPR: TXMODE Position */
+#define TPIU_SPPR_TXMODE_Msk               (0x3UL /*<< TPIU_SPPR_TXMODE_Pos*/)         /*!< TPIU SPPR: TXMODE Mask */
+
+/** \brief TPIU Formatter and Flush Status Register Definitions */
+#define TPIU_FFSR_FtNonStop_Pos             3U                                         /*!< TPIU FFSR: FtNonStop Position */
+#define TPIU_FFSR_FtNonStop_Msk            (1UL << TPIU_FFSR_FtNonStop_Pos)            /*!< TPIU FFSR: FtNonStop Mask */
+
+#define TPIU_FFSR_TCPresent_Pos             2U                                         /*!< TPIU FFSR: TCPresent Position */
+#define TPIU_FFSR_TCPresent_Msk            (1UL << TPIU_FFSR_TCPresent_Pos)            /*!< TPIU FFSR: TCPresent Mask */
+
+#define TPIU_FFSR_FtStopped_Pos             1U                                         /*!< TPIU FFSR: FtStopped Position */
+#define TPIU_FFSR_FtStopped_Msk            (1UL << TPIU_FFSR_FtStopped_Pos)            /*!< TPIU FFSR: FtStopped Mask */
+
+#define TPIU_FFSR_FlInProg_Pos              0U                                         /*!< TPIU FFSR: FlInProg Position */
+#define TPIU_FFSR_FlInProg_Msk             (1UL /*<< TPIU_FFSR_FlInProg_Pos*/)         /*!< TPIU FFSR: FlInProg Mask */
+
+/** \brief TPIU Formatter and Flush Control Register Definitions */
+#define TPIU_FFCR_TrigIn_Pos                8U                                         /*!< TPIU FFCR: TrigIn Position */
+#define TPIU_FFCR_TrigIn_Msk               (1UL << TPIU_FFCR_TrigIn_Pos)               /*!< TPIU FFCR: TrigIn Mask */
+
+#define TPIU_FFCR_FOnMan_Pos                6U                                         /*!< TPIU FFCR: FOnMan Position */
+#define TPIU_FFCR_FOnMan_Msk               (1UL << TPIU_FFCR_FOnMan_Pos)               /*!< TPIU FFCR: FOnMan Mask */
+
+#define TPIU_FFCR_EnFCont_Pos               1U                                         /*!< TPIU FFCR: EnFCont Position */
+#define TPIU_FFCR_EnFCont_Msk              (1UL << TPIU_FFCR_EnFCont_Pos)              /*!< TPIU FFCR: EnFCont Mask */
+
+/** \brief TPIU Periodic Synchronization Control Register Definitions */
+#define TPIU_PSCR_PSCount_Pos               0U                                         /*!< TPIU PSCR: PSCount Position */
+#define TPIU_PSCR_PSCount_Msk              (0x1FUL /*<< TPIU_PSCR_PSCount_Pos*/)       /*!< TPIU PSCR: TPSCount Mask */
+
+/** \brief TPIU TRIGGER Register Definitions */
+#define TPIU_TRIGGER_TRIGGER_Pos            0U                                         /*!< TPIU TRIGGER: TRIGGER Position */
+#define TPIU_TRIGGER_TRIGGER_Msk           (1UL /*<< TPIU_TRIGGER_TRIGGER_Pos*/)       /*!< TPIU TRIGGER: TRIGGER Mask */
+
+/** \brief TPIU Integration Test FIFO Test Data 0 Register Definitions */
+#define TPIU_ITFTTD0_ATB_IF2_ATVALID_Pos   29U                                         /*!< TPIU ITFTTD0: ATB Interface 2 ATVALIDPosition */
+#define TPIU_ITFTTD0_ATB_IF2_ATVALID_Msk   (0x3UL << TPIU_ITFTTD0_ATB_IF2_ATVALID_Pos) /*!< TPIU ITFTTD0: ATB Interface 2 ATVALID Mask */
+
+#define TPIU_ITFTTD0_ATB_IF2_bytecount_Pos 27U                                         /*!< TPIU ITFTTD0: ATB Interface 2 byte count Position */
+#define TPIU_ITFTTD0_ATB_IF2_bytecount_Msk (0x3UL << TPIU_ITFTTD0_ATB_IF2_bytecount_Pos) /*!< TPIU ITFTTD0: ATB Interface 2 byte count Mask */
+
+#define TPIU_ITFTTD0_ATB_IF1_ATVALID_Pos   26U                                         /*!< TPIU ITFTTD0: ATB Interface 1 ATVALID Position */
+#define TPIU_ITFTTD0_ATB_IF1_ATVALID_Msk   (0x3UL << TPIU_ITFTTD0_ATB_IF1_ATVALID_Pos) /*!< TPIU ITFTTD0: ATB Interface 1 ATVALID Mask */
+
+#define TPIU_ITFTTD0_ATB_IF1_bytecount_Pos 24U                                         /*!< TPIU ITFTTD0: ATB Interface 1 byte count Position */
+#define TPIU_ITFTTD0_ATB_IF1_bytecount_Msk (0x3UL << TPIU_ITFTTD0_ATB_IF1_bytecount_Pos) /*!< TPIU ITFTTD0: ATB Interface 1 byte countt Mask */
+
+#define TPIU_ITFTTD0_ATB_IF1_data2_Pos     16U                                         /*!< TPIU ITFTTD0: ATB Interface 1 data2 Position */
+#define TPIU_ITFTTD0_ATB_IF1_data2_Msk     (0xFFUL << TPIU_ITFTTD0_ATB_IF1_data1_Pos)  /*!< TPIU ITFTTD0: ATB Interface 1 data2 Mask */
+
+#define TPIU_ITFTTD0_ATB_IF1_data1_Pos      8U                                         /*!< TPIU ITFTTD0: ATB Interface 1 data1 Position */
+#define TPIU_ITFTTD0_ATB_IF1_data1_Msk     (0xFFUL << TPIU_ITFTTD0_ATB_IF1_data1_Pos)  /*!< TPIU ITFTTD0: ATB Interface 1 data1 Mask */
+
+#define TPIU_ITFTTD0_ATB_IF1_data0_Pos      0U                                          /*!< TPIU ITFTTD0: ATB Interface 1 data0 Position */
+#define TPIU_ITFTTD0_ATB_IF1_data0_Msk     (0xFFUL /*<< TPIU_ITFTTD0_ATB_IF1_data0_Pos*/) /*!< TPIU ITFTTD0: ATB Interface 1 data0 Mask */
+
+/** \brief TPIU Integration Test ATB Control Register 2 Register Definitions */
+#define TPIU_ITATBCTR2_AFVALID2S_Pos        1U                                         /*!< TPIU ITATBCTR2: AFVALID2S Position */
+#define TPIU_ITATBCTR2_AFVALID2S_Msk       (1UL << TPIU_ITATBCTR2_AFVALID2S_Pos)       /*!< TPIU ITATBCTR2: AFVALID2SS Mask */
+
+#define TPIU_ITATBCTR2_AFVALID1S_Pos        1U                                         /*!< TPIU ITATBCTR2: AFVALID1S Position */
+#define TPIU_ITATBCTR2_AFVALID1S_Msk       (1UL << TPIU_ITATBCTR2_AFVALID1S_Pos)       /*!< TPIU ITATBCTR2: AFVALID1SS Mask */
+
+#define TPIU_ITATBCTR2_ATREADY2S_Pos        0U                                         /*!< TPIU ITATBCTR2: ATREADY2S Position */
+#define TPIU_ITATBCTR2_ATREADY2S_Msk       (1UL /*<< TPIU_ITATBCTR2_ATREADY2S_Pos*/)   /*!< TPIU ITATBCTR2: ATREADY2S Mask */
+
+#define TPIU_ITATBCTR2_ATREADY1S_Pos        0U                                         /*!< TPIU ITATBCTR2: ATREADY1S Position */
+#define TPIU_ITATBCTR2_ATREADY1S_Msk       (1UL /*<< TPIU_ITATBCTR2_ATREADY1S_Pos*/)   /*!< TPIU ITATBCTR2: ATREADY1S Mask */
+
+/** \brief TPIU Integration Test FIFO Test Data 1 Register Definitions */
+#define TPIU_ITFTTD1_ATB_IF2_ATVALID_Pos   29U                                         /*!< TPIU ITFTTD1: ATB Interface 2 ATVALID Position */
+#define TPIU_ITFTTD1_ATB_IF2_ATVALID_Msk   (0x3UL << TPIU_ITFTTD1_ATB_IF2_ATVALID_Pos) /*!< TPIU ITFTTD1: ATB Interface 2 ATVALID Mask */
+
+#define TPIU_ITFTTD1_ATB_IF2_bytecount_Pos 27U                                         /*!< TPIU ITFTTD1: ATB Interface 2 byte count Position */
+#define TPIU_ITFTTD1_ATB_IF2_bytecount_Msk (0x3UL << TPIU_ITFTTD1_ATB_IF2_bytecount_Pos) /*!< TPIU ITFTTD1: ATB Interface 2 byte count Mask */
+
+#define TPIU_ITFTTD1_ATB_IF1_ATVALID_Pos   26U                                         /*!< TPIU ITFTTD1: ATB Interface 1 ATVALID Position */
+#define TPIU_ITFTTD1_ATB_IF1_ATVALID_Msk   (0x3UL << TPIU_ITFTTD1_ATB_IF1_ATVALID_Pos) /*!< TPIU ITFTTD1: ATB Interface 1 ATVALID Mask */
+
+#define TPIU_ITFTTD1_ATB_IF1_bytecount_Pos 24U                                         /*!< TPIU ITFTTD1: ATB Interface 1 byte count Position */
+#define TPIU_ITFTTD1_ATB_IF1_bytecount_Msk (0x3UL << TPIU_ITFTTD1_ATB_IF1_bytecount_Pos) /*!< TPIU ITFTTD1: ATB Interface 1 byte countt Mask */
+
+#define TPIU_ITFTTD1_ATB_IF2_data2_Pos     16U                                         /*!< TPIU ITFTTD1: ATB Interface 2 data2 Position */
+#define TPIU_ITFTTD1_ATB_IF2_data2_Msk     (0xFFUL << TPIU_ITFTTD1_ATB_IF2_data1_Pos)  /*!< TPIU ITFTTD1: ATB Interface 2 data2 Mask */
+
+#define TPIU_ITFTTD1_ATB_IF2_data1_Pos      8U                                         /*!< TPIU ITFTTD1: ATB Interface 2 data1 Position */
+#define TPIU_ITFTTD1_ATB_IF2_data1_Msk     (0xFFUL << TPIU_ITFTTD1_ATB_IF2_data1_Pos)  /*!< TPIU ITFTTD1: ATB Interface 2 data1 Mask */
+
+#define TPIU_ITFTTD1_ATB_IF2_data0_Pos      0U                                         /*!< TPIU ITFTTD1: ATB Interface 2 data0 Position */
+#define TPIU_ITFTTD1_ATB_IF2_data0_Msk     (0xFFUL /*<< TPIU_ITFTTD1_ATB_IF2_data0_Pos*/) /*!< TPIU ITFTTD1: ATB Interface 2 data0 Mask */
+
+/** \brief TPIU Integration Test ATB Control Register 0 Definitions */
+#define TPIU_ITATBCTR0_AFVALID2S_Pos        1U                                         /*!< TPIU ITATBCTR0: AFVALID2S Position */
+#define TPIU_ITATBCTR0_AFVALID2S_Msk       (1UL << TPIU_ITATBCTR0_AFVALID2S_Pos)       /*!< TPIU ITATBCTR0: AFVALID2SS Mask */
+
+#define TPIU_ITATBCTR0_AFVALID1S_Pos        1U                                         /*!< TPIU ITATBCTR0: AFVALID1S Position */
+#define TPIU_ITATBCTR0_AFVALID1S_Msk       (1UL << TPIU_ITATBCTR0_AFVALID1S_Pos)       /*!< TPIU ITATBCTR0: AFVALID1SS Mask */
+
+#define TPIU_ITATBCTR0_ATREADY2S_Pos        0U                                         /*!< TPIU ITATBCTR0: ATREADY2S Position */
+#define TPIU_ITATBCTR0_ATREADY2S_Msk       (1UL /*<< TPIU_ITATBCTR0_ATREADY2S_Pos*/)   /*!< TPIU ITATBCTR0: ATREADY2S Mask */
+
+#define TPIU_ITATBCTR0_ATREADY1S_Pos        0U                                         /*!< TPIU ITATBCTR0: ATREADY1S Position */
+#define TPIU_ITATBCTR0_ATREADY1S_Msk       (1UL /*<< TPIU_ITATBCTR0_ATREADY1S_Pos*/)   /*!< TPIU ITATBCTR0: ATREADY1S Mask */
+
+/** \brief TPIU Integration Mode Control Register Definitions */
+#define TPIU_ITCTRL_Mode_Pos                0U                                         /*!< TPIU ITCTRL: Mode Position */
+#define TPIU_ITCTRL_Mode_Msk               (0x3UL /*<< TPIU_ITCTRL_Mode_Pos*/)         /*!< TPIU ITCTRL: Mode Mask */
+
+/** \brief TPIU Claim Tag Set Register Definitions */
+#define TPIU_CLAIMSET_SET_Pos               0U                                         /*!< TPIU CLAIMSET: SET Position */
+#define TPIU_CLAIMSET_SET_Msk              (0xFUL /*<< TPIU_CLAIMSET_SET_Pos*/)        /*!< TPIU CLAIMSET: SET Mask */
+
+/** \brief TPIU Claim Tag Clear Register Definitions */
+#define TPIU_CLAIMCLR_CLR_Pos               0U                                         /*!< TPIU CLAIMCLR: CLR Position */
+#define TPIU_CLAIMCLR_CLR_Msk              (0xFUL /*<< TPIU_CLAIMCLR_CLR_Pos*/)        /*!< TPIU CLAIMCLR: CLR Mask */
+
+/** \brief TPIU DEVID Register Definitions */
+#define TPIU_DEVID_NRZVALID_Pos            11U                                         /*!< TPIU DEVID: NRZVALID Position */
+#define TPIU_DEVID_NRZVALID_Msk            (1UL << TPIU_DEVID_NRZVALID_Pos)            /*!< TPIU DEVID: NRZVALID Mask */
+
+#define TPIU_DEVID_MANCVALID_Pos           10U                                         /*!< TPIU DEVID: MANCVALID Position */
+#define TPIU_DEVID_MANCVALID_Msk           (1UL << TPIU_DEVID_MANCVALID_Pos)           /*!< TPIU DEVID: MANCVALID Mask */
+
+#define TPIU_DEVID_PTINVALID_Pos            9U                                         /*!< TPIU DEVID: PTINVALID Position */
+#define TPIU_DEVID_PTINVALID_Msk           (1UL << TPIU_DEVID_PTINVALID_Pos)           /*!< TPIU DEVID: PTINVALID Mask */
+
+#define TPIU_DEVID_FIFOSZ_Pos               6U                                         /*!< TPIU DEVID: FIFOSZ Position */
+#define TPIU_DEVID_FIFOSZ_Msk              (0x7UL << TPIU_DEVID_FIFOSZ_Pos)            /*!< TPIU DEVID: FIFOSZ Mask */
+
+#define TPIU_DEVID_NrTraceInput_Pos         0U                                         /*!< TPIU DEVID: NrTraceInput Position */
+#define TPIU_DEVID_NrTraceInput_Msk        (0x3FUL /*<< TPIU_DEVID_NrTraceInput_Pos*/) /*!< TPIU DEVID: NrTraceInput Mask */
+
+/** \brief TPIU DEVTYPE Register Definitions */
+#define TPIU_DEVTYPE_SubType_Pos            4U                                         /*!< TPIU DEVTYPE: SubType Position */
+#define TPIU_DEVTYPE_SubType_Msk           (0xFUL /*<< TPIU_DEVTYPE_SubType_Pos*/)     /*!< TPIU DEVTYPE: SubType Mask */
+
+#define TPIU_DEVTYPE_MajorType_Pos          0U                                         /*!< TPIU DEVTYPE: MajorType Position */
+#define TPIU_DEVTYPE_MajorType_Msk         (0xFUL << TPIU_DEVTYPE_MajorType_Pos)       /*!< TPIU DEVTYPE: MajorType Mask */
+
+/*@}*/ /* end of group CMSIS_TPIU */
+
+
+#if defined (__PMU_PRESENT) && (__PMU_PRESENT == 1U)
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_PMU     Performance Monitoring Unit (PMU)
+  \brief    Type definitions for the Performance Monitoring Unit (PMU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Performance Monitoring Unit (PMU).
+ */
+typedef struct
+{
+  __IOM uint32_t EVCNTR[__PMU_NUM_EVENTCNT];        /*!< Offset: 0x0 (R/W)    Event Counter Registers */
+#if __PMU_NUM_EVENTCNT<31
+        uint32_t RESERVED0[31U-__PMU_NUM_EVENTCNT];
+#endif
+  __IOM uint32_t CCNTR;                             /*!< Offset: 0x7C (R/W)   Cycle Counter Register */
+        uint32_t RESERVED1[224];
+  __IOM uint32_t EVTYPER[__PMU_NUM_EVENTCNT];       /*!< Offset: 0x400 (R/W)  Event Type and Filter Registers */
+#if __PMU_NUM_EVENTCNT<31
+        uint32_t RESERVED2[31U-__PMU_NUM_EVENTCNT];
+#endif
+  __IOM uint32_t CCFILTR;                           /*!< Offset: 0x47C (R/W)  Cycle Counter Filter Register */
+        uint32_t RESERVED3[480];
+  __IOM uint32_t CNTENSET;                          /*!< Offset: 0xC00 (R/W)  Count Enable Set Register */
+        uint32_t RESERVED4[7];
+  __IOM uint32_t CNTENCLR;                          /*!< Offset: 0xC20 (R/W)  Count Enable Clear Register */
+        uint32_t RESERVED5[7];
+  __IOM uint32_t INTENSET;                          /*!< Offset: 0xC40 (R/W)  Interrupt Enable Set Register */
+        uint32_t RESERVED6[7];
+  __IOM uint32_t INTENCLR;                          /*!< Offset: 0xC60 (R/W)  Interrupt Enable Clear Register */
+        uint32_t RESERVED7[7];
+  __IOM uint32_t OVSCLR;                            /*!< Offset: 0xC80 (R/W)  Overflow Flag Status Clear Register */
+        uint32_t RESERVED8[7];
+  __IOM uint32_t SWINC;                             /*!< Offset: 0xCA0 (R/W)  Software Increment Register */
+        uint32_t RESERVED9[7];
+  __IOM uint32_t OVSSET;                            /*!< Offset: 0xCC0 (R/W)  Overflow Flag Status Set Register */
+        uint32_t RESERVED10[79];
+  __IOM uint32_t TYPE;                              /*!< Offset: 0xE00 (R/W)  Type Register */
+  __IOM uint32_t CTRL;                              /*!< Offset: 0xE04 (R/W)  Control Register */
+        uint32_t RESERVED11[108];
+  __IOM uint32_t AUTHSTATUS;                        /*!< Offset: 0xFB8 (R/W)  Authentication Status Register */
+  __IOM uint32_t DEVARCH;                           /*!< Offset: 0xFBC (R/W)  Device Architecture Register */
+        uint32_t RESERVED12[3];
+  __IOM uint32_t DEVTYPE;                           /*!< Offset: 0xFCC (R/W)  Device Type Register */
+} PMU_Type;
+
+/** \brief PMU Event Counter Registers (0-30) Definitions  */
+#define PMU_EVCNTR_CNT_Pos                    0U                                           /*!< PMU EVCNTR: Counter Position */
+#define PMU_EVCNTR_CNT_Msk                   (0xFFFFUL /*<< PMU_EVCNTRx_CNT_Pos*/)         /*!< PMU EVCNTR: Counter Mask */
+
+/** \brief PMU Event Type and Filter Registers (0-30) Definitions  */
+#define PMU_EVTYPER_EVENTTOCNT_Pos            0U                                           /*!< PMU EVTYPER: Event to Count Position */
+#define PMU_EVTYPER_EVENTTOCNT_Msk           (0xFFFFUL /*<< EVTYPERx_EVENTTOCNT_Pos*/)     /*!< PMU EVTYPER: Event to Count Mask */
+
+/** \brief PMU Count Enable Set Register Definitions */
+#define PMU_CNTENSET_CNT0_ENABLE_Pos          0U                                           /*!< PMU CNTENSET: Event Counter 0 Enable Set Position */
+#define PMU_CNTENSET_CNT0_ENABLE_Msk         (1UL /*<< PMU_CNTENSET_CNT0_ENABLE_Pos*/)     /*!< PMU CNTENSET: Event Counter 0 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT1_ENABLE_Pos          1U                                           /*!< PMU CNTENSET: Event Counter 1 Enable Set Position */
+#define PMU_CNTENSET_CNT1_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT1_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 1 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT2_ENABLE_Pos          2U                                           /*!< PMU CNTENSET: Event Counter 2 Enable Set Position */
+#define PMU_CNTENSET_CNT2_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT2_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 2 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT3_ENABLE_Pos          3U                                           /*!< PMU CNTENSET: Event Counter 3 Enable Set Position */
+#define PMU_CNTENSET_CNT3_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT3_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 3 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT4_ENABLE_Pos          4U                                           /*!< PMU CNTENSET: Event Counter 4 Enable Set Position */
+#define PMU_CNTENSET_CNT4_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT4_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 4 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT5_ENABLE_Pos          5U                                           /*!< PMU CNTENSET: Event Counter 5 Enable Set Position */
+#define PMU_CNTENSET_CNT5_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT5_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 5 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT6_ENABLE_Pos          6U                                           /*!< PMU CNTENSET: Event Counter 6 Enable Set Position */
+#define PMU_CNTENSET_CNT6_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT6_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 6 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT7_ENABLE_Pos          7U                                           /*!< PMU CNTENSET: Event Counter 7 Enable Set Position */
+#define PMU_CNTENSET_CNT7_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT7_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 7 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT8_ENABLE_Pos          8U                                           /*!< PMU CNTENSET: Event Counter 8 Enable Set Position */
+#define PMU_CNTENSET_CNT8_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT8_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 8 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT9_ENABLE_Pos          9U                                           /*!< PMU CNTENSET: Event Counter 9 Enable Set Position */
+#define PMU_CNTENSET_CNT9_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT9_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 9 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT10_ENABLE_Pos         10U                                          /*!< PMU CNTENSET: Event Counter 10 Enable Set Position */
+#define PMU_CNTENSET_CNT10_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT10_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 10 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT11_ENABLE_Pos         11U                                          /*!< PMU CNTENSET: Event Counter 11 Enable Set Position */
+#define PMU_CNTENSET_CNT11_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT11_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 11 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT12_ENABLE_Pos         12U                                          /*!< PMU CNTENSET: Event Counter 12 Enable Set Position */
+#define PMU_CNTENSET_CNT12_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT12_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 12 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT13_ENABLE_Pos         13U                                          /*!< PMU CNTENSET: Event Counter 13 Enable Set Position */
+#define PMU_CNTENSET_CNT13_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT13_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 13 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT14_ENABLE_Pos         14U                                          /*!< PMU CNTENSET: Event Counter 14 Enable Set Position */
+#define PMU_CNTENSET_CNT14_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT14_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 14 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT15_ENABLE_Pos         15U                                          /*!< PMU CNTENSET: Event Counter 15 Enable Set Position */
+#define PMU_CNTENSET_CNT15_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT15_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 15 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT16_ENABLE_Pos         16U                                          /*!< PMU CNTENSET: Event Counter 16 Enable Set Position */
+#define PMU_CNTENSET_CNT16_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT16_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 16 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT17_ENABLE_Pos         17U                                          /*!< PMU CNTENSET: Event Counter 17 Enable Set Position */
+#define PMU_CNTENSET_CNT17_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT17_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 17 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT18_ENABLE_Pos         18U                                          /*!< PMU CNTENSET: Event Counter 18 Enable Set Position */
+#define PMU_CNTENSET_CNT18_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT18_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 18 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT19_ENABLE_Pos         19U                                          /*!< PMU CNTENSET: Event Counter 19 Enable Set Position */
+#define PMU_CNTENSET_CNT19_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT19_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 19 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT20_ENABLE_Pos         20U                                          /*!< PMU CNTENSET: Event Counter 20 Enable Set Position */
+#define PMU_CNTENSET_CNT20_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT20_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 20 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT21_ENABLE_Pos         21U                                          /*!< PMU CNTENSET: Event Counter 21 Enable Set Position */
+#define PMU_CNTENSET_CNT21_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT21_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 21 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT22_ENABLE_Pos         22U                                          /*!< PMU CNTENSET: Event Counter 22 Enable Set Position */
+#define PMU_CNTENSET_CNT22_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT22_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 22 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT23_ENABLE_Pos         23U                                          /*!< PMU CNTENSET: Event Counter 23 Enable Set Position */
+#define PMU_CNTENSET_CNT23_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT23_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 23 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT24_ENABLE_Pos         24U                                          /*!< PMU CNTENSET: Event Counter 24 Enable Set Position */
+#define PMU_CNTENSET_CNT24_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT24_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 24 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT25_ENABLE_Pos         25U                                          /*!< PMU CNTENSET: Event Counter 25 Enable Set Position */
+#define PMU_CNTENSET_CNT25_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT25_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 25 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT26_ENABLE_Pos         26U                                          /*!< PMU CNTENSET: Event Counter 26 Enable Set Position */
+#define PMU_CNTENSET_CNT26_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT26_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 26 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT27_ENABLE_Pos         27U                                          /*!< PMU CNTENSET: Event Counter 27 Enable Set Position */
+#define PMU_CNTENSET_CNT27_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT27_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 27 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT28_ENABLE_Pos         28U                                          /*!< PMU CNTENSET: Event Counter 28 Enable Set Position */
+#define PMU_CNTENSET_CNT28_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT28_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 28 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT29_ENABLE_Pos         29U                                          /*!< PMU CNTENSET: Event Counter 29 Enable Set Position */
+#define PMU_CNTENSET_CNT29_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT29_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 29 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT30_ENABLE_Pos         30U                                          /*!< PMU CNTENSET: Event Counter 30 Enable Set Position */
+#define PMU_CNTENSET_CNT30_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT30_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 30 Enable Set Mask */
+
+#define PMU_CNTENSET_CCNTR_ENABLE_Pos         31U                                          /*!< PMU CNTENSET: Cycle Counter Enable Set Position */
+#define PMU_CNTENSET_CCNTR_ENABLE_Msk        (1UL << PMU_CNTENSET_CCNTR_ENABLE_Pos)        /*!< PMU CNTENSET: Cycle Counter Enable Set Mask */
+
+/** \brief PMU Count Enable Clear Register Definitions */
+#define PMU_CNTENSET_CNT0_ENABLE_Pos          0U                                           /*!< PMU CNTENCLR: Event Counter 0 Enable Clear Position */
+#define PMU_CNTENCLR_CNT0_ENABLE_Msk         (1UL /*<< PMU_CNTENCLR_CNT0_ENABLE_Pos*/)     /*!< PMU CNTENCLR: Event Counter 0 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT1_ENABLE_Pos          1U                                           /*!< PMU CNTENCLR: Event Counter 1 Enable Clear Position */
+#define PMU_CNTENCLR_CNT1_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT1_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 1 Enable Clear */
+
+#define PMU_CNTENCLR_CNT2_ENABLE_Pos          2U                                           /*!< PMU CNTENCLR: Event Counter 2 Enable Clear Position */
+#define PMU_CNTENCLR_CNT2_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT2_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 2 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT3_ENABLE_Pos          3U                                           /*!< PMU CNTENCLR: Event Counter 3 Enable Clear Position */
+#define PMU_CNTENCLR_CNT3_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT3_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 3 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT4_ENABLE_Pos          4U                                           /*!< PMU CNTENCLR: Event Counter 4 Enable Clear Position */
+#define PMU_CNTENCLR_CNT4_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT4_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 4 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT5_ENABLE_Pos          5U                                           /*!< PMU CNTENCLR: Event Counter 5 Enable Clear Position */
+#define PMU_CNTENCLR_CNT5_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT5_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 5 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT6_ENABLE_Pos          6U                                           /*!< PMU CNTENCLR: Event Counter 6 Enable Clear Position */
+#define PMU_CNTENCLR_CNT6_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT6_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 6 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT7_ENABLE_Pos          7U                                           /*!< PMU CNTENCLR: Event Counter 7 Enable Clear Position */
+#define PMU_CNTENCLR_CNT7_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT7_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 7 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT8_ENABLE_Pos          8U                                           /*!< PMU CNTENCLR: Event Counter 8 Enable Clear Position */
+#define PMU_CNTENCLR_CNT8_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT8_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 8 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT9_ENABLE_Pos          9U                                           /*!< PMU CNTENCLR: Event Counter 9 Enable Clear Position */
+#define PMU_CNTENCLR_CNT9_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT9_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 9 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT10_ENABLE_Pos         10U                                          /*!< PMU CNTENCLR: Event Counter 10 Enable Clear Position */
+#define PMU_CNTENCLR_CNT10_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT10_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 10 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT11_ENABLE_Pos         11U                                          /*!< PMU CNTENCLR: Event Counter 11 Enable Clear Position */
+#define PMU_CNTENCLR_CNT11_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT11_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 11 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT12_ENABLE_Pos         12U                                          /*!< PMU CNTENCLR: Event Counter 12 Enable Clear Position */
+#define PMU_CNTENCLR_CNT12_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT12_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 12 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT13_ENABLE_Pos         13U                                          /*!< PMU CNTENCLR: Event Counter 13 Enable Clear Position */
+#define PMU_CNTENCLR_CNT13_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT13_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 13 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT14_ENABLE_Pos         14U                                          /*!< PMU CNTENCLR: Event Counter 14 Enable Clear Position */
+#define PMU_CNTENCLR_CNT14_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT14_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 14 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT15_ENABLE_Pos         15U                                          /*!< PMU CNTENCLR: Event Counter 15 Enable Clear Position */
+#define PMU_CNTENCLR_CNT15_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT15_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 15 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT16_ENABLE_Pos         16U                                          /*!< PMU CNTENCLR: Event Counter 16 Enable Clear Position */
+#define PMU_CNTENCLR_CNT16_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT16_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 16 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT17_ENABLE_Pos         17U                                          /*!< PMU CNTENCLR: Event Counter 17 Enable Clear Position */
+#define PMU_CNTENCLR_CNT17_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT17_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 17 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT18_ENABLE_Pos         18U                                          /*!< PMU CNTENCLR: Event Counter 18 Enable Clear Position */
+#define PMU_CNTENCLR_CNT18_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT18_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 18 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT19_ENABLE_Pos         19U                                          /*!< PMU CNTENCLR: Event Counter 19 Enable Clear Position */
+#define PMU_CNTENCLR_CNT19_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT19_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 19 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT20_ENABLE_Pos         20U                                          /*!< PMU CNTENCLR: Event Counter 20 Enable Clear Position */
+#define PMU_CNTENCLR_CNT20_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT20_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 20 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT21_ENABLE_Pos         21U                                          /*!< PMU CNTENCLR: Event Counter 21 Enable Clear Position */
+#define PMU_CNTENCLR_CNT21_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT21_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 21 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT22_ENABLE_Pos         22U                                          /*!< PMU CNTENCLR: Event Counter 22 Enable Clear Position */
+#define PMU_CNTENCLR_CNT22_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT22_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 22 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT23_ENABLE_Pos         23U                                          /*!< PMU CNTENCLR: Event Counter 23 Enable Clear Position */
+#define PMU_CNTENCLR_CNT23_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT23_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 23 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT24_ENABLE_Pos         24U                                          /*!< PMU CNTENCLR: Event Counter 24 Enable Clear Position */
+#define PMU_CNTENCLR_CNT24_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT24_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 24 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT25_ENABLE_Pos         25U                                          /*!< PMU CNTENCLR: Event Counter 25 Enable Clear Position */
+#define PMU_CNTENCLR_CNT25_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT25_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 25 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT26_ENABLE_Pos         26U                                          /*!< PMU CNTENCLR: Event Counter 26 Enable Clear Position */
+#define PMU_CNTENCLR_CNT26_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT26_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 26 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT27_ENABLE_Pos         27U                                          /*!< PMU CNTENCLR: Event Counter 27 Enable Clear Position */
+#define PMU_CNTENCLR_CNT27_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT27_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 27 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT28_ENABLE_Pos         28U                                          /*!< PMU CNTENCLR: Event Counter 28 Enable Clear Position */
+#define PMU_CNTENCLR_CNT28_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT28_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 28 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT29_ENABLE_Pos         29U                                          /*!< PMU CNTENCLR: Event Counter 29 Enable Clear Position */
+#define PMU_CNTENCLR_CNT29_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT29_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 29 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT30_ENABLE_Pos         30U                                          /*!< PMU CNTENCLR: Event Counter 30 Enable Clear Position */
+#define PMU_CNTENCLR_CNT30_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT30_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 30 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CCNTR_ENABLE_Pos         31U                                          /*!< PMU CNTENCLR: Cycle Counter Enable Clear Position */
+#define PMU_CNTENCLR_CCNTR_ENABLE_Msk        (1UL << PMU_CNTENCLR_CCNTR_ENABLE_Pos)        /*!< PMU CNTENCLR: Cycle Counter Enable Clear Mask */
+
+/** \brief PMU Interrupt Enable Set Register Definitions */
+#define PMU_INTENSET_CNT0_ENABLE_Pos          0U                                           /*!< PMU INTENSET: Event Counter 0 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT0_ENABLE_Msk         (1UL /*<< PMU_INTENSET_CNT0_ENABLE_Pos*/)     /*!< PMU INTENSET: Event Counter 0 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT1_ENABLE_Pos          1U                                           /*!< PMU INTENSET: Event Counter 1 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT1_ENABLE_Msk         (1UL << PMU_INTENSET_CNT1_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 1 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT2_ENABLE_Pos          2U                                           /*!< PMU INTENSET: Event Counter 2 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT2_ENABLE_Msk         (1UL << PMU_INTENSET_CNT2_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 2 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT3_ENABLE_Pos          3U                                           /*!< PMU INTENSET: Event Counter 3 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT3_ENABLE_Msk         (1UL << PMU_INTENSET_CNT3_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 3 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT4_ENABLE_Pos          4U                                           /*!< PMU INTENSET: Event Counter 4 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT4_ENABLE_Msk         (1UL << PMU_INTENSET_CNT4_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 4 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT5_ENABLE_Pos          5U                                           /*!< PMU INTENSET: Event Counter 5 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT5_ENABLE_Msk         (1UL << PMU_INTENSET_CNT5_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 5 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT6_ENABLE_Pos          6U                                           /*!< PMU INTENSET: Event Counter 6 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT6_ENABLE_Msk         (1UL << PMU_INTENSET_CNT6_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 6 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT7_ENABLE_Pos          7U                                           /*!< PMU INTENSET: Event Counter 7 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT7_ENABLE_Msk         (1UL << PMU_INTENSET_CNT7_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 7 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT8_ENABLE_Pos          8U                                           /*!< PMU INTENSET: Event Counter 8 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT8_ENABLE_Msk         (1UL << PMU_INTENSET_CNT8_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 8 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT9_ENABLE_Pos          9U                                           /*!< PMU INTENSET: Event Counter 9 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT9_ENABLE_Msk         (1UL << PMU_INTENSET_CNT9_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 9 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT10_ENABLE_Pos         10U                                          /*!< PMU INTENSET: Event Counter 10 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT10_ENABLE_Msk        (1UL << PMU_INTENSET_CNT10_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 10 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT11_ENABLE_Pos         11U                                          /*!< PMU INTENSET: Event Counter 11 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT11_ENABLE_Msk        (1UL << PMU_INTENSET_CNT11_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 11 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT12_ENABLE_Pos         12U                                          /*!< PMU INTENSET: Event Counter 12 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT12_ENABLE_Msk        (1UL << PMU_INTENSET_CNT12_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 12 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT13_ENABLE_Pos         13U                                          /*!< PMU INTENSET: Event Counter 13 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT13_ENABLE_Msk        (1UL << PMU_INTENSET_CNT13_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 13 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT14_ENABLE_Pos         14U                                          /*!< PMU INTENSET: Event Counter 14 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT14_ENABLE_Msk        (1UL << PMU_INTENSET_CNT14_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 14 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT15_ENABLE_Pos         15U                                          /*!< PMU INTENSET: Event Counter 15 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT15_ENABLE_Msk        (1UL << PMU_INTENSET_CNT15_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 15 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT16_ENABLE_Pos         16U                                          /*!< PMU INTENSET: Event Counter 16 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT16_ENABLE_Msk        (1UL << PMU_INTENSET_CNT16_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 16 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT17_ENABLE_Pos         17U                                          /*!< PMU INTENSET: Event Counter 17 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT17_ENABLE_Msk        (1UL << PMU_INTENSET_CNT17_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 17 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT18_ENABLE_Pos         18U                                          /*!< PMU INTENSET: Event Counter 18 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT18_ENABLE_Msk        (1UL << PMU_INTENSET_CNT18_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 18 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT19_ENABLE_Pos         19U                                          /*!< PMU INTENSET: Event Counter 19 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT19_ENABLE_Msk        (1UL << PMU_INTENSET_CNT19_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 19 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT20_ENABLE_Pos         20U                                          /*!< PMU INTENSET: Event Counter 20 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT20_ENABLE_Msk        (1UL << PMU_INTENSET_CNT20_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 20 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT21_ENABLE_Pos         21U                                          /*!< PMU INTENSET: Event Counter 21 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT21_ENABLE_Msk        (1UL << PMU_INTENSET_CNT21_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 21 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT22_ENABLE_Pos         22U                                          /*!< PMU INTENSET: Event Counter 22 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT22_ENABLE_Msk        (1UL << PMU_INTENSET_CNT22_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 22 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT23_ENABLE_Pos         23U                                          /*!< PMU INTENSET: Event Counter 23 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT23_ENABLE_Msk        (1UL << PMU_INTENSET_CNT23_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 23 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT24_ENABLE_Pos         24U                                          /*!< PMU INTENSET: Event Counter 24 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT24_ENABLE_Msk        (1UL << PMU_INTENSET_CNT24_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 24 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT25_ENABLE_Pos         25U                                          /*!< PMU INTENSET: Event Counter 25 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT25_ENABLE_Msk        (1UL << PMU_INTENSET_CNT25_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 25 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT26_ENABLE_Pos         26U                                          /*!< PMU INTENSET: Event Counter 26 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT26_ENABLE_Msk        (1UL << PMU_INTENSET_CNT26_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 26 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT27_ENABLE_Pos         27U                                          /*!< PMU INTENSET: Event Counter 27 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT27_ENABLE_Msk        (1UL << PMU_INTENSET_CNT27_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 27 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT28_ENABLE_Pos         28U                                          /*!< PMU INTENSET: Event Counter 28 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT28_ENABLE_Msk        (1UL << PMU_INTENSET_CNT28_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 28 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT29_ENABLE_Pos         29U                                          /*!< PMU INTENSET: Event Counter 29 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT29_ENABLE_Msk        (1UL << PMU_INTENSET_CNT29_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 29 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT30_ENABLE_Pos         30U                                          /*!< PMU INTENSET: Event Counter 30 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT30_ENABLE_Msk        (1UL << PMU_INTENSET_CNT30_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 30 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CYCCNT_ENABLE_Pos        31U                                          /*!< PMU INTENSET: Cycle Counter Interrupt Enable Set Position */
+#define PMU_INTENSET_CCYCNT_ENABLE_Msk       (1UL << PMU_INTENSET_CYCCNT_ENABLE_Pos)       /*!< PMU INTENSET: Cycle Counter Interrupt Enable Set Mask */
+
+/** \brief PMU Interrupt Enable Clear Register Definitions */
+#define PMU_INTENSET_CNT0_ENABLE_Pos          0U                                           /*!< PMU INTENCLR: Event Counter 0 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT0_ENABLE_Msk         (1UL /*<< PMU_INTENCLR_CNT0_ENABLE_Pos*/)     /*!< PMU INTENCLR: Event Counter 0 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT1_ENABLE_Pos          1U                                           /*!< PMU INTENCLR: Event Counter 1 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT1_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT1_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 1 Interrupt Enable Clear */
+
+#define PMU_INTENCLR_CNT2_ENABLE_Pos          2U                                           /*!< PMU INTENCLR: Event Counter 2 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT2_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT2_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 2 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT3_ENABLE_Pos          3U                                           /*!< PMU INTENCLR: Event Counter 3 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT3_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT3_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 3 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT4_ENABLE_Pos          4U                                           /*!< PMU INTENCLR: Event Counter 4 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT4_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT4_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 4 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT5_ENABLE_Pos          5U                                           /*!< PMU INTENCLR: Event Counter 5 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT5_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT5_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 5 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT6_ENABLE_Pos          6U                                           /*!< PMU INTENCLR: Event Counter 6 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT6_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT6_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 6 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT7_ENABLE_Pos          7U                                           /*!< PMU INTENCLR: Event Counter 7 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT7_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT7_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 7 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT8_ENABLE_Pos          8U                                           /*!< PMU INTENCLR: Event Counter 8 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT8_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT8_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 8 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT9_ENABLE_Pos          9U                                           /*!< PMU INTENCLR: Event Counter 9 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT9_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT9_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 9 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT10_ENABLE_Pos         10U                                          /*!< PMU INTENCLR: Event Counter 10 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT10_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT10_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 10 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT11_ENABLE_Pos         11U                                          /*!< PMU INTENCLR: Event Counter 11 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT11_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT11_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 11 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT12_ENABLE_Pos         12U                                          /*!< PMU INTENCLR: Event Counter 12 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT12_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT12_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 12 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT13_ENABLE_Pos         13U                                          /*!< PMU INTENCLR: Event Counter 13 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT13_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT13_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 13 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT14_ENABLE_Pos         14U                                          /*!< PMU INTENCLR: Event Counter 14 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT14_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT14_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 14 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT15_ENABLE_Pos         15U                                          /*!< PMU INTENCLR: Event Counter 15 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT15_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT15_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 15 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT16_ENABLE_Pos         16U                                          /*!< PMU INTENCLR: Event Counter 16 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT16_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT16_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 16 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT17_ENABLE_Pos         17U                                          /*!< PMU INTENCLR: Event Counter 17 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT17_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT17_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 17 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT18_ENABLE_Pos         18U                                          /*!< PMU INTENCLR: Event Counter 18 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT18_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT18_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 18 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT19_ENABLE_Pos         19U                                          /*!< PMU INTENCLR: Event Counter 19 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT19_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT19_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 19 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT20_ENABLE_Pos         20U                                          /*!< PMU INTENCLR: Event Counter 20 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT20_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT20_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 20 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT21_ENABLE_Pos         21U                                          /*!< PMU INTENCLR: Event Counter 21 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT21_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT21_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 21 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT22_ENABLE_Pos         22U                                          /*!< PMU INTENCLR: Event Counter 22 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT22_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT22_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 22 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT23_ENABLE_Pos         23U                                          /*!< PMU INTENCLR: Event Counter 23 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT23_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT23_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 23 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT24_ENABLE_Pos         24U                                          /*!< PMU INTENCLR: Event Counter 24 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT24_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT24_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 24 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT25_ENABLE_Pos         25U                                          /*!< PMU INTENCLR: Event Counter 25 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT25_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT25_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 25 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT26_ENABLE_Pos         26U                                          /*!< PMU INTENCLR: Event Counter 26 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT26_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT26_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 26 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT27_ENABLE_Pos         27U                                          /*!< PMU INTENCLR: Event Counter 27 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT27_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT27_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 27 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT28_ENABLE_Pos         28U                                          /*!< PMU INTENCLR: Event Counter 28 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT28_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT28_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 28 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT29_ENABLE_Pos         29U                                          /*!< PMU INTENCLR: Event Counter 29 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT29_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT29_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 29 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT30_ENABLE_Pos         30U                                          /*!< PMU INTENCLR: Event Counter 30 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT30_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT30_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 30 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CYCCNT_ENABLE_Pos        31U                                          /*!< PMU INTENCLR: Cycle Counter Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CYCCNT_ENABLE_Msk       (1UL << PMU_INTENCLR_CYCCNT_ENABLE_Pos)       /*!< PMU INTENCLR: Cycle Counter Interrupt Enable Clear Mask */
+
+/** \brief PMU Overflow Flag Status Set Register Definitions */
+#define PMU_OVSSET_CNT0_STATUS_Pos            0U                                           /*!< PMU OVSSET: Event Counter 0 Overflow Set Position */
+#define PMU_OVSSET_CNT0_STATUS_Msk           (1UL /*<< PMU_OVSSET_CNT0_STATUS_Pos*/)       /*!< PMU OVSSET: Event Counter 0 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT1_STATUS_Pos            1U                                           /*!< PMU OVSSET: Event Counter 1 Overflow Set Position */
+#define PMU_OVSSET_CNT1_STATUS_Msk           (1UL << PMU_OVSSET_CNT1_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 1 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT2_STATUS_Pos            2U                                           /*!< PMU OVSSET: Event Counter 2 Overflow Set Position */
+#define PMU_OVSSET_CNT2_STATUS_Msk           (1UL << PMU_OVSSET_CNT2_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 2 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT3_STATUS_Pos            3U                                           /*!< PMU OVSSET: Event Counter 3 Overflow Set Position */
+#define PMU_OVSSET_CNT3_STATUS_Msk           (1UL << PMU_OVSSET_CNT3_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 3 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT4_STATUS_Pos            4U                                           /*!< PMU OVSSET: Event Counter 4 Overflow Set Position */
+#define PMU_OVSSET_CNT4_STATUS_Msk           (1UL << PMU_OVSSET_CNT4_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 4 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT5_STATUS_Pos            5U                                           /*!< PMU OVSSET: Event Counter 5 Overflow Set Position */
+#define PMU_OVSSET_CNT5_STATUS_Msk           (1UL << PMU_OVSSET_CNT5_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 5 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT6_STATUS_Pos            6U                                           /*!< PMU OVSSET: Event Counter 6 Overflow Set Position */
+#define PMU_OVSSET_CNT6_STATUS_Msk           (1UL << PMU_OVSSET_CNT6_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 6 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT7_STATUS_Pos            7U                                           /*!< PMU OVSSET: Event Counter 7 Overflow Set Position */
+#define PMU_OVSSET_CNT7_STATUS_Msk           (1UL << PMU_OVSSET_CNT7_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 7 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT8_STATUS_Pos            8U                                           /*!< PMU OVSSET: Event Counter 8 Overflow Set Position */
+#define PMU_OVSSET_CNT8_STATUS_Msk           (1UL << PMU_OVSSET_CNT8_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 8 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT9_STATUS_Pos            9U                                           /*!< PMU OVSSET: Event Counter 9 Overflow Set Position */
+#define PMU_OVSSET_CNT9_STATUS_Msk           (1UL << PMU_OVSSET_CNT9_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 9 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT10_STATUS_Pos           10U                                          /*!< PMU OVSSET: Event Counter 10 Overflow Set Position */
+#define PMU_OVSSET_CNT10_STATUS_Msk          (1UL << PMU_OVSSET_CNT10_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 10 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT11_STATUS_Pos           11U                                          /*!< PMU OVSSET: Event Counter 11 Overflow Set Position */
+#define PMU_OVSSET_CNT11_STATUS_Msk          (1UL << PMU_OVSSET_CNT11_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 11 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT12_STATUS_Pos           12U                                          /*!< PMU OVSSET: Event Counter 12 Overflow Set Position */
+#define PMU_OVSSET_CNT12_STATUS_Msk          (1UL << PMU_OVSSET_CNT12_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 12 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT13_STATUS_Pos           13U                                          /*!< PMU OVSSET: Event Counter 13 Overflow Set Position */
+#define PMU_OVSSET_CNT13_STATUS_Msk          (1UL << PMU_OVSSET_CNT13_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 13 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT14_STATUS_Pos           14U                                          /*!< PMU OVSSET: Event Counter 14 Overflow Set Position */
+#define PMU_OVSSET_CNT14_STATUS_Msk          (1UL << PMU_OVSSET_CNT14_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 14 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT15_STATUS_Pos           15U                                          /*!< PMU OVSSET: Event Counter 15 Overflow Set Position */
+#define PMU_OVSSET_CNT15_STATUS_Msk          (1UL << PMU_OVSSET_CNT15_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 15 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT16_STATUS_Pos           16U                                          /*!< PMU OVSSET: Event Counter 16 Overflow Set Position */
+#define PMU_OVSSET_CNT16_STATUS_Msk          (1UL << PMU_OVSSET_CNT16_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 16 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT17_STATUS_Pos           17U                                          /*!< PMU OVSSET: Event Counter 17 Overflow Set Position */
+#define PMU_OVSSET_CNT17_STATUS_Msk          (1UL << PMU_OVSSET_CNT17_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 17 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT18_STATUS_Pos           18U                                          /*!< PMU OVSSET: Event Counter 18 Overflow Set Position */
+#define PMU_OVSSET_CNT18_STATUS_Msk          (1UL << PMU_OVSSET_CNT18_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 18 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT19_STATUS_Pos           19U                                          /*!< PMU OVSSET: Event Counter 19 Overflow Set Position */
+#define PMU_OVSSET_CNT19_STATUS_Msk          (1UL << PMU_OVSSET_CNT19_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 19 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT20_STATUS_Pos           20U                                          /*!< PMU OVSSET: Event Counter 20 Overflow Set Position */
+#define PMU_OVSSET_CNT20_STATUS_Msk          (1UL << PMU_OVSSET_CNT20_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 20 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT21_STATUS_Pos           21U                                          /*!< PMU OVSSET: Event Counter 21 Overflow Set Position */
+#define PMU_OVSSET_CNT21_STATUS_Msk          (1UL << PMU_OVSSET_CNT21_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 21 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT22_STATUS_Pos           22U                                          /*!< PMU OVSSET: Event Counter 22 Overflow Set Position */
+#define PMU_OVSSET_CNT22_STATUS_Msk          (1UL << PMU_OVSSET_CNT22_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 22 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT23_STATUS_Pos           23U                                          /*!< PMU OVSSET: Event Counter 23 Overflow Set Position */
+#define PMU_OVSSET_CNT23_STATUS_Msk          (1UL << PMU_OVSSET_CNT23_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 23 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT24_STATUS_Pos           24U                                          /*!< PMU OVSSET: Event Counter 24 Overflow Set Position */
+#define PMU_OVSSET_CNT24_STATUS_Msk          (1UL << PMU_OVSSET_CNT24_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 24 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT25_STATUS_Pos           25U                                          /*!< PMU OVSSET: Event Counter 25 Overflow Set Position */
+#define PMU_OVSSET_CNT25_STATUS_Msk          (1UL << PMU_OVSSET_CNT25_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 25 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT26_STATUS_Pos           26U                                          /*!< PMU OVSSET: Event Counter 26 Overflow Set Position */
+#define PMU_OVSSET_CNT26_STATUS_Msk          (1UL << PMU_OVSSET_CNT26_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 26 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT27_STATUS_Pos           27U                                          /*!< PMU OVSSET: Event Counter 27 Overflow Set Position */
+#define PMU_OVSSET_CNT27_STATUS_Msk          (1UL << PMU_OVSSET_CNT27_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 27 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT28_STATUS_Pos           28U                                          /*!< PMU OVSSET: Event Counter 28 Overflow Set Position */
+#define PMU_OVSSET_CNT28_STATUS_Msk          (1UL << PMU_OVSSET_CNT28_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 28 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT29_STATUS_Pos           29U                                          /*!< PMU OVSSET: Event Counter 29 Overflow Set Position */
+#define PMU_OVSSET_CNT29_STATUS_Msk          (1UL << PMU_OVSSET_CNT29_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 29 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT30_STATUS_Pos           30U                                          /*!< PMU OVSSET: Event Counter 30 Overflow Set Position */
+#define PMU_OVSSET_CNT30_STATUS_Msk          (1UL << PMU_OVSSET_CNT30_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 30 Overflow Set Mask */
+
+#define PMU_OVSSET_CYCCNT_STATUS_Pos          31U                                          /*!< PMU OVSSET: Cycle Counter Overflow Set Position */
+#define PMU_OVSSET_CYCCNT_STATUS_Msk         (1UL << PMU_OVSSET_CYCCNT_STATUS_Pos)         /*!< PMU OVSSET: Cycle Counter Overflow Set Mask */
+
+/** \brief PMU Overflow Flag Status Clear Register Definitions */
+#define PMU_OVSCLR_CNT0_STATUS_Pos            0U                                           /*!< PMU OVSCLR: Event Counter 0 Overflow Clear Position */
+#define PMU_OVSCLR_CNT0_STATUS_Msk           (1UL /*<< PMU_OVSCLR_CNT0_STATUS_Pos*/)       /*!< PMU OVSCLR: Event Counter 0 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT1_STATUS_Pos            1U                                           /*!< PMU OVSCLR: Event Counter 1 Overflow Clear Position */
+#define PMU_OVSCLR_CNT1_STATUS_Msk           (1UL << PMU_OVSCLR_CNT1_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 1 Overflow Clear */
+
+#define PMU_OVSCLR_CNT2_STATUS_Pos            2U                                           /*!< PMU OVSCLR: Event Counter 2 Overflow Clear Position */
+#define PMU_OVSCLR_CNT2_STATUS_Msk           (1UL << PMU_OVSCLR_CNT2_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 2 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT3_STATUS_Pos            3U                                           /*!< PMU OVSCLR: Event Counter 3 Overflow Clear Position */
+#define PMU_OVSCLR_CNT3_STATUS_Msk           (1UL << PMU_OVSCLR_CNT3_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 3 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT4_STATUS_Pos            4U                                           /*!< PMU OVSCLR: Event Counter 4 Overflow Clear Position */
+#define PMU_OVSCLR_CNT4_STATUS_Msk           (1UL << PMU_OVSCLR_CNT4_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 4 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT5_STATUS_Pos            5U                                           /*!< PMU OVSCLR: Event Counter 5 Overflow Clear Position */
+#define PMU_OVSCLR_CNT5_STATUS_Msk           (1UL << PMU_OVSCLR_CNT5_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 5 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT6_STATUS_Pos            6U                                           /*!< PMU OVSCLR: Event Counter 6 Overflow Clear Position */
+#define PMU_OVSCLR_CNT6_STATUS_Msk           (1UL << PMU_OVSCLR_CNT6_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 6 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT7_STATUS_Pos            7U                                           /*!< PMU OVSCLR: Event Counter 7 Overflow Clear Position */
+#define PMU_OVSCLR_CNT7_STATUS_Msk           (1UL << PMU_OVSCLR_CNT7_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 7 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT8_STATUS_Pos            8U                                           /*!< PMU OVSCLR: Event Counter 8 Overflow Clear Position */
+#define PMU_OVSCLR_CNT8_STATUS_Msk           (1UL << PMU_OVSCLR_CNT8_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 8 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT9_STATUS_Pos            9U                                           /*!< PMU OVSCLR: Event Counter 9 Overflow Clear Position */
+#define PMU_OVSCLR_CNT9_STATUS_Msk           (1UL << PMU_OVSCLR_CNT9_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 9 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT10_STATUS_Pos           10U                                          /*!< PMU OVSCLR: Event Counter 10 Overflow Clear Position */
+#define PMU_OVSCLR_CNT10_STATUS_Msk          (1UL << PMU_OVSCLR_CNT10_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 10 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT11_STATUS_Pos           11U                                          /*!< PMU OVSCLR: Event Counter 11 Overflow Clear Position */
+#define PMU_OVSCLR_CNT11_STATUS_Msk          (1UL << PMU_OVSCLR_CNT11_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 11 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT12_STATUS_Pos           12U                                          /*!< PMU OVSCLR: Event Counter 12 Overflow Clear Position */
+#define PMU_OVSCLR_CNT12_STATUS_Msk          (1UL << PMU_OVSCLR_CNT12_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 12 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT13_STATUS_Pos           13U                                          /*!< PMU OVSCLR: Event Counter 13 Overflow Clear Position */
+#define PMU_OVSCLR_CNT13_STATUS_Msk          (1UL << PMU_OVSCLR_CNT13_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 13 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT14_STATUS_Pos           14U                                          /*!< PMU OVSCLR: Event Counter 14 Overflow Clear Position */
+#define PMU_OVSCLR_CNT14_STATUS_Msk          (1UL << PMU_OVSCLR_CNT14_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 14 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT15_STATUS_Pos           15U                                          /*!< PMU OVSCLR: Event Counter 15 Overflow Clear Position */
+#define PMU_OVSCLR_CNT15_STATUS_Msk          (1UL << PMU_OVSCLR_CNT15_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 15 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT16_STATUS_Pos           16U                                          /*!< PMU OVSCLR: Event Counter 16 Overflow Clear Position */
+#define PMU_OVSCLR_CNT16_STATUS_Msk          (1UL << PMU_OVSCLR_CNT16_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 16 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT17_STATUS_Pos           17U                                          /*!< PMU OVSCLR: Event Counter 17 Overflow Clear Position */
+#define PMU_OVSCLR_CNT17_STATUS_Msk          (1UL << PMU_OVSCLR_CNT17_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 17 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT18_STATUS_Pos           18U                                          /*!< PMU OVSCLR: Event Counter 18 Overflow Clear Position */
+#define PMU_OVSCLR_CNT18_STATUS_Msk          (1UL << PMU_OVSCLR_CNT18_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 18 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT19_STATUS_Pos           19U                                          /*!< PMU OVSCLR: Event Counter 19 Overflow Clear Position */
+#define PMU_OVSCLR_CNT19_STATUS_Msk          (1UL << PMU_OVSCLR_CNT19_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 19 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT20_STATUS_Pos           20U                                          /*!< PMU OVSCLR: Event Counter 20 Overflow Clear Position */
+#define PMU_OVSCLR_CNT20_STATUS_Msk          (1UL << PMU_OVSCLR_CNT20_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 20 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT21_STATUS_Pos           21U                                          /*!< PMU OVSCLR: Event Counter 21 Overflow Clear Position */
+#define PMU_OVSCLR_CNT21_STATUS_Msk          (1UL << PMU_OVSCLR_CNT21_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 21 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT22_STATUS_Pos           22U                                          /*!< PMU OVSCLR: Event Counter 22 Overflow Clear Position */
+#define PMU_OVSCLR_CNT22_STATUS_Msk          (1UL << PMU_OVSCLR_CNT22_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 22 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT23_STATUS_Pos           23U                                          /*!< PMU OVSCLR: Event Counter 23 Overflow Clear Position */
+#define PMU_OVSCLR_CNT23_STATUS_Msk          (1UL << PMU_OVSCLR_CNT23_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 23 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT24_STATUS_Pos           24U                                          /*!< PMU OVSCLR: Event Counter 24 Overflow Clear Position */
+#define PMU_OVSCLR_CNT24_STATUS_Msk          (1UL << PMU_OVSCLR_CNT24_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 24 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT25_STATUS_Pos           25U                                          /*!< PMU OVSCLR: Event Counter 25 Overflow Clear Position */
+#define PMU_OVSCLR_CNT25_STATUS_Msk          (1UL << PMU_OVSCLR_CNT25_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 25 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT26_STATUS_Pos           26U                                          /*!< PMU OVSCLR: Event Counter 26 Overflow Clear Position */
+#define PMU_OVSCLR_CNT26_STATUS_Msk          (1UL << PMU_OVSCLR_CNT26_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 26 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT27_STATUS_Pos           27U                                          /*!< PMU OVSCLR: Event Counter 27 Overflow Clear Position */
+#define PMU_OVSCLR_CNT27_STATUS_Msk          (1UL << PMU_OVSCLR_CNT27_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 27 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT28_STATUS_Pos           28U                                          /*!< PMU OVSCLR: Event Counter 28 Overflow Clear Position */
+#define PMU_OVSCLR_CNT28_STATUS_Msk          (1UL << PMU_OVSCLR_CNT28_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 28 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT29_STATUS_Pos           29U                                          /*!< PMU OVSCLR: Event Counter 29 Overflow Clear Position */
+#define PMU_OVSCLR_CNT29_STATUS_Msk          (1UL << PMU_OVSCLR_CNT29_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 29 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT30_STATUS_Pos           30U                                          /*!< PMU OVSCLR: Event Counter 30 Overflow Clear Position */
+#define PMU_OVSCLR_CNT30_STATUS_Msk          (1UL << PMU_OVSCLR_CNT30_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 30 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CYCCNT_STATUS_Pos          31U                                          /*!< PMU OVSCLR: Cycle Counter Overflow Clear Position */
+#define PMU_OVSCLR_CYCCNT_STATUS_Msk         (1UL << PMU_OVSCLR_CYCCNT_STATUS_Pos)         /*!< PMU OVSCLR: Cycle Counter Overflow Clear Mask */
+
+/** \brief PMU Software Increment Counter */
+#define PMU_SWINC_CNT0_Pos                    0U                                           /*!< PMU SWINC: Event Counter 0 Software Increment Position */
+#define PMU_SWINC_CNT0_Msk                   (1UL /*<< PMU_SWINC_CNT0_Pos */)              /*!< PMU SWINC: Event Counter 0 Software Increment Mask */
+
+#define PMU_SWINC_CNT1_Pos                    1U                                           /*!< PMU SWINC: Event Counter 1 Software Increment Position */
+#define PMU_SWINC_CNT1_Msk                   (1UL << PMU_SWINC_CNT1_Pos)                   /*!< PMU SWINC: Event Counter 1 Software Increment Mask */
+
+#define PMU_SWINC_CNT2_Pos                    2U                                           /*!< PMU SWINC: Event Counter 2 Software Increment Position */
+#define PMU_SWINC_CNT2_Msk                   (1UL << PMU_SWINC_CNT2_Pos)                   /*!< PMU SWINC: Event Counter 2 Software Increment Mask */
+
+#define PMU_SWINC_CNT3_Pos                    3U                                           /*!< PMU SWINC: Event Counter 3 Software Increment Position */
+#define PMU_SWINC_CNT3_Msk                   (1UL << PMU_SWINC_CNT3_Pos)                   /*!< PMU SWINC: Event Counter 3 Software Increment Mask */
+
+#define PMU_SWINC_CNT4_Pos                    4U                                           /*!< PMU SWINC: Event Counter 4 Software Increment Position */
+#define PMU_SWINC_CNT4_Msk                   (1UL << PMU_SWINC_CNT4_Pos)                   /*!< PMU SWINC: Event Counter 4 Software Increment Mask */
+
+#define PMU_SWINC_CNT5_Pos                    5U                                           /*!< PMU SWINC: Event Counter 5 Software Increment Position */
+#define PMU_SWINC_CNT5_Msk                   (1UL << PMU_SWINC_CNT5_Pos)                   /*!< PMU SWINC: Event Counter 5 Software Increment Mask */
+
+#define PMU_SWINC_CNT6_Pos                    6U                                           /*!< PMU SWINC: Event Counter 6 Software Increment Position */
+#define PMU_SWINC_CNT6_Msk                   (1UL << PMU_SWINC_CNT6_Pos)                   /*!< PMU SWINC: Event Counter 6 Software Increment Mask */
+
+#define PMU_SWINC_CNT7_Pos                    7U                                           /*!< PMU SWINC: Event Counter 7 Software Increment Position */
+#define PMU_SWINC_CNT7_Msk                   (1UL << PMU_SWINC_CNT7_Pos)                   /*!< PMU SWINC: Event Counter 7 Software Increment Mask */
+
+#define PMU_SWINC_CNT8_Pos                    8U                                           /*!< PMU SWINC: Event Counter 8 Software Increment Position */
+#define PMU_SWINC_CNT8_Msk                   (1UL << PMU_SWINC_CNT8_Pos)                   /*!< PMU SWINC: Event Counter 8 Software Increment Mask */
+
+#define PMU_SWINC_CNT9_Pos                    9U                                           /*!< PMU SWINC: Event Counter 9 Software Increment Position */
+#define PMU_SWINC_CNT9_Msk                   (1UL << PMU_SWINC_CNT9_Pos)                   /*!< PMU SWINC: Event Counter 9 Software Increment Mask */
+
+#define PMU_SWINC_CNT10_Pos                   10U                                          /*!< PMU SWINC: Event Counter 10 Software Increment Position */
+#define PMU_SWINC_CNT10_Msk                  (1UL << PMU_SWINC_CNT10_Pos)                  /*!< PMU SWINC: Event Counter 10 Software Increment Mask */
+
+#define PMU_SWINC_CNT11_Pos                   11U                                          /*!< PMU SWINC: Event Counter 11 Software Increment Position */
+#define PMU_SWINC_CNT11_Msk                  (1UL << PMU_SWINC_CNT11_Pos)                  /*!< PMU SWINC: Event Counter 11 Software Increment Mask */
+
+#define PMU_SWINC_CNT12_Pos                   12U                                          /*!< PMU SWINC: Event Counter 12 Software Increment Position */
+#define PMU_SWINC_CNT12_Msk                  (1UL << PMU_SWINC_CNT12_Pos)                  /*!< PMU SWINC: Event Counter 12 Software Increment Mask */
+
+#define PMU_SWINC_CNT13_Pos                   13U                                          /*!< PMU SWINC: Event Counter 13 Software Increment Position */
+#define PMU_SWINC_CNT13_Msk                  (1UL << PMU_SWINC_CNT13_Pos)                  /*!< PMU SWINC: Event Counter 13 Software Increment Mask */
+
+#define PMU_SWINC_CNT14_Pos                   14U                                          /*!< PMU SWINC: Event Counter 14 Software Increment Position */
+#define PMU_SWINC_CNT14_Msk                  (1UL << PMU_SWINC_CNT14_Pos)                  /*!< PMU SWINC: Event Counter 14 Software Increment Mask */
+
+#define PMU_SWINC_CNT15_Pos                   15U                                          /*!< PMU SWINC: Event Counter 15 Software Increment Position */
+#define PMU_SWINC_CNT15_Msk                  (1UL << PMU_SWINC_CNT15_Pos)                  /*!< PMU SWINC: Event Counter 15 Software Increment Mask */
+
+#define PMU_SWINC_CNT16_Pos                   16U                                          /*!< PMU SWINC: Event Counter 16 Software Increment Position */
+#define PMU_SWINC_CNT16_Msk                  (1UL << PMU_SWINC_CNT16_Pos)                  /*!< PMU SWINC: Event Counter 16 Software Increment Mask */
+
+#define PMU_SWINC_CNT17_Pos                   17U                                          /*!< PMU SWINC: Event Counter 17 Software Increment Position */
+#define PMU_SWINC_CNT17_Msk                  (1UL << PMU_SWINC_CNT17_Pos)                  /*!< PMU SWINC: Event Counter 17 Software Increment Mask */
+
+#define PMU_SWINC_CNT18_Pos                   18U                                          /*!< PMU SWINC: Event Counter 18 Software Increment Position */
+#define PMU_SWINC_CNT18_Msk                  (1UL << PMU_SWINC_CNT18_Pos)                  /*!< PMU SWINC: Event Counter 18 Software Increment Mask */
+
+#define PMU_SWINC_CNT19_Pos                   19U                                          /*!< PMU SWINC: Event Counter 19 Software Increment Position */
+#define PMU_SWINC_CNT19_Msk                  (1UL << PMU_SWINC_CNT19_Pos)                  /*!< PMU SWINC: Event Counter 19 Software Increment Mask */
+
+#define PMU_SWINC_CNT20_Pos                   20U                                          /*!< PMU SWINC: Event Counter 20 Software Increment Position */
+#define PMU_SWINC_CNT20_Msk                  (1UL << PMU_SWINC_CNT20_Pos)                  /*!< PMU SWINC: Event Counter 20 Software Increment Mask */
+
+#define PMU_SWINC_CNT21_Pos                   21U                                          /*!< PMU SWINC: Event Counter 21 Software Increment Position */
+#define PMU_SWINC_CNT21_Msk                  (1UL << PMU_SWINC_CNT21_Pos)                  /*!< PMU SWINC: Event Counter 21 Software Increment Mask */
+
+#define PMU_SWINC_CNT22_Pos                   22U                                          /*!< PMU SWINC: Event Counter 22 Software Increment Position */
+#define PMU_SWINC_CNT22_Msk                  (1UL << PMU_SWINC_CNT22_Pos)                  /*!< PMU SWINC: Event Counter 22 Software Increment Mask */
+
+#define PMU_SWINC_CNT23_Pos                   23U                                          /*!< PMU SWINC: Event Counter 23 Software Increment Position */
+#define PMU_SWINC_CNT23_Msk                  (1UL << PMU_SWINC_CNT23_Pos)                  /*!< PMU SWINC: Event Counter 23 Software Increment Mask */
+
+#define PMU_SWINC_CNT24_Pos                   24U                                          /*!< PMU SWINC: Event Counter 24 Software Increment Position */
+#define PMU_SWINC_CNT24_Msk                  (1UL << PMU_SWINC_CNT24_Pos)                  /*!< PMU SWINC: Event Counter 24 Software Increment Mask */
+
+#define PMU_SWINC_CNT25_Pos                   25U                                          /*!< PMU SWINC: Event Counter 25 Software Increment Position */
+#define PMU_SWINC_CNT25_Msk                  (1UL << PMU_SWINC_CNT25_Pos)                  /*!< PMU SWINC: Event Counter 25 Software Increment Mask */
+
+#define PMU_SWINC_CNT26_Pos                   26U                                          /*!< PMU SWINC: Event Counter 26 Software Increment Position */
+#define PMU_SWINC_CNT26_Msk                  (1UL << PMU_SWINC_CNT26_Pos)                  /*!< PMU SWINC: Event Counter 26 Software Increment Mask */
+
+#define PMU_SWINC_CNT27_Pos                   27U                                          /*!< PMU SWINC: Event Counter 27 Software Increment Position */
+#define PMU_SWINC_CNT27_Msk                  (1UL << PMU_SWINC_CNT27_Pos)                  /*!< PMU SWINC: Event Counter 27 Software Increment Mask */
+
+#define PMU_SWINC_CNT28_Pos                   28U                                          /*!< PMU SWINC: Event Counter 28 Software Increment Position */
+#define PMU_SWINC_CNT28_Msk                  (1UL << PMU_SWINC_CNT28_Pos)                  /*!< PMU SWINC: Event Counter 28 Software Increment Mask */
+
+#define PMU_SWINC_CNT29_Pos                   29U                                          /*!< PMU SWINC: Event Counter 29 Software Increment Position */
+#define PMU_SWINC_CNT29_Msk                  (1UL << PMU_SWINC_CNT29_Pos)                  /*!< PMU SWINC: Event Counter 29 Software Increment Mask */
+
+#define PMU_SWINC_CNT30_Pos                   30U                                          /*!< PMU SWINC: Event Counter 30 Software Increment Position */
+#define PMU_SWINC_CNT30_Msk                  (1UL << PMU_SWINC_CNT30_Pos)                  /*!< PMU SWINC: Event Counter 30 Software Increment Mask */
+
+/** \brief PMU Control Register Definitions */
+#define PMU_CTRL_ENABLE_Pos                   0U                                           /*!< PMU CTRL: ENABLE Position */
+#define PMU_CTRL_ENABLE_Msk                  (1UL /*<< PMU_CTRL_ENABLE_Pos*/)              /*!< PMU CTRL: ENABLE Mask */
+
+#define PMU_CTRL_EVENTCNT_RESET_Pos           1U                                           /*!< PMU CTRL: Event Counter Reset Position */
+#define PMU_CTRL_EVENTCNT_RESET_Msk          (1UL << PMU_CTRL_EVENTCNT_RESET_Pos)          /*!< PMU CTRL: Event Counter Reset Mask */
+
+#define PMU_CTRL_CYCCNT_RESET_Pos             2U                                           /*!< PMU CTRL: Cycle Counter Reset Position */
+#define PMU_CTRL_CYCCNT_RESET_Msk            (1UL << PMU_CTRL_CYCCNT_RESET_Pos)            /*!< PMU CTRL: Cycle Counter Reset Mask */
+
+#define PMU_CTRL_CYCCNT_DISABLE_Pos           5U                                           /*!< PMU CTRL: Disable Cycle Counter Position */
+#define PMU_CTRL_CYCCNT_DISABLE_Msk          (1UL << PMU_CTRL_CYCCNT_DISABLE_Pos)          /*!< PMU CTRL: Disable Cycle Counter Mask */
+
+#define PMU_CTRL_FRZ_ON_OV_Pos                9U                                           /*!< PMU CTRL: Freeze-on-overflow Position */
+#define PMU_CTRL_FRZ_ON_OV_Msk               (1UL << PMU_CTRL_FRZ_ON_OVERFLOW_Pos)         /*!< PMU CTRL: Freeze-on-overflow Mask */
+
+#define PMU_CTRL_TRACE_ON_OV_Pos              11U                                          /*!< PMU CTRL: Trace-on-overflow Position */
+#define PMU_CTRL_TRACE_ON_OV_Msk             (1UL << PMU_CTRL_TRACE_ON_OVERFLOW_Pos)       /*!< PMU CTRL: Trace-on-overflow Mask */
+
+/** \brief PMU Type Register Definitions */
+#define PMU_TYPE_NUM_CNTS_Pos                 0U                                           /*!< PMU TYPE: Number of Counters Position */
+#define PMU_TYPE_NUM_CNTS_Msk                (0xFFUL /*<< PMU_TYPE_NUM_CNTS_Pos*/)         /*!< PMU TYPE: Number of Counters Mask */
+
+#define PMU_TYPE_SIZE_CNTS_Pos                8U                                           /*!< PMU TYPE: Size of Counters Position */
+#define PMU_TYPE_SIZE_CNTS_Msk               (0x3FUL << PMU_TYPE_SIZE_CNTS_Pos)            /*!< PMU TYPE: Size of Counters Mask */
+
+#define PMU_TYPE_CYCCNT_PRESENT_Pos           14U                                          /*!< PMU TYPE: Cycle Counter Present Position */
+#define PMU_TYPE_CYCCNT_PRESENT_Msk          (1UL << PMU_TYPE_CYCCNT_PRESENT_Pos)          /*!< PMU TYPE: Cycle Counter Present Mask */
+
+#define PMU_TYPE_FRZ_OV_SUPPORT_Pos           21U                                          /*!< PMU TYPE: Freeze-on-overflow Support Position */
+#define PMU_TYPE_FRZ_OV_SUPPORT_Msk          (1UL << PMU_TYPE_FRZ_OV_SUPPORT_Pos)          /*!< PMU TYPE: Freeze-on-overflow Support Mask */
+
+#define PMU_TYPE_TRACE_ON_OV_SUPPORT_Pos      23U                                          /*!< PMU TYPE: Trace-on-overflow Support Position */
+#define PMU_TYPE_TRACE_ON_OV_SUPPORT_Msk     (1UL << PMU_TYPE_FRZ_OV_SUPPORT_Pos)          /*!< PMU TYPE: Trace-on-overflow Support Mask */
+
+/** \brief PMU Authentication Status Register Definitions */
+#define PMU_AUTHSTATUS_NSID_Pos               0U                                           /*!< PMU AUTHSTATUS: Non-secure Invasive Debug Position */
+#define PMU_AUTHSTATUS_NSID_Msk              (0x3UL /*<< PMU_AUTHSTATUS_NSID_Pos*/)        /*!< PMU AUTHSTATUS: Non-secure Invasive Debug Mask */
+
+#define PMU_AUTHSTATUS_NSNID_Pos              2U                                           /*!< PMU AUTHSTATUS: Non-secure Non-invasive Debug Position */
+#define PMU_AUTHSTATUS_NSNID_Msk             (0x3UL << PMU_AUTHSTATUS_NSNID_Pos)           /*!< PMU AUTHSTATUS: Non-secure Non-invasive Debug Mask */
+
+#define PMU_AUTHSTATUS_SID_Pos                4U                                           /*!< PMU AUTHSTATUS: Secure Invasive Debug Position */
+#define PMU_AUTHSTATUS_SID_Msk               (0x3UL << PMU_AUTHSTATUS_SID_Pos)             /*!< PMU AUTHSTATUS: Secure Invasive Debug Mask */
+
+#define PMU_AUTHSTATUS_SNID_Pos               6U                                           /*!< PMU AUTHSTATUS: Secure Non-invasive Debug Position */
+#define PMU_AUTHSTATUS_SNID_Msk              (0x3UL << PMU_AUTHSTATUS_SNID_Pos)            /*!< PMU AUTHSTATUS: Secure Non-invasive Debug Mask */
+
+#define PMU_AUTHSTATUS_NSUID_Pos              16U                                          /*!< PMU AUTHSTATUS: Non-secure Unprivileged Invasive Debug Position */
+#define PMU_AUTHSTATUS_NSUID_Msk             (0x3UL << PMU_AUTHSTATUS_NSUID_Pos)           /*!< PMU AUTHSTATUS: Non-secure Unprivileged Invasive Debug Mask */
+
+#define PMU_AUTHSTATUS_NSUNID_Pos             18U                                          /*!< PMU AUTHSTATUS: Non-secure Unprivileged Non-invasive Debug Position */
+#define PMU_AUTHSTATUS_NSUNID_Msk            (0x3UL << PMU_AUTHSTATUS_NSUNID_Pos)          /*!< PMU AUTHSTATUS: Non-secure Unprivileged Non-invasive Debug Mask */
+
+#define PMU_AUTHSTATUS_SUID_Pos               20U                                          /*!< PMU AUTHSTATUS: Secure Unprivileged Invasive Debug Position */
+#define PMU_AUTHSTATUS_SUID_Msk              (0x3UL << PMU_AUTHSTATUS_SUID_Pos)            /*!< PMU AUTHSTATUS: Secure Unprivileged Invasive Debug Mask */
+
+#define PMU_AUTHSTATUS_SUNID_Pos              22U                                          /*!< PMU AUTHSTATUS: Secure Unprivileged Non-invasive Debug Position */
+#define PMU_AUTHSTATUS_SUNID_Msk             (0x3UL << PMU_AUTHSTATUS_SUNID_Pos)           /*!< PMU AUTHSTATUS: Secure Unprivileged Non-invasive Debug Mask */
+
+/*@} end of group CMSIS_PMU */
+#endif
+
+
+#if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_MPU     Memory Protection Unit (MPU)
+  \brief    Type definitions for the Memory Protection Unit (MPU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Memory Protection Unit (MPU).
+ */
+typedef struct
+{
+  __IM  uint32_t TYPE;                   /*!< Offset: 0x000 (R/ )  MPU Type Register */
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x004 (R/W)  MPU Control Register */
+  __IOM uint32_t RNR;                    /*!< Offset: 0x008 (R/W)  MPU Region Number Register */
+  __IOM uint32_t RBAR;                   /*!< Offset: 0x00C (R/W)  MPU Region Base Address Register */
+  __IOM uint32_t RLAR;                   /*!< Offset: 0x010 (R/W)  MPU Region Limit Address Register */
+  __IOM uint32_t RBAR_A1;                /*!< Offset: 0x014 (R/W)  MPU Region Base Address Register Alias 1 */
+  __IOM uint32_t RLAR_A1;                /*!< Offset: 0x018 (R/W)  MPU Region Limit Address Register Alias 1 */
+  __IOM uint32_t RBAR_A2;                /*!< Offset: 0x01C (R/W)  MPU Region Base Address Register Alias 2 */
+  __IOM uint32_t RLAR_A2;                /*!< Offset: 0x020 (R/W)  MPU Region Limit Address Register Alias 2 */
+  __IOM uint32_t RBAR_A3;                /*!< Offset: 0x024 (R/W)  MPU Region Base Address Register Alias 3 */
+  __IOM uint32_t RLAR_A3;                /*!< Offset: 0x028 (R/W)  MPU Region Limit Address Register Alias 3 */
+        uint32_t RESERVED0[1];
+  union {
+  __IOM uint32_t MAIR[2];
+  struct {
+  __IOM uint32_t MAIR0;                  /*!< Offset: 0x030 (R/W)  MPU Memory Attribute Indirection Register 0 */
+  __IOM uint32_t MAIR1;                  /*!< Offset: 0x034 (R/W)  MPU Memory Attribute Indirection Register 1 */
+  };
+  };
+} MPU_Type;
+
+#define MPU_TYPE_RALIASES                  4U
+
+/** \brief MPU Type Register Definitions */
+#define MPU_TYPE_IREGION_Pos               16U                                            /*!< MPU TYPE: IREGION Position */
+#define MPU_TYPE_IREGION_Msk               (0xFFUL << MPU_TYPE_IREGION_Pos)               /*!< MPU TYPE: IREGION Mask */
+
+#define MPU_TYPE_DREGION_Pos                8U                                            /*!< MPU TYPE: DREGION Position */
+#define MPU_TYPE_DREGION_Msk               (0xFFUL << MPU_TYPE_DREGION_Pos)               /*!< MPU TYPE: DREGION Mask */
+
+#define MPU_TYPE_SEPARATE_Pos               0U                                            /*!< MPU TYPE: SEPARATE Position */
+#define MPU_TYPE_SEPARATE_Msk              (1UL /*<< MPU_TYPE_SEPARATE_Pos*/)             /*!< MPU TYPE: SEPARATE Mask */
+
+/** \brief MPU Control Register Definitions */
+#define MPU_CTRL_PRIVDEFENA_Pos             2U                                            /*!< MPU CTRL: PRIVDEFENA Position */
+#define MPU_CTRL_PRIVDEFENA_Msk            (1UL << MPU_CTRL_PRIVDEFENA_Pos)               /*!< MPU CTRL: PRIVDEFENA Mask */
+
+#define MPU_CTRL_HFNMIENA_Pos               1U                                            /*!< MPU CTRL: HFNMIENA Position */
+#define MPU_CTRL_HFNMIENA_Msk              (1UL << MPU_CTRL_HFNMIENA_Pos)                 /*!< MPU CTRL: HFNMIENA Mask */
+
+#define MPU_CTRL_ENABLE_Pos                 0U                                            /*!< MPU CTRL: ENABLE Position */
+#define MPU_CTRL_ENABLE_Msk                (1UL /*<< MPU_CTRL_ENABLE_Pos*/)               /*!< MPU CTRL: ENABLE Mask */
+
+/** \brief MPU Region Number Register Definitions */
+#define MPU_RNR_REGION_Pos                  0U                                            /*!< MPU RNR: REGION Position */
+#define MPU_RNR_REGION_Msk                 (0xFFUL /*<< MPU_RNR_REGION_Pos*/)             /*!< MPU RNR: REGION Mask */
+
+/** \brief MPU Region Base Address Register Definitions */
+#define MPU_RBAR_BASE_Pos                   5U                                            /*!< MPU RBAR: BASE Position */
+#define MPU_RBAR_BASE_Msk                  (0x7FFFFFFUL << MPU_RBAR_BASE_Pos)             /*!< MPU RBAR: BASE Mask */
+
+#define MPU_RBAR_SH_Pos                     3U                                            /*!< MPU RBAR: SH Position */
+#define MPU_RBAR_SH_Msk                    (0x3UL << MPU_RBAR_SH_Pos)                     /*!< MPU RBAR: SH Mask */
+
+#define MPU_RBAR_AP_Pos                     1U                                            /*!< MPU RBAR: AP Position */
+#define MPU_RBAR_AP_Msk                    (0x3UL << MPU_RBAR_AP_Pos)                     /*!< MPU RBAR: AP Mask */
+
+#define MPU_RBAR_XN_Pos                     0U                                            /*!< MPU RBAR: XN Position */
+#define MPU_RBAR_XN_Msk                    (01UL /*<< MPU_RBAR_XN_Pos*/)                  /*!< MPU RBAR: XN Mask */
+
+/** \brief MPU Region Limit Address Register Definitions */
+#define MPU_RLAR_LIMIT_Pos                  5U                                            /*!< MPU RLAR: LIMIT Position */
+#define MPU_RLAR_LIMIT_Msk                 (0x7FFFFFFUL << MPU_RLAR_LIMIT_Pos)            /*!< MPU RLAR: LIMIT Mask */
+
+#define MPU_RLAR_PXN_Pos                    4U                                            /*!< MPU RLAR: PXN Position */
+#define MPU_RLAR_PXN_Msk                   (1UL << MPU_RLAR_PXN_Pos)                      /*!< MPU RLAR: PXN Mask */
+
+#define MPU_RLAR_AttrIndx_Pos               1U                                            /*!< MPU RLAR: AttrIndx Position */
+#define MPU_RLAR_AttrIndx_Msk              (0x7UL << MPU_RLAR_AttrIndx_Pos)               /*!< MPU RLAR: AttrIndx Mask */
+
+#define MPU_RLAR_EN_Pos                     0U                                            /*!< MPU RLAR: Region enable bit Position */
+#define MPU_RLAR_EN_Msk                    (1UL /*<< MPU_RLAR_EN_Pos*/)                   /*!< MPU RLAR: Region enable bit Mask */
+
+/** \brief MPU Memory Attribute Indirection Register 0 Definitions */
+#define MPU_MAIR0_Attr3_Pos                24U                                            /*!< MPU MAIR0: Attr3 Position */
+#define MPU_MAIR0_Attr3_Msk                (0xFFUL << MPU_MAIR0_Attr3_Pos)                /*!< MPU MAIR0: Attr3 Mask */
+
+#define MPU_MAIR0_Attr2_Pos                16U                                            /*!< MPU MAIR0: Attr2 Position */
+#define MPU_MAIR0_Attr2_Msk                (0xFFUL << MPU_MAIR0_Attr2_Pos)                /*!< MPU MAIR0: Attr2 Mask */
+
+#define MPU_MAIR0_Attr1_Pos                 8U                                            /*!< MPU MAIR0: Attr1 Position */
+#define MPU_MAIR0_Attr1_Msk                (0xFFUL << MPU_MAIR0_Attr1_Pos)                /*!< MPU MAIR0: Attr1 Mask */
+
+#define MPU_MAIR0_Attr0_Pos                 0U                                            /*!< MPU MAIR0: Attr0 Position */
+#define MPU_MAIR0_Attr0_Msk                (0xFFUL /*<< MPU_MAIR0_Attr0_Pos*/)            /*!< MPU MAIR0: Attr0 Mask */
+
+/** \brief MPU Memory Attribute Indirection Register 1 Definitions */
+#define MPU_MAIR1_Attr7_Pos                24U                                            /*!< MPU MAIR1: Attr7 Position */
+#define MPU_MAIR1_Attr7_Msk                (0xFFUL << MPU_MAIR1_Attr7_Pos)                /*!< MPU MAIR1: Attr7 Mask */
+
+#define MPU_MAIR1_Attr6_Pos                16U                                            /*!< MPU MAIR1: Attr6 Position */
+#define MPU_MAIR1_Attr6_Msk                (0xFFUL << MPU_MAIR1_Attr6_Pos)                /*!< MPU MAIR1: Attr6 Mask */
+
+#define MPU_MAIR1_Attr5_Pos                 8U                                            /*!< MPU MAIR1: Attr5 Position */
+#define MPU_MAIR1_Attr5_Msk                (0xFFUL << MPU_MAIR1_Attr5_Pos)                /*!< MPU MAIR1: Attr5 Mask */
+
+#define MPU_MAIR1_Attr4_Pos                 0U                                            /*!< MPU MAIR1: Attr4 Position */
+#define MPU_MAIR1_Attr4_Msk                (0xFFUL /*<< MPU_MAIR1_Attr4_Pos*/)            /*!< MPU MAIR1: Attr4 Mask */
+
+/*@} end of group CMSIS_MPU */
+#endif
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SAU     Security Attribution Unit (SAU)
+  \brief    Type definitions for the Security Attribution Unit (SAU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Security Attribution Unit (SAU).
+ */
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  SAU Control Register */
+  __IM  uint32_t TYPE;                   /*!< Offset: 0x004 (R/ )  SAU Type Register */
+#if defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U)
+  __IOM uint32_t RNR;                    /*!< Offset: 0x008 (R/W)  SAU Region Number Register */
+  __IOM uint32_t RBAR;                   /*!< Offset: 0x00C (R/W)  SAU Region Base Address Register */
+  __IOM uint32_t RLAR;                   /*!< Offset: 0x010 (R/W)  SAU Region Limit Address Register */
+#else
+        uint32_t RESERVED0[3];
+#endif
+  __IOM uint32_t SFSR;                   /*!< Offset: 0x014 (R/W)  Secure Fault Status Register */
+  __IOM uint32_t SFAR;                   /*!< Offset: 0x018 (R/W)  Secure Fault Address Register */
+} SAU_Type;
+
+/** \brief SAU Control Register Definitions */
+#define SAU_CTRL_ALLNS_Pos                  1U                                            /*!< SAU CTRL: ALLNS Position */
+#define SAU_CTRL_ALLNS_Msk                 (1UL << SAU_CTRL_ALLNS_Pos)                    /*!< SAU CTRL: ALLNS Mask */
+
+#define SAU_CTRL_ENABLE_Pos                 0U                                            /*!< SAU CTRL: ENABLE Position */
+#define SAU_CTRL_ENABLE_Msk                (1UL /*<< SAU_CTRL_ENABLE_Pos*/)               /*!< SAU CTRL: ENABLE Mask */
+
+/** \brief SAU Type Register Definitions */
+#define SAU_TYPE_SREGION_Pos                0U                                            /*!< SAU TYPE: SREGION Position */
+#define SAU_TYPE_SREGION_Msk               (0xFFUL /*<< SAU_TYPE_SREGION_Pos*/)           /*!< SAU TYPE: SREGION Mask */
+
+#if defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U)
+/** \brief SAU Region Number Register Definitions */
+#define SAU_RNR_REGION_Pos                  0U                                            /*!< SAU RNR: REGION Position */
+#define SAU_RNR_REGION_Msk                 (0xFFUL /*<< SAU_RNR_REGION_Pos*/)             /*!< SAU RNR: REGION Mask */
+
+/** \brief SAU Region Base Address Register Definitions */
+#define SAU_RBAR_BADDR_Pos                  5U                                            /*!< SAU RBAR: BADDR Position */
+#define SAU_RBAR_BADDR_Msk                 (0x7FFFFFFUL << SAU_RBAR_BADDR_Pos)            /*!< SAU RBAR: BADDR Mask */
+
+/** \brief SAU Region Limit Address Register Definitions */
+#define SAU_RLAR_LADDR_Pos                  5U                                            /*!< SAU RLAR: LADDR Position */
+#define SAU_RLAR_LADDR_Msk                 (0x7FFFFFFUL << SAU_RLAR_LADDR_Pos)            /*!< SAU RLAR: LADDR Mask */
+
+#define SAU_RLAR_NSC_Pos                    1U                                            /*!< SAU RLAR: NSC Position */
+#define SAU_RLAR_NSC_Msk                   (1UL << SAU_RLAR_NSC_Pos)                      /*!< SAU RLAR: NSC Mask */
+
+#define SAU_RLAR_ENABLE_Pos                 0U                                            /*!< SAU RLAR: ENABLE Position */
+#define SAU_RLAR_ENABLE_Msk                (1UL /*<< SAU_RLAR_ENABLE_Pos*/)               /*!< SAU RLAR: ENABLE Mask */
+
+#endif /* defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U) */
+
+/** \brief SAU Secure Fault Status Register Definitions */
+#define SAU_SFSR_LSERR_Pos                  7U                                            /*!< SAU SFSR: LSERR Position */
+#define SAU_SFSR_LSERR_Msk                 (1UL << SAU_SFSR_LSERR_Pos)                    /*!< SAU SFSR: LSERR Mask */
+
+#define SAU_SFSR_SFARVALID_Pos              6U                                            /*!< SAU SFSR: SFARVALID Position */
+#define SAU_SFSR_SFARVALID_Msk             (1UL << SAU_SFSR_SFARVALID_Pos)                /*!< SAU SFSR: SFARVALID Mask */
+
+#define SAU_SFSR_LSPERR_Pos                 5U                                            /*!< SAU SFSR: LSPERR Position */
+#define SAU_SFSR_LSPERR_Msk                (1UL << SAU_SFSR_LSPERR_Pos)                   /*!< SAU SFSR: LSPERR Mask */
+
+#define SAU_SFSR_INVTRAN_Pos                4U                                            /*!< SAU SFSR: INVTRAN Position */
+#define SAU_SFSR_INVTRAN_Msk               (1UL << SAU_SFSR_INVTRAN_Pos)                  /*!< SAU SFSR: INVTRAN Mask */
+
+#define SAU_SFSR_AUVIOL_Pos                 3U                                            /*!< SAU SFSR: AUVIOL Position */
+#define SAU_SFSR_AUVIOL_Msk                (1UL << SAU_SFSR_AUVIOL_Pos)                   /*!< SAU SFSR: AUVIOL Mask */
+
+#define SAU_SFSR_INVER_Pos                  2U                                            /*!< SAU SFSR: INVER Position */
+#define SAU_SFSR_INVER_Msk                 (1UL << SAU_SFSR_INVER_Pos)                    /*!< SAU SFSR: INVER Mask */
+
+#define SAU_SFSR_INVIS_Pos                  1U                                            /*!< SAU SFSR: INVIS Position */
+#define SAU_SFSR_INVIS_Msk                 (1UL << SAU_SFSR_INVIS_Pos)                    /*!< SAU SFSR: INVIS Mask */
+
+#define SAU_SFSR_INVEP_Pos                  0U                                            /*!< SAU SFSR: INVEP Position */
+#define SAU_SFSR_INVEP_Msk                 (1UL /*<< SAU_SFSR_INVEP_Pos*/)                /*!< SAU SFSR: INVEP Mask */
+
+/*@} end of group CMSIS_SAU */
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_FPU     Floating Point Unit (FPU)
+  \brief    Type definitions for the Floating Point Unit (FPU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Floating Point Unit (FPU).
+ */
+typedef struct
+{
+        uint32_t RESERVED0[1U];
+  __IOM uint32_t FPCCR;                  /*!< Offset: 0x004 (R/W)  Floating-Point Context Control Register */
+  __IOM uint32_t FPCAR;                  /*!< Offset: 0x008 (R/W)  Floating-Point Context Address Register */
+  __IOM uint32_t FPDSCR;                 /*!< Offset: 0x00C (R/W)  Floating-Point Default Status Control Register */
+  __IM  uint32_t MVFR0;                  /*!< Offset: 0x010 (R/ )  Media and VFP Feature Register 0 */
+  __IM  uint32_t MVFR1;                  /*!< Offset: 0x014 (R/ )  Media and VFP Feature Register 1 */
+  __IM  uint32_t MVFR2;                  /*!< Offset: 0x018 (R/ )  Media and VFP Feature Register 2 */
+} FPU_Type;
+
+/** \brief FPU Floating-Point Context Control Register Definitions */
+#define FPU_FPCCR_ASPEN_Pos                31U                                            /*!< FPCCR: ASPEN bit Position */
+#define FPU_FPCCR_ASPEN_Msk                (1UL << FPU_FPCCR_ASPEN_Pos)                   /*!< FPCCR: ASPEN bit Mask */
+
+#define FPU_FPCCR_LSPEN_Pos                30U                                            /*!< FPCCR: LSPEN Position */
+#define FPU_FPCCR_LSPEN_Msk                (1UL << FPU_FPCCR_LSPEN_Pos)                   /*!< FPCCR: LSPEN bit Mask */
+
+#define FPU_FPCCR_LSPENS_Pos               29U                                            /*!< FPCCR: LSPENS Position */
+#define FPU_FPCCR_LSPENS_Msk               (1UL << FPU_FPCCR_LSPENS_Pos)                  /*!< FPCCR: LSPENS bit Mask */
+
+#define FPU_FPCCR_CLRONRET_Pos             28U                                            /*!< FPCCR: CLRONRET Position */
+#define FPU_FPCCR_CLRONRET_Msk             (1UL << FPU_FPCCR_CLRONRET_Pos)                /*!< FPCCR: CLRONRET bit Mask */
+
+#define FPU_FPCCR_CLRONRETS_Pos            27U                                            /*!< FPCCR: CLRONRETS Position */
+#define FPU_FPCCR_CLRONRETS_Msk            (1UL << FPU_FPCCR_CLRONRETS_Pos)               /*!< FPCCR: CLRONRETS bit Mask */
+
+#define FPU_FPCCR_TS_Pos                   26U                                            /*!< FPCCR: TS Position */
+#define FPU_FPCCR_TS_Msk                   (1UL << FPU_FPCCR_TS_Pos)                      /*!< FPCCR: TS bit Mask */
+
+#define FPU_FPCCR_UFRDY_Pos                10U                                            /*!< FPCCR: UFRDY Position */
+#define FPU_FPCCR_UFRDY_Msk                (1UL << FPU_FPCCR_UFRDY_Pos)                   /*!< FPCCR: UFRDY bit Mask */
+
+#define FPU_FPCCR_SPLIMVIOL_Pos             9U                                            /*!< FPCCR: SPLIMVIOL Position */
+#define FPU_FPCCR_SPLIMVIOL_Msk            (1UL << FPU_FPCCR_SPLIMVIOL_Pos)               /*!< FPCCR: SPLIMVIOL bit Mask */
+
+#define FPU_FPCCR_MONRDY_Pos                8U                                            /*!< FPCCR: MONRDY Position */
+#define FPU_FPCCR_MONRDY_Msk               (1UL << FPU_FPCCR_MONRDY_Pos)                  /*!< FPCCR: MONRDY bit Mask */
+
+#define FPU_FPCCR_SFRDY_Pos                 7U                                            /*!< FPCCR: SFRDY Position */
+#define FPU_FPCCR_SFRDY_Msk                (1UL << FPU_FPCCR_SFRDY_Pos)                   /*!< FPCCR: SFRDY bit Mask */
+
+#define FPU_FPCCR_BFRDY_Pos                 6U                                            /*!< FPCCR: BFRDY Position */
+#define FPU_FPCCR_BFRDY_Msk                (1UL << FPU_FPCCR_BFRDY_Pos)                   /*!< FPCCR: BFRDY bit Mask */
+
+#define FPU_FPCCR_MMRDY_Pos                 5U                                            /*!< FPCCR: MMRDY Position */
+#define FPU_FPCCR_MMRDY_Msk                (1UL << FPU_FPCCR_MMRDY_Pos)                   /*!< FPCCR: MMRDY bit Mask */
+
+#define FPU_FPCCR_HFRDY_Pos                 4U                                            /*!< FPCCR: HFRDY Position */
+#define FPU_FPCCR_HFRDY_Msk                (1UL << FPU_FPCCR_HFRDY_Pos)                   /*!< FPCCR: HFRDY bit Mask */
+
+#define FPU_FPCCR_THREAD_Pos                3U                                            /*!< FPCCR: processor mode bit Position */
+#define FPU_FPCCR_THREAD_Msk               (1UL << FPU_FPCCR_THREAD_Pos)                  /*!< FPCCR: processor mode active bit Mask */
+
+#define FPU_FPCCR_S_Pos                     2U                                            /*!< FPCCR: Security status of the FP context bit Position */
+#define FPU_FPCCR_S_Msk                    (1UL << FPU_FPCCR_S_Pos)                       /*!< FPCCR: Security status of the FP context bit Mask */
+
+#define FPU_FPCCR_USER_Pos                  1U                                            /*!< FPCCR: privilege level bit Position */
+#define FPU_FPCCR_USER_Msk                 (1UL << FPU_FPCCR_USER_Pos)                    /*!< FPCCR: privilege level bit Mask */
+
+#define FPU_FPCCR_LSPACT_Pos                0U                                            /*!< FPCCR: Lazy state preservation active bit Position */
+#define FPU_FPCCR_LSPACT_Msk               (1UL /*<< FPU_FPCCR_LSPACT_Pos*/)              /*!< FPCCR: Lazy state preservation active bit Mask */
+
+/** \brief FPU Floating-Point Context Address Register Definitions */
+#define FPU_FPCAR_ADDRESS_Pos               3U                                            /*!< FPCAR: ADDRESS bit Position */
+#define FPU_FPCAR_ADDRESS_Msk              (0x1FFFFFFFUL << FPU_FPCAR_ADDRESS_Pos)        /*!< FPCAR: ADDRESS bit Mask */
+
+/** \brief FPU Floating-Point Default Status Control Register Definitions */
+#define FPU_FPDSCR_AHP_Pos                 26U                                            /*!< FPDSCR: AHP bit Position */
+#define FPU_FPDSCR_AHP_Msk                 (1UL << FPU_FPDSCR_AHP_Pos)                    /*!< FPDSCR: AHP bit Mask */
+
+#define FPU_FPDSCR_DN_Pos                  25U                                            /*!< FPDSCR: DN bit Position */
+#define FPU_FPDSCR_DN_Msk                  (1UL << FPU_FPDSCR_DN_Pos)                     /*!< FPDSCR: DN bit Mask */
+
+#define FPU_FPDSCR_FZ_Pos                  24U                                            /*!< FPDSCR: FZ bit Position */
+#define FPU_FPDSCR_FZ_Msk                  (1UL << FPU_FPDSCR_FZ_Pos)                     /*!< FPDSCR: FZ bit Mask */
+
+#define FPU_FPDSCR_RMode_Pos               22U                                            /*!< FPDSCR: RMode bit Position */
+#define FPU_FPDSCR_RMode_Msk               (3UL << FPU_FPDSCR_RMode_Pos)                  /*!< FPDSCR: RMode bit Mask */
+
+#define FPU_FPDSCR_FZ16_Pos                19U                                            /*!< FPDSCR: FZ16 bit Position */
+#define FPU_FPDSCR_FZ16_Msk                (1UL << FPU_FPDSCR_FZ16_Pos)                   /*!< FPDSCR: FZ16 bit Mask */
+
+#define FPU_FPDSCR_LTPSIZE_Pos             16U                                            /*!< FPDSCR: LTPSIZE bit Position */
+#define FPU_FPDSCR_LTPSIZE_Msk             (7UL << FPU_FPDSCR_LTPSIZE_Pos)                /*!< FPDSCR: LTPSIZE bit Mask */
+
+/** \brief FPU Media and VFP Feature Register 0 Definitions */
+#define FPU_MVFR0_FPRound_Pos              28U                                            /*!< MVFR0: Rounding modes bits Position */
+#define FPU_MVFR0_FPRound_Msk              (0xFUL << FPU_MVFR0_FPRound_Pos)               /*!< MVFR0: Rounding modes bits Mask */
+
+#define FPU_MVFR0_FPSqrt_Pos               20U                                            /*!< MVFR0: Square root bits Position */
+#define FPU_MVFR0_FPSqrt_Msk               (0xFUL << FPU_MVFR0_FPSqrt_Pos)                /*!< MVFR0: Square root bits Mask */
+
+#define FPU_MVFR0_FPDivide_Pos             16U                                            /*!< MVFR0: Divide bits Position */
+#define FPU_MVFR0_FPDivide_Msk             (0xFUL << FPU_MVFR0_FPDivide_Pos)              /*!< MVFR0: Divide bits Mask */
+
+#define FPU_MVFR0_FPDP_Pos                  8U                                            /*!< MVFR0: Double-precision bits Position */
+#define FPU_MVFR0_FPDP_Msk                 (0xFUL << FPU_MVFR0_FPDP_Pos)                  /*!< MVFR0: Double-precision bits Mask */
+
+#define FPU_MVFR0_FPSP_Pos                  4U                                            /*!< MVFR0: Single-precision bits Position */
+#define FPU_MVFR0_FPSP_Msk                 (0xFUL << FPU_MVFR0_FPSP_Pos)                  /*!< MVFR0: Single-precision bits Mask */
+
+#define FPU_MVFR0_SIMDReg_Pos               0U                                            /*!< MVFR0: SIMD registers bits Position */
+#define FPU_MVFR0_SIMDReg_Msk              (0xFUL /*<< FPU_MVFR0_SIMDReg_Pos*/)           /*!< MVFR0: SIMD registers bits Mask */
+
+/** \brief FPU Media and VFP Feature Register 1 Definitions */
+#define FPU_MVFR1_FMAC_Pos                 28U                                            /*!< MVFR1: Fused MAC bits Position */
+#define FPU_MVFR1_FMAC_Msk                 (0xFUL << FPU_MVFR1_FMAC_Pos)                  /*!< MVFR1: Fused MAC bits Mask */
+
+#define FPU_MVFR1_FPHP_Pos                 24U                                            /*!< MVFR1: FP HPFP bits Position */
+#define FPU_MVFR1_FPHP_Msk                 (0xFUL << FPU_MVFR1_FPHP_Pos)                  /*!< MVFR1: FP HPFP bits Mask */
+
+#define FPU_MVFR1_FP16_Pos                 20U                                            /*!< MVFR1: FP16 bits Position */
+#define FPU_MVFR1_FP16_Msk                 (0xFUL << FPU_MVFR1_FP16_Pos)                  /*!< MVFR1: FP16 bits Mask */
+
+#define FPU_MVFR1_MVE_Pos                   8U                                            /*!< MVFR1: MVE bits Position */
+#define FPU_MVFR1_MVE_Msk                  (0xFUL << FPU_MVFR1_MVE_Pos)                   /*!< MVFR1: MVE bits Mask */
+
+#define FPU_MVFR1_FPDNaN_Pos                4U                                            /*!< MVFR1: D_NaN mode bits Position */
+#define FPU_MVFR1_FPDNaN_Msk               (0xFUL << FPU_MVFR1_FPDNaN_Pos)                /*!< MVFR1: D_NaN mode bits Mask */
+
+#define FPU_MVFR1_FPFtZ_Pos                 0U                                            /*!< MVFR1: FtZ mode bits Position */
+#define FPU_MVFR1_FPFtZ_Msk                (0xFUL /*<< FPU_MVFR1_FPFtZ_Pos*/)             /*!< MVFR1: FtZ mode bits Mask */
+
+/** \brief FPU Media and VFP Feature Register 2 Definitions */
+#define FPU_MVFR2_FPMisc_Pos                4U                                            /*!< MVFR2: VFP Misc bits Position */
+#define FPU_MVFR2_FPMisc_Msk               (0xFUL << FPU_MVFR2_FPMisc_Pos)                /*!< MVFR2: VFP Misc bits Mask */
+
+/*@} end of group CMSIS_FPU */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_DCB       Debug Control Block
+  \brief    Type definitions for the Debug Control Block Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Debug Control Block Registers (DCB).
+ */
+typedef struct
+{
+  __IOM uint32_t DHCSR;                  /*!< Offset: 0x000 (R/W)  Debug Halting Control and Status Register */
+  __OM  uint32_t DCRSR;                  /*!< Offset: 0x004 ( /W)  Debug Core Register Selector Register */
+  __IOM uint32_t DCRDR;                  /*!< Offset: 0x008 (R/W)  Debug Core Register Data Register */
+  __IOM uint32_t DEMCR;                  /*!< Offset: 0x00C (R/W)  Debug Exception and Monitor Control Register */
+  __OM  uint32_t DSCEMCR;                /*!< Offset: 0x010 ( /W)  Debug Set Clear Exception and Monitor Control Register */
+  __IOM uint32_t DAUTHCTRL;              /*!< Offset: 0x014 (R/W)  Debug Authentication Control Register */
+  __IOM uint32_t DSCSR;                  /*!< Offset: 0x018 (R/W)  Debug Security Control and Status Register */
+} DCB_Type;
+
+/** \brief DCB Debug Halting Control and Status Register Definitions */
+#define DCB_DHCSR_DBGKEY_Pos               16U                                            /*!< DCB DHCSR: Debug key Position */
+#define DCB_DHCSR_DBGKEY_Msk               (0xFFFFUL << DCB_DHCSR_DBGKEY_Pos)             /*!< DCB DHCSR: Debug key Mask */
+
+#define DCB_DHCSR_S_RESTART_ST_Pos         26U                                            /*!< DCB DHCSR: Restart sticky status Position */
+#define DCB_DHCSR_S_RESTART_ST_Msk         (1UL << DCB_DHCSR_S_RESTART_ST_Pos)            /*!< DCB DHCSR: Restart sticky status Mask */
+
+#define DCB_DHCSR_S_RESET_ST_Pos           25U                                            /*!< DCB DHCSR: Reset sticky status Position */
+#define DCB_DHCSR_S_RESET_ST_Msk           (1UL << DCB_DHCSR_S_RESET_ST_Pos)              /*!< DCB DHCSR: Reset sticky status Mask */
+
+#define DCB_DHCSR_S_RETIRE_ST_Pos          24U                                            /*!< DCB DHCSR: Retire sticky status Position */
+#define DCB_DHCSR_S_RETIRE_ST_Msk          (1UL << DCB_DHCSR_S_RETIRE_ST_Pos)             /*!< DCB DHCSR: Retire sticky status Mask */
+
+#define DCB_DHCSR_S_FPD_Pos                23U                                            /*!< DCB DHCSR: Floating-point registers Debuggable Position */
+#define DCB_DHCSR_S_FPD_Msk                (1UL << DCB_DHCSR_S_FPD_Pos)                   /*!< DCB DHCSR: Floating-point registers Debuggable Mask */
+
+#define DCB_DHCSR_S_SUIDE_Pos              22U                                            /*!< DCB DHCSR: Secure unprivileged halting debug enabled Position */
+#define DCB_DHCSR_S_SUIDE_Msk              (1UL << DCB_DHCSR_S_SUIDE_Pos)                 /*!< DCB DHCSR: Secure unprivileged halting debug enabled Mask */
+
+#define DCB_DHCSR_S_NSUIDE_Pos             21U                                            /*!< DCB DHCSR: Non-secure unprivileged halting debug enabled Position */
+#define DCB_DHCSR_S_NSUIDE_Msk             (1UL << DCB_DHCSR_S_NSUIDE_Pos)                /*!< DCB DHCSR: Non-secure unprivileged halting debug enabled Mask */
+
+#define DCB_DHCSR_S_SDE_Pos                20U                                            /*!< DCB DHCSR: Secure debug enabled Position */
+#define DCB_DHCSR_S_SDE_Msk                (1UL << DCB_DHCSR_S_SDE_Pos)                   /*!< DCB DHCSR: Secure debug enabled Mask */
+
+#define DCB_DHCSR_S_LOCKUP_Pos             19U                                            /*!< DCB DHCSR: Lockup status Position */
+#define DCB_DHCSR_S_LOCKUP_Msk             (1UL << DCB_DHCSR_S_LOCKUP_Pos)                /*!< DCB DHCSR: Lockup status Mask */
+
+#define DCB_DHCSR_S_SLEEP_Pos              18U                                            /*!< DCB DHCSR: Sleeping status Position */
+#define DCB_DHCSR_S_SLEEP_Msk              (1UL << DCB_DHCSR_S_SLEEP_Pos)                 /*!< DCB DHCSR: Sleeping status Mask */
+
+#define DCB_DHCSR_S_HALT_Pos               17U                                            /*!< DCB DHCSR: Halted status Position */
+#define DCB_DHCSR_S_HALT_Msk               (1UL << DCB_DHCSR_S_HALT_Pos)                  /*!< DCB DHCSR: Halted status Mask */
+
+#define DCB_DHCSR_S_REGRDY_Pos             16U                                            /*!< DCB DHCSR: Register ready status Position */
+#define DCB_DHCSR_S_REGRDY_Msk             (1UL << DCB_DHCSR_S_REGRDY_Pos)                /*!< DCB DHCSR: Register ready status Mask */
+
+#define DCB_DHCSR_C_PMOV_Pos                6U                                            /*!< DCB DHCSR: Halt on PMU overflow control Position */
+#define DCB_DHCSR_C_PMOV_Msk               (1UL << DCB_DHCSR_C_PMOV_Pos)                  /*!< DCB DHCSR: Halt on PMU overflow control Mask */
+
+#define DCB_DHCSR_C_SNAPSTALL_Pos           5U                                            /*!< DCB DHCSR: Snap stall control Position */
+#define DCB_DHCSR_C_SNAPSTALL_Msk          (1UL << DCB_DHCSR_C_SNAPSTALL_Pos)             /*!< DCB DHCSR: Snap stall control Mask */
+
+#define DCB_DHCSR_C_MASKINTS_Pos            3U                                            /*!< DCB DHCSR: Mask interrupts control Position */
+#define DCB_DHCSR_C_MASKINTS_Msk           (1UL << DCB_DHCSR_C_MASKINTS_Pos)              /*!< DCB DHCSR: Mask interrupts control Mask */
+
+#define DCB_DHCSR_C_STEP_Pos                2U                                            /*!< DCB DHCSR: Step control Position */
+#define DCB_DHCSR_C_STEP_Msk               (1UL << DCB_DHCSR_C_STEP_Pos)                  /*!< DCB DHCSR: Step control Mask */
+
+#define DCB_DHCSR_C_HALT_Pos                1U                                            /*!< DCB DHCSR: Halt control Position */
+#define DCB_DHCSR_C_HALT_Msk               (1UL << DCB_DHCSR_C_HALT_Pos)                  /*!< DCB DHCSR: Halt control Mask */
+
+#define DCB_DHCSR_C_DEBUGEN_Pos             0U                                            /*!< DCB DHCSR: Debug enable control Position */
+#define DCB_DHCSR_C_DEBUGEN_Msk            (1UL /*<< DCB_DHCSR_C_DEBUGEN_Pos*/)           /*!< DCB DHCSR: Debug enable control Mask */
+
+/** \brief DCB Debug Core Register Selector Register Definitions */
+#define DCB_DCRSR_REGWnR_Pos               16U                                            /*!< DCB DCRSR: Register write/not-read Position */
+#define DCB_DCRSR_REGWnR_Msk               (1UL << DCB_DCRSR_REGWnR_Pos)                  /*!< DCB DCRSR: Register write/not-read Mask */
+
+#define DCB_DCRSR_REGSEL_Pos                0U                                            /*!< DCB DCRSR: Register selector Position */
+#define DCB_DCRSR_REGSEL_Msk               (0x7FUL /*<< DCB_DCRSR_REGSEL_Pos*/)           /*!< DCB DCRSR: Register selector Mask */
+
+/** \brief DCB Debug Core Register Data Register Definitions */
+#define DCB_DCRDR_DBGTMP_Pos                0U                                            /*!< DCB DCRDR: Data temporary buffer Position */
+#define DCB_DCRDR_DBGTMP_Msk               (0xFFFFFFFFUL /*<< DCB_DCRDR_DBGTMP_Pos*/)     /*!< DCB DCRDR: Data temporary buffer Mask */
+
+/** \brief DCB Debug Exception and Monitor Control Register Definitions */
+#define DCB_DEMCR_TRCENA_Pos               24U                                            /*!< DCB DEMCR: Trace enable Position */
+#define DCB_DEMCR_TRCENA_Msk               (1UL << DCB_DEMCR_TRCENA_Pos)                  /*!< DCB DEMCR: Trace enable Mask */
+
+#define DCB_DEMCR_MONPRKEY_Pos             23U                                            /*!< DCB DEMCR: Monitor pend req key Position */
+#define DCB_DEMCR_MONPRKEY_Msk             (1UL << DCB_DEMCR_MONPRKEY_Pos)                /*!< DCB DEMCR: Monitor pend req key Mask */
+
+#define DCB_DEMCR_UMON_EN_Pos              21U                                            /*!< DCB DEMCR: Unprivileged monitor enable Position */
+#define DCB_DEMCR_UMON_EN_Msk              (1UL << DCB_DEMCR_UMON_EN_Pos)                 /*!< DCB DEMCR: Unprivileged monitor enable Mask */
+
+#define DCB_DEMCR_SDME_Pos                 20U                                            /*!< DCB DEMCR: Secure DebugMonitor enable Position */
+#define DCB_DEMCR_SDME_Msk                 (1UL << DCB_DEMCR_SDME_Pos)                    /*!< DCB DEMCR: Secure DebugMonitor enable Mask */
+
+#define DCB_DEMCR_MON_REQ_Pos              19U                                            /*!< DCB DEMCR: Monitor request Position */
+#define DCB_DEMCR_MON_REQ_Msk              (1UL << DCB_DEMCR_MON_REQ_Pos)                 /*!< DCB DEMCR: Monitor request Mask */
+
+#define DCB_DEMCR_MON_STEP_Pos             18U                                            /*!< DCB DEMCR: Monitor step Position */
+#define DCB_DEMCR_MON_STEP_Msk             (1UL << DCB_DEMCR_MON_STEP_Pos)                /*!< DCB DEMCR: Monitor step Mask */
+
+#define DCB_DEMCR_MON_PEND_Pos             17U                                            /*!< DCB DEMCR: Monitor pend Position */
+#define DCB_DEMCR_MON_PEND_Msk             (1UL << DCB_DEMCR_MON_PEND_Pos)                /*!< DCB DEMCR: Monitor pend Mask */
+
+#define DCB_DEMCR_MON_EN_Pos               16U                                            /*!< DCB DEMCR: Monitor enable Position */
+#define DCB_DEMCR_MON_EN_Msk               (1UL << DCB_DEMCR_MON_EN_Pos)                  /*!< DCB DEMCR: Monitor enable Mask */
+
+#define DCB_DEMCR_VC_SFERR_Pos             11U                                            /*!< DCB DEMCR: Vector Catch SecureFault Position */
+#define DCB_DEMCR_VC_SFERR_Msk             (1UL << DCB_DEMCR_VC_SFERR_Pos)                /*!< DCB DEMCR: Vector Catch SecureFault Mask */
+
+#define DCB_DEMCR_VC_HARDERR_Pos           10U                                            /*!< DCB DEMCR: Vector Catch HardFault errors Position */
+#define DCB_DEMCR_VC_HARDERR_Msk           (1UL << DCB_DEMCR_VC_HARDERR_Pos)              /*!< DCB DEMCR: Vector Catch HardFault errors Mask */
+
+#define DCB_DEMCR_VC_INTERR_Pos             9U                                            /*!< DCB DEMCR: Vector Catch interrupt errors Position */
+#define DCB_DEMCR_VC_INTERR_Msk            (1UL << DCB_DEMCR_VC_INTERR_Pos)               /*!< DCB DEMCR: Vector Catch interrupt errors Mask */
+
+#define DCB_DEMCR_VC_BUSERR_Pos             8U                                            /*!< DCB DEMCR: Vector Catch BusFault errors Position */
+#define DCB_DEMCR_VC_BUSERR_Msk            (1UL << DCB_DEMCR_VC_BUSERR_Pos)               /*!< DCB DEMCR: Vector Catch BusFault errors Mask */
+
+#define DCB_DEMCR_VC_STATERR_Pos            7U                                            /*!< DCB DEMCR: Vector Catch state errors Position */
+#define DCB_DEMCR_VC_STATERR_Msk           (1UL << DCB_DEMCR_VC_STATERR_Pos)              /*!< DCB DEMCR: Vector Catch state errors Mask */
+
+#define DCB_DEMCR_VC_CHKERR_Pos             6U                                            /*!< DCB DEMCR: Vector Catch check errors Position */
+#define DCB_DEMCR_VC_CHKERR_Msk            (1UL << DCB_DEMCR_VC_CHKERR_Pos)               /*!< DCB DEMCR: Vector Catch check errors Mask */
+
+#define DCB_DEMCR_VC_NOCPERR_Pos            5U                                            /*!< DCB DEMCR: Vector Catch NOCP errors Position */
+#define DCB_DEMCR_VC_NOCPERR_Msk           (1UL << DCB_DEMCR_VC_NOCPERR_Pos)              /*!< DCB DEMCR: Vector Catch NOCP errors Mask */
+
+#define DCB_DEMCR_VC_MMERR_Pos              4U                                            /*!< DCB DEMCR: Vector Catch MemManage errors Position */
+#define DCB_DEMCR_VC_MMERR_Msk             (1UL << DCB_DEMCR_VC_MMERR_Pos)                /*!< DCB DEMCR: Vector Catch MemManage errors Mask */
+
+#define DCB_DEMCR_VC_CORERESET_Pos          0U                                            /*!< DCB DEMCR: Vector Catch Core reset Position */
+#define DCB_DEMCR_VC_CORERESET_Msk         (1UL /*<< DCB_DEMCR_VC_CORERESET_Pos*/)        /*!< DCB DEMCR: Vector Catch Core reset Mask */
+
+/** \brief DCB Debug Set Clear Exception and Monitor Control Register Definitions */
+#define DCB_DSCEMCR_CLR_MON_REQ_Pos        19U                                            /*!< DCB DSCEMCR: Clear monitor request Position */
+#define DCB_DSCEMCR_CLR_MON_REQ_Msk        (1UL << DCB_DSCEMCR_CLR_MON_REQ_Pos)           /*!< DCB DSCEMCR: Clear monitor request Mask */
+
+#define DCB_DSCEMCR_CLR_MON_PEND_Pos       17U                                            /*!< DCB DSCEMCR: Clear monitor pend Position */
+#define DCB_DSCEMCR_CLR_MON_PEND_Msk       (1UL << DCB_DSCEMCR_CLR_MON_PEND_Pos)          /*!< DCB DSCEMCR: Clear monitor pend Mask */
+
+#define DCB_DSCEMCR_SET_MON_REQ_Pos         3U                                            /*!< DCB DSCEMCR: Set monitor request Position */
+#define DCB_DSCEMCR_SET_MON_REQ_Msk        (1UL << DCB_DSCEMCR_SET_MON_REQ_Pos)           /*!< DCB DSCEMCR: Set monitor request Mask */
+
+#define DCB_DSCEMCR_SET_MON_PEND_Pos        1U                                            /*!< DCB DSCEMCR: Set monitor pend Position */
+#define DCB_DSCEMCR_SET_MON_PEND_Msk       (1UL << DCB_DSCEMCR_SET_MON_PEND_Pos)          /*!< DCB DSCEMCR: Set monitor pend Mask */
+
+/** \brief DCB Debug Authentication Control Register Definitions */
+#define DCB_DAUTHCTRL_UIDEN_Pos            10U                                            /*!< DCB DAUTHCTRL: Unprivileged Invasive Debug Enable Position */
+#define DCB_DAUTHCTRL_UIDEN_Msk            (1UL << DCB_DAUTHCTRL_UIDEN_Pos)               /*!< DCB DAUTHCTRL: Unprivileged Invasive Debug Enable Mask */
+
+#define DCB_DAUTHCTRL_UIDAPEN_Pos           9U                                            /*!< DCB DAUTHCTRL: Unprivileged Invasive DAP Access Enable Position */
+#define DCB_DAUTHCTRL_UIDAPEN_Msk          (1UL << DCB_DAUTHCTRL_UIDAPEN_Pos)             /*!< DCB DAUTHCTRL: Unprivileged Invasive DAP Access Enable Mask */
+
+#define DCB_DAUTHCTRL_FSDMA_Pos             8U                                            /*!< DCB DAUTHCTRL: Force Secure DebugMonitor Allowed Position */
+#define DCB_DAUTHCTRL_FSDMA_Msk            (1UL << DCB_DAUTHCTRL_FSDMA_Pos)               /*!< DCB DAUTHCTRL: Force Secure DebugMonitor Allowed Mask */
+
+#define DCB_DAUTHCTRL_INTSPNIDEN_Pos        3U                                            /*!< DCB DAUTHCTRL: Internal Secure non-invasive debug enable Position */
+#define DCB_DAUTHCTRL_INTSPNIDEN_Msk       (1UL << DCB_DAUTHCTRL_INTSPNIDEN_Pos)          /*!< DCB DAUTHCTRL: Internal Secure non-invasive debug enable Mask */
+
+#define DCB_DAUTHCTRL_SPNIDENSEL_Pos        2U                                            /*!< DCB DAUTHCTRL: Secure non-invasive debug enable select Position */
+#define DCB_DAUTHCTRL_SPNIDENSEL_Msk       (1UL << DCB_DAUTHCTRL_SPNIDENSEL_Pos)          /*!< DCB DAUTHCTRL: Secure non-invasive debug enable select Mask */
+
+#define DCB_DAUTHCTRL_INTSPIDEN_Pos         1U                                            /*!< DCB DAUTHCTRL: Internal Secure invasive debug enable Position */
+#define DCB_DAUTHCTRL_INTSPIDEN_Msk        (1UL << DCB_DAUTHCTRL_INTSPIDEN_Pos)           /*!< DCB DAUTHCTRL: Internal Secure invasive debug enable Mask */
+
+#define DCB_DAUTHCTRL_SPIDENSEL_Pos         0U                                            /*!< DCB DAUTHCTRL: Secure invasive debug enable select Position */
+#define DCB_DAUTHCTRL_SPIDENSEL_Msk        (1UL /*<< DCB_DAUTHCTRL_SPIDENSEL_Pos*/)       /*!< DCB DAUTHCTRL: Secure invasive debug enable select Mask */
+
+/** \brief DCB Debug Security Control and Status Register Definitions */
+#define DCB_DSCSR_CDSKEY_Pos               17U                                            /*!< DCB DSCSR: CDS write-enable key Position */
+#define DCB_DSCSR_CDSKEY_Msk               (1UL << DCB_DSCSR_CDSKEY_Pos)                  /*!< DCB DSCSR: CDS write-enable key Mask */
+
+#define DCB_DSCSR_CDS_Pos                  16U                                            /*!< DCB DSCSR: Current domain Secure Position */
+#define DCB_DSCSR_CDS_Msk                  (1UL << DCB_DSCSR_CDS_Pos)                     /*!< DCB DSCSR: Current domain Secure Mask */
+
+#define DCB_DSCSR_SBRSEL_Pos                1U                                            /*!< DCB DSCSR: Secure banked register select Position */
+#define DCB_DSCSR_SBRSEL_Msk               (1UL << DCB_DSCSR_SBRSEL_Pos)                  /*!< DCB DSCSR: Secure banked register select Mask */
+
+#define DCB_DSCSR_SBRSELEN_Pos              0U                                            /*!< DCB DSCSR: Secure banked register select enable Position */
+#define DCB_DSCSR_SBRSELEN_Msk             (1UL /*<< DCB_DSCSR_SBRSELEN_Pos*/)            /*!< DCB DSCSR: Secure banked register select enable Mask */
+
+/*@} end of group CMSIS_DCB */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_DIB       Debug Identification Block
+  \brief    Type definitions for the Debug Identification Block Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Debug Identification Block Registers (DIB).
+ */
+typedef struct
+{
+        uint32_t RESERVED0[2U];
+  __IM  uint32_t DAUTHSTATUS;            /*!< Offset: 0x008 (R/ )  Debug Authentication Status Register */
+  __IM  uint32_t DDEVARCH;               /*!< Offset: 0x00C (R/ )  SCS Device Architecture Register */
+        uint32_t RESERVED1[3U];
+  __IM  uint32_t DDEVTYPE;               /*!< Offset: 0x01C (R/ )  SCS Device Type Register */
+} DIB_Type;
+
+/** \brief DIB Debug Authentication Status Register Definitions */
+#define DIB_DAUTHSTATUS_SUNID_Pos          22U                                            /*!< DIB DAUTHSTATUS: Secure Unprivileged Non-invasive Debug Allowed Position */
+#define DIB_DAUTHSTATUS_SUNID_Msk          (0x3UL << DIB_DAUTHSTATUS_SUNID_Pos )          /*!< DIB DAUTHSTATUS: Secure Unprivileged Non-invasive Debug Allowed Mask */
+
+#define DIB_DAUTHSTATUS_SUID_Pos           20U                                            /*!< DIB DAUTHSTATUS: Secure Unprivileged Invasive Debug Allowed Position */
+#define DIB_DAUTHSTATUS_SUID_Msk           (0x3UL << DIB_DAUTHSTATUS_SUID_Pos )           /*!< DIB DAUTHSTATUS: Secure Unprivileged Invasive Debug Allowed Mask */
+
+#define DIB_DAUTHSTATUS_NSUNID_Pos         18U                                            /*!< DIB DAUTHSTATUS: Non-secure Unprivileged Non-invasive Debug Allo Position */
+#define DIB_DAUTHSTATUS_NSUNID_Msk         (0x3UL << DIB_DAUTHSTATUS_NSUNID_Pos )         /*!< DIB DAUTHSTATUS: Non-secure Unprivileged Non-invasive Debug Allo Mask */
+
+#define DIB_DAUTHSTATUS_NSUID_Pos          16U                                            /*!< DIB DAUTHSTATUS: Non-secure Unprivileged Invasive Debug Allowed Position */
+#define DIB_DAUTHSTATUS_NSUID_Msk          (0x3UL << DIB_DAUTHSTATUS_NSUID_Pos )          /*!< DIB DAUTHSTATUS: Non-secure Unprivileged Invasive Debug Allowed Mask */
+
+#define DIB_DAUTHSTATUS_SNID_Pos            6U                                            /*!< DIB DAUTHSTATUS: Secure Non-invasive Debug Position */
+#define DIB_DAUTHSTATUS_SNID_Msk           (0x3UL << DIB_DAUTHSTATUS_SNID_Pos )           /*!< DIB DAUTHSTATUS: Secure Non-invasive Debug Mask */
+
+#define DIB_DAUTHSTATUS_SID_Pos             4U                                            /*!< DIB DAUTHSTATUS: Secure Invasive Debug Position */
+#define DIB_DAUTHSTATUS_SID_Msk            (0x3UL << DIB_DAUTHSTATUS_SID_Pos )            /*!< DIB DAUTHSTATUS: Secure Invasive Debug Mask */
+
+#define DIB_DAUTHSTATUS_NSNID_Pos           2U                                            /*!< DIB DAUTHSTATUS: Non-secure Non-invasive Debug Position */
+#define DIB_DAUTHSTATUS_NSNID_Msk          (0x3UL << DIB_DAUTHSTATUS_NSNID_Pos )          /*!< DIB DAUTHSTATUS: Non-secure Non-invasive Debug Mask */
+
+#define DIB_DAUTHSTATUS_NSID_Pos            0U                                            /*!< DIB DAUTHSTATUS: Non-secure Invasive Debug Position */
+#define DIB_DAUTHSTATUS_NSID_Msk           (0x3UL /*<< DIB_DAUTHSTATUS_NSID_Pos*/)        /*!< DIB DAUTHSTATUS: Non-secure Invasive Debug Mask */
+
+/** \brief DIB SCS Device Architecture Register Definitions */
+#define DIB_DDEVARCH_ARCHITECT_Pos         21U                                            /*!< DIB DDEVARCH: Architect Position */
+#define DIB_DDEVARCH_ARCHITECT_Msk         (0x7FFUL << DIB_DDEVARCH_ARCHITECT_Pos )       /*!< DIB DDEVARCH: Architect Mask */
+
+#define DIB_DDEVARCH_PRESENT_Pos           20U                                            /*!< DIB DDEVARCH: DEVARCH Present Position */
+#define DIB_DDEVARCH_PRESENT_Msk           (0x1FUL << DIB_DDEVARCH_PRESENT_Pos )          /*!< DIB DDEVARCH: DEVARCH Present Mask */
+
+#define DIB_DDEVARCH_REVISION_Pos          16U                                            /*!< DIB DDEVARCH: Revision Position */
+#define DIB_DDEVARCH_REVISION_Msk          (0xFUL << DIB_DDEVARCH_REVISION_Pos )          /*!< DIB DDEVARCH: Revision Mask */
+
+#define DIB_DDEVARCH_ARCHVER_Pos           12U                                            /*!< DIB DDEVARCH: Architecture Version Position */
+#define DIB_DDEVARCH_ARCHVER_Msk           (0xFUL << DIB_DDEVARCH_ARCHVER_Pos )           /*!< DIB DDEVARCH: Architecture Version Mask */
+
+#define DIB_DDEVARCH_ARCHPART_Pos           0U                                            /*!< DIB DDEVARCH: Architecture Part Position */
+#define DIB_DDEVARCH_ARCHPART_Msk          (0xFFFUL /*<< DIB_DDEVARCH_ARCHPART_Pos*/)     /*!< DIB DDEVARCH: Architecture Part Mask */
+
+/** \brief DIB SCS Device Type Register Definitions */
+#define DIB_DDEVTYPE_SUB_Pos                4U                                            /*!< DIB DDEVTYPE: Sub-type Position */
+#define DIB_DDEVTYPE_SUB_Msk               (0xFUL << DIB_DDEVTYPE_SUB_Pos )               /*!< DIB DDEVTYPE: Sub-type Mask */
+
+#define DIB_DDEVTYPE_MAJOR_Pos              0U                                            /*!< DIB DDEVTYPE: Major type Position */
+#define DIB_DDEVTYPE_MAJOR_Msk             (0xFUL /*<< DIB_DDEVTYPE_MAJOR_Pos*/)          /*!< DIB DDEVTYPE: Major type Mask */
+
+/*@} end of group CMSIS_DIB */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_core_bitfield     Core register bit field macros
+  \brief      Macros for use with bit field definitions (xxx_Pos, xxx_Msk).
+  @{
+ */
+
+/**
+  \brief   Mask and shift a bit field value for use in a register bit range.
+  \param[in] field  Name of the register bit field.
+  \param[in] value  Value of the bit field. This parameter is interpreted as an uint32_t type.
+  \return           Masked and shifted value.
+*/
+#define _VAL2FLD(field, value)    (((uint32_t)(value) << field ## _Pos) & field ## _Msk)
+
+/**
+  \brief     Mask and shift a register value to extract a bit filed value.
+  \param[in] field  Name of the register bit field.
+  \param[in] value  Value of register. This parameter is interpreted as an uint32_t type.
+  \return           Masked and shifted bit field value.
+*/
+#define _FLD2VAL(field, value)    (((uint32_t)(value) & field ## _Msk) >> field ## _Pos)
+
+/*@} end of group CMSIS_core_bitfield */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_core_base     Core Definitions
+  \brief      Definitions for base addresses, unions, and structures.
+  @{
+ */
+
+/* Memory mapping of Core Hardware */
+  #define SCS_BASE            (0xE000E000UL)                             /*!< System Control Space Base Address */
+  #define ITM_BASE            (0xE0000000UL)                             /*!< ITM Base Address */
+  #define DWT_BASE            (0xE0001000UL)                             /*!< DWT Base Address */
+  #define MEMSYSCTL_BASE      (0xE001E000UL)                             /*!< Memory System Control Base Address */
+  #define ERRBNK_BASE         (0xE001E100UL)                             /*!< Error Banking Base Address */
+  #define DCAR_BASE           (0xE001E200UL)                             /*!< Direct Cache Access Registers */
+  #define PWRMODCTL_BASE      (0xE001E300UL)                             /*!< Power Mode Control Base Address */
+  #define EWIC_ISA_BASE       (0xE001E400UL)                             /*!< External Wakeup Interrupt Controller interrupt status access Base Address */
+  #define PRCCFGINF_BASE      (0xE001E700UL)                             /*!< Processor Configuration Information Base Address */
+  #define STL_BASE            (0xE001E800UL)                             /*!< Software Test Library Base Address */
+  #define TPIU_BASE           (0xE0040000UL)                             /*!< TPIU Base Address */
+  #define EWIC_BASE           (0xE0047000UL)                             /*!< External Wakeup Interrupt Controller Base Address */
+  #define DCB_BASE            (0xE000EDF0UL)                             /*!< DCB Base Address */
+  #define DIB_BASE            (0xE000EFB0UL)                             /*!< DIB Base Address */
+  #define SysTick_BASE        (SCS_BASE +  0x0010UL)                     /*!< SysTick Base Address */
+  #define NVIC_BASE           (SCS_BASE +  0x0100UL)                     /*!< NVIC Base Address */
+  #define SCB_BASE            (SCS_BASE +  0x0D00UL)                     /*!< System Control Block Base Address */
+
+  #define ICB                 ((ICB_Type       *)     SCS_BASE         ) /*!< System control Register not in SCB */
+  #define SCB                 ((SCB_Type       *)     SCB_BASE         ) /*!< SCB configuration struct */
+  #define SysTick             ((SysTick_Type   *)     SysTick_BASE     ) /*!< SysTick configuration struct */
+  #define NVIC                ((NVIC_Type      *)     NVIC_BASE        ) /*!< NVIC configuration struct */
+  #define ITM                 ((ITM_Type       *)     ITM_BASE         ) /*!< ITM configuration struct */
+  #define DWT                 ((DWT_Type       *)     DWT_BASE         ) /*!< DWT configuration struct */
+  #define TPIU                ((TPIU_Type      *)     TPIU_BASE        ) /*!< TPIU configuration struct */
+  #define MEMSYSCTL           ((MemSysCtl_Type *)     MEMSYSCTL_BASE   ) /*!< Memory System Control configuration struct */
+  #define ERRBNK              ((ErrBnk_Type    *)     ERRBNK_BASE      ) /*!< Error Banking configuration struct */
+  #define DCAR                ((DCAR_Type      *)     DCAR_BASE        ) /*!< Direct Read Access to the embedded RAM associated with the L1 instruction and data cache */
+  #define PWRMODCTL           ((PwrModCtl_Type *)     PWRMODCTL_BASE   ) /*!< Power Mode Control configuration struct */
+  #define EWIC_ISA            ((EWIC_ISA_Type  *)     EWIC_ISA_BASE    ) /*!< EWIC interrupt status access struct */
+  #define EWIC                ((EWIC_Type      *)     EWIC_BASE        ) /*!< EWIC configuration struct */
+  #define PRCCFGINF           ((PrcCfgInf_Type *)     PRCCFGINF_BASE   ) /*!< Processor Configuration Information configuration struct */
+  #define STL                 ((STL_Type       *)     STL_BASE         ) /*!< Software Test Library configuration struct */
+  #define DCB                 ((DCB_Type       *)     DCB_BASE         ) /*!< DCB configuration struct */
+  #define DIB                 ((DIB_Type       *)     DIB_BASE         ) /*!< DIB configuration struct */
+
+  #if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+    #define MPU_BASE          (SCS_BASE +  0x0D90UL)                     /*!< Memory Protection Unit */
+    #define MPU               ((MPU_Type       *)     MPU_BASE         ) /*!< Memory Protection Unit */
+  #endif
+
+  #if defined (__PMU_PRESENT) && (__PMU_PRESENT == 1U)
+    #define PMU_BASE          (0xE0003000UL)                             /*!< PMU Base Address */
+    #define PMU               ((PMU_Type       *)     PMU_BASE         ) /*!< PMU configuration struct */
+  #endif
+
+  #if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+    #define SAU_BASE          (SCS_BASE +  0x0DD0UL)                     /*!< Security Attribution Unit */
+    #define SAU               ((SAU_Type       *)     SAU_BASE         ) /*!< Security Attribution Unit */
+  #endif
+
+  #define FPU_BASE            (SCS_BASE +  0x0F30UL)                     /*!< Floating Point Unit */
+  #define FPU                 ((FPU_Type       *)     FPU_BASE         ) /*!< Floating Point Unit */
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  #define SCS_BASE_NS         (0xE002E000UL)                             /*!< System Control Space Base Address (non-secure address space) */
+  #define DCB_BASE_NS         (0xE002EDF0UL)                             /*!< DCB Base Address                  (non-secure address space) */
+  #define DIB_BASE_NS         (0xE002EFB0UL)                             /*!< DIB Base Address                  (non-secure address space) */
+  #define SysTick_BASE_NS     (SCS_BASE_NS +  0x0010UL)                  /*!< SysTick Base Address              (non-secure address space) */
+  #define NVIC_BASE_NS        (SCS_BASE_NS +  0x0100UL)                  /*!< NVIC Base Address                 (non-secure address space) */
+  #define SCB_BASE_NS         (SCS_BASE_NS +  0x0D00UL)                  /*!< System Control Block Base Address (non-secure address space) */
+
+  #define ICB_NS              ((ICB_Type       *)     SCS_BASE_NS      ) /*!< System control Register not in SCB(non-secure address space) */
+  #define SCB_NS              ((SCB_Type       *)     SCB_BASE_NS      ) /*!< SCB configuration struct          (non-secure address space) */
+  #define SysTick_NS          ((SysTick_Type   *)     SysTick_BASE_NS  ) /*!< SysTick configuration struct      (non-secure address space) */
+  #define NVIC_NS             ((NVIC_Type      *)     NVIC_BASE_NS     ) /*!< NVIC configuration struct         (non-secure address space) */
+  #define DCB_NS              ((DCB_Type       *)     DCB_BASE_NS      ) /*!< DCB configuration struct          (non-secure address space) */
+  #define DIB_NS              ((DIB_Type       *)     DIB_BASE_NS      ) /*!< DIB configuration struct          (non-secure address space) */
+
+  #if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+    #define MPU_BASE_NS       (SCS_BASE_NS +  0x0D90UL)                  /*!< Memory Protection Unit            (non-secure address space) */
+    #define MPU_NS            ((MPU_Type       *)     MPU_BASE_NS      ) /*!< Memory Protection Unit            (non-secure address space) */
+  #endif
+
+  #define FPU_BASE_NS         (SCS_BASE_NS +  0x0F30UL)                  /*!< Floating Point Unit               (non-secure address space) */
+  #define FPU_NS              ((FPU_Type       *)     FPU_BASE_NS      ) /*!< Floating Point Unit               (non-secure address space) */
+
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+/*@} */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_register_aliases     Backwards Compatibility Aliases
+  \brief      Register alias definitions for backwards compatibility.
+  @{
+ */
+
+/*@} */
+
+
+/*******************************************************************************
+ *                Hardware Abstraction Layer
+  Core Function Interface contains:
+  - Core NVIC Functions
+  - Core SysTick Functions
+  - Core Debug Functions
+  - Core Register Access Functions
+ ******************************************************************************/
+/**
+  \defgroup CMSIS_Core_FunctionInterface Functions and Instructions Reference
+*/
+
+
+
+/* ##########################   NVIC functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_NVICFunctions NVIC Functions
+  \brief    Functions that manage interrupts and exceptions via the NVIC.
+  @{
+ */
+
+#ifdef CMSIS_NVIC_VIRTUAL
+  #ifndef CMSIS_NVIC_VIRTUAL_HEADER_FILE
+    #define CMSIS_NVIC_VIRTUAL_HEADER_FILE "cmsis_nvic_virtual.h"
+  #endif
+  #include CMSIS_NVIC_VIRTUAL_HEADER_FILE
+#else
+  #define NVIC_SetPriorityGrouping    __NVIC_SetPriorityGrouping
+  #define NVIC_GetPriorityGrouping    __NVIC_GetPriorityGrouping
+  #define NVIC_EnableIRQ              __NVIC_EnableIRQ
+  #define NVIC_GetEnableIRQ           __NVIC_GetEnableIRQ
+  #define NVIC_DisableIRQ             __NVIC_DisableIRQ
+  #define NVIC_GetPendingIRQ          __NVIC_GetPendingIRQ
+  #define NVIC_SetPendingIRQ          __NVIC_SetPendingIRQ
+  #define NVIC_ClearPendingIRQ        __NVIC_ClearPendingIRQ
+  #define NVIC_GetActive              __NVIC_GetActive
+  #define NVIC_SetPriority            __NVIC_SetPriority
+  #define NVIC_GetPriority            __NVIC_GetPriority
+  #define NVIC_SystemReset            __NVIC_SystemReset
+#endif /* CMSIS_NVIC_VIRTUAL */
+
+#ifdef CMSIS_VECTAB_VIRTUAL
+  #ifndef CMSIS_VECTAB_VIRTUAL_HEADER_FILE
+    #define CMSIS_VECTAB_VIRTUAL_HEADER_FILE "cmsis_vectab_virtual.h"
+  #endif
+  #include CMSIS_VECTAB_VIRTUAL_HEADER_FILE
+#else
+  #define NVIC_SetVector              __NVIC_SetVector
+  #define NVIC_GetVector              __NVIC_GetVector
+#endif  /* (CMSIS_VECTAB_VIRTUAL) */
+
+#define NVIC_USER_IRQ_OFFSET          16
+
+
+/* Special LR values for Secure/Non-Secure call handling and exception handling                                               */
+
+/* Function Return Payload (from ARMv8-M Architecture Reference Manual) LR value on entry from Secure BLXNS                   */
+#define FNC_RETURN                 (0xFEFFFFFFUL)     /* bit [0] ignored when processing a branch                             */
+
+/* The following EXC_RETURN mask values are used to evaluate the LR on exception entry */
+#define EXC_RETURN_PREFIX          (0xFF000000UL)     /* bits [31:24] set to indicate an EXC_RETURN value                     */
+#define EXC_RETURN_S               (0x00000040UL)     /* bit [6] stack used to push registers: 0=Non-secure 1=Secure          */
+#define EXC_RETURN_DCRS            (0x00000020UL)     /* bit [5] stacking rules for called registers: 0=skipped 1=saved       */
+#define EXC_RETURN_FTYPE           (0x00000010UL)     /* bit [4] allocate stack for floating-point context: 0=done 1=skipped  */
+#define EXC_RETURN_MODE            (0x00000008UL)     /* bit [3] processor mode for return: 0=Handler mode 1=Thread mode      */
+#define EXC_RETURN_SPSEL           (0x00000004UL)     /* bit [2] stack pointer used to restore context: 0=MSP 1=PSP           */
+#define EXC_RETURN_ES              (0x00000001UL)     /* bit [0] security state exception was taken to: 0=Non-secure 1=Secure */
+
+/* Integrity Signature (from ARMv8-M Architecture Reference Manual) for exception context stacking                            */
+#if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)  /* Value for processors with floating-point extension:                  */
+#define EXC_INTEGRITY_SIGNATURE     (0xFEFA125AUL)     /* bit [0] SFTC must match LR bit[4] EXC_RETURN_FTYPE                   */
+#else
+#define EXC_INTEGRITY_SIGNATURE     (0xFEFA125BUL)     /* Value for processors without floating-point extension                */
+#endif
+
+
+/**
+  \brief   Set Priority Grouping
+  \details Sets the priority grouping field using the required unlock sequence.
+           The parameter PriorityGroup is assigned to the field SCB->AIRCR [10:8] PRIGROUP field.
+           Only values from 0..7 are used.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+  \param [in]      PriorityGroup  Priority grouping field.
+ */
+__STATIC_INLINE void __NVIC_SetPriorityGrouping(uint32_t PriorityGroup)
+{
+  uint32_t reg_value;
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);             /* only values 0..7 are used          */
+
+  reg_value  =  SCB->AIRCR;                                                   /* read old register configuration    */
+  reg_value &= ~((uint32_t)(SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk)); /* clear bits to change               */
+  reg_value  =  (reg_value                                   |
+                ((uint32_t)0x5FAUL << SCB_AIRCR_VECTKEY_Pos) |
+                (PriorityGroupTmp << SCB_AIRCR_PRIGROUP_Pos)  );              /* Insert write key and priority group */
+  SCB->AIRCR =  reg_value;
+}
+
+
+/**
+  \brief   Get Priority Grouping
+  \details Reads the priority grouping field from the NVIC Interrupt Controller.
+  \return                Priority grouping field (SCB->AIRCR [10:8] PRIGROUP field).
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPriorityGrouping(void)
+{
+  return ((uint32_t)((SCB->AIRCR & SCB_AIRCR_PRIGROUP_Msk) >> SCB_AIRCR_PRIGROUP_Pos));
+}
+
+
+/**
+  \brief   Enable Interrupt
+  \details Enables a device specific interrupt in the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_EnableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    __COMPILER_BARRIER();
+    NVIC->ISER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+    __COMPILER_BARRIER();
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Enable status
+  \details Returns a device specific interrupt enable status from the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt is not enabled.
+  \return             1  Interrupt is enabled.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetEnableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ISER[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Disable Interrupt
+  \details Disables a device specific interrupt in the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_DisableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ICER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+    __DSB();
+    __ISB();
+  }
+}
+
+
+/**
+  \brief   Get Pending Interrupt
+  \details Reads the NVIC pending register and returns the pending bit for the specified device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not pending.
+  \return             1  Interrupt status is pending.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ISPR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Pending Interrupt
+  \details Sets the pending bit of a device specific interrupt in the NVIC pending register.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_SetPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ISPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Clear Pending Interrupt
+  \details Clears the pending bit of a device specific interrupt in the NVIC pending register.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_ClearPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ICPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Active Interrupt
+  \details Reads the active register in the NVIC and returns the active bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not active.
+  \return             1  Interrupt status is active.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetActive(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->IABR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   Get Interrupt Target State
+  \details Reads the interrupt target field in the NVIC and returns the interrupt target bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  if interrupt is assigned to Secure
+  \return             1  if interrupt is assigned to Non Secure
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t NVIC_GetTargetState(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Interrupt Target State
+  \details Sets the interrupt target field in the NVIC and returns the interrupt target bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  if interrupt is assigned to Secure
+                      1  if interrupt is assigned to Non Secure
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t NVIC_SetTargetState(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] |=  ((uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL)));
+    return((uint32_t)(((NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Clear Interrupt Target State
+  \details Clears the interrupt target field in the NVIC and returns the interrupt target bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  if interrupt is assigned to Secure
+                      1  if interrupt is assigned to Non Secure
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t NVIC_ClearTargetState(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] &= ~((uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL)));
+    return((uint32_t)(((NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+
+/**
+  \brief   Set Interrupt Priority
+  \details Sets the priority of a device specific interrupt or a processor exception.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]      IRQn  Interrupt number.
+  \param [in]  priority  Priority to set.
+  \note    The priority cannot be set for every processor exception.
+ */
+__STATIC_INLINE void __NVIC_SetPriority(IRQn_Type IRQn, uint32_t priority)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->IPR[((uint32_t)IRQn)]               = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+  else
+  {
+    SCB->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Priority
+  \details Reads the priority of a device specific interrupt or a processor exception.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn  Interrupt number.
+  \return             Interrupt Priority.
+                      Value is aligned automatically to the implemented priority bits of the microcontroller.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPriority(IRQn_Type IRQn)
+{
+
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return(((uint32_t)NVIC->IPR[((uint32_t)IRQn)]               >> (8U - __NVIC_PRIO_BITS)));
+  }
+  else
+  {
+    return(((uint32_t)SCB->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] >> (8U - __NVIC_PRIO_BITS)));
+  }
+}
+
+
+/**
+  \brief   Encode Priority
+  \details Encodes the priority for an interrupt with the given priority group,
+           preemptive priority value, and subpriority value.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+  \param [in]     PriorityGroup  Used priority group.
+  \param [in]   PreemptPriority  Preemptive priority value (starting from 0).
+  \param [in]       SubPriority  Subpriority value (starting from 0).
+  \return                        Encoded priority. Value can be used in the function \ref NVIC_SetPriority().
+ */
+__STATIC_INLINE uint32_t NVIC_EncodePriority (uint32_t PriorityGroup, uint32_t PreemptPriority, uint32_t SubPriority)
+{
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);   /* only values 0..7 are used          */
+  uint32_t PreemptPriorityBits;
+  uint32_t SubPriorityBits;
+
+  PreemptPriorityBits = ((7UL - PriorityGroupTmp) > (uint32_t)(__NVIC_PRIO_BITS)) ? (uint32_t)(__NVIC_PRIO_BITS) : (uint32_t)(7UL - PriorityGroupTmp);
+  SubPriorityBits     = ((PriorityGroupTmp + (uint32_t)(__NVIC_PRIO_BITS)) < (uint32_t)7UL) ? (uint32_t)0UL : (uint32_t)((PriorityGroupTmp - 7UL) + (uint32_t)(__NVIC_PRIO_BITS));
+
+  return (
+           ((PreemptPriority & (uint32_t)((1UL << (PreemptPriorityBits)) - 1UL)) << SubPriorityBits) |
+           ((SubPriority     & (uint32_t)((1UL << (SubPriorityBits    )) - 1UL)))
+         );
+}
+
+
+/**
+  \brief   Decode Priority
+  \details Decodes an interrupt priority value with a given priority group to
+           preemptive priority value and subpriority value.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS) the smallest possible priority group is set.
+  \param [in]         Priority   Priority value, which can be retrieved with the function \ref NVIC_GetPriority().
+  \param [in]     PriorityGroup  Used priority group.
+  \param [out] pPreemptPriority  Preemptive priority value (starting from 0).
+  \param [out]     pSubPriority  Subpriority value (starting from 0).
+ */
+__STATIC_INLINE void NVIC_DecodePriority (uint32_t Priority, uint32_t PriorityGroup, uint32_t* const pPreemptPriority, uint32_t* const pSubPriority)
+{
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);   /* only values 0..7 are used          */
+  uint32_t PreemptPriorityBits;
+  uint32_t SubPriorityBits;
+
+  PreemptPriorityBits = ((7UL - PriorityGroupTmp) > (uint32_t)(__NVIC_PRIO_BITS)) ? (uint32_t)(__NVIC_PRIO_BITS) : (uint32_t)(7UL - PriorityGroupTmp);
+  SubPriorityBits     = ((PriorityGroupTmp + (uint32_t)(__NVIC_PRIO_BITS)) < (uint32_t)7UL) ? (uint32_t)0UL : (uint32_t)((PriorityGroupTmp - 7UL) + (uint32_t)(__NVIC_PRIO_BITS));
+
+  *pPreemptPriority = (Priority >> SubPriorityBits) & (uint32_t)((1UL << (PreemptPriorityBits)) - 1UL);
+  *pSubPriority     = (Priority                   ) & (uint32_t)((1UL << (SubPriorityBits    )) - 1UL);
+}
+
+
+/**
+  \brief   Set Interrupt Vector
+  \details Sets an interrupt vector in SRAM based interrupt vector table.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+           VTOR must been relocated to SRAM before.
+  \param [in]   IRQn      Interrupt number
+  \param [in]   vector    Address of interrupt handler function
+ */
+__STATIC_INLINE void __NVIC_SetVector(IRQn_Type IRQn, uint32_t vector)
+{
+  uint32_t *vectors = (uint32_t *) ((uintptr_t) SCB->VTOR);
+  vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET] = vector;
+  __DSB();
+}
+
+
+/**
+  \brief   Get Interrupt Vector
+  \details Reads an interrupt vector from interrupt vector table.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn      Interrupt number.
+  \return                 Address of interrupt handler function
+ */
+__STATIC_INLINE uint32_t __NVIC_GetVector(IRQn_Type IRQn)
+{
+  uint32_t *vectors = (uint32_t *) ((uintptr_t) SCB->VTOR);
+  return vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET];
+}
+
+
+/**
+  \brief   System Reset
+  \details Initiates a system reset request to reset the MCU.
+ */
+__NO_RETURN __STATIC_INLINE void __NVIC_SystemReset(void)
+{
+  __DSB();                                                          /* Ensure all outstanding memory accesses included
+                                                                       buffered write are completed before reset */
+  SCB->AIRCR  = (uint32_t)((0x5FAUL << SCB_AIRCR_VECTKEY_Pos)    |
+                           (SCB->AIRCR & SCB_AIRCR_PRIGROUP_Msk) |
+                            SCB_AIRCR_SYSRESETREQ_Msk    );         /* Keep priority group unchanged */
+  __DSB();                                                          /* Ensure completion of memory access */
+
+  for(;;)                                                           /* wait until reset */
+  {
+    __NOP();
+  }
+}
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   Set Priority Grouping (non-secure)
+  \details Sets the non-secure priority grouping field when in secure state using the required unlock sequence.
+           The parameter PriorityGroup is assigned to the field SCB->AIRCR [10:8] PRIGROUP field.
+           Only values from 0..7 are used.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+  \param [in]      PriorityGroup  Priority grouping field.
+ */
+__STATIC_INLINE void TZ_NVIC_SetPriorityGrouping_NS(uint32_t PriorityGroup)
+{
+  uint32_t reg_value;
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);             /* only values 0..7 are used          */
+
+  reg_value  =  SCB_NS->AIRCR;                                                /* read old register configuration    */
+  reg_value &= ~((uint32_t)(SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk)); /* clear bits to change               */
+  reg_value  =  (reg_value                                   |
+                ((uint32_t)0x5FAUL << SCB_AIRCR_VECTKEY_Pos) |
+                (PriorityGroupTmp << SCB_AIRCR_PRIGROUP_Pos)  );              /* Insert write key and priority group */
+  SCB_NS->AIRCR =  reg_value;
+}
+
+
+/**
+  \brief   Get Priority Grouping (non-secure)
+  \details Reads the priority grouping field from the non-secure NVIC when in secure state.
+  \return                Priority grouping field (SCB->AIRCR [10:8] PRIGROUP field).
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetPriorityGrouping_NS(void)
+{
+  return ((uint32_t)((SCB_NS->AIRCR & SCB_AIRCR_PRIGROUP_Msk) >> SCB_AIRCR_PRIGROUP_Pos));
+}
+
+
+/**
+  \brief   Enable Interrupt (non-secure)
+  \details Enables a device specific interrupt in the non-secure NVIC interrupt controller when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void TZ_NVIC_EnableIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->ISER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Enable status (non-secure)
+  \details Returns a device specific interrupt enable status from the non-secure NVIC interrupt controller when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt is not enabled.
+  \return             1  Interrupt is enabled.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetEnableIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC_NS->ISER[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Disable Interrupt (non-secure)
+  \details Disables a device specific interrupt in the non-secure NVIC interrupt controller when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void TZ_NVIC_DisableIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->ICER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Pending Interrupt (non-secure)
+  \details Reads the NVIC pending register in the non-secure NVIC when in secure state and returns the pending bit for the specified device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not pending.
+  \return             1  Interrupt status is pending.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetPendingIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC_NS->ISPR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Pending Interrupt (non-secure)
+  \details Sets the pending bit of a device specific interrupt in the non-secure NVIC pending register when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void TZ_NVIC_SetPendingIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->ISPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Clear Pending Interrupt (non-secure)
+  \details Clears the pending bit of a device specific interrupt in the non-secure NVIC pending register when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void TZ_NVIC_ClearPendingIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->ICPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Active Interrupt (non-secure)
+  \details Reads the active register in non-secure NVIC when in secure state and returns the active bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not active.
+  \return             1  Interrupt status is active.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetActive_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC_NS->IABR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Interrupt Priority (non-secure)
+  \details Sets the priority of a non-secure device specific interrupt or a non-secure processor exception when in secure state.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]      IRQn  Interrupt number.
+  \param [in]  priority  Priority to set.
+  \note    The priority cannot be set for every non-secure processor exception.
+ */
+__STATIC_INLINE void TZ_NVIC_SetPriority_NS(IRQn_Type IRQn, uint32_t priority)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->IPR[((uint32_t)IRQn)]               = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+  else
+  {
+    SCB_NS->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Priority (non-secure)
+  \details Reads the priority of a non-secure device specific interrupt or a non-secure processor exception when in secure state.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn  Interrupt number.
+  \return             Interrupt Priority. Value is aligned automatically to the implemented priority bits of the microcontroller.
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetPriority_NS(IRQn_Type IRQn)
+{
+
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return(((uint32_t)NVIC_NS->IPR[((uint32_t)IRQn)]               >> (8U - __NVIC_PRIO_BITS)));
+  }
+  else
+  {
+    return(((uint32_t)SCB_NS->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] >> (8U - __NVIC_PRIO_BITS)));
+  }
+}
+#endif /*  defined (__ARM_FEATURE_CMSE) &&(__ARM_FEATURE_CMSE == 3U) */
+
+/*@} end of CMSIS_Core_NVICFunctions */
+
+/* ##########################  MPU functions  #################################### */
+
+#if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+
+  #include "m-profile/armv8m_mpu.h"
+
+#endif
+
+/* ##########################  PMU functions and events  #################################### */
+
+#if defined (__PMU_PRESENT) && (__PMU_PRESENT == 1U)
+
+#include "m-profile/armv8m_pmu.h"
+
+/**
+  \brief   Cortex-M52 PMU events
+  \note    Architectural PMU events can be found in armv8m_pmu.h
+*/
+
+#define ARMCM52_PMU_ECC_ERR                          0xC000             /*!< One or more Error Correcting Code (ECC) errors detected */
+#define ARMCM52_PMU_ECC_ERR_MBIT                     0xC001             /*!< One or more multi-bit ECC errors detected */
+#define ARMCM52_PMU_ECC_ERR_DCACHE                   0xC010             /*!< One or more ECC errors in the data cache */
+#define ARMCM52_PMU_ECC_ERR_ICACHE                   0xC011             /*!< One or more ECC errors in the instruction cache */
+#define ARMCM52_PMU_ECC_ERR_MBIT_DCACHE              0xC012             /*!< One or more multi-bit ECC errors in the data cache */
+#define ARMCM52_PMU_ECC_ERR_MBIT_ICACHE              0xC013             /*!< One or more multi-bit ECC errors in the instruction cache */
+#define ARMCM52_PMU_ECC_ERR_DTCM                     0xC020             /*!< Any ECC error in the DTCM */
+#define ARMCM52_PMU_ECC_ERR_ITCM                     0xC021             /*!< Any ECC error in the ITCM */
+#define ARMCM52_PMU_ECC_ERR_MBIT_DTCM                0xC022             /*!< One or more multi-bit ECC errors in the DTCM */
+#define ARMCM52_PMU_ECC_ERR_MBIT_ITCM                0xC023             /*!< One or more multi-bit ECC errors in the ITCM */
+#define ARMCM52_PMU_NWAMODE_ENTER                    0xC200             /*!< No write-allocate mode entry */
+#define ARMCM52_PMU_NWAMODE                          0xC201             /*!< Write-allocate store is not allocated into the data cache due to no-write-allocate mode */
+#define ARMCM52_PMU_SAHB_ACCESS                      0xC300             /*!< Read or write access on the S-AHB interface to the TCM */
+#define ARMCM52_PMU_PAHB_ACCESS                      0xC301             /*!< Read or write access to the P-AHB write interface */
+#define ARMCM52_PMU_AXI_SAHB_WRITE_ACCESS            0xC302             /*!< M-AXI configuration: Any beat access to the M-AXI write interface.M-AHB configuration: Any write beat access to the SYS-AHB interface */
+#define ARMCM52_PMU_AXI_SAHB_READ_ACCESS             0xC303             /*!< M-AXI configuration: Any beat access to the M-AXI read interface.M-AHB configuration: Any read beat access to the SYS-AHB interface */
+#define ARMCM52_PMU_DOSTIMEOUT_DOUBLE                0xC400             /*!< Denial of Service timeout has fired twice and caused buffers to drain to allow forward progress */
+#define ARMCM52_PMU_DOSTIMEOUT_TRIPLE                0xC401             /*!< Denial of Service timeout has fired three times and blocked the LSU to force forward progress */
+#define ARMCM52_PMU_CDE_INST_RETIRED                 0xC402             /*!< CDE instruction architecturally executed. */
+#define ARMCM52_PMU_CDE_CX1_INST_RETIRED             0xC404             /*!< CDE CX1 instruction architecturally executed. */
+#define ARMCM52_PMU_CDE_CX2_INST_RETIRED             0xC406             /*!< CDE CX2 instruction architecturally executed. */
+#define ARMCM52_PMU_CDE_CX3_INST_RETIRED             0xC408             /*!< CDE CX3 instruction architecturally executed. */
+#define ARMCM52_PMU_CDE_VCX1_INST_RETIRED            0xC40A             /*!< CDE VCX1 instruction architecturally executed. */
+#define ARMCM52_PMU_CDE_VCX2_INST_RETIRED            0xC40C             /*!< CDE VCX2 instruction architecturally executed. */
+#define ARMCM52_PMU_CDE_VCX3_INST_RETIRED            0xC40E             /*!< CDE VCX3 instruction architecturally executed. */
+#define ARMCM52_PMU_CDE_VCX1_VEC_INST_RETIRED        0xC410             /*!< CDE VCX1 Vector instruction architecturally executed. */
+#define ARMCM52_PMU_CDE_VCX2_VEC_INST_RETIRED        0xC412             /*!< CDE VCX2 Vector instruction architecturally executed. */
+#define ARMCM52_PMU_CDE_VCX3_VEC_INST_RETIRED        0xC414             /*!< CDE VCX3 Vector instruction architecturally executed. */
+#define ARMCM52_PMU_CDE_PRED                         0xC416             /*!< Cycles where one or more predicated beats of a CDE instruction architecturally executed. */
+#define ARMCM52_PMU_CDE_STALL                        0xC417             /*!< Stall cycles caused by a CDE instruction. */
+#define ARMCM52_PMU_CDE_STALL_RESOURCE               0xC418             /*!< Stall cycles caused by a CDE instruction because of resource conflicts */
+#define ARMCM52_PMU_CDE_STALL_DEPENDENCY             0xC419             /*!< Stall cycles caused by a CDE register dependency. */
+#define ARMCM52_PMU_CDE_STALL_CUSTOM                 0xC41A             /*!< Stall cycles caused by a CDE instruction are generated by the custom hardware. */
+#define ARMCM52_PMU_CDE_STALL_OTHER                  0xC41B             /*!< Stall cycles caused by a CDE instruction are not covered by the other counters. */
+#define ARMCM52_PMU_CAHB_WRITE_ACCESS                0xC420             /*!< M-AHB configuration: A Write beat transfer on Code-AHB */
+#define ARMCM52_PMU_CAHB_READ_ACCESS                 0xC421             /*!< M-AHB configuration: A Read beat transfer on Code-AHB. */
+
+#endif
+
+/* ##########################  FPU functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_FpuFunctions FPU Functions
+  \brief    Function that provides FPU type.
+  @{
+ */
+
+/**
+  \brief   get FPU type
+  \details returns the FPU type
+  \returns
+   - \b  0: No FPU
+   - \b  1: Single precision FPU
+   - \b  2: Double + Single precision FPU
+ */
+__STATIC_INLINE uint32_t SCB_GetFPUType(void)
+{
+  uint32_t mvfr0;
+
+  mvfr0 = FPU->MVFR0;
+  if      ((mvfr0 & (FPU_MVFR0_FPSP_Msk | FPU_MVFR0_FPDP_Msk)) == 0x220U)
+  {
+    return 2U;           /* Double + Single precision FPU */
+  }
+  else if ((mvfr0 & (FPU_MVFR0_FPSP_Msk | FPU_MVFR0_FPDP_Msk)) == 0x020U)
+  {
+    return 1U;           /* Single precision FPU */
+  }
+  else
+  {
+    return 0U;           /* No FPU */
+  }
+}
+
+
+/*@} end of CMSIS_Core_FpuFunctions */
+
+/* ##########################  MVE functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_MveFunctions MVE Functions
+  \brief    Function that provides MVE type.
+  @{
+ */
+
+/**
+  \brief   get MVE type
+  \details returns the MVE type
+  \returns
+   - \b  0: No Vector Extension (MVE)
+   - \b  1: Integer Vector Extension (MVE-I)
+   - \b  2: Floating-point Vector Extension (MVE-F)
+ */
+__STATIC_INLINE uint32_t SCB_GetMVEType(void)
+{
+  const uint32_t mvfr1 = FPU->MVFR1;
+  if      ((mvfr1 & FPU_MVFR1_MVE_Msk) == (0x2U << FPU_MVFR1_MVE_Pos))
+  {
+    return 2U;
+  }
+  else if ((mvfr1 & FPU_MVFR1_MVE_Msk) == (0x1U << FPU_MVFR1_MVE_Pos))
+  {
+    return 1U;
+  }
+  else
+  {
+    return 0U;
+  }
+}
+
+
+/*@} end of CMSIS_Core_MveFunctions */
+
+
+/* ##########################  Cache functions  #################################### */
+
+#if ((defined (__ICACHE_PRESENT) && (__ICACHE_PRESENT == 1U)) || \
+     (defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)))
+  #include "m-profile/armv7m_cachel1.h"
+#endif
+
+
+/* ##########################   SAU functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_SAUFunctions SAU Functions
+  \brief    Functions that configure the SAU.
+  @{
+ */
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+
+/**
+  \brief   Enable SAU
+  \details Enables the Security Attribution Unit (SAU).
+ */
+__STATIC_INLINE void TZ_SAU_Enable(void)
+{
+    SAU->CTRL |=  (SAU_CTRL_ENABLE_Msk);
+}
+
+
+
+/**
+  \brief   Disable SAU
+  \details Disables the Security Attribution Unit (SAU).
+ */
+__STATIC_INLINE void TZ_SAU_Disable(void)
+{
+    SAU->CTRL &= ~(SAU_CTRL_ENABLE_Msk);
+}
+
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+/*@} end of CMSIS_Core_SAUFunctions */
+
+
+
+/* ###################  PAC Key functions  ########################### */
+
+#if (defined (__ARM_FEATURE_PAUTH) && (__ARM_FEATURE_PAUTH == 1))
+#include "m-profile/armv81m_pac.h"
+#endif
+
+
+/* ##################################    Debug Control function  ############################################ */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_DCBFunctions Debug Control Functions
+  \brief    Functions that access the Debug Control Block.
+  @{
+ */
+
+
+/**
+  \brief   Set Debug Authentication Control Register
+  \details writes to Debug Authentication Control register.
+  \param [in]  value  value to be writen.
+ */
+__STATIC_INLINE void DCB_SetAuthCtrl(uint32_t value)
+{
+    __DSB();
+    __ISB();
+    DCB->DAUTHCTRL = value;
+    __DSB();
+    __ISB();
+}
+
+
+/**
+  \brief   Get Debug Authentication Control Register
+  \details Reads Debug Authentication Control register.
+  \return             Debug Authentication Control Register.
+ */
+__STATIC_INLINE uint32_t DCB_GetAuthCtrl(void)
+{
+    return (DCB->DAUTHCTRL);
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   Set Debug Authentication Control Register (non-secure)
+  \details writes to non-secure Debug Authentication Control register when in secure state.
+  \param [in]  value  value to be writen
+ */
+__STATIC_INLINE void TZ_DCB_SetAuthCtrl_NS(uint32_t value)
+{
+    __DSB();
+    __ISB();
+    DCB_NS->DAUTHCTRL = value;
+    __DSB();
+    __ISB();
+}
+
+
+/**
+  \brief   Get Debug Authentication Control Register (non-secure)
+  \details Reads non-secure Debug Authentication Control register when in secure state.
+  \return             Debug Authentication Control Register.
+ */
+__STATIC_INLINE uint32_t TZ_DCB_GetAuthCtrl_NS(void)
+{
+    return (DCB_NS->DAUTHCTRL);
+}
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+/*@} end of CMSIS_Core_DCBFunctions */
+
+
+
+
+/* ##################################    Debug Identification function  ############################################ */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_DIBFunctions Debug Identification Functions
+  \brief    Functions that access the Debug Identification Block.
+  @{
+ */
+
+
+/**
+  \brief   Get Debug Authentication Status Register
+  \details Reads Debug Authentication Status register.
+  \return             Debug Authentication Status Register.
+ */
+__STATIC_INLINE uint32_t DIB_GetAuthStatus(void)
+{
+    return (DIB->DAUTHSTATUS);
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   Get Debug Authentication Status Register (non-secure)
+  \details Reads non-secure Debug Authentication Status register when in secure state.
+  \return             Debug Authentication Status Register.
+ */
+__STATIC_INLINE uint32_t TZ_DIB_GetAuthStatus_NS(void)
+{
+    return (DIB_NS->DAUTHSTATUS);
+}
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+/*@} end of CMSIS_Core_DCBFunctions */
+
+
+
+
+/* ##################################    SysTick function  ############################################ */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_SysTickFunctions SysTick Functions
+  \brief    Functions that configure the System.
+  @{
+ */
+
+#if defined (__Vendor_SysTickConfig) && (__Vendor_SysTickConfig == 0U)
+
+/**
+  \brief   System Tick Configuration
+  \details Initializes the System Timer and its interrupt, and starts the System Tick Timer.
+           Counter is in free running mode to generate periodic interrupts.
+  \param [in]  ticks  Number of ticks between two interrupts.
+  \return          0  Function succeeded.
+  \return          1  Function failed.
+  \note    When the variable <b>__Vendor_SysTickConfig</b> is set to 1, then the
+           function <b>SysTick_Config</b> is not included. In this case, the file <b><i>device</i>.h</b>
+           must contain a vendor-specific implementation of this function.
+ */
+__STATIC_INLINE uint32_t SysTick_Config(uint32_t ticks)
+{
+  if ((ticks - 1UL) > SysTick_LOAD_RELOAD_Msk)
+  {
+    return (1UL);                                                   /* Reload value impossible */
+  }
+
+  SysTick->LOAD  = (uint32_t)(ticks - 1UL);                         /* set reload register */
+  NVIC_SetPriority (SysTick_IRQn, (1UL << __NVIC_PRIO_BITS) - 1UL); /* set Priority for Systick Interrupt */
+  SysTick->VAL   = 0UL;                                             /* Load the SysTick Counter Value */
+  SysTick->CTRL  = SysTick_CTRL_CLKSOURCE_Msk |
+                   SysTick_CTRL_TICKINT_Msk   |
+                   SysTick_CTRL_ENABLE_Msk;                         /* Enable SysTick IRQ and SysTick Timer */
+  return (0UL);                                                     /* Function successful */
+}
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   System Tick Configuration (non-secure)
+  \details Initializes the non-secure System Timer and its interrupt when in secure state, and starts the System Tick Timer.
+           Counter is in free running mode to generate periodic interrupts.
+  \param [in]  ticks  Number of ticks between two interrupts.
+  \return          0  Function succeeded.
+  \return          1  Function failed.
+  \note    When the variable <b>__Vendor_SysTickConfig</b> is set to 1, then the
+           function <b>TZ_SysTick_Config_NS</b> is not included. In this case, the file <b><i>device</i>.h</b>
+           must contain a vendor-specific implementation of this function.
+
+ */
+__STATIC_INLINE uint32_t TZ_SysTick_Config_NS(uint32_t ticks)
+{
+  if ((ticks - 1UL) > SysTick_LOAD_RELOAD_Msk)
+  {
+    return (1UL);                                                         /* Reload value impossible */
+  }
+
+  SysTick_NS->LOAD  = (uint32_t)(ticks - 1UL);                            /* set reload register */
+  TZ_NVIC_SetPriority_NS (SysTick_IRQn, (1UL << __NVIC_PRIO_BITS) - 1UL); /* set Priority for Systick Interrupt */
+  SysTick_NS->VAL   = 0UL;                                                /* Load the SysTick Counter Value */
+  SysTick_NS->CTRL  = SysTick_CTRL_CLKSOURCE_Msk |
+                      SysTick_CTRL_TICKINT_Msk   |
+                      SysTick_CTRL_ENABLE_Msk;                            /* Enable SysTick IRQ and SysTick Timer */
+  return (0UL);                                                           /* Function successful */
+}
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+#endif
+
+/*@} end of CMSIS_Core_SysTickFunctions */
+
+
+
+/* ##################################### Debug In/Output function ########################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_core_DebugFunctions ITM Functions
+  \brief    Functions that access the ITM debug interface.
+  @{
+ */
+
+extern volatile int32_t ITM_RxBuffer;                              /*!< External variable to receive characters. */
+#define                 ITM_RXBUFFER_EMPTY  ((int32_t)0x5AA55AA5U) /*!< Value identifying \ref ITM_RxBuffer is ready for next character. */
+
+
+/**
+  \brief   ITM Send Character
+  \details Transmits a character via the ITM channel 0, and
+           \li Just returns when no debugger is connected that has booked the output.
+           \li Is blocking when a debugger is connected, but the previous character sent has not been transmitted.
+  \param [in]     ch  Character to transmit.
+  \returns            Character to transmit.
+ */
+__STATIC_INLINE uint32_t ITM_SendChar (uint32_t ch)
+{
+  if (((ITM->TCR & ITM_TCR_ITMENA_Msk) != 0UL) &&      /* ITM enabled */
+      ((ITM->TER & 1UL               ) != 0UL)   )     /* ITM Port #0 enabled */
+  {
+    while (ITM->PORT[0U].u32 == 0UL)
+    {
+      __NOP();
+    }
+    ITM->PORT[0U].u8 = (uint8_t)ch;
+  }
+  return (ch);
+}
+
+
+/**
+  \brief   ITM Receive Character
+  \details Inputs a character via the external variable \ref ITM_RxBuffer.
+  \return             Received character.
+  \return         -1  No character pending.
+ */
+__STATIC_INLINE int32_t ITM_ReceiveChar (void)
+{
+  int32_t ch = -1;                           /* no character available */
+
+  if (ITM_RxBuffer != ITM_RXBUFFER_EMPTY)
+  {
+    ch = ITM_RxBuffer;
+    ITM_RxBuffer = ITM_RXBUFFER_EMPTY;       /* ready for next character */
+  }
+
+  return (ch);
+}
+
+
+/**
+  \brief   ITM Check Character
+  \details Checks whether a character is pending for reading in the variable \ref ITM_RxBuffer.
+  \return          0  No character available.
+  \return          1  Character available.
+ */
+__STATIC_INLINE int32_t ITM_CheckChar (void)
+{
+
+  if (ITM_RxBuffer == ITM_RXBUFFER_EMPTY)
+  {
+    return (0);                              /* no character available */
+  }
+  else
+  {
+    return (1);                              /*    character available */
+  }
+}
+
+/*@} end of CMSIS_core_DebugFunctions */
+
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_CM52_H_DEPENDANT */
+
+#endif /* __CMSIS_GENERIC */
+
+
+
+
+

--- a/platform/ext/cmsis/CMSIS/Core/Include/core_cm55.h
+++ b/platform/ext/cmsis/CMSIS/Core/Include/core_cm55.h
@@ -1,0 +1,4724 @@
+/*
+ * Copyright (c) 2018-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS Cortex-M55 Core Peripheral Access Layer Header File
+ */
+
+#if   defined ( __ICCARM__ )
+  #pragma system_include                        /* treat file as system include file for MISRA check */
+#elif defined (__clang__)
+  #pragma clang system_header                   /* treat file as system include file */
+#elif defined ( __GNUC__ )
+  #pragma GCC diagnostic ignored "-Wpedantic"   /* disable pedantic warning due to unnamed structs/unions */
+#endif
+
+#ifndef __CORE_CM55_H_GENERIC
+#define __CORE_CM55_H_GENERIC
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/**
+  \page CMSIS_MISRA_Exceptions  MISRA-C:2004 Compliance Exceptions
+  CMSIS violates the following MISRA-C:2004 rules:
+
+   \li Required Rule 8.5, object/function definition in header file.<br>
+     Function definitions in header files are used to allow 'inlining'.
+
+   \li Required Rule 18.4, declaration of union type or object of union type: '{...}'.<br>
+     Unions are used for effective representation of core registers.
+
+   \li Advisory Rule 19.7, Function-like macro defined.<br>
+     Function-like macros are used to allow more efficient code.
+ */
+
+
+/*******************************************************************************
+ *                 CMSIS definitions
+ ******************************************************************************/
+/**
+  \ingroup Cortex_M55
+  @{
+ */
+
+#include "cmsis_version.h"
+
+/* CMSIS CM55 definitions */
+
+#define __CORTEX_M                (55U)                               /*!< Cortex-M Core */
+
+#if defined ( __CC_ARM )
+  #error Legacy Arm Compiler does not support Armv8.1-M target architecture.
+#elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #if defined (__ARM_FP)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+  #if defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1U)
+    #if defined (__DSP_PRESENT) && (__DSP_PRESENT == 1U)
+      #define __DSP_USED       1U
+    #else
+      #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
+      #define __DSP_USED       0U
+    #endif
+  #else
+    #define __DSP_USED         0U
+  #endif
+
+#elif defined (__ti__)
+  #if defined (__ARM_FP)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+  #if defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1U)
+    #if defined (__DSP_PRESENT) && (__DSP_PRESENT == 1U)
+      #define __DSP_USED       1U
+    #else
+      #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
+      #define __DSP_USED       0U
+    #endif
+  #else
+    #define __DSP_USED         0U
+  #endif
+
+#elif defined ( __GNUC__ )
+  #if defined (__VFP_FP__) && !defined(__SOFTFP__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+  #if defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1U)
+    #if defined (__DSP_PRESENT) && (__DSP_PRESENT == 1U)
+      #define __DSP_USED       1U
+    #else
+      #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
+      #define __DSP_USED         0U
+    #endif
+  #else
+    #define __DSP_USED         0U
+  #endif
+
+#elif defined ( __ICCARM__ )
+  #if defined (__ARMVFP__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+  #if defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1U)
+    #if defined (__DSP_PRESENT) && (__DSP_PRESENT == 1U)
+      #define __DSP_USED       1U
+    #else
+      #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
+      #define __DSP_USED         0U
+    #endif
+  #else
+    #define __DSP_USED         0U
+  #endif
+
+#elif defined ( __TI_ARM__ )
+  #if defined (__TI_VFP_SUPPORT__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#elif defined ( __TASKING__ )
+  #if defined (__FPU_VFP__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#elif defined ( __CSMC__ )
+  #if ( __CSMC__ & 0x400U)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#endif
+
+#include "cmsis_compiler.h"               /* CMSIS compiler specific defines */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_CM55_H_GENERIC */
+
+#ifndef __CMSIS_GENERIC
+
+#ifndef __CORE_CM55_H_DEPENDANT
+#define __CORE_CM55_H_DEPENDANT
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* check device defines and use defaults */
+#if defined __CHECK_DEVICE_DEFINES
+  #ifndef __CM55_REV
+    #define __CM55_REV               0x0000U
+    #warning "__CM55_REV not defined in device header file; using default!"
+  #endif
+
+  #ifndef __FPU_PRESENT
+    #define __FPU_PRESENT             0U
+    #warning "__FPU_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #if __FPU_PRESENT != 0U
+    #ifndef __FPU_DP
+      #define __FPU_DP             0U
+      #warning "__FPU_DP not defined in device header file; using default!"
+    #endif
+  #endif
+
+  #ifndef __MPU_PRESENT
+    #define __MPU_PRESENT             0U
+    #warning "__MPU_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __ICACHE_PRESENT
+    #define __ICACHE_PRESENT          0U
+    #warning "__ICACHE_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __DCACHE_PRESENT
+    #define __DCACHE_PRESENT          0U
+    #warning "__DCACHE_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __VTOR_PRESENT
+    #define __VTOR_PRESENT             1U
+    #warning "__VTOR_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __PMU_PRESENT
+    #define __PMU_PRESENT             0U
+    #warning "__PMU_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #if __PMU_PRESENT != 0U
+    #ifndef __PMU_NUM_EVENTCNT
+      #define __PMU_NUM_EVENTCNT      8U
+      #warning "__PMU_NUM_EVENTCNT not defined in device header file; using default!"
+    #elif (__PMU_NUM_EVENTCNT > 8 || __PMU_NUM_EVENTCNT < 2)
+    #error "__PMU_NUM_EVENTCNT is out of range in device header file!" */
+    #endif
+  #endif
+
+  #ifndef __SAUREGION_PRESENT
+    #define __SAUREGION_PRESENT       0U
+    #warning "__SAUREGION_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __DSP_PRESENT
+    #define __DSP_PRESENT             0U
+    #warning "__DSP_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __NVIC_PRIO_BITS
+    #define __NVIC_PRIO_BITS          3U
+    #warning "__NVIC_PRIO_BITS not defined in device header file; using default!"
+  #endif
+
+  #ifndef __Vendor_SysTickConfig
+    #define __Vendor_SysTickConfig    0U
+    #warning "__Vendor_SysTickConfig not defined in device header file; using default!"
+  #endif
+#endif
+
+/* IO definitions (access restrictions to peripheral registers) */
+/**
+    \defgroup CMSIS_glob_defs CMSIS Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+*/
+#ifdef __cplusplus
+  #define   __I     volatile             /*!< Defines 'read only' permissions */
+#else
+  #define   __I     volatile const       /*!< Defines 'read only' permissions */
+#endif
+#define     __O     volatile             /*!< Defines 'write only' permissions */
+#define     __IO    volatile             /*!< Defines 'read / write' permissions */
+
+/* following defines should be used for structure members */
+#define     __IM     volatile const      /*! Defines 'read only' structure member permissions */
+#define     __OM     volatile            /*! Defines 'write only' structure member permissions */
+#define     __IOM    volatile            /*! Defines 'read / write' structure member permissions */
+
+/*@} end of group Cortex_M55 */
+
+
+
+/*******************************************************************************
+ *                 Register Abstraction
+  Core Register contain:
+  - Core Register
+  - Core NVIC Register
+  - Core EWIC Register
+  - Core EWIC Interrupt Status Access Register
+  - Core SCB Register
+  - Core SysTick Register
+  - Core Debug Register
+  - Core PMU Register
+  - Core MPU Register
+  - Core SAU Register
+  - Core FPU Register
+ ******************************************************************************/
+/**
+  \defgroup CMSIS_core_register Defines and Type Definitions
+  \brief Type definitions and defines for Cortex-M processor based devices.
+*/
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_CORE  Status and Control Registers
+  \brief      Core Register type definitions.
+  @{
+ */
+
+/**
+  \brief  Union type to access the Application Program Status Register (APSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t _reserved0:16;              /*!< bit:  0..15  Reserved */
+    uint32_t GE:4;                       /*!< bit: 16..19  Greater than or Equal flags */
+    uint32_t _reserved1:7;               /*!< bit: 20..26  Reserved */
+    uint32_t Q:1;                        /*!< bit:     27  Saturation condition flag */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} APSR_Type;
+
+/** \brief APSR Register Definitions */
+#define APSR_N_Pos                         31U                                            /*!< APSR: N Position */
+#define APSR_N_Msk                         (1UL << APSR_N_Pos)                            /*!< APSR: N Mask */
+
+#define APSR_Z_Pos                         30U                                            /*!< APSR: Z Position */
+#define APSR_Z_Msk                         (1UL << APSR_Z_Pos)                            /*!< APSR: Z Mask */
+
+#define APSR_C_Pos                         29U                                            /*!< APSR: C Position */
+#define APSR_C_Msk                         (1UL << APSR_C_Pos)                            /*!< APSR: C Mask */
+
+#define APSR_V_Pos                         28U                                            /*!< APSR: V Position */
+#define APSR_V_Msk                         (1UL << APSR_V_Pos)                            /*!< APSR: V Mask */
+
+#define APSR_Q_Pos                         27U                                            /*!< APSR: Q Position */
+#define APSR_Q_Msk                         (1UL << APSR_Q_Pos)                            /*!< APSR: Q Mask */
+
+#define APSR_GE_Pos                        16U                                            /*!< APSR: GE Position */
+#define APSR_GE_Msk                        (0xFUL << APSR_GE_Pos)                         /*!< APSR: GE Mask */
+
+
+/**
+  \brief  Union type to access the Interrupt Program Status Register (IPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number */
+    uint32_t _reserved0:23;              /*!< bit:  9..31  Reserved */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} IPSR_Type;
+
+/** \brief IPSR Register Definitions */
+#define IPSR_ISR_Pos                        0U                                            /*!< IPSR: ISR Position */
+#define IPSR_ISR_Msk                       (0x1FFUL /*<< IPSR_ISR_Pos*/)                  /*!< IPSR: ISR Mask */
+
+
+/**
+  \brief  Union type to access the Special-Purpose Program Status Registers (xPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number */
+    uint32_t _reserved0:7;               /*!< bit:  9..15  Reserved */
+    uint32_t GE:4;                       /*!< bit: 16..19  Greater than or Equal flags */
+    uint32_t _reserved1:4;               /*!< bit: 20..23  Reserved */
+    uint32_t T:1;                        /*!< bit:     24  Thumb bit        (read 0) */
+    uint32_t IT:2;                       /*!< bit: 25..26  saved IT state   (read 0) */
+    uint32_t Q:1;                        /*!< bit:     27  Saturation condition flag */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} xPSR_Type;
+
+/** \brief xPSR Register Definitions */
+#define xPSR_N_Pos                         31U                                            /*!< xPSR: N Position */
+#define xPSR_N_Msk                         (1UL << xPSR_N_Pos)                            /*!< xPSR: N Mask */
+
+#define xPSR_Z_Pos                         30U                                            /*!< xPSR: Z Position */
+#define xPSR_Z_Msk                         (1UL << xPSR_Z_Pos)                            /*!< xPSR: Z Mask */
+
+#define xPSR_C_Pos                         29U                                            /*!< xPSR: C Position */
+#define xPSR_C_Msk                         (1UL << xPSR_C_Pos)                            /*!< xPSR: C Mask */
+
+#define xPSR_V_Pos                         28U                                            /*!< xPSR: V Position */
+#define xPSR_V_Msk                         (1UL << xPSR_V_Pos)                            /*!< xPSR: V Mask */
+
+#define xPSR_Q_Pos                         27U                                            /*!< xPSR: Q Position */
+#define xPSR_Q_Msk                         (1UL << xPSR_Q_Pos)                            /*!< xPSR: Q Mask */
+
+#define xPSR_IT_Pos                        25U                                            /*!< xPSR: IT Position */
+#define xPSR_IT_Msk                        (3UL << xPSR_IT_Pos)                           /*!< xPSR: IT Mask */
+
+#define xPSR_T_Pos                         24U                                            /*!< xPSR: T Position */
+#define xPSR_T_Msk                         (1UL << xPSR_T_Pos)                            /*!< xPSR: T Mask */
+
+#define xPSR_GE_Pos                        16U                                            /*!< xPSR: GE Position */
+#define xPSR_GE_Msk                        (0xFUL << xPSR_GE_Pos)                         /*!< xPSR: GE Mask */
+
+#define xPSR_ISR_Pos                        0U                                            /*!< xPSR: ISR Position */
+#define xPSR_ISR_Msk                       (0x1FFUL /*<< xPSR_ISR_Pos*/)                  /*!< xPSR: ISR Mask */
+
+
+/**
+  \brief  Union type to access the Control Registers (CONTROL).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t nPRIV:1;                    /*!< bit:      0  Execution privilege in Thread mode */
+    uint32_t SPSEL:1;                    /*!< bit:      1  Stack-pointer select */
+    uint32_t FPCA:1;                     /*!< bit:      2  Floating-point context active */
+    uint32_t SFPA:1;                     /*!< bit:      3  Secure floating-point active */
+    uint32_t _reserved1:28;              /*!< bit:  4..31  Reserved */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} CONTROL_Type;
+
+/** \brief CONTROL Register Definitions */
+#define CONTROL_SFPA_Pos                    3U                                            /*!< CONTROL: SFPA Position */
+#define CONTROL_SFPA_Msk                   (1UL << CONTROL_SFPA_Pos)                      /*!< CONTROL: SFPA Mask */
+
+#define CONTROL_FPCA_Pos                    2U                                            /*!< CONTROL: FPCA Position */
+#define CONTROL_FPCA_Msk                   (1UL << CONTROL_FPCA_Pos)                      /*!< CONTROL: FPCA Mask */
+
+#define CONTROL_SPSEL_Pos                   1U                                            /*!< CONTROL: SPSEL Position */
+#define CONTROL_SPSEL_Msk                  (1UL << CONTROL_SPSEL_Pos)                     /*!< CONTROL: SPSEL Mask */
+
+#define CONTROL_nPRIV_Pos                   0U                                            /*!< CONTROL: nPRIV Position */
+#define CONTROL_nPRIV_Msk                  (1UL /*<< CONTROL_nPRIV_Pos*/)                 /*!< CONTROL: nPRIV Mask */
+
+/*@} end of group CMSIS_CORE */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_NVIC  Nested Vectored Interrupt Controller (NVIC)
+  \brief      Type definitions for the NVIC Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Nested Vectored Interrupt Controller (NVIC).
+ */
+typedef struct
+{
+  __IOM uint32_t ISER[16U];              /*!< Offset: 0x000 (R/W)  Interrupt Set Enable Register */
+        uint32_t RESERVED0[16U];
+  __IOM uint32_t ICER[16U];              /*!< Offset: 0x080 (R/W)  Interrupt Clear Enable Register */
+        uint32_t RESERVED1[16U];
+  __IOM uint32_t ISPR[16U];              /*!< Offset: 0x100 (R/W)  Interrupt Set Pending Register */
+        uint32_t RESERVED2[16U];
+  __IOM uint32_t ICPR[16U];              /*!< Offset: 0x180 (R/W)  Interrupt Clear Pending Register */
+        uint32_t RESERVED3[16U];
+  __IOM uint32_t IABR[16U];              /*!< Offset: 0x200 (R/W)  Interrupt Active bit Register */
+        uint32_t RESERVED4[16U];
+  __IOM uint32_t ITNS[16U];              /*!< Offset: 0x280 (R/W)  Interrupt Non-Secure State Register */
+        uint32_t RESERVED5[16U];
+  __IOM uint8_t  IPR[496U];              /*!< Offset: 0x300 (R/W)  Interrupt Priority Register (8Bit wide) */
+        uint32_t RESERVED6[580U];
+  __OM  uint32_t STIR;                   /*!< Offset: 0xE00 ( /W)  Software Trigger Interrupt Register */
+}  NVIC_Type;
+
+/** \brief NVIC Software Triggered Interrupt Register Definitions */
+#define NVIC_STIR_INTID_Pos                 0U                                         /*!< STIR: INTLINESNUM Position */
+#define NVIC_STIR_INTID_Msk                (0x1FFUL /*<< NVIC_STIR_INTID_Pos*/)        /*!< STIR: INTLINESNUM Mask */
+
+/*@} end of group CMSIS_NVIC */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SCB     System Control Block (SCB)
+  \brief    Type definitions for the System Control Block Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Control Block (SCB).
+ */
+typedef struct
+{
+  __IM  uint32_t CPUID;                  /*!< Offset: 0x000 (R/ )  CPUID Base Register */
+  __IOM uint32_t ICSR;                   /*!< Offset: 0x004 (R/W)  Interrupt Control and State Register */
+  __IOM uint32_t VTOR;                   /*!< Offset: 0x008 (R/W)  Vector Table Offset Register */
+  __IOM uint32_t AIRCR;                  /*!< Offset: 0x00C (R/W)  Application Interrupt and Reset Control Register */
+  __IOM uint32_t SCR;                    /*!< Offset: 0x010 (R/W)  System Control Register */
+  __IOM uint32_t CCR;                    /*!< Offset: 0x014 (R/W)  Configuration Control Register */
+  __IOM uint8_t  SHPR[12U];              /*!< Offset: 0x018 (R/W)  System Handlers Priority Registers (4-7, 8-11, 12-15) */
+  __IOM uint32_t SHCSR;                  /*!< Offset: 0x024 (R/W)  System Handler Control and State Register */
+  __IOM uint32_t CFSR;                   /*!< Offset: 0x028 (R/W)  Configurable Fault Status Register */
+  __IOM uint32_t HFSR;                   /*!< Offset: 0x02C (R/W)  HardFault Status Register */
+  __IOM uint32_t DFSR;                   /*!< Offset: 0x030 (R/W)  Debug Fault Status Register */
+  __IOM uint32_t MMFAR;                  /*!< Offset: 0x034 (R/W)  MemManage Fault Address Register */
+  __IOM uint32_t BFAR;                   /*!< Offset: 0x038 (R/W)  BusFault Address Register */
+  __IOM uint32_t AFSR;                   /*!< Offset: 0x03C (R/W)  Auxiliary Fault Status Register */
+  __IM  uint32_t ID_PFR[2U];             /*!< Offset: 0x040 (R/ )  Processor Feature Register */
+  __IM  uint32_t ID_DFR;                 /*!< Offset: 0x048 (R/ )  Debug Feature Register */
+  __IM  uint32_t ID_AFR;                 /*!< Offset: 0x04C (R/ )  Auxiliary Feature Register */
+  __IM  uint32_t ID_MMFR[4U];            /*!< Offset: 0x050 (R/ )  Memory Model Feature Register */
+  __IM  uint32_t ID_ISAR[6U];            /*!< Offset: 0x060 (R/ )  Instruction Set Attributes Register */
+  __IM  uint32_t CLIDR;                  /*!< Offset: 0x078 (R/ )  Cache Level ID register */
+  __IM  uint32_t CTR;                    /*!< Offset: 0x07C (R/ )  Cache Type register */
+  __IM  uint32_t CCSIDR;                 /*!< Offset: 0x080 (R/ )  Cache Size ID Register */
+  __IOM uint32_t CSSELR;                 /*!< Offset: 0x084 (R/W)  Cache Size Selection Register */
+  __IOM uint32_t CPACR;                  /*!< Offset: 0x088 (R/W)  Coprocessor Access Control Register */
+  __IOM uint32_t NSACR;                  /*!< Offset: 0x08C (R/W)  Non-Secure Access Control Register */
+        uint32_t RESERVED7[21U];
+  __IOM uint32_t SFSR;                   /*!< Offset: 0x0E4 (R/W)  Secure Fault Status Register */
+  __IOM uint32_t SFAR;                   /*!< Offset: 0x0E8 (R/W)  Secure Fault Address Register */
+        uint32_t RESERVED3[69U];
+  __OM  uint32_t STIR;                   /*!< Offset: 0x200 ( /W)  Software Triggered Interrupt Register */
+  __IOM uint32_t RFSR;                   /*!< Offset: 0x204 (R/W)  RAS Fault Status Register */
+        uint32_t RESERVED4[14U];
+  __IM  uint32_t MVFR0;                  /*!< Offset: 0x240 (R/ )  Media and VFP Feature Register 0 */
+  __IM  uint32_t MVFR1;                  /*!< Offset: 0x244 (R/ )  Media and VFP Feature Register 1 */
+  __IM  uint32_t MVFR2;                  /*!< Offset: 0x248 (R/ )  Media and VFP Feature Register 2 */
+        uint32_t RESERVED5[1U];
+  __OM  uint32_t ICIALLU;                /*!< Offset: 0x250 ( /W)  I-Cache Invalidate All to PoU */
+        uint32_t RESERVED6[1U];
+  __OM  uint32_t ICIMVAU;                /*!< Offset: 0x258 ( /W)  I-Cache Invalidate by MVA to PoU */
+  __OM  uint32_t DCIMVAC;                /*!< Offset: 0x25C ( /W)  D-Cache Invalidate by MVA to PoC */
+  __OM  uint32_t DCISW;                  /*!< Offset: 0x260 ( /W)  D-Cache Invalidate by Set-way */
+  __OM  uint32_t DCCMVAU;                /*!< Offset: 0x264 ( /W)  D-Cache Clean by MVA to PoU */
+  __OM  uint32_t DCCMVAC;                /*!< Offset: 0x268 ( /W)  D-Cache Clean by MVA to PoC */
+  __OM  uint32_t DCCSW;                  /*!< Offset: 0x26C ( /W)  D-Cache Clean by Set-way */
+  __OM  uint32_t DCCIMVAC;               /*!< Offset: 0x270 ( /W)  D-Cache Clean and Invalidate by MVA to PoC */
+  __OM  uint32_t DCCISW;                 /*!< Offset: 0x274 ( /W)  D-Cache Clean and Invalidate by Set-way */
+  __OM  uint32_t BPIALL;                 /*!< Offset: 0x278 ( /W)  Branch Predictor Invalidate All */
+} SCB_Type;
+
+/** \brief SCB CPUID Register Definitions */
+#define SCB_CPUID_IMPLEMENTER_Pos          24U                                            /*!< SCB CPUID: IMPLEMENTER Position */
+#define SCB_CPUID_IMPLEMENTER_Msk          (0xFFUL << SCB_CPUID_IMPLEMENTER_Pos)          /*!< SCB CPUID: IMPLEMENTER Mask */
+
+#define SCB_CPUID_VARIANT_Pos              20U                                            /*!< SCB CPUID: VARIANT Position */
+#define SCB_CPUID_VARIANT_Msk              (0xFUL << SCB_CPUID_VARIANT_Pos)               /*!< SCB CPUID: VARIANT Mask */
+
+#define SCB_CPUID_ARCHITECTURE_Pos         16U                                            /*!< SCB CPUID: ARCHITECTURE Position */
+#define SCB_CPUID_ARCHITECTURE_Msk         (0xFUL << SCB_CPUID_ARCHITECTURE_Pos)          /*!< SCB CPUID: ARCHITECTURE Mask */
+
+#define SCB_CPUID_PARTNO_Pos                4U                                            /*!< SCB CPUID: PARTNO Position */
+#define SCB_CPUID_PARTNO_Msk               (0xFFFUL << SCB_CPUID_PARTNO_Pos)              /*!< SCB CPUID: PARTNO Mask */
+
+#define SCB_CPUID_REVISION_Pos              0U                                            /*!< SCB CPUID: REVISION Position */
+#define SCB_CPUID_REVISION_Msk             (0xFUL /*<< SCB_CPUID_REVISION_Pos*/)          /*!< SCB CPUID: REVISION Mask */
+
+/** \brief SCB Interrupt Control State Register Definitions */
+#define SCB_ICSR_PENDNMISET_Pos            31U                                            /*!< SCB ICSR: PENDNMISET Position */
+#define SCB_ICSR_PENDNMISET_Msk            (1UL << SCB_ICSR_PENDNMISET_Pos)               /*!< SCB ICSR: PENDNMISET Mask */
+
+#define SCB_ICSR_PENDNMICLR_Pos            30U                                            /*!< SCB ICSR: PENDNMICLR Position */
+#define SCB_ICSR_PENDNMICLR_Msk            (1UL << SCB_ICSR_PENDNMICLR_Pos)               /*!< SCB ICSR: PENDNMICLR Mask */
+
+#define SCB_ICSR_PENDSVSET_Pos             28U                                            /*!< SCB ICSR: PENDSVSET Position */
+#define SCB_ICSR_PENDSVSET_Msk             (1UL << SCB_ICSR_PENDSVSET_Pos)                /*!< SCB ICSR: PENDSVSET Mask */
+
+#define SCB_ICSR_PENDSVCLR_Pos             27U                                            /*!< SCB ICSR: PENDSVCLR Position */
+#define SCB_ICSR_PENDSVCLR_Msk             (1UL << SCB_ICSR_PENDSVCLR_Pos)                /*!< SCB ICSR: PENDSVCLR Mask */
+
+#define SCB_ICSR_PENDSTSET_Pos             26U                                            /*!< SCB ICSR: PENDSTSET Position */
+#define SCB_ICSR_PENDSTSET_Msk             (1UL << SCB_ICSR_PENDSTSET_Pos)                /*!< SCB ICSR: PENDSTSET Mask */
+
+#define SCB_ICSR_PENDSTCLR_Pos             25U                                            /*!< SCB ICSR: PENDSTCLR Position */
+#define SCB_ICSR_PENDSTCLR_Msk             (1UL << SCB_ICSR_PENDSTCLR_Pos)                /*!< SCB ICSR: PENDSTCLR Mask */
+
+#define SCB_ICSR_STTNS_Pos                 24U                                            /*!< SCB ICSR: STTNS Position (Security Extension) */
+#define SCB_ICSR_STTNS_Msk                 (1UL << SCB_ICSR_STTNS_Pos)                    /*!< SCB ICSR: STTNS Mask (Security Extension) */
+
+#define SCB_ICSR_ISRPREEMPT_Pos            23U                                            /*!< SCB ICSR: ISRPREEMPT Position */
+#define SCB_ICSR_ISRPREEMPT_Msk            (1UL << SCB_ICSR_ISRPREEMPT_Pos)               /*!< SCB ICSR: ISRPREEMPT Mask */
+
+#define SCB_ICSR_ISRPENDING_Pos            22U                                            /*!< SCB ICSR: ISRPENDING Position */
+#define SCB_ICSR_ISRPENDING_Msk            (1UL << SCB_ICSR_ISRPENDING_Pos)               /*!< SCB ICSR: ISRPENDING Mask */
+
+#define SCB_ICSR_VECTPENDING_Pos           12U                                            /*!< SCB ICSR: VECTPENDING Position */
+#define SCB_ICSR_VECTPENDING_Msk           (0x1FFUL << SCB_ICSR_VECTPENDING_Pos)          /*!< SCB ICSR: VECTPENDING Mask */
+
+#define SCB_ICSR_RETTOBASE_Pos             11U                                            /*!< SCB ICSR: RETTOBASE Position */
+#define SCB_ICSR_RETTOBASE_Msk             (1UL << SCB_ICSR_RETTOBASE_Pos)                /*!< SCB ICSR: RETTOBASE Mask */
+
+#define SCB_ICSR_VECTACTIVE_Pos             0U                                            /*!< SCB ICSR: VECTACTIVE Position */
+#define SCB_ICSR_VECTACTIVE_Msk            (0x1FFUL /*<< SCB_ICSR_VECTACTIVE_Pos*/)       /*!< SCB ICSR: VECTACTIVE Mask */
+
+/** \brief SCB Vector Table Offset Register Definitions */
+#define SCB_VTOR_TBLOFF_Pos                 7U                                            /*!< SCB VTOR: TBLOFF Position */
+#define SCB_VTOR_TBLOFF_Msk                (0x1FFFFFFUL << SCB_VTOR_TBLOFF_Pos)           /*!< SCB VTOR: TBLOFF Mask */
+
+/** \brief SCB Application Interrupt and Reset Control Register Definitions */
+#define SCB_AIRCR_VECTKEY_Pos              16U                                            /*!< SCB AIRCR: VECTKEY Position */
+#define SCB_AIRCR_VECTKEY_Msk              (0xFFFFUL << SCB_AIRCR_VECTKEY_Pos)            /*!< SCB AIRCR: VECTKEY Mask */
+
+#define SCB_AIRCR_VECTKEYSTAT_Pos          16U                                            /*!< SCB AIRCR: VECTKEYSTAT Position */
+#define SCB_AIRCR_VECTKEYSTAT_Msk          (0xFFFFUL << SCB_AIRCR_VECTKEYSTAT_Pos)        /*!< SCB AIRCR: VECTKEYSTAT Mask */
+
+#define SCB_AIRCR_ENDIANESS_Pos            15U                                            /*!< SCB AIRCR: ENDIANESS Position */
+#define SCB_AIRCR_ENDIANESS_Msk            (1UL << SCB_AIRCR_ENDIANESS_Pos)               /*!< SCB AIRCR: ENDIANESS Mask */
+
+#define SCB_AIRCR_PRIS_Pos                 14U                                            /*!< SCB AIRCR: PRIS Position */
+#define SCB_AIRCR_PRIS_Msk                 (1UL << SCB_AIRCR_PRIS_Pos)                    /*!< SCB AIRCR: PRIS Mask */
+
+#define SCB_AIRCR_BFHFNMINS_Pos            13U                                            /*!< SCB AIRCR: BFHFNMINS Position */
+#define SCB_AIRCR_BFHFNMINS_Msk            (1UL << SCB_AIRCR_BFHFNMINS_Pos)               /*!< SCB AIRCR: BFHFNMINS Mask */
+
+#define SCB_AIRCR_PRIGROUP_Pos              8U                                            /*!< SCB AIRCR: PRIGROUP Position */
+#define SCB_AIRCR_PRIGROUP_Msk             (7UL << SCB_AIRCR_PRIGROUP_Pos)                /*!< SCB AIRCR: PRIGROUP Mask */
+
+#define SCB_AIRCR_IESB_Pos                  5U                                            /*!< SCB AIRCR: Implicit ESB Enable Position */
+#define SCB_AIRCR_IESB_Msk                 (1UL << SCB_AIRCR_IESB_Pos)                    /*!< SCB AIRCR: Implicit ESB Enable Mask */
+
+#define SCB_AIRCR_DIT_Pos                   4U                                            /*!< SCB AIRCR: Data Independent Timing Position */
+#define SCB_AIRCR_DIT_Msk                  (1UL << SCB_AIRCR_DIT_Pos)                     /*!< SCB AIRCR: Data Independent Timing Mask */
+
+#define SCB_AIRCR_SYSRESETREQS_Pos          3U                                            /*!< SCB AIRCR: SYSRESETREQS Position */
+#define SCB_AIRCR_SYSRESETREQS_Msk         (1UL << SCB_AIRCR_SYSRESETREQS_Pos)            /*!< SCB AIRCR: SYSRESETREQS Mask */
+
+#define SCB_AIRCR_SYSRESETREQ_Pos           2U                                            /*!< SCB AIRCR: SYSRESETREQ Position */
+#define SCB_AIRCR_SYSRESETREQ_Msk          (1UL << SCB_AIRCR_SYSRESETREQ_Pos)             /*!< SCB AIRCR: SYSRESETREQ Mask */
+
+#define SCB_AIRCR_VECTCLRACTIVE_Pos         1U                                            /*!< SCB AIRCR: VECTCLRACTIVE Position */
+#define SCB_AIRCR_VECTCLRACTIVE_Msk        (1UL << SCB_AIRCR_VECTCLRACTIVE_Pos)           /*!< SCB AIRCR: VECTCLRACTIVE Mask */
+
+/** \brief SCB System Control Register Definitions */
+#define SCB_SCR_SEVONPEND_Pos               4U                                            /*!< SCB SCR: SEVONPEND Position */
+#define SCB_SCR_SEVONPEND_Msk              (1UL << SCB_SCR_SEVONPEND_Pos)                 /*!< SCB SCR: SEVONPEND Mask */
+
+#define SCB_SCR_SLEEPDEEPS_Pos              3U                                            /*!< SCB SCR: SLEEPDEEPS Position */
+#define SCB_SCR_SLEEPDEEPS_Msk             (1UL << SCB_SCR_SLEEPDEEPS_Pos)                /*!< SCB SCR: SLEEPDEEPS Mask */
+
+#define SCB_SCR_SLEEPDEEP_Pos               2U                                            /*!< SCB SCR: SLEEPDEEP Position */
+#define SCB_SCR_SLEEPDEEP_Msk              (1UL << SCB_SCR_SLEEPDEEP_Pos)                 /*!< SCB SCR: SLEEPDEEP Mask */
+
+#define SCB_SCR_SLEEPONEXIT_Pos             1U                                            /*!< SCB SCR: SLEEPONEXIT Position */
+#define SCB_SCR_SLEEPONEXIT_Msk            (1UL << SCB_SCR_SLEEPONEXIT_Pos)               /*!< SCB SCR: SLEEPONEXIT Mask */
+
+/** \brief SCB Configuration Control Register Definitions */
+#define SCB_CCR_TRD_Pos                    20U                                            /*!< SCB CCR: TRD Position */
+#define SCB_CCR_TRD_Msk                    (1UL << SCB_CCR_TRD_Pos)                       /*!< SCB CCR: TRD Mask */
+
+#define SCB_CCR_LOB_Pos                    19U                                            /*!< SCB CCR: LOB Position */
+#define SCB_CCR_LOB_Msk                    (1UL << SCB_CCR_LOB_Pos)                       /*!< SCB CCR: LOB Mask */
+
+#define SCB_CCR_BP_Pos                     18U                                            /*!< SCB CCR: BP Position */
+#define SCB_CCR_BP_Msk                     (1UL << SCB_CCR_BP_Pos)                        /*!< SCB CCR: BP Mask */
+
+#define SCB_CCR_IC_Pos                     17U                                            /*!< SCB CCR: IC Position */
+#define SCB_CCR_IC_Msk                     (1UL << SCB_CCR_IC_Pos)                        /*!< SCB CCR: IC Mask */
+
+#define SCB_CCR_DC_Pos                     16U                                            /*!< SCB CCR: DC Position */
+#define SCB_CCR_DC_Msk                     (1UL << SCB_CCR_DC_Pos)                        /*!< SCB CCR: DC Mask */
+
+#define SCB_CCR_STKOFHFNMIGN_Pos           10U                                            /*!< SCB CCR: STKOFHFNMIGN Position */
+#define SCB_CCR_STKOFHFNMIGN_Msk           (1UL << SCB_CCR_STKOFHFNMIGN_Pos)              /*!< SCB CCR: STKOFHFNMIGN Mask */
+
+#define SCB_CCR_BFHFNMIGN_Pos               8U                                            /*!< SCB CCR: BFHFNMIGN Position */
+#define SCB_CCR_BFHFNMIGN_Msk              (1UL << SCB_CCR_BFHFNMIGN_Pos)                 /*!< SCB CCR: BFHFNMIGN Mask */
+
+#define SCB_CCR_DIV_0_TRP_Pos               4U                                            /*!< SCB CCR: DIV_0_TRP Position */
+#define SCB_CCR_DIV_0_TRP_Msk              (1UL << SCB_CCR_DIV_0_TRP_Pos)                 /*!< SCB CCR: DIV_0_TRP Mask */
+
+#define SCB_CCR_UNALIGN_TRP_Pos             3U                                            /*!< SCB CCR: UNALIGN_TRP Position */
+#define SCB_CCR_UNALIGN_TRP_Msk            (1UL << SCB_CCR_UNALIGN_TRP_Pos)               /*!< SCB CCR: UNALIGN_TRP Mask */
+
+#define SCB_CCR_USERSETMPEND_Pos            1U                                            /*!< SCB CCR: USERSETMPEND Position */
+#define SCB_CCR_USERSETMPEND_Msk           (1UL << SCB_CCR_USERSETMPEND_Pos)              /*!< SCB CCR: USERSETMPEND Mask */
+
+/** \brief SCB System Handler Control and State Register Definitions */
+#define SCB_SHCSR_HARDFAULTPENDED_Pos      21U                                            /*!< SCB SHCSR: HARDFAULTPENDED Position */
+#define SCB_SHCSR_HARDFAULTPENDED_Msk      (1UL << SCB_SHCSR_HARDFAULTPENDED_Pos)         /*!< SCB SHCSR: HARDFAULTPENDED Mask */
+
+#define SCB_SHCSR_SECUREFAULTPENDED_Pos    20U                                            /*!< SCB SHCSR: SECUREFAULTPENDED Position */
+#define SCB_SHCSR_SECUREFAULTPENDED_Msk    (1UL << SCB_SHCSR_SECUREFAULTPENDED_Pos)       /*!< SCB SHCSR: SECUREFAULTPENDED Mask */
+
+#define SCB_SHCSR_SECUREFAULTENA_Pos       19U                                            /*!< SCB SHCSR: SECUREFAULTENA Position */
+#define SCB_SHCSR_SECUREFAULTENA_Msk       (1UL << SCB_SHCSR_SECUREFAULTENA_Pos)          /*!< SCB SHCSR: SECUREFAULTENA Mask */
+
+#define SCB_SHCSR_USGFAULTENA_Pos          18U                                            /*!< SCB SHCSR: USGFAULTENA Position */
+#define SCB_SHCSR_USGFAULTENA_Msk          (1UL << SCB_SHCSR_USGFAULTENA_Pos)             /*!< SCB SHCSR: USGFAULTENA Mask */
+
+#define SCB_SHCSR_BUSFAULTENA_Pos          17U                                            /*!< SCB SHCSR: BUSFAULTENA Position */
+#define SCB_SHCSR_BUSFAULTENA_Msk          (1UL << SCB_SHCSR_BUSFAULTENA_Pos)             /*!< SCB SHCSR: BUSFAULTENA Mask */
+
+#define SCB_SHCSR_MEMFAULTENA_Pos          16U                                            /*!< SCB SHCSR: MEMFAULTENA Position */
+#define SCB_SHCSR_MEMFAULTENA_Msk          (1UL << SCB_SHCSR_MEMFAULTENA_Pos)             /*!< SCB SHCSR: MEMFAULTENA Mask */
+
+#define SCB_SHCSR_SVCALLPENDED_Pos         15U                                            /*!< SCB SHCSR: SVCALLPENDED Position */
+#define SCB_SHCSR_SVCALLPENDED_Msk         (1UL << SCB_SHCSR_SVCALLPENDED_Pos)            /*!< SCB SHCSR: SVCALLPENDED Mask */
+
+#define SCB_SHCSR_BUSFAULTPENDED_Pos       14U                                            /*!< SCB SHCSR: BUSFAULTPENDED Position */
+#define SCB_SHCSR_BUSFAULTPENDED_Msk       (1UL << SCB_SHCSR_BUSFAULTPENDED_Pos)          /*!< SCB SHCSR: BUSFAULTPENDED Mask */
+
+#define SCB_SHCSR_MEMFAULTPENDED_Pos       13U                                            /*!< SCB SHCSR: MEMFAULTPENDED Position */
+#define SCB_SHCSR_MEMFAULTPENDED_Msk       (1UL << SCB_SHCSR_MEMFAULTPENDED_Pos)          /*!< SCB SHCSR: MEMFAULTPENDED Mask */
+
+#define SCB_SHCSR_USGFAULTPENDED_Pos       12U                                            /*!< SCB SHCSR: USGFAULTPENDED Position */
+#define SCB_SHCSR_USGFAULTPENDED_Msk       (1UL << SCB_SHCSR_USGFAULTPENDED_Pos)          /*!< SCB SHCSR: USGFAULTPENDED Mask */
+
+#define SCB_SHCSR_SYSTICKACT_Pos           11U                                            /*!< SCB SHCSR: SYSTICKACT Position */
+#define SCB_SHCSR_SYSTICKACT_Msk           (1UL << SCB_SHCSR_SYSTICKACT_Pos)              /*!< SCB SHCSR: SYSTICKACT Mask */
+
+#define SCB_SHCSR_PENDSVACT_Pos            10U                                            /*!< SCB SHCSR: PENDSVACT Position */
+#define SCB_SHCSR_PENDSVACT_Msk            (1UL << SCB_SHCSR_PENDSVACT_Pos)               /*!< SCB SHCSR: PENDSVACT Mask */
+
+#define SCB_SHCSR_MONITORACT_Pos            8U                                            /*!< SCB SHCSR: MONITORACT Position */
+#define SCB_SHCSR_MONITORACT_Msk           (1UL << SCB_SHCSR_MONITORACT_Pos)              /*!< SCB SHCSR: MONITORACT Mask */
+
+#define SCB_SHCSR_SVCALLACT_Pos             7U                                            /*!< SCB SHCSR: SVCALLACT Position */
+#define SCB_SHCSR_SVCALLACT_Msk            (1UL << SCB_SHCSR_SVCALLACT_Pos)               /*!< SCB SHCSR: SVCALLACT Mask */
+
+#define SCB_SHCSR_NMIACT_Pos                5U                                            /*!< SCB SHCSR: NMIACT Position */
+#define SCB_SHCSR_NMIACT_Msk               (1UL << SCB_SHCSR_NMIACT_Pos)                  /*!< SCB SHCSR: NMIACT Mask */
+
+#define SCB_SHCSR_SECUREFAULTACT_Pos        4U                                            /*!< SCB SHCSR: SECUREFAULTACT Position */
+#define SCB_SHCSR_SECUREFAULTACT_Msk       (1UL << SCB_SHCSR_SECUREFAULTACT_Pos)          /*!< SCB SHCSR: SECUREFAULTACT Mask */
+
+#define SCB_SHCSR_USGFAULTACT_Pos           3U                                            /*!< SCB SHCSR: USGFAULTACT Position */
+#define SCB_SHCSR_USGFAULTACT_Msk          (1UL << SCB_SHCSR_USGFAULTACT_Pos)             /*!< SCB SHCSR: USGFAULTACT Mask */
+
+#define SCB_SHCSR_HARDFAULTACT_Pos          2U                                            /*!< SCB SHCSR: HARDFAULTACT Position */
+#define SCB_SHCSR_HARDFAULTACT_Msk         (1UL << SCB_SHCSR_HARDFAULTACT_Pos)            /*!< SCB SHCSR: HARDFAULTACT Mask */
+
+#define SCB_SHCSR_BUSFAULTACT_Pos           1U                                            /*!< SCB SHCSR: BUSFAULTACT Position */
+#define SCB_SHCSR_BUSFAULTACT_Msk          (1UL << SCB_SHCSR_BUSFAULTACT_Pos)             /*!< SCB SHCSR: BUSFAULTACT Mask */
+
+#define SCB_SHCSR_MEMFAULTACT_Pos           0U                                            /*!< SCB SHCSR: MEMFAULTACT Position */
+#define SCB_SHCSR_MEMFAULTACT_Msk          (1UL /*<< SCB_SHCSR_MEMFAULTACT_Pos*/)         /*!< SCB SHCSR: MEMFAULTACT Mask */
+
+/** \brief SCB Configurable Fault Status Register Definitions */
+#define SCB_CFSR_USGFAULTSR_Pos            16U                                            /*!< SCB CFSR: Usage Fault Status Register Position */
+#define SCB_CFSR_USGFAULTSR_Msk            (0xFFFFUL << SCB_CFSR_USGFAULTSR_Pos)          /*!< SCB CFSR: Usage Fault Status Register Mask */
+
+#define SCB_CFSR_BUSFAULTSR_Pos             8U                                            /*!< SCB CFSR: Bus Fault Status Register Position */
+#define SCB_CFSR_BUSFAULTSR_Msk            (0xFFUL << SCB_CFSR_BUSFAULTSR_Pos)            /*!< SCB CFSR: Bus Fault Status Register Mask */
+
+#define SCB_CFSR_MEMFAULTSR_Pos             0U                                            /*!< SCB CFSR: Memory Manage Fault Status Register Position */
+#define SCB_CFSR_MEMFAULTSR_Msk            (0xFFUL /*<< SCB_CFSR_MEMFAULTSR_Pos*/)        /*!< SCB CFSR: Memory Manage Fault Status Register Mask */
+
+/** \brief SCB MemManage Fault Status Register Definitions (part of SCB Configurable Fault Status Register) */
+#define SCB_CFSR_MMARVALID_Pos             (SCB_CFSR_MEMFAULTSR_Pos + 7U)                 /*!< SCB CFSR (MMFSR): MMARVALID Position */
+#define SCB_CFSR_MMARVALID_Msk             (1UL << SCB_CFSR_MMARVALID_Pos)                /*!< SCB CFSR (MMFSR): MMARVALID Mask */
+
+#define SCB_CFSR_MLSPERR_Pos               (SCB_CFSR_MEMFAULTSR_Pos + 5U)                 /*!< SCB CFSR (MMFSR): MLSPERR Position */
+#define SCB_CFSR_MLSPERR_Msk               (1UL << SCB_CFSR_MLSPERR_Pos)                  /*!< SCB CFSR (MMFSR): MLSPERR Mask */
+
+#define SCB_CFSR_MSTKERR_Pos               (SCB_CFSR_MEMFAULTSR_Pos + 4U)                 /*!< SCB CFSR (MMFSR): MSTKERR Position */
+#define SCB_CFSR_MSTKERR_Msk               (1UL << SCB_CFSR_MSTKERR_Pos)                  /*!< SCB CFSR (MMFSR): MSTKERR Mask */
+
+#define SCB_CFSR_MUNSTKERR_Pos             (SCB_CFSR_MEMFAULTSR_Pos + 3U)                 /*!< SCB CFSR (MMFSR): MUNSTKERR Position */
+#define SCB_CFSR_MUNSTKERR_Msk             (1UL << SCB_CFSR_MUNSTKERR_Pos)                /*!< SCB CFSR (MMFSR): MUNSTKERR Mask */
+
+#define SCB_CFSR_DACCVIOL_Pos              (SCB_CFSR_MEMFAULTSR_Pos + 1U)                 /*!< SCB CFSR (MMFSR): DACCVIOL Position */
+#define SCB_CFSR_DACCVIOL_Msk              (1UL << SCB_CFSR_DACCVIOL_Pos)                 /*!< SCB CFSR (MMFSR): DACCVIOL Mask */
+
+#define SCB_CFSR_IACCVIOL_Pos              (SCB_CFSR_MEMFAULTSR_Pos + 0U)                 /*!< SCB CFSR (MMFSR): IACCVIOL Position */
+#define SCB_CFSR_IACCVIOL_Msk              (1UL /*<< SCB_CFSR_IACCVIOL_Pos*/)             /*!< SCB CFSR (MMFSR): IACCVIOL Mask */
+
+/** \brief SCB BusFault Status Register Definitions (part of SCB Configurable Fault Status Register) */
+#define SCB_CFSR_BFARVALID_Pos            (SCB_CFSR_BUSFAULTSR_Pos + 7U)                  /*!< SCB CFSR (BFSR): BFARVALID Position */
+#define SCB_CFSR_BFARVALID_Msk            (1UL << SCB_CFSR_BFARVALID_Pos)                 /*!< SCB CFSR (BFSR): BFARVALID Mask */
+
+#define SCB_CFSR_LSPERR_Pos               (SCB_CFSR_BUSFAULTSR_Pos + 5U)                  /*!< SCB CFSR (BFSR): LSPERR Position */
+#define SCB_CFSR_LSPERR_Msk               (1UL << SCB_CFSR_LSPERR_Pos)                    /*!< SCB CFSR (BFSR): LSPERR Mask */
+
+#define SCB_CFSR_STKERR_Pos               (SCB_CFSR_BUSFAULTSR_Pos + 4U)                  /*!< SCB CFSR (BFSR): STKERR Position */
+#define SCB_CFSR_STKERR_Msk               (1UL << SCB_CFSR_STKERR_Pos)                    /*!< SCB CFSR (BFSR): STKERR Mask */
+
+#define SCB_CFSR_UNSTKERR_Pos             (SCB_CFSR_BUSFAULTSR_Pos + 3U)                  /*!< SCB CFSR (BFSR): UNSTKERR Position */
+#define SCB_CFSR_UNSTKERR_Msk             (1UL << SCB_CFSR_UNSTKERR_Pos)                  /*!< SCB CFSR (BFSR): UNSTKERR Mask */
+
+#define SCB_CFSR_IMPRECISERR_Pos          (SCB_CFSR_BUSFAULTSR_Pos + 2U)                  /*!< SCB CFSR (BFSR): IMPRECISERR Position */
+#define SCB_CFSR_IMPRECISERR_Msk          (1UL << SCB_CFSR_IMPRECISERR_Pos)               /*!< SCB CFSR (BFSR): IMPRECISERR Mask */
+
+#define SCB_CFSR_PRECISERR_Pos            (SCB_CFSR_BUSFAULTSR_Pos + 1U)                  /*!< SCB CFSR (BFSR): PRECISERR Position */
+#define SCB_CFSR_PRECISERR_Msk            (1UL << SCB_CFSR_PRECISERR_Pos)                 /*!< SCB CFSR (BFSR): PRECISERR Mask */
+
+#define SCB_CFSR_IBUSERR_Pos              (SCB_CFSR_BUSFAULTSR_Pos + 0U)                  /*!< SCB CFSR (BFSR): IBUSERR Position */
+#define SCB_CFSR_IBUSERR_Msk              (1UL << SCB_CFSR_IBUSERR_Pos)                   /*!< SCB CFSR (BFSR): IBUSERR Mask */
+
+/** \brief SCB UsageFault Status Register Definitions (part of SCB Configurable Fault Status Register) */
+#define SCB_CFSR_DIVBYZERO_Pos            (SCB_CFSR_USGFAULTSR_Pos + 9U)                  /*!< SCB CFSR (UFSR): DIVBYZERO Position */
+#define SCB_CFSR_DIVBYZERO_Msk            (1UL << SCB_CFSR_DIVBYZERO_Pos)                 /*!< SCB CFSR (UFSR): DIVBYZERO Mask */
+
+#define SCB_CFSR_UNALIGNED_Pos            (SCB_CFSR_USGFAULTSR_Pos + 8U)                  /*!< SCB CFSR (UFSR): UNALIGNED Position */
+#define SCB_CFSR_UNALIGNED_Msk            (1UL << SCB_CFSR_UNALIGNED_Pos)                 /*!< SCB CFSR (UFSR): UNALIGNED Mask */
+
+#define SCB_CFSR_STKOF_Pos                (SCB_CFSR_USGFAULTSR_Pos + 4U)                  /*!< SCB CFSR (UFSR): STKOF Position */
+#define SCB_CFSR_STKOF_Msk                (1UL << SCB_CFSR_STKOF_Pos)                     /*!< SCB CFSR (UFSR): STKOF Mask */
+
+#define SCB_CFSR_NOCP_Pos                 (SCB_CFSR_USGFAULTSR_Pos + 3U)                  /*!< SCB CFSR (UFSR): NOCP Position */
+#define SCB_CFSR_NOCP_Msk                 (1UL << SCB_CFSR_NOCP_Pos)                      /*!< SCB CFSR (UFSR): NOCP Mask */
+
+#define SCB_CFSR_INVPC_Pos                (SCB_CFSR_USGFAULTSR_Pos + 2U)                  /*!< SCB CFSR (UFSR): INVPC Position */
+#define SCB_CFSR_INVPC_Msk                (1UL << SCB_CFSR_INVPC_Pos)                     /*!< SCB CFSR (UFSR): INVPC Mask */
+
+#define SCB_CFSR_INVSTATE_Pos             (SCB_CFSR_USGFAULTSR_Pos + 1U)                  /*!< SCB CFSR (UFSR): INVSTATE Position */
+#define SCB_CFSR_INVSTATE_Msk             (1UL << SCB_CFSR_INVSTATE_Pos)                  /*!< SCB CFSR (UFSR): INVSTATE Mask */
+
+#define SCB_CFSR_UNDEFINSTR_Pos           (SCB_CFSR_USGFAULTSR_Pos + 0U)                  /*!< SCB CFSR (UFSR): UNDEFINSTR Position */
+#define SCB_CFSR_UNDEFINSTR_Msk           (1UL << SCB_CFSR_UNDEFINSTR_Pos)                /*!< SCB CFSR (UFSR): UNDEFINSTR Mask */
+
+/** \brief SCB Hard Fault Status Register Definitions */
+#define SCB_HFSR_DEBUGEVT_Pos              31U                                            /*!< SCB HFSR: DEBUGEVT Position */
+#define SCB_HFSR_DEBUGEVT_Msk              (1UL << SCB_HFSR_DEBUGEVT_Pos)                 /*!< SCB HFSR: DEBUGEVT Mask */
+
+#define SCB_HFSR_FORCED_Pos                30U                                            /*!< SCB HFSR: FORCED Position */
+#define SCB_HFSR_FORCED_Msk                (1UL << SCB_HFSR_FORCED_Pos)                   /*!< SCB HFSR: FORCED Mask */
+
+#define SCB_HFSR_VECTTBL_Pos                1U                                            /*!< SCB HFSR: VECTTBL Position */
+#define SCB_HFSR_VECTTBL_Msk               (1UL << SCB_HFSR_VECTTBL_Pos)                  /*!< SCB HFSR: VECTTBL Mask */
+
+/** \brief SCB Debug Fault Status Register Definitions */
+#define SCB_DFSR_PMU_Pos                    5U                                            /*!< SCB DFSR: PMU Position */
+#define SCB_DFSR_PMU_Msk                   (1UL << SCB_DFSR_PMU_Pos)                      /*!< SCB DFSR: PMU Mask */
+
+#define SCB_DFSR_EXTERNAL_Pos               4U                                            /*!< SCB DFSR: EXTERNAL Position */
+#define SCB_DFSR_EXTERNAL_Msk              (1UL << SCB_DFSR_EXTERNAL_Pos)                 /*!< SCB DFSR: EXTERNAL Mask */
+
+#define SCB_DFSR_VCATCH_Pos                 3U                                            /*!< SCB DFSR: VCATCH Position */
+#define SCB_DFSR_VCATCH_Msk                (1UL << SCB_DFSR_VCATCH_Pos)                   /*!< SCB DFSR: VCATCH Mask */
+
+#define SCB_DFSR_DWTTRAP_Pos                2U                                            /*!< SCB DFSR: DWTTRAP Position */
+#define SCB_DFSR_DWTTRAP_Msk               (1UL << SCB_DFSR_DWTTRAP_Pos)                  /*!< SCB DFSR: DWTTRAP Mask */
+
+#define SCB_DFSR_BKPT_Pos                   1U                                            /*!< SCB DFSR: BKPT Position */
+#define SCB_DFSR_BKPT_Msk                  (1UL << SCB_DFSR_BKPT_Pos)                     /*!< SCB DFSR: BKPT Mask */
+
+#define SCB_DFSR_HALTED_Pos                 0U                                            /*!< SCB DFSR: HALTED Position */
+#define SCB_DFSR_HALTED_Msk                (1UL /*<< SCB_DFSR_HALTED_Pos*/)               /*!< SCB DFSR: HALTED Mask */
+
+/** \brief SCB Non-Secure Access Control Register Definitions */
+#define SCB_NSACR_CP11_Pos                 11U                                            /*!< SCB NSACR: CP11 Position */
+#define SCB_NSACR_CP11_Msk                 (1UL << SCB_NSACR_CP11_Pos)                    /*!< SCB NSACR: CP11 Mask */
+
+#define SCB_NSACR_CP10_Pos                 10U                                            /*!< SCB NSACR: CP10 Position */
+#define SCB_NSACR_CP10_Msk                 (1UL << SCB_NSACR_CP10_Pos)                    /*!< SCB NSACR: CP10 Mask */
+
+#define SCB_NSACR_CP7_Pos                   7U                                            /*!< SCB NSACR: CP7 Position */
+#define SCB_NSACR_CP7_Msk                  (1UL << SCB_NSACR_CP7_Pos)                     /*!< SCB NSACR: CP7 Mask */
+
+#define SCB_NSACR_CP6_Pos                   6U                                            /*!< SCB NSACR: CP6 Position */
+#define SCB_NSACR_CP6_Msk                  (1UL << SCB_NSACR_CP6_Pos)                     /*!< SCB NSACR: CP6 Mask */
+
+#define SCB_NSACR_CP5_Pos                   5U                                            /*!< SCB NSACR: CP5 Position */
+#define SCB_NSACR_CP5_Msk                  (1UL << SCB_NSACR_CP5_Pos)                     /*!< SCB NSACR: CP5 Mask */
+
+#define SCB_NSACR_CP4_Pos                   4U                                            /*!< SCB NSACR: CP4 Position */
+#define SCB_NSACR_CP4_Msk                  (1UL << SCB_NSACR_CP4_Pos)                     /*!< SCB NSACR: CP4 Mask */
+
+#define SCB_NSACR_CP3_Pos                   3U                                            /*!< SCB NSACR: CP3 Position */
+#define SCB_NSACR_CP3_Msk                  (1UL << SCB_NSACR_CP3_Pos)                     /*!< SCB NSACR: CP3 Mask */
+
+#define SCB_NSACR_CP2_Pos                   2U                                            /*!< SCB NSACR: CP2 Position */
+#define SCB_NSACR_CP2_Msk                  (1UL << SCB_NSACR_CP2_Pos)                     /*!< SCB NSACR: CP2 Mask */
+
+#define SCB_NSACR_CP1_Pos                   1U                                            /*!< SCB NSACR: CP1 Position */
+#define SCB_NSACR_CP1_Msk                  (1UL << SCB_NSACR_CP1_Pos)                     /*!< SCB NSACR: CP1 Mask */
+
+#define SCB_NSACR_CP0_Pos                   0U                                            /*!< SCB NSACR: CP0 Position */
+#define SCB_NSACR_CP0_Msk                  (1UL /*<< SCB_NSACR_CP0_Pos*/)                 /*!< SCB NSACR: CP0 Mask */
+
+/** \brief SCB Debug Feature Register 0 Definitions */
+#define SCB_ID_DFR_UDE_Pos                 28U                                            /*!< SCB ID_DFR: UDE Position */
+#define SCB_ID_DFR_UDE_Msk                 (0xFUL << SCB_ID_DFR_UDE_Pos)                  /*!< SCB ID_DFR: UDE Mask */
+
+#define SCB_ID_DFR_MProfDbg_Pos            20U                                            /*!< SCB ID_DFR: MProfDbg Position */
+#define SCB_ID_DFR_MProfDbg_Msk            (0xFUL << SCB_ID_DFR_MProfDbg_Pos)             /*!< SCB ID_DFR: MProfDbg Mask */
+
+/** \brief SCB Cache Level ID Register Definitions */
+#define SCB_CLIDR_LOUU_Pos                 27U                                            /*!< SCB CLIDR: LoUU Position */
+#define SCB_CLIDR_LOUU_Msk                 (7UL << SCB_CLIDR_LOUU_Pos)                    /*!< SCB CLIDR: LoUU Mask */
+
+#define SCB_CLIDR_LOC_Pos                  24U                                            /*!< SCB CLIDR: LoC Position */
+#define SCB_CLIDR_LOC_Msk                  (7UL << SCB_CLIDR_LOC_Pos)                     /*!< SCB CLIDR: LoC Mask */
+
+/** \brief SCB Cache Type Register Definitions */
+#define SCB_CTR_FORMAT_Pos                 29U                                            /*!< SCB CTR: Format Position */
+#define SCB_CTR_FORMAT_Msk                 (7UL << SCB_CTR_FORMAT_Pos)                    /*!< SCB CTR: Format Mask */
+
+#define SCB_CTR_CWG_Pos                    24U                                            /*!< SCB CTR: CWG Position */
+#define SCB_CTR_CWG_Msk                    (0xFUL << SCB_CTR_CWG_Pos)                     /*!< SCB CTR: CWG Mask */
+
+#define SCB_CTR_ERG_Pos                    20U                                            /*!< SCB CTR: ERG Position */
+#define SCB_CTR_ERG_Msk                    (0xFUL << SCB_CTR_ERG_Pos)                     /*!< SCB CTR: ERG Mask */
+
+#define SCB_CTR_DMINLINE_Pos               16U                                            /*!< SCB CTR: DminLine Position */
+#define SCB_CTR_DMINLINE_Msk               (0xFUL << SCB_CTR_DMINLINE_Pos)                /*!< SCB CTR: DminLine Mask */
+
+#define SCB_CTR_IMINLINE_Pos                0U                                            /*!< SCB CTR: ImInLine Position */
+#define SCB_CTR_IMINLINE_Msk               (0xFUL /*<< SCB_CTR_IMINLINE_Pos*/)            /*!< SCB CTR: ImInLine Mask */
+
+/** \brief SCB Cache Size ID Register Definitions */
+#define SCB_CCSIDR_WT_Pos                  31U                                            /*!< SCB CCSIDR: WT Position */
+#define SCB_CCSIDR_WT_Msk                  (1UL << SCB_CCSIDR_WT_Pos)                     /*!< SCB CCSIDR: WT Mask */
+
+#define SCB_CCSIDR_WB_Pos                  30U                                            /*!< SCB CCSIDR: WB Position */
+#define SCB_CCSIDR_WB_Msk                  (1UL << SCB_CCSIDR_WB_Pos)                     /*!< SCB CCSIDR: WB Mask */
+
+#define SCB_CCSIDR_RA_Pos                  29U                                            /*!< SCB CCSIDR: RA Position */
+#define SCB_CCSIDR_RA_Msk                  (1UL << SCB_CCSIDR_RA_Pos)                     /*!< SCB CCSIDR: RA Mask */
+
+#define SCB_CCSIDR_WA_Pos                  28U                                            /*!< SCB CCSIDR: WA Position */
+#define SCB_CCSIDR_WA_Msk                  (1UL << SCB_CCSIDR_WA_Pos)                     /*!< SCB CCSIDR: WA Mask */
+
+#define SCB_CCSIDR_NUMSETS_Pos             13U                                            /*!< SCB CCSIDR: NumSets Position */
+#define SCB_CCSIDR_NUMSETS_Msk             (0x7FFFUL << SCB_CCSIDR_NUMSETS_Pos)           /*!< SCB CCSIDR: NumSets Mask */
+
+#define SCB_CCSIDR_ASSOCIATIVITY_Pos        3U                                            /*!< SCB CCSIDR: Associativity Position */
+#define SCB_CCSIDR_ASSOCIATIVITY_Msk       (0x3FFUL << SCB_CCSIDR_ASSOCIATIVITY_Pos)      /*!< SCB CCSIDR: Associativity Mask */
+
+#define SCB_CCSIDR_LINESIZE_Pos             0U                                            /*!< SCB CCSIDR: LineSize Position */
+#define SCB_CCSIDR_LINESIZE_Msk            (7UL /*<< SCB_CCSIDR_LINESIZE_Pos*/)           /*!< SCB CCSIDR: LineSize Mask */
+
+/** \brief SCB Cache Size Selection Register Definitions */
+#define SCB_CSSELR_LEVEL_Pos                1U                                            /*!< SCB CSSELR: Level Position */
+#define SCB_CSSELR_LEVEL_Msk               (7UL << SCB_CSSELR_LEVEL_Pos)                  /*!< SCB CSSELR: Level Mask */
+
+#define SCB_CSSELR_IND_Pos                  0U                                            /*!< SCB CSSELR: InD Position */
+#define SCB_CSSELR_IND_Msk                 (1UL /*<< SCB_CSSELR_IND_Pos*/)                /*!< SCB CSSELR: InD Mask */
+
+/** \brief SCB Software Triggered Interrupt Register Definitions */
+#define SCB_STIR_INTID_Pos                  0U                                            /*!< SCB STIR: INTID Position */
+#define SCB_STIR_INTID_Msk                 (0x1FFUL /*<< SCB_STIR_INTID_Pos*/)            /*!< SCB STIR: INTID Mask */
+
+/** \brief SCB RAS Fault Status Register Definitions */
+#define SCB_RFSR_V_Pos                     31U                                            /*!< SCB RFSR: V Position */
+#define SCB_RFSR_V_Msk                     (1UL << SCB_RFSR_V_Pos)                        /*!< SCB RFSR: V Mask */
+
+#define SCB_RFSR_IS_Pos                    16U                                            /*!< SCB RFSR: IS Position */
+#define SCB_RFSR_IS_Msk                    (0x7FFFUL << SCB_RFSR_IS_Pos)                  /*!< SCB RFSR: IS Mask */
+
+#define SCB_RFSR_UET_Pos                    0U                                            /*!< SCB RFSR: UET Position */
+#define SCB_RFSR_UET_Msk                   (3UL /*<< SCB_RFSR_UET_Pos*/)                  /*!< SCB RFSR: UET Mask */
+
+/** \brief SCB D-Cache Invalidate by Set-way Register Definitions */
+#define SCB_DCISW_WAY_Pos                  30U                                            /*!< SCB DCISW: Way Position */
+#define SCB_DCISW_WAY_Msk                  (3UL << SCB_DCISW_WAY_Pos)                     /*!< SCB DCISW: Way Mask */
+
+#define SCB_DCISW_SET_Pos                   5U                                            /*!< SCB DCISW: Set Position */
+#define SCB_DCISW_SET_Msk                  (0x1FFUL << SCB_DCISW_SET_Pos)                 /*!< SCB DCISW: Set Mask */
+
+/** \brief SCB D-Cache Clean by Set-way Register Definitions */
+#define SCB_DCCSW_WAY_Pos                  30U                                            /*!< SCB DCCSW: Way Position */
+#define SCB_DCCSW_WAY_Msk                  (3UL << SCB_DCCSW_WAY_Pos)                     /*!< SCB DCCSW: Way Mask */
+
+#define SCB_DCCSW_SET_Pos                   5U                                            /*!< SCB DCCSW: Set Position */
+#define SCB_DCCSW_SET_Msk                  (0x1FFUL << SCB_DCCSW_SET_Pos)                 /*!< SCB DCCSW: Set Mask */
+
+/** \brief SCB D-Cache Clean and Invalidate by Set-way Register Definitions */
+#define SCB_DCCISW_WAY_Pos                 30U                                            /*!< SCB DCCISW: Way Position */
+#define SCB_DCCISW_WAY_Msk                 (3UL << SCB_DCCISW_WAY_Pos)                    /*!< SCB DCCISW: Way Mask */
+
+#define SCB_DCCISW_SET_Pos                  5U                                            /*!< SCB DCCISW: Set Position */
+#define SCB_DCCISW_SET_Msk                 (0x1FFUL << SCB_DCCISW_SET_Pos)                /*!< SCB DCCISW: Set Mask */
+
+/*@} end of group CMSIS_SCB */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_ICB Implementation Control Block register (ICB)
+  \brief    Type definitions for the Implementation Control Block Register
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Implementation Control Block (ICB).
+ */
+typedef struct
+{
+        uint32_t RESERVED0[1U];
+  __IM  uint32_t ICTR;                   /*!< Offset: 0x004 (R/ )  Interrupt Controller Type Register */
+  __IOM uint32_t ACTLR;                  /*!< Offset: 0x008 (R/W)  Auxiliary Control Register */
+  __IOM uint32_t CPPWR;                  /*!< Offset: 0x00C (R/W)  Coprocessor Power Control  Register */
+} ICB_Type;
+
+/** \brief ICB Auxiliary Control Register Definitions */
+#define ICB_ACTLR_DISCRITAXIRUW_Pos     27U                                               /*!< ACTLR: DISCRITAXIRUW Position */
+#define ICB_ACTLR_DISCRITAXIRUW_Msk     (1UL << ICB_ACTLR_DISCRITAXIRUW_Pos)              /*!< ACTLR: DISCRITAXIRUW Mask */
+
+#define ICB_ACTLR_DISDI_Pos             16U                                               /*!< ACTLR: DISDI Position */
+#define ICB_ACTLR_DISDI_Msk             (3UL << ICB_ACTLR_DISDI_Pos)                      /*!< ACTLR: DISDI Mask */
+
+#define ICB_ACTLR_DISCRITAXIRUR_Pos     15U                                               /*!< ACTLR: DISCRITAXIRUR Position */
+#define ICB_ACTLR_DISCRITAXIRUR_Msk     (1UL << ICB_ACTLR_DISCRITAXIRUR_Pos)              /*!< ACTLR: DISCRITAXIRUR Mask */
+
+#define ICB_ACTLR_EVENTBUSEN_Pos        14U                                               /*!< ACTLR: EVENTBUSEN Position */
+#define ICB_ACTLR_EVENTBUSEN_Msk        (1UL << ICB_ACTLR_EVENTBUSEN_Pos)                 /*!< ACTLR: EVENTBUSEN Mask */
+
+#define ICB_ACTLR_EVENTBUSEN_S_Pos      13U                                               /*!< ACTLR: EVENTBUSEN_S Position */
+#define ICB_ACTLR_EVENTBUSEN_S_Msk      (1UL << ICB_ACTLR_EVENTBUSEN_S_Pos)               /*!< ACTLR: EVENTBUSEN_S Mask */
+
+#define ICB_ACTLR_DISITMATBFLUSH_Pos    12U                                               /*!< ACTLR: DISITMATBFLUSH Position */
+#define ICB_ACTLR_DISITMATBFLUSH_Msk    (1UL << ICB_ACTLR_DISITMATBFLUSH_Pos)             /*!< ACTLR: DISITMATBFLUSH Mask */
+
+#define ICB_ACTLR_DISNWAMODE_Pos        11U                                               /*!< ACTLR: DISNWAMODE Position */
+#define ICB_ACTLR_DISNWAMODE_Msk        (1UL << ICB_ACTLR_DISNWAMODE_Pos)                 /*!< ACTLR: DISNWAMODE Mask */
+
+#define ICB_ACTLR_FPEXCODIS_Pos         10U                                               /*!< ACTLR: FPEXCODIS Position */
+#define ICB_ACTLR_FPEXCODIS_Msk         (1UL << ICB_ACTLR_FPEXCODIS_Pos)                  /*!< ACTLR: FPEXCODIS Mask */
+
+#define ICB_ACTLR_DISOLAP_Pos            7U                                               /*!< ACTLR: DISOLAP Position */
+#define ICB_ACTLR_DISOLAP_Msk           (1UL << ICB_ACTLR_DISOLAP_Pos)                    /*!< ACTLR: DISOLAP Mask */
+
+#define ICB_ACTLR_DISOLAPS_Pos           6U                                               /*!< ACTLR: DISOLAPS Position */
+#define ICB_ACTLR_DISOLAPS_Msk          (1UL << ICB_ACTLR_DISOLAPS_Pos)                   /*!< ACTLR: DISOLAPS Mask */
+
+#define ICB_ACTLR_DISLOBR_Pos            5U                                               /*!< ACTLR: DISLOBR Position */
+#define ICB_ACTLR_DISLOBR_Msk           (1UL << ICB_ACTLR_DISLOBR_Pos)                    /*!< ACTLR: DISLOBR Mask */
+
+#define ICB_ACTLR_DISLO_Pos              4U                                               /*!< ACTLR: DISLO Position */
+#define ICB_ACTLR_DISLO_Msk             (1UL << ICB_ACTLR_DISLO_Pos)                      /*!< ACTLR: DISLO Mask */
+
+#define ICB_ACTLR_DISLOLEP_Pos           3U                                               /*!< ACTLR: DISLOLEP Position */
+#define ICB_ACTLR_DISLOLEP_Msk          (1UL << ICB_ACTLR_DISLOLEP_Pos)                   /*!< ACTLR: DISLOLEP Mask */
+
+#define ICB_ACTLR_DISFOLD_Pos            2U                                               /*!< ACTLR: DISFOLD Position */
+#define ICB_ACTLR_DISFOLD_Msk           (1UL << ICB_ACTLR_DISFOLD_Pos)                    /*!< ACTLR: DISFOLD Mask */
+
+/** \brief ICB Interrupt Controller Type Register Definitions */
+#define ICB_ICTR_INTLINESNUM_Pos         0U                                               /*!< ICTR: INTLINESNUM Position */
+#define ICB_ICTR_INTLINESNUM_Msk        (0xFUL /*<< ICB_ICTR_INTLINESNUM_Pos*/)           /*!< ICTR: INTLINESNUM Mask */
+
+/*@} end of group CMSIS_ICB */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SysTick     System Tick Timer (SysTick)
+  \brief    Type definitions for the System Timer Registers.
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Timer (SysTick).
+ */
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  SysTick Control and Status Register */
+  __IOM uint32_t LOAD;                   /*!< Offset: 0x004 (R/W)  SysTick Reload Value Register */
+  __IOM uint32_t VAL;                    /*!< Offset: 0x008 (R/W)  SysTick Current Value Register */
+  __IM  uint32_t CALIB;                  /*!< Offset: 0x00C (R/ )  SysTick Calibration Register */
+} SysTick_Type;
+
+/** \brief SysTick Control / Status Register Definitions */
+#define SysTick_CTRL_COUNTFLAG_Pos         16U                                            /*!< SysTick CTRL: COUNTFLAG Position */
+#define SysTick_CTRL_COUNTFLAG_Msk         (1UL << SysTick_CTRL_COUNTFLAG_Pos)            /*!< SysTick CTRL: COUNTFLAG Mask */
+
+#define SysTick_CTRL_CLKSOURCE_Pos          2U                                            /*!< SysTick CTRL: CLKSOURCE Position */
+#define SysTick_CTRL_CLKSOURCE_Msk         (1UL << SysTick_CTRL_CLKSOURCE_Pos)            /*!< SysTick CTRL: CLKSOURCE Mask */
+
+#define SysTick_CTRL_TICKINT_Pos            1U                                            /*!< SysTick CTRL: TICKINT Position */
+#define SysTick_CTRL_TICKINT_Msk           (1UL << SysTick_CTRL_TICKINT_Pos)              /*!< SysTick CTRL: TICKINT Mask */
+
+#define SysTick_CTRL_ENABLE_Pos             0U                                            /*!< SysTick CTRL: ENABLE Position */
+#define SysTick_CTRL_ENABLE_Msk            (1UL /*<< SysTick_CTRL_ENABLE_Pos*/)           /*!< SysTick CTRL: ENABLE Mask */
+
+/** \brief SysTick Reload Register Definitions */
+#define SysTick_LOAD_RELOAD_Pos             0U                                            /*!< SysTick LOAD: RELOAD Position */
+#define SysTick_LOAD_RELOAD_Msk            (0xFFFFFFUL /*<< SysTick_LOAD_RELOAD_Pos*/)    /*!< SysTick LOAD: RELOAD Mask */
+
+/** \brief SysTick Current Register Definitions */
+#define SysTick_VAL_CURRENT_Pos             0U                                            /*!< SysTick VAL: CURRENT Position */
+#define SysTick_VAL_CURRENT_Msk            (0xFFFFFFUL /*<< SysTick_VAL_CURRENT_Pos*/)    /*!< SysTick VAL: CURRENT Mask */
+
+/** \brief SysTick Calibration Register Definitions */
+#define SysTick_CALIB_NOREF_Pos            31U                                            /*!< SysTick CALIB: NOREF Position */
+#define SysTick_CALIB_NOREF_Msk            (1UL << SysTick_CALIB_NOREF_Pos)               /*!< SysTick CALIB: NOREF Mask */
+
+#define SysTick_CALIB_SKEW_Pos             30U                                            /*!< SysTick CALIB: SKEW Position */
+#define SysTick_CALIB_SKEW_Msk             (1UL << SysTick_CALIB_SKEW_Pos)                /*!< SysTick CALIB: SKEW Mask */
+
+#define SysTick_CALIB_TENMS_Pos             0U                                            /*!< SysTick CALIB: TENMS Position */
+#define SysTick_CALIB_TENMS_Msk            (0xFFFFFFUL /*<< SysTick_CALIB_TENMS_Pos*/)    /*!< SysTick CALIB: TENMS Mask */
+
+/*@} end of group CMSIS_SysTick */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_ITM     Instrumentation Trace Macrocell (ITM)
+  \brief    Type definitions for the Instrumentation Trace Macrocell (ITM)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Instrumentation Trace Macrocell Register (ITM).
+ */
+typedef struct
+{
+  __OM  union
+  {
+    __OM  uint8_t    u8;                 /*!< Offset: 0x000 ( /W)  Stimulus Port 8-bit */
+    __OM  uint16_t   u16;                /*!< Offset: 0x000 ( /W)  Stimulus Port 16-bit */
+    __OM  uint32_t   u32;                /*!< Offset: 0x000 ( /W)  Stimulus Port 32-bit */
+  }  PORT [32U];                         /*!< Offset: 0x000 ( /W)  Stimulus Port Registers */
+        uint32_t RESERVED0[864U];
+  __IOM uint32_t TER;                    /*!< Offset: 0xE00 (R/W)  Trace Enable Register */
+        uint32_t RESERVED1[15U];
+  __IOM uint32_t TPR;                    /*!< Offset: 0xE40 (R/W)  Trace Privilege Register */
+        uint32_t RESERVED2[15U];
+  __IOM uint32_t TCR;                    /*!< Offset: 0xE80 (R/W)  Trace Control Register */
+        uint32_t RESERVED3[27U];
+  __IM  uint32_t ITREAD;                 /*!< Offset: 0xEF0 (R/ )  Integration Read Register */
+        uint32_t RESERVED4[1U];
+  __OM  uint32_t ITWRITE;                /*!< Offset: 0xEF8 ( /W)  Integration Write Register */
+        uint32_t RESERVED5[1U];
+  __IOM uint32_t ITCTRL;                 /*!< Offset: 0xF00 (R/W)  Integration Mode Control Register */
+        uint32_t RESERVED6[46U];
+  __IM  uint32_t DEVARCH;                /*!< Offset: 0xFBC (R/ )  Device Architecture Register */
+        uint32_t RESERVED7[3U];
+  __IM  uint32_t DEVTYPE;                /*!< Offset: 0xFCC (R/ )  Device Type Register */
+} ITM_Type;
+
+/** \brief ITM Stimulus Port Register Definitions */
+#define ITM_STIM_DISABLED_Pos               1U                                            /*!< ITM STIM: DISABLED Position */
+#define ITM_STIM_DISABLED_Msk              (1UL << ITM_STIM_DISABLED_Pos)                 /*!< ITM STIM: DISABLED Mask */
+
+#define ITM_STIM_FIFOREADY_Pos              0U                                            /*!< ITM STIM: FIFOREADY Position */
+#define ITM_STIM_FIFOREADY_Msk             (1UL /*<< ITM_STIM_FIFOREADY_Pos*/)            /*!< ITM STIM: FIFOREADY Mask */
+
+/** \brief ITM Trace Privilege Register Definitions */
+#define ITM_TPR_PRIVMASK_Pos                0U                                            /*!< ITM TPR: PRIVMASK Position */
+#define ITM_TPR_PRIVMASK_Msk               (0xFUL /*<< ITM_TPR_PRIVMASK_Pos*/)            /*!< ITM TPR: PRIVMASK Mask */
+
+/** \brief ITM Trace Control Register Definitions */
+#define ITM_TCR_BUSY_Pos                   23U                                            /*!< ITM TCR: BUSY Position */
+#define ITM_TCR_BUSY_Msk                   (1UL << ITM_TCR_BUSY_Pos)                      /*!< ITM TCR: BUSY Mask */
+
+#define ITM_TCR_TRACEBUSID_Pos             16U                                            /*!< ITM TCR: ATBID Position */
+#define ITM_TCR_TRACEBUSID_Msk             (0x7FUL << ITM_TCR_TRACEBUSID_Pos)             /*!< ITM TCR: ATBID Mask */
+
+#define ITM_TCR_GTSFREQ_Pos                10U                                            /*!< ITM TCR: Global timestamp frequency Position */
+#define ITM_TCR_GTSFREQ_Msk                (3UL << ITM_TCR_GTSFREQ_Pos)                   /*!< ITM TCR: Global timestamp frequency Mask */
+
+#define ITM_TCR_TSPRESCALE_Pos              8U                                            /*!< ITM TCR: TSPRESCALE Position */
+#define ITM_TCR_TSPRESCALE_Msk             (3UL << ITM_TCR_TSPRESCALE_Pos)                /*!< ITM TCR: TSPRESCALE Mask */
+
+#define ITM_TCR_STALLENA_Pos                5U                                            /*!< ITM TCR: STALLENA Position */
+#define ITM_TCR_STALLENA_Msk               (1UL << ITM_TCR_STALLENA_Pos)                  /*!< ITM TCR: STALLENA Mask */
+
+#define ITM_TCR_SWOENA_Pos                  4U                                            /*!< ITM TCR: SWOENA Position */
+#define ITM_TCR_SWOENA_Msk                 (1UL << ITM_TCR_SWOENA_Pos)                    /*!< ITM TCR: SWOENA Mask */
+
+#define ITM_TCR_DWTENA_Pos                  3U                                            /*!< ITM TCR: DWTENA Position */
+#define ITM_TCR_DWTENA_Msk                 (1UL << ITM_TCR_DWTENA_Pos)                    /*!< ITM TCR: DWTENA Mask */
+
+#define ITM_TCR_SYNCENA_Pos                 2U                                            /*!< ITM TCR: SYNCENA Position */
+#define ITM_TCR_SYNCENA_Msk                (1UL << ITM_TCR_SYNCENA_Pos)                   /*!< ITM TCR: SYNCENA Mask */
+
+#define ITM_TCR_TSENA_Pos                   1U                                            /*!< ITM TCR: TSENA Position */
+#define ITM_TCR_TSENA_Msk                  (1UL << ITM_TCR_TSENA_Pos)                     /*!< ITM TCR: TSENA Mask */
+
+#define ITM_TCR_ITMENA_Pos                  0U                                            /*!< ITM TCR: ITM Enable bit Position */
+#define ITM_TCR_ITMENA_Msk                 (1UL /*<< ITM_TCR_ITMENA_Pos*/)                /*!< ITM TCR: ITM Enable bit Mask */
+
+/** \brief ITM Integration Read Register Definitions */
+#define ITM_ITREAD_AFVALID_Pos              1U                                            /*!< ITM ITREAD: AFVALID Position */
+#define ITM_ITREAD_AFVALID_Msk             (1UL << ITM_ITREAD_AFVALID_Pos)                /*!< ITM ITREAD: AFVALID Mask */
+
+#define ITM_ITREAD_ATREADY_Pos              0U                                            /*!< ITM ITREAD: ATREADY Position */
+#define ITM_ITREAD_ATREADY_Msk             (1UL /*<< ITM_ITREAD_ATREADY_Pos*/)            /*!< ITM ITREAD: ATREADY Mask */
+
+/** \brief ITM Integration Write Register Definitions */
+#define ITM_ITWRITE_AFVALID_Pos             1U                                            /*!< ITM ITWRITE: AFVALID Position */
+#define ITM_ITWRITE_AFVALID_Msk            (1UL << ITM_ITWRITE_AFVALID_Pos)               /*!< ITM ITWRITE: AFVALID Mask */
+
+#define ITM_ITWRITE_ATREADY_Pos             0U                                            /*!< ITM ITWRITE: ATREADY Position */
+#define ITM_ITWRITE_ATREADY_Msk            (1UL /*<< ITM_ITWRITE_ATREADY_Pos*/)           /*!< ITM ITWRITE: ATREADY Mask */
+
+/** \brief ITM Integration Mode Control Register Definitions */
+#define ITM_ITCTRL_IME_Pos                  0U                                            /*!< ITM ITCTRL: IME Position */
+#define ITM_ITCTRL_IME_Msk                 (1UL /*<< ITM_ITCTRL_IME_Pos*/)                /*!< ITM ITCTRL: IME Mask */
+
+/*@}*/ /* end of group CMSIS_ITM */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_DWT     Data Watchpoint and Trace (DWT)
+  \brief    Type definitions for the Data Watchpoint and Trace (DWT)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Data Watchpoint and Trace Register (DWT).
+ */
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  Control Register */
+  __IOM uint32_t CYCCNT;                 /*!< Offset: 0x004 (R/W)  Cycle Count Register */
+  __IOM uint32_t CPICNT;                 /*!< Offset: 0x008 (R/W)  CPI Count Register */
+  __IOM uint32_t EXCCNT;                 /*!< Offset: 0x00C (R/W)  Exception Overhead Count Register */
+  __IOM uint32_t SLEEPCNT;               /*!< Offset: 0x010 (R/W)  Sleep Count Register */
+  __IOM uint32_t LSUCNT;                 /*!< Offset: 0x014 (R/W)  LSU Count Register */
+  __IOM uint32_t FOLDCNT;                /*!< Offset: 0x018 (R/W)  Folded-instruction Count Register */
+  __IM  uint32_t PCSR;                   /*!< Offset: 0x01C (R/ )  Program Counter Sample Register */
+  __IOM uint32_t COMP0;                  /*!< Offset: 0x020 (R/W)  Comparator Register 0 */
+        uint32_t RESERVED1[1U];
+  __IOM uint32_t FUNCTION0;              /*!< Offset: 0x028 (R/W)  Function Register 0 */
+        uint32_t RESERVED2[1U];
+  __IOM uint32_t COMP1;                  /*!< Offset: 0x030 (R/W)  Comparator Register 1 */
+        uint32_t RESERVED3[1U];
+  __IOM uint32_t FUNCTION1;              /*!< Offset: 0x038 (R/W)  Function Register 1 */
+  __IOM uint32_t VMASK1;                 /*!< Offset: 0x03C (R/W)  Comparator Value Mask 1 */
+  __IOM uint32_t COMP2;                  /*!< Offset: 0x040 (R/W)  Comparator Register 2 */
+        uint32_t RESERVED4[1U];
+  __IOM uint32_t FUNCTION2;              /*!< Offset: 0x048 (R/W)  Function Register 2 */
+        uint32_t RESERVED5[1U];
+  __IOM uint32_t COMP3;                  /*!< Offset: 0x050 (R/W)  Comparator Register 3 */
+        uint32_t RESERVED6[1U];
+  __IOM uint32_t FUNCTION3;              /*!< Offset: 0x058 (R/W)  Function Register 3 */
+  __IOM uint32_t VMASK3;                 /*!< Offset: 0x05C (R/W)  Comparator Value Mask 3 */
+  __IOM uint32_t COMP4;                  /*!< Offset: 0x060 (R/W)  Comparator Register 4 */
+        uint32_t RESERVED7[1U];
+  __IOM uint32_t FUNCTION4;              /*!< Offset: 0x068 (R/W)  Function Register 4 */
+        uint32_t RESERVED8[1U];
+  __IOM uint32_t COMP5;                  /*!< Offset: 0x070 (R/W)  Comparator Register 5 */
+        uint32_t RESERVED9[1U];
+  __IOM uint32_t FUNCTION5;              /*!< Offset: 0x078 (R/W)  Function Register 5 */
+        uint32_t RESERVED10[1U];
+  __IOM uint32_t COMP6;                  /*!< Offset: 0x080 (R/W)  Comparator Register 6 */
+        uint32_t RESERVED11[1U];
+  __IOM uint32_t FUNCTION6;              /*!< Offset: 0x088 (R/W)  Function Register 6 */
+        uint32_t RESERVED12[1U];
+  __IOM uint32_t COMP7;                  /*!< Offset: 0x090 (R/W)  Comparator Register 7 */
+        uint32_t RESERVED13[1U];
+  __IOM uint32_t FUNCTION7;              /*!< Offset: 0x098 (R/W)  Function Register 7 */
+        uint32_t RESERVED14[968U];
+  __IM  uint32_t DEVARCH;                /*!< Offset: 0xFBC (R/ )  Device Type Architecture Register */
+        uint32_t RESERVED15[3U];
+  __IM  uint32_t DEVTYPE;                /*!< Offset: 0xFCC (R/ )  Device Type Identifier Register */
+} DWT_Type;
+
+/** \brief DWT Control Register Definitions */
+#define DWT_CTRL_NUMCOMP_Pos               28U                                         /*!< DWT CTRL: NUMCOMP Position */
+#define DWT_CTRL_NUMCOMP_Msk               (0xFUL << DWT_CTRL_NUMCOMP_Pos)             /*!< DWT CTRL: NUMCOMP Mask */
+
+#define DWT_CTRL_NOTRCPKT_Pos              27U                                         /*!< DWT CTRL: NOTRCPKT Position */
+#define DWT_CTRL_NOTRCPKT_Msk              (1UL << DWT_CTRL_NOTRCPKT_Pos)              /*!< DWT CTRL: NOTRCPKT Mask */
+
+#define DWT_CTRL_NOEXTTRIG_Pos             26U                                         /*!< DWT CTRL: NOEXTTRIG Position */
+#define DWT_CTRL_NOEXTTRIG_Msk             (1UL << DWT_CTRL_NOEXTTRIG_Pos)             /*!< DWT CTRL: NOEXTTRIG Mask */
+
+#define DWT_CTRL_NOCYCCNT_Pos              25U                                         /*!< DWT CTRL: NOCYCCNT Position */
+#define DWT_CTRL_NOCYCCNT_Msk              (1UL << DWT_CTRL_NOCYCCNT_Pos)              /*!< DWT CTRL: NOCYCCNT Mask */
+
+#define DWT_CTRL_NOPRFCNT_Pos              24U                                         /*!< DWT CTRL: NOPRFCNT Position */
+#define DWT_CTRL_NOPRFCNT_Msk              (1UL << DWT_CTRL_NOPRFCNT_Pos)              /*!< DWT CTRL: NOPRFCNT Mask */
+
+#define DWT_CTRL_CYCDISS_Pos               23U                                         /*!< DWT CTRL: CYCDISS Position */
+#define DWT_CTRL_CYCDISS_Msk               (1UL << DWT_CTRL_CYCDISS_Pos)               /*!< DWT CTRL: CYCDISS Mask */
+
+#define DWT_CTRL_CYCEVTENA_Pos             22U                                         /*!< DWT CTRL: CYCEVTENA Position */
+#define DWT_CTRL_CYCEVTENA_Msk             (1UL << DWT_CTRL_CYCEVTENA_Pos)             /*!< DWT CTRL: CYCEVTENA Mask */
+
+#define DWT_CTRL_FOLDEVTENA_Pos            21U                                         /*!< DWT CTRL: FOLDEVTENA Position */
+#define DWT_CTRL_FOLDEVTENA_Msk            (1UL << DWT_CTRL_FOLDEVTENA_Pos)            /*!< DWT CTRL: FOLDEVTENA Mask */
+
+#define DWT_CTRL_LSUEVTENA_Pos             20U                                         /*!< DWT CTRL: LSUEVTENA Position */
+#define DWT_CTRL_LSUEVTENA_Msk             (1UL << DWT_CTRL_LSUEVTENA_Pos)             /*!< DWT CTRL: LSUEVTENA Mask */
+
+#define DWT_CTRL_SLEEPEVTENA_Pos           19U                                         /*!< DWT CTRL: SLEEPEVTENA Position */
+#define DWT_CTRL_SLEEPEVTENA_Msk           (1UL << DWT_CTRL_SLEEPEVTENA_Pos)           /*!< DWT CTRL: SLEEPEVTENA Mask */
+
+#define DWT_CTRL_EXCEVTENA_Pos             18U                                         /*!< DWT CTRL: EXCEVTENA Position */
+#define DWT_CTRL_EXCEVTENA_Msk             (1UL << DWT_CTRL_EXCEVTENA_Pos)             /*!< DWT CTRL: EXCEVTENA Mask */
+
+#define DWT_CTRL_CPIEVTENA_Pos             17U                                         /*!< DWT CTRL: CPIEVTENA Position */
+#define DWT_CTRL_CPIEVTENA_Msk             (1UL << DWT_CTRL_CPIEVTENA_Pos)             /*!< DWT CTRL: CPIEVTENA Mask */
+
+#define DWT_CTRL_EXCTRCENA_Pos             16U                                         /*!< DWT CTRL: EXCTRCENA Position */
+#define DWT_CTRL_EXCTRCENA_Msk             (1UL << DWT_CTRL_EXCTRCENA_Pos)             /*!< DWT CTRL: EXCTRCENA Mask */
+
+#define DWT_CTRL_PCSAMPLENA_Pos            12U                                         /*!< DWT CTRL: PCSAMPLENA Position */
+#define DWT_CTRL_PCSAMPLENA_Msk            (1UL << DWT_CTRL_PCSAMPLENA_Pos)            /*!< DWT CTRL: PCSAMPLENA Mask */
+
+#define DWT_CTRL_SYNCTAP_Pos               10U                                         /*!< DWT CTRL: SYNCTAP Position */
+#define DWT_CTRL_SYNCTAP_Msk               (0x3UL << DWT_CTRL_SYNCTAP_Pos)             /*!< DWT CTRL: SYNCTAP Mask */
+
+#define DWT_CTRL_CYCTAP_Pos                 9U                                         /*!< DWT CTRL: CYCTAP Position */
+#define DWT_CTRL_CYCTAP_Msk                (1UL << DWT_CTRL_CYCTAP_Pos)                /*!< DWT CTRL: CYCTAP Mask */
+
+#define DWT_CTRL_POSTINIT_Pos               5U                                         /*!< DWT CTRL: POSTINIT Position */
+#define DWT_CTRL_POSTINIT_Msk              (0xFUL << DWT_CTRL_POSTINIT_Pos)            /*!< DWT CTRL: POSTINIT Mask */
+
+#define DWT_CTRL_POSTPRESET_Pos             1U                                         /*!< DWT CTRL: POSTPRESET Position */
+#define DWT_CTRL_POSTPRESET_Msk            (0xFUL << DWT_CTRL_POSTPRESET_Pos)          /*!< DWT CTRL: POSTPRESET Mask */
+
+#define DWT_CTRL_CYCCNTENA_Pos              0U                                         /*!< DWT CTRL: CYCCNTENA Position */
+#define DWT_CTRL_CYCCNTENA_Msk             (1UL /*<< DWT_CTRL_CYCCNTENA_Pos*/)         /*!< DWT CTRL: CYCCNTENA Mask */
+
+/** \brief DWT CPI Count Register Definitions */
+#define DWT_CPICNT_CPICNT_Pos               0U                                         /*!< DWT CPICNT: CPICNT Position */
+#define DWT_CPICNT_CPICNT_Msk              (0xFFUL /*<< DWT_CPICNT_CPICNT_Pos*/)       /*!< DWT CPICNT: CPICNT Mask */
+
+/** \brief DWT Exception Overhead Count Register Definitions */
+#define DWT_EXCCNT_EXCCNT_Pos               0U                                         /*!< DWT EXCCNT: EXCCNT Position */
+#define DWT_EXCCNT_EXCCNT_Msk              (0xFFUL /*<< DWT_EXCCNT_EXCCNT_Pos*/)       /*!< DWT EXCCNT: EXCCNT Mask */
+
+/** \brief DWT Sleep Count Register Definitions */
+#define DWT_SLEEPCNT_SLEEPCNT_Pos           0U                                         /*!< DWT SLEEPCNT: SLEEPCNT Position */
+#define DWT_SLEEPCNT_SLEEPCNT_Msk          (0xFFUL /*<< DWT_SLEEPCNT_SLEEPCNT_Pos*/)   /*!< DWT SLEEPCNT: SLEEPCNT Mask */
+
+/** \brief DWT LSU Count Register Definitions */
+#define DWT_LSUCNT_LSUCNT_Pos               0U                                         /*!< DWT LSUCNT: LSUCNT Position */
+#define DWT_LSUCNT_LSUCNT_Msk              (0xFFUL /*<< DWT_LSUCNT_LSUCNT_Pos*/)       /*!< DWT LSUCNT: LSUCNT Mask */
+
+/** \brief DWT Folded-instruction Count Register Definitions */
+#define DWT_FOLDCNT_FOLDCNT_Pos             0U                                         /*!< DWT FOLDCNT: FOLDCNT Position */
+#define DWT_FOLDCNT_FOLDCNT_Msk            (0xFFUL /*<< DWT_FOLDCNT_FOLDCNT_Pos*/)     /*!< DWT FOLDCNT: FOLDCNT Mask */
+
+/** \brief DWT Comparator Function Register Definitions */
+#define DWT_FUNCTION_ID_Pos                27U                                         /*!< DWT FUNCTION: ID Position */
+#define DWT_FUNCTION_ID_Msk                (0x1FUL << DWT_FUNCTION_ID_Pos)             /*!< DWT FUNCTION: ID Mask */
+
+#define DWT_FUNCTION_MATCHED_Pos           24U                                         /*!< DWT FUNCTION: MATCHED Position */
+#define DWT_FUNCTION_MATCHED_Msk           (1UL << DWT_FUNCTION_MATCHED_Pos)           /*!< DWT FUNCTION: MATCHED Mask */
+
+#define DWT_FUNCTION_DATAVSIZE_Pos         10U                                         /*!< DWT FUNCTION: DATAVSIZE Position */
+#define DWT_FUNCTION_DATAVSIZE_Msk         (0x3UL << DWT_FUNCTION_DATAVSIZE_Pos)       /*!< DWT FUNCTION: DATAVSIZE Mask */
+
+#define DWT_FUNCTION_ACTION_Pos             4U                                         /*!< DWT FUNCTION: ACTION Position */
+#define DWT_FUNCTION_ACTION_Msk            (0x3UL << DWT_FUNCTION_ACTION_Pos)          /*!< DWT FUNCTION: ACTION Mask */
+
+#define DWT_FUNCTION_MATCH_Pos              0U                                         /*!< DWT FUNCTION: MATCH Position */
+#define DWT_FUNCTION_MATCH_Msk             (0xFUL /*<< DWT_FUNCTION_MATCH_Pos*/)       /*!< DWT FUNCTION: MATCH Mask */
+
+/*@}*/ /* end of group CMSIS_DWT */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup MemSysCtl_Type     Memory System Control Registers (IMPLEMENTATION DEFINED)
+  \brief    Type definitions for the Memory System Control Registers (MEMSYSCTL)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Memory System Control Registers (MEMSYSCTL).
+ */
+typedef struct
+{
+  __IOM uint32_t MSCR;                   /*!< Offset: 0x000 (R/W)  Memory System Control Register */
+  __IOM uint32_t PFCR;                   /*!< Offset: 0x004 (R/W)  Prefetcher Control Register */
+        uint32_t RESERVED1[2U];
+  __IOM uint32_t ITCMCR;                 /*!< Offset: 0x010 (R/W)  ITCM Control Register */
+  __IOM uint32_t DTCMCR;                 /*!< Offset: 0x014 (R/W)  DTCM Control Register */
+  __IOM uint32_t PAHBCR;                 /*!< Offset: 0x018 (R/W)  P-AHB Control Register */
+        uint32_t RESERVED2[313U];
+  __IOM uint32_t ITGU_CTRL;              /*!< Offset: 0x500 (R/W)  ITGU Control Register */
+  __IOM uint32_t ITGU_CFG;               /*!< Offset: 0x504 (R/W)  ITGU Configuration Register */
+        uint32_t RESERVED3[2U];
+  __IOM uint32_t ITGU_LUT[16U];          /*!< Offset: 0x510 (R/W)  ITGU Look Up Table Register */
+        uint32_t RESERVED4[44U];
+  __IOM uint32_t DTGU_CTRL;              /*!< Offset: 0x600 (R/W)  DTGU Control Registers */
+  __IOM uint32_t DTGU_CFG;               /*!< Offset: 0x604 (R/W)  DTGU Configuration Register */
+        uint32_t RESERVED5[2U];
+  __IOM uint32_t DTGU_LUT[16U];          /*!< Offset: 0x610 (R/W)  DTGU Look Up Table Register */
+} MemSysCtl_Type;
+
+/** \brief MemSysCtl Memory System Control Register Definitions */
+#define MEMSYSCTL_MSCR_CPWRDN_Pos          17U                                         /*!< MEMSYSCTL MSCR: CPWRDN Position */
+#define MEMSYSCTL_MSCR_CPWRDN_Msk          (1UL << MEMSYSCTL_MSCR_CPWRDN_Pos)          /*!< MEMSYSCTL MSCR: CPWRDN Mask */
+
+#define MEMSYSCTL_MSCR_DCCLEAN_Pos         16U                                         /*!< MEMSYSCTL MSCR: DCCLEAN Position */
+#define MEMSYSCTL_MSCR_DCCLEAN_Msk         (1UL << MEMSYSCTL_MSCR_DCCLEAN_Pos)         /*!< MEMSYSCTL MSCR: DCCLEAN Mask */
+
+#define MEMSYSCTL_MSCR_ICACTIVE_Pos        13U                                         /*!< MEMSYSCTL MSCR: ICACTIVE Position */
+#define MEMSYSCTL_MSCR_ICACTIVE_Msk        (1UL << MEMSYSCTL_MSCR_ICACTIVE_Pos)        /*!< MEMSYSCTL MSCR: ICACTIVE Mask */
+
+#define MEMSYSCTL_MSCR_DCACTIVE_Pos        12U                                         /*!< MEMSYSCTL MSCR: DCACTIVE Position */
+#define MEMSYSCTL_MSCR_DCACTIVE_Msk        (1UL << MEMSYSCTL_MSCR_DCACTIVE_Pos)        /*!< MEMSYSCTL MSCR: DCACTIVE Mask */
+
+#define MEMSYSCTL_MSCR_TECCCHKDIS_Pos       4U                                         /*!< MEMSYSCTL MSCR: TECCCHKDIS Position */
+#define MEMSYSCTL_MSCR_TECCCHKDIS_Msk      (1UL << MEMSYSCTL_MSCR_TECCCHKDIS_Pos)      /*!< MEMSYSCTL MSCR: TECCCHKDIS Mask */
+
+#define MEMSYSCTL_MSCR_EVECCFAULT_Pos       3U                                         /*!< MEMSYSCTL MSCR: EVECCFAULT Position */
+#define MEMSYSCTL_MSCR_EVECCFAULT_Msk      (1UL << MEMSYSCTL_MSCR_EVECCFAULT_Pos)      /*!< MEMSYSCTL MSCR: EVECCFAULT Mask */
+
+#define MEMSYSCTL_MSCR_FORCEWT_Pos          2U                                         /*!< MEMSYSCTL MSCR: FORCEWT Position */
+#define MEMSYSCTL_MSCR_FORCEWT_Msk         (1UL << MEMSYSCTL_MSCR_FORCEWT_Pos)         /*!< MEMSYSCTL MSCR: FORCEWT Mask */
+
+#define MEMSYSCTL_MSCR_ECCEN_Pos            1U                                         /*!< MEMSYSCTL MSCR: ECCEN Position */
+#define MEMSYSCTL_MSCR_ECCEN_Msk           (1UL << MEMSYSCTL_MSCR_ECCEN_Pos)           /*!< MEMSYSCTL MSCR: ECCEN Mask */
+
+/** \brief MemSysCtl Prefetcher Control Register Definitions */
+#define MEMSYSCTL_PFCR_MAX_OS_Pos           7U                                         /*!< MEMSYSCTL PFCR: MAX_OS Position */
+#define MEMSYSCTL_PFCR_MAX_OS_Msk          (0x7UL << MEMSYSCTL_PFCR_MAX_OS_Pos)        /*!< MEMSYSCTL PFCR: MAX_OS Mask */
+
+#define MEMSYSCTL_PFCR_MAX_LA_Pos           4U                                         /*!< MEMSYSCTL PFCR: MAX_LA Position */
+#define MEMSYSCTL_PFCR_MAX_LA_Msk          (0x7UL << MEMSYSCTL_PFCR_MAX_LA_Pos)        /*!< MEMSYSCTL PFCR: MAX_LA Mask */
+
+#define MEMSYSCTL_PFCR_MIN_LA_Pos           1U                                         /*!< MEMSYSCTL PFCR: MIN_LA Position */
+#define MEMSYSCTL_PFCR_MIN_LA_Msk          (0x7UL << MEMSYSCTL_PFCR_MIN_LA_Pos)        /*!< MEMSYSCTL PFCR: MIN_LA Mask */
+
+#define MEMSYSCTL_PFCR_ENABLE_Pos           0U                                         /*!< MEMSYSCTL PFCR: ENABLE Position */
+#define MEMSYSCTL_PFCR_ENABLE_Msk          (1UL /*<< MEMSYSCTL_PFCR_ENABLE_Pos*/)      /*!< MEMSYSCTL PFCR: ENABLE Mask */
+
+/** \brief MemSysCtl ITCM Control Register Definitions */
+#define MEMSYSCTL_ITCMCR_SZ_Pos             3U                                         /*!< MEMSYSCTL ITCMCR: SZ Position */
+#define MEMSYSCTL_ITCMCR_SZ_Msk            (0xFUL << MEMSYSCTL_ITCMCR_SZ_Pos)          /*!< MEMSYSCTL ITCMCR: SZ Mask */
+
+#define MEMSYSCTL_ITCMCR_EN_Pos             0U                                         /*!< MEMSYSCTL ITCMCR: EN Position */
+#define MEMSYSCTL_ITCMCR_EN_Msk            (1UL /*<< MEMSYSCTL_ITCMCR_EN_Pos*/)        /*!< MEMSYSCTL ITCMCR: EN Mask */
+
+/** \brief MemSysCtl DTCM Control Register Definitions */
+#define MEMSYSCTL_DTCMCR_SZ_Pos             3U                                         /*!< MEMSYSCTL DTCMCR: SZ Position */
+#define MEMSYSCTL_DTCMCR_SZ_Msk            (0xFUL << MEMSYSCTL_DTCMCR_SZ_Pos)          /*!< MEMSYSCTL DTCMCR: SZ Mask */
+
+#define MEMSYSCTL_DTCMCR_EN_Pos             0U                                         /*!< MEMSYSCTL DTCMCR: EN Position */
+#define MEMSYSCTL_DTCMCR_EN_Msk            (1UL /*<< MEMSYSCTL_DTCMCR_EN_Pos*/)        /*!< MEMSYSCTL DTCMCR: EN Mask */
+
+/** \brief MemSysCtl P-AHB Control Register Definitions */
+#define MEMSYSCTL_PAHBCR_SZ_Pos             1U                                         /*!< MEMSYSCTL PAHBCR: SZ Position */
+#define MEMSYSCTL_PAHBCR_SZ_Msk            (0x7UL << MEMSYSCTL_PAHBCR_SZ_Pos)          /*!< MEMSYSCTL PAHBCR: SZ Mask */
+
+#define MEMSYSCTL_PAHBCR_EN_Pos             0U                                         /*!< MEMSYSCTL PAHBCR: EN Position */
+#define MEMSYSCTL_PAHBCR_EN_Msk            (1UL /*<< MEMSYSCTL_PAHBCR_EN_Pos*/)        /*!< MEMSYSCTL PAHBCR: EN Mask */
+
+/** \brief MemSysCtl ITGU Control Register Definitions */
+#define MEMSYSCTL_ITGU_CTRL_DEREN_Pos       1U                                         /*!< MEMSYSCTL ITGU_CTRL: DEREN Position */
+#define MEMSYSCTL_ITGU_CTRL_DEREN_Msk      (1UL << MEMSYSCTL_ITGU_CTRL_DEREN_Pos)      /*!< MEMSYSCTL ITGU_CTRL: DEREN Mask */
+
+#define MEMSYSCTL_ITGU_CTRL_DBFEN_Pos       0U                                         /*!< MEMSYSCTL ITGU_CTRL: DBFEN Position */
+#define MEMSYSCTL_ITGU_CTRL_DBFEN_Msk      (1UL /*<< MEMSYSCTL_ITGU_CTRL_DBFEN_Pos*/)  /*!< MEMSYSCTL ITGU_CTRL: DBFEN Mask */
+
+/** \brief MemSysCtl ITGU Configuration Register Definitions */
+#define MEMSYSCTL_ITGU_CFG_PRESENT_Pos     31U                                         /*!< MEMSYSCTL ITGU_CFG: PRESENT Position */
+#define MEMSYSCTL_ITGU_CFG_PRESENT_Msk     (1UL << MEMSYSCTL_ITGU_CFG_PRESENT_Pos)     /*!< MEMSYSCTL ITGU_CFG: PRESENT Mask */
+
+#define MEMSYSCTL_ITGU_CFG_NUMBLKS_Pos      8U                                         /*!< MEMSYSCTL ITGU_CFG: NUMBLKS Position */
+#define MEMSYSCTL_ITGU_CFG_NUMBLKS_Msk     (0xFUL << MEMSYSCTL_ITGU_CFG_NUMBLKS_Pos)   /*!< MEMSYSCTL ITGU_CFG: NUMBLKS Mask */
+
+#define MEMSYSCTL_ITGU_CFG_BLKSZ_Pos        0U                                         /*!< MEMSYSCTL ITGU_CFG: BLKSZ Position */
+#define MEMSYSCTL_ITGU_CFG_BLKSZ_Msk       (0xFUL /*<< MEMSYSCTL_ITGU_CFG_BLKSZ_Pos*/) /*!< MEMSYSCTL ITGU_CFG: BLKSZ Mask */
+
+/** \brief MemSysCtl DTGU Control Registers Definitions */
+#define MEMSYSCTL_DTGU_CTRL_DEREN_Pos       1U                                         /*!< MEMSYSCTL DTGU_CTRL: DEREN Position */
+#define MEMSYSCTL_DTGU_CTRL_DEREN_Msk      (1UL << MEMSYSCTL_DTGU_CTRL_DEREN_Pos)      /*!< MEMSYSCTL DTGU_CTRL: DEREN Mask */
+
+#define MEMSYSCTL_DTGU_CTRL_DBFEN_Pos       0U                                         /*!< MEMSYSCTL DTGU_CTRL: DBFEN Position */
+#define MEMSYSCTL_DTGU_CTRL_DBFEN_Msk      (1UL /*<< MEMSYSCTL_DTGU_CTRL_DBFEN_Pos*/)  /*!< MEMSYSCTL DTGU_CTRL: DBFEN Mask */
+
+/** \brief MemSysCtl DTGU Configuration Register Definitions */
+#define MEMSYSCTL_DTGU_CFG_PRESENT_Pos     31U                                         /*!< MEMSYSCTL DTGU_CFG: PRESENT Position */
+#define MEMSYSCTL_DTGU_CFG_PRESENT_Msk     (1UL << MEMSYSCTL_DTGU_CFG_PRESENT_Pos)     /*!< MEMSYSCTL DTGU_CFG: PRESENT Mask */
+
+#define MEMSYSCTL_DTGU_CFG_NUMBLKS_Pos      8U                                         /*!< MEMSYSCTL DTGU_CFG: NUMBLKS Position */
+#define MEMSYSCTL_DTGU_CFG_NUMBLKS_Msk     (0xFUL << MEMSYSCTL_DTGU_CFG_NUMBLKS_Pos)   /*!< MEMSYSCTL DTGU_CFG: NUMBLKS Mask */
+
+#define MEMSYSCTL_DTGU_CFG_BLKSZ_Pos        0U                                         /*!< MEMSYSCTL DTGU_CFG: BLKSZ Position */
+#define MEMSYSCTL_DTGU_CFG_BLKSZ_Msk       (0xFUL /*<< MEMSYSCTL_DTGU_CFG_BLKSZ_Pos*/) /*!< MEMSYSCTL DTGU_CFG: BLKSZ Mask */
+
+/*@}*/ /* end of group MemSysCtl_Type */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup PwrModCtl_Type     Power Mode Control Registers
+  \brief    Type definitions for the Power Mode Control Registers (PWRMODCTL)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Power Mode Control Registers (PWRMODCTL).
+ */
+typedef struct
+{
+  __IOM uint32_t CPDLPSTATE;             /*!< Offset: 0x000 (R/W)  Core Power Domain Low Power State Register */
+  __IOM uint32_t DPDLPSTATE;             /*!< Offset: 0x004 (R/W)  Debug Power Domain Low Power State Register */
+} PwrModCtl_Type;
+
+/** \brief PwrModCtl Core Power Domain Low Power State Register Definitions */
+#define PWRMODCTL_CPDLPSTATE_RLPSTATE_Pos   8U                                              /*!< PWRMODCTL CPDLPSTATE: RLPSTATE Position */
+#define PWRMODCTL_CPDLPSTATE_RLPSTATE_Msk  (0x3UL << PWRMODCTL_CPDLPSTATE_RLPSTATE_Pos)     /*!< PWRMODCTL CPDLPSTATE: RLPSTATE Mask */
+
+#define PWRMODCTL_CPDLPSTATE_ELPSTATE_Pos   4U                                              /*!< PWRMODCTL CPDLPSTATE: ELPSTATE Position */
+#define PWRMODCTL_CPDLPSTATE_ELPSTATE_Msk  (0x3UL << PWRMODCTL_CPDLPSTATE_ELPSTATE_Pos)     /*!< PWRMODCTL CPDLPSTATE: ELPSTATE Mask */
+
+#define PWRMODCTL_CPDLPSTATE_CLPSTATE_Pos   0U                                              /*!< PWRMODCTL CPDLPSTATE: CLPSTATE Position */
+#define PWRMODCTL_CPDLPSTATE_CLPSTATE_Msk  (0x3UL /*<< PWRMODCTL_CPDLPSTATE_CLPSTATE_Pos*/) /*!< PWRMODCTL CPDLPSTATE: CLPSTATE Mask */
+
+/** \brief PwrModCtl Debug Power Domain Low Power State Register Definitions */
+#define PWRMODCTL_DPDLPSTATE_DLPSTATE_Pos   0U                                              /*!< PWRMODCTL DPDLPSTATE: DLPSTATE Position */
+#define PWRMODCTL_DPDLPSTATE_DLPSTATE_Msk  (0x3UL /*<< PWRMODCTL_DPDLPSTATE_DLPSTATE_Pos*/) /*!< PWRMODCTL DPDLPSTATE: DLPSTATE Mask */
+
+/*@}*/ /* end of group PwrModCtl_Type */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup EWIC_Type     External Wakeup Interrupt Controller Registers
+  \brief    Type definitions for the External Wakeup Interrupt Controller Registers (EWIC)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the External Wakeup Interrupt Controller Registers (EWIC).
+ */
+typedef struct
+{
+  __IOM uint32_t EWIC_CR;                /*!< Offset: 0x000 (R/W)  EWIC Control Register */
+  __IOM uint32_t EWIC_ASCR;              /*!< Offset: 0x004 (R/W)  EWIC Automatic Sequence Control Register */
+  __OM  uint32_t EWIC_CLRMASK;           /*!< Offset: 0x008 ( /W)  EWIC Clear Mask Register */
+  __IM  uint32_t EWIC_NUMID;             /*!< Offset: 0x00C (R/ )  EWIC Event Number ID Register */
+        uint32_t RESERVED0[124U];
+  __IOM uint32_t EWIC_MASKA;             /*!< Offset: 0x200 (R/W)  EWIC MaskA Register */
+  __IOM uint32_t EWIC_MASKn[15];         /*!< Offset: 0x204 (R/W)  EWIC Maskn Registers */
+        uint32_t RESERVED1[112U];
+  __IM  uint32_t EWIC_PENDA;             /*!< Offset: 0x400 (R/ )  EWIC PendA Event Register */
+  __IOM uint32_t EWIC_PENDn[15];         /*!< Offset: 0x404 (R/W)  EWIC Pendn Event Registers */
+        uint32_t RESERVED2[112U];
+  __IM  uint32_t EWIC_PSR;               /*!< Offset: 0x600 (R/ )  EWIC Pend Summary Register */
+} EWIC_Type;
+
+/** \brief EWIC Control Register Definitions */
+#define EWIC_EWIC_CR_EN_Pos                 0U                                         /*!< EWIC EWIC_CR: EN Position */
+#define EWIC_EWIC_CR_EN_Msk                (1UL /*<< EWIC_EWIC_CR_EN_Pos*/)            /*!< EWIC EWIC_CR: EN Mask */
+
+/** \brief EWIC Automatic Sequence Control Register Definitions */
+#define EWIC_EWIC_ASCR_ASPU_Pos             1U                                         /*!< EWIC EWIC_ASCR: ASPU Position */
+#define EWIC_EWIC_ASCR_ASPU_Msk            (1UL << EWIC_EWIC_ASCR_ASPU_Pos)            /*!< EWIC EWIC_ASCR: ASPU Mask */
+
+#define EWIC_EWIC_ASCR_ASPD_Pos             0U                                         /*!< EWIC EWIC_ASCR: ASPD Position */
+#define EWIC_EWIC_ASCR_ASPD_Msk            (1UL /*<< EWIC_EWIC_ASCR_ASPD_Pos*/)        /*!< EWIC EWIC_ASCR: ASPD Mask */
+
+/** \brief EWIC Event Number ID Register Definitions */
+#define EWIC_EWIC_NUMID_NUMEVENT_Pos        0U                                         /*!< EWIC_NUMID: NUMEVENT Position */
+#define EWIC_EWIC_NUMID_NUMEVENT_Msk       (0xFFFFUL /*<< EWIC_EWIC_NUMID_NUMEVENT_Pos*/) /*!< EWIC_NUMID: NUMEVENT Mask */
+
+/** \brief EWIC Mask A Register Definitions */
+#define EWIC_EWIC_MASKA_EDBGREQ_Pos         2U                                         /*!< EWIC EWIC_MASKA: EDBGREQ Position */
+#define EWIC_EWIC_MASKA_EDBGREQ_Msk        (1UL << EWIC_EWIC_MASKA_EDBGREQ_Pos)        /*!< EWIC EWIC_MASKA: EDBGREQ Mask */
+
+#define EWIC_EWIC_MASKA_NMI_Pos             1U                                         /*!< EWIC EWIC_MASKA: NMI Position */
+#define EWIC_EWIC_MASKA_NMI_Msk            (1UL << EWIC_EWIC_MASKA_NMI_Pos)            /*!< EWIC EWIC_MASKA: NMI Mask */
+
+#define EWIC_EWIC_MASKA_EVENT_Pos           0U                                         /*!< EWIC EWIC_MASKA: EVENT Position */
+#define EWIC_EWIC_MASKA_EVENT_Msk          (1UL /*<< EWIC_EWIC_MASKA_EVENT_Pos*/)      /*!< EWIC EWIC_MASKA: EVENT Mask */
+
+/** \brief EWIC Mask n Register Definitions */
+#define EWIC_EWIC_MASKn_IRQ_Pos             0U                                         /*!< EWIC EWIC_MASKn: IRQ Position */
+#define EWIC_EWIC_MASKn_IRQ_Msk            (0xFFFFFFFFUL /*<< EWIC_EWIC_MASKn_IRQ_Pos*/) /*!< EWIC EWIC_MASKn: IRQ Mask */
+
+/** \brief EWIC Pend A Register Definitions */
+#define EWIC_EWIC_PENDA_EDBGREQ_Pos         2U                                         /*!< EWIC EWIC_PENDA: EDBGREQ Position */
+#define EWIC_EWIC_PENDA_EDBGREQ_Msk        (1UL << EWIC_EWIC_PENDA_EDBGREQ_Pos)        /*!< EWIC EWIC_PENDA: EDBGREQ Mask */
+
+#define EWIC_EWIC_PENDA_NMI_Pos             1U                                         /*!< EWIC EWIC_PENDA: NMI Position */
+#define EWIC_EWIC_PENDA_NMI_Msk            (1UL << EWIC_EWIC_PENDA_NMI_Pos)            /*!< EWIC EWIC_PENDA: NMI Mask */
+
+#define EWIC_EWIC_PENDA_EVENT_Pos           0U                                         /*!< EWIC EWIC_PENDA: EVENT Position */
+#define EWIC_EWIC_PENDA_EVENT_Msk          (1UL /*<< EWIC_EWIC_PENDA_EVENT_Pos*/)      /*!< EWIC EWIC_PENDA: EVENT Mask */
+
+/** \brief EWIC Pend n Register Definitions */
+#define EWIC_EWIC_PENDn_IRQ_Pos             0U                                         /*!< EWIC EWIC_PENDn: IRQ Position */
+#define EWIC_EWIC_PENDn_IRQ_Msk            (0xFFFFFFFFUL /*<< EWIC_EWIC_PENDn_IRQ_Pos*/) /*!< EWIC EWIC_PENDn: IRQ Mask */
+
+/** \brief EWIC Pend Summary Register Definitions */
+#define EWIC_EWIC_PSR_NZ_Pos                1U                                         /*!< EWIC EWIC_PSR: NZ Position */
+#define EWIC_EWIC_PSR_NZ_Msk               (0x7FFFUL << EWIC_EWIC_PSR_NZ_Pos)          /*!< EWIC EWIC_PSR: NZ Mask */
+
+#define EWIC_EWIC_PSR_NZA_Pos               0U                                         /*!< EWIC EWIC_PSR: NZA Position */
+#define EWIC_EWIC_PSR_NZA_Msk              (1UL /*<< EWIC_EWIC_PSR_NZA_Pos*/)          /*!< EWIC EWIC_PSR: NZA Mask */
+
+/*@}*/ /* end of group EWIC_Type */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup EWIC_ISA_Type     External Wakeup Interrupt Controller (EWIC) interrupt status access registers
+  \brief    Type definitions for the External Wakeup Interrupt Controller interrupt status access registers (EWIC_ISA)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the External Wakeup Interrupt Controller interrupt status access registers (EWIC_ISA).
+ */
+typedef struct
+{
+  __OM  uint32_t EVENTSPR;               /*!< Offset: 0x000 ( /W)  Event Set Pending Register */
+        uint32_t RESERVED0[31U];
+  __IM  uint32_t EVENTMASKA;             /*!< Offset: 0x080 (R/ )  Event Mask A Register */
+  __IM  uint32_t EVENTMASKn[15];         /*!< Offset: 0x084 (R/ )  Event Mask Register */
+} EWIC_ISA_Type;
+
+/** \brief EWIC_ISA Event Set Pending Register Definitions */
+#define EWIC_ISA_EVENTSPR_EDBGREQ_Pos       2U                                         /*!< EWIC_ISA EVENTSPR: EDBGREQ Position */
+#define EWIC_ISA_EVENTSPR_EDBGREQ_Msk      (1UL << EWIC_ISA_EVENTSPR_EDBGREQ_Pos)      /*!< EWIC_ISA EVENTSPR: EDBGREQ Mask */
+
+#define EWIC_ISA_EVENTSPR_NMI_Pos           1U                                         /*!< EWIC_ISA EVENTSPR: NMI Position */
+#define EWIC_ISA_EVENTSPR_NMI_Msk          (1UL << EWIC_ISA_EVENTSPR_NMI_Pos)          /*!< EWIC_ISA EVENTSPR: NMI Mask */
+
+#define EWIC_ISA_EVENTSPR_EVENT_Pos         0U                                         /*!< EWIC_ISA EVENTSPR: EVENT Position */
+#define EWIC_ISA_EVENTSPR_EVENT_Msk        (1UL /*<< EWIC_ISA_EVENTSPR_EVENT_Pos*/)    /*!< EWIC_ISA EVENTSPR: EVENT Mask */
+
+/** \brief EWIC_ISA Event Mask A Register Definitions */
+#define EWIC_ISA_EVENTMASKA_EDBGREQ_Pos     2U                                         /*!< EWIC_ISA EVENTMASKA: EDBGREQ Position */
+#define EWIC_ISA_EVENTMASKA_EDBGREQ_Msk    (1UL << EWIC_ISA_EVENTMASKA_EDBGREQ_Pos)    /*!< EWIC_ISA EVENTMASKA: EDBGREQ Mask */
+
+#define EWIC_ISA_EVENTMASKA_NMI_Pos         1U                                         /*!< EWIC_ISA EVENTMASKA: NMI Position */
+#define EWIC_ISA_EVENTMASKA_NMI_Msk        (1UL << EWIC_ISA_EVENTMASKA_NMI_Pos)        /*!< EWIC_ISA EVENTMASKA: NMI Mask */
+
+#define EWIC_ISA_EVENTMASKA_EVENT_Pos       0U                                         /*!< EWIC_ISA EVENTMASKA: EVENT Position */
+#define EWIC_ISA_EVENTMASKA_EVENT_Msk      (1UL /*<< EWIC_ISA_EVENTMASKA_EVENT_Pos*/)  /*!< EWIC_ISA EVENTMASKA: EVENT Mask */
+
+/** \brief EWIC_ISA Event Mask n Register Definitions */
+#define EWIC_ISA_EVENTMASKn_IRQ_Pos         0U                                         /*!< EWIC_ISA EVENTMASKn: IRQ Position */
+#define EWIC_ISA_EVENTMASKn_IRQ_Msk        (0xFFFFFFFFUL /*<< EWIC_ISA_EVENTMASKn_IRQ_Pos*/) /*!< EWIC_ISA EVENTMASKn: IRQ Mask */
+
+/*@}*/ /* end of group EWIC_ISA_Type */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup ErrBnk_Type     Error Banking Registers (IMPLEMENTATION DEFINED)
+  \brief    Type definitions for the Error Banking Registers (ERRBNK)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Error Banking Registers (ERRBNK).
+ */
+typedef struct
+{
+  __IOM uint32_t IEBR0;                  /*!< Offset: 0x000 (R/W)  Instruction Cache Error Bank Register 0 */
+  __IOM uint32_t IEBR1;                  /*!< Offset: 0x004 (R/W)  Instruction Cache Error Bank Register 1 */
+        uint32_t RESERVED0[2U];
+  __IOM uint32_t DEBR0;                  /*!< Offset: 0x010 (R/W)  Data Cache Error Bank Register 0 */
+  __IOM uint32_t DEBR1;                  /*!< Offset: 0x014 (R/W)  Data Cache Error Bank Register 1 */
+        uint32_t RESERVED1[2U];
+  __IOM uint32_t TEBR0;                  /*!< Offset: 0x020 (R/W)  TCM Error Bank Register 0 */
+        uint32_t RESERVED2[1U];
+  __IOM uint32_t TEBR1;                  /*!< Offset: 0x028 (R/W)  TCM Error Bank Register 1 */
+} ErrBnk_Type;
+
+/** \brief ErrBnk Instruction Cache Error Bank Register 0 Definitions */
+#define ERRBNK_IEBR0_SWDEF_Pos             30U                                         /*!< ERRBNK IEBR0: SWDEF Position */
+#define ERRBNK_IEBR0_SWDEF_Msk             (0x3UL << ERRBNK_IEBR0_SWDEF_Pos)           /*!< ERRBNK IEBR0: SWDEF Mask */
+
+#define ERRBNK_IEBR0_BANK_Pos              16U                                         /*!< ERRBNK IEBR0: BANK Position */
+#define ERRBNK_IEBR0_BANK_Msk              (1UL << ERRBNK_IEBR0_BANK_Pos)              /*!< ERRBNK IEBR0: BANK Mask */
+
+#define ERRBNK_IEBR0_LOCATION_Pos           2U                                         /*!< ERRBNK IEBR0: LOCATION Position */
+#define ERRBNK_IEBR0_LOCATION_Msk          (0x3FFFUL << ERRBNK_IEBR0_LOCATION_Pos)     /*!< ERRBNK IEBR0: LOCATION Mask */
+
+#define ERRBNK_IEBR0_LOCKED_Pos             1U                                         /*!< ERRBNK IEBR0: LOCKED Position */
+#define ERRBNK_IEBR0_LOCKED_Msk            (1UL << ERRBNK_IEBR0_LOCKED_Pos)            /*!< ERRBNK IEBR0: LOCKED Mask */
+
+#define ERRBNK_IEBR0_VALID_Pos              0U                                         /*!< ERRBNK IEBR0: VALID Position */
+#define ERRBNK_IEBR0_VALID_Msk             (1UL << /*ERRBNK_IEBR0_VALID_Pos*/)         /*!< ERRBNK IEBR0: VALID Mask */
+
+/** \brief ErrBnk Instruction Cache Error Bank Register 1 Definitions */
+#define ERRBNK_IEBR1_SWDEF_Pos             30U                                         /*!< ERRBNK IEBR1: SWDEF Position */
+#define ERRBNK_IEBR1_SWDEF_Msk             (0x3UL << ERRBNK_IEBR1_SWDEF_Pos)           /*!< ERRBNK IEBR1: SWDEF Mask */
+
+#define ERRBNK_IEBR1_BANK_Pos              16U                                         /*!< ERRBNK IEBR1: BANK Position */
+#define ERRBNK_IEBR1_BANK_Msk              (1UL << ERRBNK_IEBR1_BANK_Pos)              /*!< ERRBNK IEBR1: BANK Mask */
+
+#define ERRBNK_IEBR1_LOCATION_Pos           2U                                         /*!< ERRBNK IEBR1: LOCATION Position */
+#define ERRBNK_IEBR1_LOCATION_Msk          (0x3FFFUL << ERRBNK_IEBR1_LOCATION_Pos)     /*!< ERRBNK IEBR1: LOCATION Mask */
+
+#define ERRBNK_IEBR1_LOCKED_Pos             1U                                         /*!< ERRBNK IEBR1: LOCKED Position */
+#define ERRBNK_IEBR1_LOCKED_Msk            (1UL << ERRBNK_IEBR1_LOCKED_Pos)            /*!< ERRBNK IEBR1: LOCKED Mask */
+
+#define ERRBNK_IEBR1_VALID_Pos              0U                                         /*!< ERRBNK IEBR1: VALID Position */
+#define ERRBNK_IEBR1_VALID_Msk             (1UL << /*ERRBNK_IEBR1_VALID_Pos*/)         /*!< ERRBNK IEBR1: VALID Mask */
+
+/** \brief ErrBnk Data Cache Error Bank Register 0 Definitions */
+#define ERRBNK_DEBR0_SWDEF_Pos             30U                                         /*!< ERRBNK DEBR0: SWDEF Position */
+#define ERRBNK_DEBR0_SWDEF_Msk             (0x3UL << ERRBNK_DEBR0_SWDEF_Pos)           /*!< ERRBNK DEBR0: SWDEF Mask */
+
+#define ERRBNK_DEBR0_TYPE_Pos              17U                                         /*!< ERRBNK DEBR0: TYPE Position */
+#define ERRBNK_DEBR0_TYPE_Msk              (1UL << ERRBNK_DEBR0_TYPE_Pos)              /*!< ERRBNK DEBR0: TYPE Mask */
+
+#define ERRBNK_DEBR0_BANK_Pos              16U                                         /*!< ERRBNK DEBR0: BANK Position */
+#define ERRBNK_DEBR0_BANK_Msk              (1UL << ERRBNK_DEBR0_BANK_Pos)              /*!< ERRBNK DEBR0: BANK Mask */
+
+#define ERRBNK_DEBR0_LOCATION_Pos           2U                                         /*!< ERRBNK DEBR0: LOCATION Position */
+#define ERRBNK_DEBR0_LOCATION_Msk          (0x3FFFUL << ERRBNK_DEBR0_LOCATION_Pos)     /*!< ERRBNK DEBR0: LOCATION Mask */
+
+#define ERRBNK_DEBR0_LOCKED_Pos             1U                                         /*!< ERRBNK DEBR0: LOCKED Position */
+#define ERRBNK_DEBR0_LOCKED_Msk            (1UL << ERRBNK_DEBR0_LOCKED_Pos)            /*!< ERRBNK DEBR0: LOCKED Mask */
+
+#define ERRBNK_DEBR0_VALID_Pos              0U                                         /*!< ERRBNK DEBR0: VALID Position */
+#define ERRBNK_DEBR0_VALID_Msk             (1UL << /*ERRBNK_DEBR0_VALID_Pos*/)         /*!< ERRBNK DEBR0: VALID Mask */
+
+/** \brief ErrBnk Data Cache Error Bank Register 1 Definitions */
+#define ERRBNK_DEBR1_SWDEF_Pos             30U                                         /*!< ERRBNK DEBR1: SWDEF Position */
+#define ERRBNK_DEBR1_SWDEF_Msk             (0x3UL << ERRBNK_DEBR1_SWDEF_Pos)           /*!< ERRBNK DEBR1: SWDEF Mask */
+
+#define ERRBNK_DEBR1_TYPE_Pos              17U                                         /*!< ERRBNK DEBR1: TYPE Position */
+#define ERRBNK_DEBR1_TYPE_Msk              (1UL << ERRBNK_DEBR1_TYPE_Pos)              /*!< ERRBNK DEBR1: TYPE Mask */
+
+#define ERRBNK_DEBR1_BANK_Pos              16U                                         /*!< ERRBNK DEBR1: BANK Position */
+#define ERRBNK_DEBR1_BANK_Msk              (1UL << ERRBNK_DEBR1_BANK_Pos)              /*!< ERRBNK DEBR1: BANK Mask */
+
+#define ERRBNK_DEBR1_LOCATION_Pos           2U                                         /*!< ERRBNK DEBR1: LOCATION Position */
+#define ERRBNK_DEBR1_LOCATION_Msk          (0x3FFFUL << ERRBNK_DEBR1_LOCATION_Pos)     /*!< ERRBNK DEBR1: LOCATION Mask */
+
+#define ERRBNK_DEBR1_LOCKED_Pos             1U                                         /*!< ERRBNK DEBR1: LOCKED Position */
+#define ERRBNK_DEBR1_LOCKED_Msk            (1UL << ERRBNK_DEBR1_LOCKED_Pos)            /*!< ERRBNK DEBR1: LOCKED Mask */
+
+#define ERRBNK_DEBR1_VALID_Pos              0U                                         /*!< ERRBNK DEBR1: VALID Position */
+#define ERRBNK_DEBR1_VALID_Msk             (1UL << /*ERRBNK_DEBR1_VALID_Pos*/)         /*!< ERRBNK DEBR1: VALID Mask */
+
+/** \brief ErrBnk TCM Error Bank Register 0 Definitions */
+#define ERRBNK_TEBR0_SWDEF_Pos             30U                                         /*!< ERRBNK TEBR0: SWDEF Position */
+#define ERRBNK_TEBR0_SWDEF_Msk             (0x3UL << ERRBNK_TEBR0_SWDEF_Pos)           /*!< ERRBNK TEBR0: SWDEF Mask */
+
+#define ERRBNK_TEBR0_POISON_Pos            28U                                         /*!< ERRBNK TEBR0: POISON Position */
+#define ERRBNK_TEBR0_POISON_Msk            (1UL << ERRBNK_TEBR0_POISON_Pos)            /*!< ERRBNK TEBR0: POISON Mask */
+
+#define ERRBNK_TEBR0_TYPE_Pos              27U                                         /*!< ERRBNK TEBR0: TYPE Position */
+#define ERRBNK_TEBR0_TYPE_Msk              (1UL << ERRBNK_TEBR0_TYPE_Pos)              /*!< ERRBNK TEBR0: TYPE Mask */
+
+#define ERRBNK_TEBR0_BANK_Pos              24U                                         /*!< ERRBNK TEBR0: BANK Position */
+#define ERRBNK_TEBR0_BANK_Msk              (0x7UL << ERRBNK_TEBR0_BANK_Pos)            /*!< ERRBNK TEBR0: BANK Mask */
+
+#define ERRBNK_TEBR0_LOCATION_Pos           2U                                         /*!< ERRBNK TEBR0: LOCATION Position */
+#define ERRBNK_TEBR0_LOCATION_Msk          (0x3FFFFFUL << ERRBNK_TEBR0_LOCATION_Pos)   /*!< ERRBNK TEBR0: LOCATION Mask */
+
+#define ERRBNK_TEBR0_LOCKED_Pos             1U                                         /*!< ERRBNK TEBR0: LOCKED Position */
+#define ERRBNK_TEBR0_LOCKED_Msk            (1UL << ERRBNK_TEBR0_LOCKED_Pos)            /*!< ERRBNK TEBR0: LOCKED Mask */
+
+#define ERRBNK_TEBR0_VALID_Pos              0U                                         /*!< ERRBNK TEBR0: VALID Position */
+#define ERRBNK_TEBR0_VALID_Msk             (1UL << /*ERRBNK_TEBR0_VALID_Pos*/)         /*!< ERRBNK TEBR0: VALID Mask */
+
+/** \brief ErrBnk TCM Error Bank Register 1 Definitions */
+#define ERRBNK_TEBR1_SWDEF_Pos             30U                                         /*!< ERRBNK TEBR1: SWDEF Position */
+#define ERRBNK_TEBR1_SWDEF_Msk             (0x3UL << ERRBNK_TEBR1_SWDEF_Pos)           /*!< ERRBNK TEBR1: SWDEF Mask */
+
+#define ERRBNK_TEBR1_POISON_Pos            28U                                         /*!< ERRBNK TEBR1: POISON Position */
+#define ERRBNK_TEBR1_POISON_Msk            (1UL << ERRBNK_TEBR1_POISON_Pos)            /*!< ERRBNK TEBR1: POISON Mask */
+
+#define ERRBNK_TEBR1_TYPE_Pos              27U                                         /*!< ERRBNK TEBR1: TYPE Position */
+#define ERRBNK_TEBR1_TYPE_Msk              (1UL << ERRBNK_TEBR1_TYPE_Pos)              /*!< ERRBNK TEBR1: TYPE Mask */
+
+#define ERRBNK_TEBR1_BANK_Pos              24U                                         /*!< ERRBNK TEBR1: BANK Position */
+#define ERRBNK_TEBR1_BANK_Msk              (0x7UL << ERRBNK_TEBR1_BANK_Pos)            /*!< ERRBNK TEBR1: BANK Mask */
+
+#define ERRBNK_TEBR1_LOCATION_Pos           2U                                         /*!< ERRBNK TEBR1: LOCATION Position */
+#define ERRBNK_TEBR1_LOCATION_Msk          (0x3FFFFFUL << ERRBNK_TEBR1_LOCATION_Pos)   /*!< ERRBNK TEBR1: LOCATION Mask */
+
+#define ERRBNK_TEBR1_LOCKED_Pos             1U                                         /*!< ERRBNK TEBR1: LOCKED Position */
+#define ERRBNK_TEBR1_LOCKED_Msk            (1UL << ERRBNK_TEBR1_LOCKED_Pos)            /*!< ERRBNK TEBR1: LOCKED Mask */
+
+#define ERRBNK_TEBR1_VALID_Pos              0U                                         /*!< ERRBNK TEBR1: VALID Position */
+#define ERRBNK_TEBR1_VALID_Msk             (1UL << /*ERRBNK_TEBR1_VALID_Pos*/)         /*!< ERRBNK TEBR1: VALID Mask */
+
+/*@}*/ /* end of group ErrBnk_Type */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup PrcCfgInf_Type     Processor Configuration Information Registers (IMPLEMENTATION DEFINED)
+  \brief    Type definitions for the Processor Configuration Information Registerss (PRCCFGINF)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Processor Configuration Information Registerss (PRCCFGINF).
+ */
+typedef struct
+{
+  __OM  uint32_t CFGINFOSEL;             /*!< Offset: 0x000 ( /W)  Processor Configuration Information Selection Register */
+  __IM  uint32_t CFGINFORD;              /*!< Offset: 0x004 (R/ )  Processor Configuration Information Read Data Register */
+} PrcCfgInf_Type;
+
+/** \brief PrcCfgInf Processor Configuration Information Selection Register Definitions */
+
+/** \brief PrcCfgInf Processor Configuration Information Read Data Register Definitions */
+
+/*@}*/ /* end of group PrcCfgInf_Type */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup STL_Type     Software Test Library Observation Registers
+  \brief    Type definitions for the Software Test Library Observation Registerss (STL)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Software Test Library Observation Registerss (STL).
+ */
+typedef struct
+{
+  __IM  uint32_t STLNVICPENDOR;          /*!< Offset: 0x000 (R/ )  NVIC Pending Priority Tree Register */
+  __IM  uint32_t STLNVICACTVOR;          /*!< Offset: 0x004 (R/ )  NVIC Active Priority Tree Register */
+        uint32_t RESERVED0[2U];
+  __IOM uint32_t STLIDMPUSR;             /*!< Offset: 0x010 ( /W)  MPU Sample Register */
+  __IM  uint32_t STLIMPUOR;              /*!< Offset: 0x014 (R/ )  MPU Region Hit Register */
+  __IM  uint32_t STLD0MPUOR;             /*!< Offset: 0x018 (R/ )  MPU Memory Attributes Register 0 */
+  __IM  uint32_t STLD1MPUOR;             /*!< Offset: 0x01C (R/ )  MPU Memory Attributes Register 1 */
+
+} STL_Type;
+
+/** \brief STL NVIC Pending Priority Tree Register Definitions */
+#define STL_STLNVICPENDOR_VALID_Pos        18U                                         /*!< STL STLNVICPENDOR: VALID Position */
+#define STL_STLNVICPENDOR_VALID_Msk        (1UL << STL_STLNVICPENDOR_VALID_Pos)        /*!< STL STLNVICPENDOR: VALID Mask */
+
+#define STL_STLNVICPENDOR_TARGET_Pos       17U                                         /*!< STL STLNVICPENDOR: TARGET Position */
+#define STL_STLNVICPENDOR_TARGET_Msk       (1UL << STL_STLNVICPENDOR_TARGET_Pos)       /*!< STL STLNVICPENDOR: TARGET Mask */
+
+#define STL_STLNVICPENDOR_PRIORITY_Pos      9U                                         /*!< STL STLNVICPENDOR: PRIORITY Position */
+#define STL_STLNVICPENDOR_PRIORITY_Msk     (0xFFUL << STL_STLNVICPENDOR_PRIORITY_Pos)  /*!< STL STLNVICPENDOR: PRIORITY Mask */
+
+#define STL_STLNVICPENDOR_INTNUM_Pos        0U                                         /*!< STL STLNVICPENDOR: INTNUM Position */
+#define STL_STLNVICPENDOR_INTNUM_Msk       (0x1FFUL /*<< STL_STLNVICPENDOR_INTNUM_Pos*/) /*!< STL STLNVICPENDOR: INTNUM Mask */
+
+/** \brief STL NVIC Active Priority Tree Register Definitions */
+#define STL_STLNVICACTVOR_VALID_Pos        18U                                         /*!< STL STLNVICACTVOR: VALID Position */
+#define STL_STLNVICACTVOR_VALID_Msk        (1UL << STL_STLNVICACTVOR_VALID_Pos)        /*!< STL STLNVICACTVOR: VALID Mask */
+
+#define STL_STLNVICACTVOR_TARGET_Pos       17U                                         /*!< STL STLNVICACTVOR: TARGET Position */
+#define STL_STLNVICACTVOR_TARGET_Msk       (1UL << STL_STLNVICACTVOR_TARGET_Pos)       /*!< STL STLNVICACTVOR: TARGET Mask */
+
+#define STL_STLNVICACTVOR_PRIORITY_Pos      9U                                         /*!< STL STLNVICACTVOR: PRIORITY Position */
+#define STL_STLNVICACTVOR_PRIORITY_Msk     (0xFFUL << STL_STLNVICACTVOR_PRIORITY_Pos)  /*!< STL STLNVICACTVOR: PRIORITY Mask */
+
+#define STL_STLNVICACTVOR_INTNUM_Pos        0U                                         /*!< STL STLNVICACTVOR: INTNUM Position */
+#define STL_STLNVICACTVOR_INTNUM_Msk       (0x1FFUL /*<< STL_STLNVICACTVOR_INTNUM_Pos*/) /*!< STL STLNVICACTVOR: INTNUM Mask */
+
+/** \brief STL MPU Sample Register Definitions */
+#define STL_STLIDMPUSR_ADDR_Pos             5U                                         /*!< STL STLIDMPUSR: ADDR Position */
+#define STL_STLIDMPUSR_ADDR_Msk            (0x7FFFFFFUL << STL_STLIDMPUSR_ADDR_Pos)    /*!< STL STLIDMPUSR: ADDR Mask */
+
+#define STL_STLIDMPUSR_INSTR_Pos            2U                                         /*!< STL STLIDMPUSR: INSTR Position */
+#define STL_STLIDMPUSR_INSTR_Msk           (1UL << STL_STLIDMPUSR_INSTR_Pos)           /*!< STL STLIDMPUSR: INSTR Mask */
+
+#define STL_STLIDMPUSR_DATA_Pos             1U                                         /*!< STL STLIDMPUSR: DATA Position */
+#define STL_STLIDMPUSR_DATA_Msk            (1UL << STL_STLIDMPUSR_DATA_Pos)            /*!< STL STLIDMPUSR: DATA Mask */
+
+/** \brief STL MPU Region Hit Register Definitions */
+#define STL_STLIMPUOR_HITREGION_Pos         9U                                         /*!< STL STLIMPUOR: HITREGION Position */
+#define STL_STLIMPUOR_HITREGION_Msk        (0xFFUL << STL_STLIMPUOR_HITREGION_Pos)     /*!< STL STLIMPUOR: HITREGION Mask */
+
+#define STL_STLIMPUOR_ATTR_Pos              0U                                         /*!< STL STLIMPUOR: ATTR Position */
+#define STL_STLIMPUOR_ATTR_Msk             (0x1FFUL /*<< STL_STLIMPUOR_ATTR_Pos*/)     /*!< STL STLIMPUOR: ATTR Mask */
+
+/** \brief STL MPU Memory Attributes Register 0 Definitions */
+#define STL_STLD0MPUOR_HITREGION_Pos        9U                                         /*!< STL STLD0MPUOR: HITREGION Position */
+#define STL_STLD0MPUOR_HITREGION_Msk       (0xFFUL << STL_STLD0MPUOR_HITREGION_Pos)    /*!< STL STLD0MPUOR: HITREGION Mask */
+
+#define STL_STLD0MPUOR_ATTR_Pos             0U                                         /*!< STL STLD0MPUOR: ATTR Position */
+#define STL_STLD0MPUOR_ATTR_Msk            (0x1FFUL /*<< STL_STLD0MPUOR_ATTR_Pos*/)    /*!< STL STLD0MPUOR: ATTR Mask */
+
+/** \brief STL MPU Memory Attributes Register 1 Definitions */
+#define STL_STLD1MPUOR_HITREGION_Pos        9U                                         /*!< STL STLD1MPUOR: HITREGION Position */
+#define STL_STLD1MPUOR_HITREGION_Msk       (0xFFUL << STL_STLD1MPUOR_HITREGION_Pos)    /*!< STL STLD1MPUOR: HITREGION Mask */
+
+#define STL_STLD1MPUOR_ATTR_Pos             0U                                         /*!< STL STLD1MPUOR: ATTR Position */
+#define STL_STLD1MPUOR_ATTR_Msk            (0x1FFUL /*<< STL_STLD1MPUOR_ATTR_Pos*/)    /*!< STL STLD1MPUOR: ATTR Mask */
+
+/*@}*/ /* end of group STL_Type */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_TPIU    Trace Port Interface Unit (TPIU)
+  \brief    Type definitions for the Trace Port Interface Unit (TPIU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Trace Port Interface Unit Register (TPIU).
+ */
+typedef struct
+{
+  __IM  uint32_t SSPSR;                  /*!< Offset: 0x000 (R/ )  Supported Parallel Port Size Register */
+  __IOM uint32_t CSPSR;                  /*!< Offset: 0x004 (R/W)  Current Parallel Port Size Register */
+        uint32_t RESERVED0[2U];
+  __IOM uint32_t ACPR;                   /*!< Offset: 0x010 (R/W)  Asynchronous Clock Prescaler Register */
+        uint32_t RESERVED1[55U];
+  __IOM uint32_t SPPR;                   /*!< Offset: 0x0F0 (R/W)  Selected Pin Protocol Register */
+        uint32_t RESERVED2[131U];
+  __IM  uint32_t FFSR;                   /*!< Offset: 0x300 (R/ )  Formatter and Flush Status Register */
+  __IOM uint32_t FFCR;                   /*!< Offset: 0x304 (R/W)  Formatter and Flush Control Register */
+  __IOM uint32_t PSCR;                   /*!< Offset: 0x308 (R/W)  Periodic Synchronization Control Register */
+        uint32_t RESERVED3[759U];
+  __IM  uint32_t TRIGGER;                /*!< Offset: 0xEE8 (R/ )  TRIGGER Register */
+  __IM  uint32_t ITFTTD0;                /*!< Offset: 0xEEC (R/ )  Integration Test FIFO Test Data 0 Register */
+  __IOM uint32_t ITATBCTR2;              /*!< Offset: 0xEF0 (R/W)  Integration Test ATB Control Register 2 */
+        uint32_t RESERVED4[1U];
+  __IM  uint32_t ITATBCTR0;              /*!< Offset: 0xEF8 (R/ )  Integration Test ATB Control Register 0 */
+  __IM  uint32_t ITFTTD1;                /*!< Offset: 0xEFC (R/ )  Integration Test FIFO Test Data 1 Register */
+  __IOM uint32_t ITCTRL;                 /*!< Offset: 0xF00 (R/W)  Integration Mode Control */
+        uint32_t RESERVED5[39U];
+  __IOM uint32_t CLAIMSET;               /*!< Offset: 0xFA0 (R/W)  Claim tag set */
+  __IOM uint32_t CLAIMCLR;               /*!< Offset: 0xFA4 (R/W)  Claim tag clear */
+        uint32_t RESERVED7[8U];
+  __IM  uint32_t DEVID;                  /*!< Offset: 0xFC8 (R/ )  Device Configuration Register */
+  __IM  uint32_t DEVTYPE;                /*!< Offset: 0xFCC (R/ )  Device Type Identifier Register */
+} TPIU_Type;
+
+/** \brief TPIU Asynchronous Clock Prescaler Register Definitions */
+#define TPIU_ACPR_PRESCALER_Pos             0U                                         /*!< TPIU ACPR: PRESCALER Position */
+#define TPIU_ACPR_PRESCALER_Msk            (0x1FFFUL /*<< TPIU_ACPR_PRESCALER_Pos*/)   /*!< TPIU ACPR: PRESCALER Mask */
+
+/** \brief TPIU Selected Pin Protocol Register Definitions */
+#define TPIU_SPPR_TXMODE_Pos                0U                                         /*!< TPIU SPPR: TXMODE Position */
+#define TPIU_SPPR_TXMODE_Msk               (0x3UL /*<< TPIU_SPPR_TXMODE_Pos*/)         /*!< TPIU SPPR: TXMODE Mask */
+
+/** \brief TPIU Formatter and Flush Status Register Definitions */
+#define TPIU_FFSR_FtNonStop_Pos             3U                                         /*!< TPIU FFSR: FtNonStop Position */
+#define TPIU_FFSR_FtNonStop_Msk            (1UL << TPIU_FFSR_FtNonStop_Pos)            /*!< TPIU FFSR: FtNonStop Mask */
+
+#define TPIU_FFSR_TCPresent_Pos             2U                                         /*!< TPIU FFSR: TCPresent Position */
+#define TPIU_FFSR_TCPresent_Msk            (1UL << TPIU_FFSR_TCPresent_Pos)            /*!< TPIU FFSR: TCPresent Mask */
+
+#define TPIU_FFSR_FtStopped_Pos             1U                                         /*!< TPIU FFSR: FtStopped Position */
+#define TPIU_FFSR_FtStopped_Msk            (1UL << TPIU_FFSR_FtStopped_Pos)            /*!< TPIU FFSR: FtStopped Mask */
+
+#define TPIU_FFSR_FlInProg_Pos              0U                                         /*!< TPIU FFSR: FlInProg Position */
+#define TPIU_FFSR_FlInProg_Msk             (1UL /*<< TPIU_FFSR_FlInProg_Pos*/)         /*!< TPIU FFSR: FlInProg Mask */
+
+/** \brief TPIU Formatter and Flush Control Register Definitions */
+#define TPIU_FFCR_TrigIn_Pos                8U                                         /*!< TPIU FFCR: TrigIn Position */
+#define TPIU_FFCR_TrigIn_Msk               (1UL << TPIU_FFCR_TrigIn_Pos)               /*!< TPIU FFCR: TrigIn Mask */
+
+#define TPIU_FFCR_FOnMan_Pos                6U                                         /*!< TPIU FFCR: FOnMan Position */
+#define TPIU_FFCR_FOnMan_Msk               (1UL << TPIU_FFCR_FOnMan_Pos)               /*!< TPIU FFCR: FOnMan Mask */
+
+#define TPIU_FFCR_EnFCont_Pos               1U                                         /*!< TPIU FFCR: EnFCont Position */
+#define TPIU_FFCR_EnFCont_Msk              (1UL << TPIU_FFCR_EnFCont_Pos)              /*!< TPIU FFCR: EnFCont Mask */
+
+/** \brief TPIU Periodic Synchronization Control Register Definitions */
+#define TPIU_PSCR_PSCount_Pos               0U                                         /*!< TPIU PSCR: PSCount Position */
+#define TPIU_PSCR_PSCount_Msk              (0x1FUL /*<< TPIU_PSCR_PSCount_Pos*/)       /*!< TPIU PSCR: TPSCount Mask */
+
+/** \brief TPIU TRIGGER Register Definitions */
+#define TPIU_TRIGGER_TRIGGER_Pos            0U                                         /*!< TPIU TRIGGER: TRIGGER Position */
+#define TPIU_TRIGGER_TRIGGER_Msk           (1UL /*<< TPIU_TRIGGER_TRIGGER_Pos*/)       /*!< TPIU TRIGGER: TRIGGER Mask */
+
+/** \brief TPIU Integration Test FIFO Test Data 0 Register Definitions */
+#define TPIU_ITFTTD0_ATB_IF2_ATVALID_Pos   29U                                         /*!< TPIU ITFTTD0: ATB Interface 2 ATVALIDPosition */
+#define TPIU_ITFTTD0_ATB_IF2_ATVALID_Msk   (0x3UL << TPIU_ITFTTD0_ATB_IF2_ATVALID_Pos) /*!< TPIU ITFTTD0: ATB Interface 2 ATVALID Mask */
+
+#define TPIU_ITFTTD0_ATB_IF2_bytecount_Pos 27U                                         /*!< TPIU ITFTTD0: ATB Interface 2 byte count Position */
+#define TPIU_ITFTTD0_ATB_IF2_bytecount_Msk (0x3UL << TPIU_ITFTTD0_ATB_IF2_bytecount_Pos) /*!< TPIU ITFTTD0: ATB Interface 2 byte count Mask */
+
+#define TPIU_ITFTTD0_ATB_IF1_ATVALID_Pos   26U                                         /*!< TPIU ITFTTD0: ATB Interface 1 ATVALID Position */
+#define TPIU_ITFTTD0_ATB_IF1_ATVALID_Msk   (0x3UL << TPIU_ITFTTD0_ATB_IF1_ATVALID_Pos) /*!< TPIU ITFTTD0: ATB Interface 1 ATVALID Mask */
+
+#define TPIU_ITFTTD0_ATB_IF1_bytecount_Pos 24U                                         /*!< TPIU ITFTTD0: ATB Interface 1 byte count Position */
+#define TPIU_ITFTTD0_ATB_IF1_bytecount_Msk (0x3UL << TPIU_ITFTTD0_ATB_IF1_bytecount_Pos) /*!< TPIU ITFTTD0: ATB Interface 1 byte countt Mask */
+
+#define TPIU_ITFTTD0_ATB_IF1_data2_Pos     16U                                         /*!< TPIU ITFTTD0: ATB Interface 1 data2 Position */
+#define TPIU_ITFTTD0_ATB_IF1_data2_Msk     (0xFFUL << TPIU_ITFTTD0_ATB_IF1_data1_Pos)  /*!< TPIU ITFTTD0: ATB Interface 1 data2 Mask */
+
+#define TPIU_ITFTTD0_ATB_IF1_data1_Pos      8U                                         /*!< TPIU ITFTTD0: ATB Interface 1 data1 Position */
+#define TPIU_ITFTTD0_ATB_IF1_data1_Msk     (0xFFUL << TPIU_ITFTTD0_ATB_IF1_data1_Pos)  /*!< TPIU ITFTTD0: ATB Interface 1 data1 Mask */
+
+#define TPIU_ITFTTD0_ATB_IF1_data0_Pos      0U                                          /*!< TPIU ITFTTD0: ATB Interface 1 data0 Position */
+#define TPIU_ITFTTD0_ATB_IF1_data0_Msk     (0xFFUL /*<< TPIU_ITFTTD0_ATB_IF1_data0_Pos*/) /*!< TPIU ITFTTD0: ATB Interface 1 data0 Mask */
+
+/** \brief TPIU Integration Test ATB Control Register 2 Register Definitions */
+#define TPIU_ITATBCTR2_AFVALID2S_Pos        1U                                         /*!< TPIU ITATBCTR2: AFVALID2S Position */
+#define TPIU_ITATBCTR2_AFVALID2S_Msk       (1UL << TPIU_ITATBCTR2_AFVALID2S_Pos)       /*!< TPIU ITATBCTR2: AFVALID2SS Mask */
+
+#define TPIU_ITATBCTR2_AFVALID1S_Pos        1U                                         /*!< TPIU ITATBCTR2: AFVALID1S Position */
+#define TPIU_ITATBCTR2_AFVALID1S_Msk       (1UL << TPIU_ITATBCTR2_AFVALID1S_Pos)       /*!< TPIU ITATBCTR2: AFVALID1SS Mask */
+
+#define TPIU_ITATBCTR2_ATREADY2S_Pos        0U                                         /*!< TPIU ITATBCTR2: ATREADY2S Position */
+#define TPIU_ITATBCTR2_ATREADY2S_Msk       (1UL /*<< TPIU_ITATBCTR2_ATREADY2S_Pos*/)   /*!< TPIU ITATBCTR2: ATREADY2S Mask */
+
+#define TPIU_ITATBCTR2_ATREADY1S_Pos        0U                                         /*!< TPIU ITATBCTR2: ATREADY1S Position */
+#define TPIU_ITATBCTR2_ATREADY1S_Msk       (1UL /*<< TPIU_ITATBCTR2_ATREADY1S_Pos*/)   /*!< TPIU ITATBCTR2: ATREADY1S Mask */
+
+/** \brief TPIU Integration Test FIFO Test Data 1 Register Definitions */
+#define TPIU_ITFTTD1_ATB_IF2_ATVALID_Pos   29U                                         /*!< TPIU ITFTTD1: ATB Interface 2 ATVALID Position */
+#define TPIU_ITFTTD1_ATB_IF2_ATVALID_Msk   (0x3UL << TPIU_ITFTTD1_ATB_IF2_ATVALID_Pos) /*!< TPIU ITFTTD1: ATB Interface 2 ATVALID Mask */
+
+#define TPIU_ITFTTD1_ATB_IF2_bytecount_Pos 27U                                         /*!< TPIU ITFTTD1: ATB Interface 2 byte count Position */
+#define TPIU_ITFTTD1_ATB_IF2_bytecount_Msk (0x3UL << TPIU_ITFTTD1_ATB_IF2_bytecount_Pos) /*!< TPIU ITFTTD1: ATB Interface 2 byte count Mask */
+
+#define TPIU_ITFTTD1_ATB_IF1_ATVALID_Pos   26U                                         /*!< TPIU ITFTTD1: ATB Interface 1 ATVALID Position */
+#define TPIU_ITFTTD1_ATB_IF1_ATVALID_Msk   (0x3UL << TPIU_ITFTTD1_ATB_IF1_ATVALID_Pos) /*!< TPIU ITFTTD1: ATB Interface 1 ATVALID Mask */
+
+#define TPIU_ITFTTD1_ATB_IF1_bytecount_Pos 24U                                         /*!< TPIU ITFTTD1: ATB Interface 1 byte count Position */
+#define TPIU_ITFTTD1_ATB_IF1_bytecount_Msk (0x3UL << TPIU_ITFTTD1_ATB_IF1_bytecount_Pos) /*!< TPIU ITFTTD1: ATB Interface 1 byte countt Mask */
+
+#define TPIU_ITFTTD1_ATB_IF2_data2_Pos     16U                                         /*!< TPIU ITFTTD1: ATB Interface 2 data2 Position */
+#define TPIU_ITFTTD1_ATB_IF2_data2_Msk     (0xFFUL << TPIU_ITFTTD1_ATB_IF2_data1_Pos)  /*!< TPIU ITFTTD1: ATB Interface 2 data2 Mask */
+
+#define TPIU_ITFTTD1_ATB_IF2_data1_Pos      8U                                         /*!< TPIU ITFTTD1: ATB Interface 2 data1 Position */
+#define TPIU_ITFTTD1_ATB_IF2_data1_Msk     (0xFFUL << TPIU_ITFTTD1_ATB_IF2_data1_Pos)  /*!< TPIU ITFTTD1: ATB Interface 2 data1 Mask */
+
+#define TPIU_ITFTTD1_ATB_IF2_data0_Pos      0U                                         /*!< TPIU ITFTTD1: ATB Interface 2 data0 Position */
+#define TPIU_ITFTTD1_ATB_IF2_data0_Msk     (0xFFUL /*<< TPIU_ITFTTD1_ATB_IF2_data0_Pos*/) /*!< TPIU ITFTTD1: ATB Interface 2 data0 Mask */
+
+/** \brief TPIU Integration Test ATB Control Register 0 Definitions */
+#define TPIU_ITATBCTR0_AFVALID2S_Pos        1U                                         /*!< TPIU ITATBCTR0: AFVALID2S Position */
+#define TPIU_ITATBCTR0_AFVALID2S_Msk       (1UL << TPIU_ITATBCTR0_AFVALID2S_Pos)       /*!< TPIU ITATBCTR0: AFVALID2SS Mask */
+
+#define TPIU_ITATBCTR0_AFVALID1S_Pos        1U                                         /*!< TPIU ITATBCTR0: AFVALID1S Position */
+#define TPIU_ITATBCTR0_AFVALID1S_Msk       (1UL << TPIU_ITATBCTR0_AFVALID1S_Pos)       /*!< TPIU ITATBCTR0: AFVALID1SS Mask */
+
+#define TPIU_ITATBCTR0_ATREADY2S_Pos        0U                                         /*!< TPIU ITATBCTR0: ATREADY2S Position */
+#define TPIU_ITATBCTR0_ATREADY2S_Msk       (1UL /*<< TPIU_ITATBCTR0_ATREADY2S_Pos*/)   /*!< TPIU ITATBCTR0: ATREADY2S Mask */
+
+#define TPIU_ITATBCTR0_ATREADY1S_Pos        0U                                         /*!< TPIU ITATBCTR0: ATREADY1S Position */
+#define TPIU_ITATBCTR0_ATREADY1S_Msk       (1UL /*<< TPIU_ITATBCTR0_ATREADY1S_Pos*/)   /*!< TPIU ITATBCTR0: ATREADY1S Mask */
+
+/** \brief TPIU Integration Mode Control Register Definitions */
+#define TPIU_ITCTRL_Mode_Pos                0U                                         /*!< TPIU ITCTRL: Mode Position */
+#define TPIU_ITCTRL_Mode_Msk               (0x3UL /*<< TPIU_ITCTRL_Mode_Pos*/)         /*!< TPIU ITCTRL: Mode Mask */
+
+/** \brief TPIU Claim Tag Set Register Definitions */
+#define TPIU_CLAIMSET_SET_Pos               0U                                         /*!< TPIU CLAIMSET: SET Position */
+#define TPIU_CLAIMSET_SET_Msk              (0xFUL /*<< TPIU_CLAIMSET_SET_Pos*/)        /*!< TPIU CLAIMSET: SET Mask */
+
+/** \brief TPIU Claim Tag Clear Register Definitions */
+#define TPIU_CLAIMCLR_CLR_Pos               0U                                         /*!< TPIU CLAIMCLR: CLR Position */
+#define TPIU_CLAIMCLR_CLR_Msk              (0xFUL /*<< TPIU_CLAIMCLR_CLR_Pos*/)        /*!< TPIU CLAIMCLR: CLR Mask */
+
+/** \brief TPIU DEVID Register Definitions */
+#define TPIU_DEVID_NRZVALID_Pos            11U                                         /*!< TPIU DEVID: NRZVALID Position */
+#define TPIU_DEVID_NRZVALID_Msk            (1UL << TPIU_DEVID_NRZVALID_Pos)            /*!< TPIU DEVID: NRZVALID Mask */
+
+#define TPIU_DEVID_MANCVALID_Pos           10U                                         /*!< TPIU DEVID: MANCVALID Position */
+#define TPIU_DEVID_MANCVALID_Msk           (1UL << TPIU_DEVID_MANCVALID_Pos)           /*!< TPIU DEVID: MANCVALID Mask */
+
+#define TPIU_DEVID_PTINVALID_Pos            9U                                         /*!< TPIU DEVID: PTINVALID Position */
+#define TPIU_DEVID_PTINVALID_Msk           (1UL << TPIU_DEVID_PTINVALID_Pos)           /*!< TPIU DEVID: PTINVALID Mask */
+
+#define TPIU_DEVID_FIFOSZ_Pos               6U                                         /*!< TPIU DEVID: FIFOSZ Position */
+#define TPIU_DEVID_FIFOSZ_Msk              (0x7UL << TPIU_DEVID_FIFOSZ_Pos)            /*!< TPIU DEVID: FIFOSZ Mask */
+
+#define TPIU_DEVID_NrTraceInput_Pos         0U                                         /*!< TPIU DEVID: NrTraceInput Position */
+#define TPIU_DEVID_NrTraceInput_Msk        (0x3FUL /*<< TPIU_DEVID_NrTraceInput_Pos*/) /*!< TPIU DEVID: NrTraceInput Mask */
+
+/** \brief TPIU DEVTYPE Register Definitions */
+#define TPIU_DEVTYPE_SubType_Pos            4U                                         /*!< TPIU DEVTYPE: SubType Position */
+#define TPIU_DEVTYPE_SubType_Msk           (0xFUL /*<< TPIU_DEVTYPE_SubType_Pos*/)     /*!< TPIU DEVTYPE: SubType Mask */
+
+#define TPIU_DEVTYPE_MajorType_Pos          0U                                         /*!< TPIU DEVTYPE: MajorType Position */
+#define TPIU_DEVTYPE_MajorType_Msk         (0xFUL << TPIU_DEVTYPE_MajorType_Pos)       /*!< TPIU DEVTYPE: MajorType Mask */
+
+/*@}*/ /* end of group CMSIS_TPIU */
+
+
+#if defined (__PMU_PRESENT) && (__PMU_PRESENT == 1U)
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_PMU     Performance Monitoring Unit (PMU)
+  \brief    Type definitions for the Performance Monitoring Unit (PMU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Performance Monitoring Unit (PMU).
+ */
+typedef struct
+{
+  __IOM uint32_t EVCNTR[__PMU_NUM_EVENTCNT];        /*!< Offset: 0x0 (R/W)    Event Counter Registers */
+#if __PMU_NUM_EVENTCNT<31
+        uint32_t RESERVED0[31U-__PMU_NUM_EVENTCNT];
+#endif
+  __IOM uint32_t CCNTR;                             /*!< Offset: 0x7C (R/W)   Cycle Counter Register */
+        uint32_t RESERVED1[224];
+  __IOM uint32_t EVTYPER[__PMU_NUM_EVENTCNT];       /*!< Offset: 0x400 (R/W)  Event Type and Filter Registers */
+#if __PMU_NUM_EVENTCNT<31
+        uint32_t RESERVED2[31U-__PMU_NUM_EVENTCNT];
+#endif
+  __IOM uint32_t CCFILTR;                           /*!< Offset: 0x47C (R/W)  Cycle Counter Filter Register */
+        uint32_t RESERVED3[480];
+  __IOM uint32_t CNTENSET;                          /*!< Offset: 0xC00 (R/W)  Count Enable Set Register */
+        uint32_t RESERVED4[7];
+  __IOM uint32_t CNTENCLR;                          /*!< Offset: 0xC20 (R/W)  Count Enable Clear Register */
+        uint32_t RESERVED5[7];
+  __IOM uint32_t INTENSET;                          /*!< Offset: 0xC40 (R/W)  Interrupt Enable Set Register */
+        uint32_t RESERVED6[7];
+  __IOM uint32_t INTENCLR;                          /*!< Offset: 0xC60 (R/W)  Interrupt Enable Clear Register */
+        uint32_t RESERVED7[7];
+  __IOM uint32_t OVSCLR;                            /*!< Offset: 0xC80 (R/W)  Overflow Flag Status Clear Register */
+        uint32_t RESERVED8[7];
+  __IOM uint32_t SWINC;                             /*!< Offset: 0xCA0 (R/W)  Software Increment Register */
+        uint32_t RESERVED9[7];
+  __IOM uint32_t OVSSET;                            /*!< Offset: 0xCC0 (R/W)  Overflow Flag Status Set Register */
+        uint32_t RESERVED10[79];
+  __IOM uint32_t TYPE;                              /*!< Offset: 0xE00 (R/W)  Type Register */
+  __IOM uint32_t CTRL;                              /*!< Offset: 0xE04 (R/W)  Control Register */
+        uint32_t RESERVED11[108];
+  __IOM uint32_t AUTHSTATUS;                        /*!< Offset: 0xFB8 (R/W)  Authentication Status Register */
+  __IOM uint32_t DEVARCH;                           /*!< Offset: 0xFBC (R/W)  Device Architecture Register */
+        uint32_t RESERVED12[3];
+  __IOM uint32_t DEVTYPE;                           /*!< Offset: 0xFCC (R/W)  Device Type Register */
+} PMU_Type;
+
+/** \brief PMU Event Counter Registers (0-30) Definitions  */
+#define PMU_EVCNTR_CNT_Pos                    0U                                           /*!< PMU EVCNTR: Counter Position */
+#define PMU_EVCNTR_CNT_Msk                   (0xFFFFUL /*<< PMU_EVCNTRx_CNT_Pos*/)         /*!< PMU EVCNTR: Counter Mask */
+
+/** \brief PMU Event Type and Filter Registers (0-30) Definitions  */
+#define PMU_EVTYPER_EVENTTOCNT_Pos            0U                                           /*!< PMU EVTYPER: Event to Count Position */
+#define PMU_EVTYPER_EVENTTOCNT_Msk           (0xFFFFUL /*<< EVTYPERx_EVENTTOCNT_Pos*/)     /*!< PMU EVTYPER: Event to Count Mask */
+
+/** \brief PMU Count Enable Set Register Definitions */
+#define PMU_CNTENSET_CNT0_ENABLE_Pos          0U                                           /*!< PMU CNTENSET: Event Counter 0 Enable Set Position */
+#define PMU_CNTENSET_CNT0_ENABLE_Msk         (1UL /*<< PMU_CNTENSET_CNT0_ENABLE_Pos*/)     /*!< PMU CNTENSET: Event Counter 0 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT1_ENABLE_Pos          1U                                           /*!< PMU CNTENSET: Event Counter 1 Enable Set Position */
+#define PMU_CNTENSET_CNT1_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT1_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 1 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT2_ENABLE_Pos          2U                                           /*!< PMU CNTENSET: Event Counter 2 Enable Set Position */
+#define PMU_CNTENSET_CNT2_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT2_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 2 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT3_ENABLE_Pos          3U                                           /*!< PMU CNTENSET: Event Counter 3 Enable Set Position */
+#define PMU_CNTENSET_CNT3_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT3_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 3 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT4_ENABLE_Pos          4U                                           /*!< PMU CNTENSET: Event Counter 4 Enable Set Position */
+#define PMU_CNTENSET_CNT4_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT4_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 4 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT5_ENABLE_Pos          5U                                           /*!< PMU CNTENSET: Event Counter 5 Enable Set Position */
+#define PMU_CNTENSET_CNT5_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT5_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 5 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT6_ENABLE_Pos          6U                                           /*!< PMU CNTENSET: Event Counter 6 Enable Set Position */
+#define PMU_CNTENSET_CNT6_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT6_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 6 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT7_ENABLE_Pos          7U                                           /*!< PMU CNTENSET: Event Counter 7 Enable Set Position */
+#define PMU_CNTENSET_CNT7_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT7_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 7 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT8_ENABLE_Pos          8U                                           /*!< PMU CNTENSET: Event Counter 8 Enable Set Position */
+#define PMU_CNTENSET_CNT8_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT8_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 8 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT9_ENABLE_Pos          9U                                           /*!< PMU CNTENSET: Event Counter 9 Enable Set Position */
+#define PMU_CNTENSET_CNT9_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT9_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 9 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT10_ENABLE_Pos         10U                                          /*!< PMU CNTENSET: Event Counter 10 Enable Set Position */
+#define PMU_CNTENSET_CNT10_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT10_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 10 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT11_ENABLE_Pos         11U                                          /*!< PMU CNTENSET: Event Counter 11 Enable Set Position */
+#define PMU_CNTENSET_CNT11_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT11_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 11 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT12_ENABLE_Pos         12U                                          /*!< PMU CNTENSET: Event Counter 12 Enable Set Position */
+#define PMU_CNTENSET_CNT12_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT12_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 12 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT13_ENABLE_Pos         13U                                          /*!< PMU CNTENSET: Event Counter 13 Enable Set Position */
+#define PMU_CNTENSET_CNT13_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT13_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 13 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT14_ENABLE_Pos         14U                                          /*!< PMU CNTENSET: Event Counter 14 Enable Set Position */
+#define PMU_CNTENSET_CNT14_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT14_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 14 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT15_ENABLE_Pos         15U                                          /*!< PMU CNTENSET: Event Counter 15 Enable Set Position */
+#define PMU_CNTENSET_CNT15_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT15_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 15 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT16_ENABLE_Pos         16U                                          /*!< PMU CNTENSET: Event Counter 16 Enable Set Position */
+#define PMU_CNTENSET_CNT16_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT16_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 16 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT17_ENABLE_Pos         17U                                          /*!< PMU CNTENSET: Event Counter 17 Enable Set Position */
+#define PMU_CNTENSET_CNT17_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT17_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 17 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT18_ENABLE_Pos         18U                                          /*!< PMU CNTENSET: Event Counter 18 Enable Set Position */
+#define PMU_CNTENSET_CNT18_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT18_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 18 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT19_ENABLE_Pos         19U                                          /*!< PMU CNTENSET: Event Counter 19 Enable Set Position */
+#define PMU_CNTENSET_CNT19_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT19_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 19 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT20_ENABLE_Pos         20U                                          /*!< PMU CNTENSET: Event Counter 20 Enable Set Position */
+#define PMU_CNTENSET_CNT20_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT20_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 20 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT21_ENABLE_Pos         21U                                          /*!< PMU CNTENSET: Event Counter 21 Enable Set Position */
+#define PMU_CNTENSET_CNT21_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT21_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 21 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT22_ENABLE_Pos         22U                                          /*!< PMU CNTENSET: Event Counter 22 Enable Set Position */
+#define PMU_CNTENSET_CNT22_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT22_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 22 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT23_ENABLE_Pos         23U                                          /*!< PMU CNTENSET: Event Counter 23 Enable Set Position */
+#define PMU_CNTENSET_CNT23_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT23_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 23 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT24_ENABLE_Pos         24U                                          /*!< PMU CNTENSET: Event Counter 24 Enable Set Position */
+#define PMU_CNTENSET_CNT24_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT24_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 24 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT25_ENABLE_Pos         25U                                          /*!< PMU CNTENSET: Event Counter 25 Enable Set Position */
+#define PMU_CNTENSET_CNT25_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT25_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 25 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT26_ENABLE_Pos         26U                                          /*!< PMU CNTENSET: Event Counter 26 Enable Set Position */
+#define PMU_CNTENSET_CNT26_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT26_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 26 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT27_ENABLE_Pos         27U                                          /*!< PMU CNTENSET: Event Counter 27 Enable Set Position */
+#define PMU_CNTENSET_CNT27_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT27_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 27 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT28_ENABLE_Pos         28U                                          /*!< PMU CNTENSET: Event Counter 28 Enable Set Position */
+#define PMU_CNTENSET_CNT28_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT28_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 28 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT29_ENABLE_Pos         29U                                          /*!< PMU CNTENSET: Event Counter 29 Enable Set Position */
+#define PMU_CNTENSET_CNT29_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT29_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 29 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT30_ENABLE_Pos         30U                                          /*!< PMU CNTENSET: Event Counter 30 Enable Set Position */
+#define PMU_CNTENSET_CNT30_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT30_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 30 Enable Set Mask */
+
+#define PMU_CNTENSET_CCNTR_ENABLE_Pos         31U                                          /*!< PMU CNTENSET: Cycle Counter Enable Set Position */
+#define PMU_CNTENSET_CCNTR_ENABLE_Msk        (1UL << PMU_CNTENSET_CCNTR_ENABLE_Pos)        /*!< PMU CNTENSET: Cycle Counter Enable Set Mask */
+
+/** \brief PMU Count Enable Clear Register Definitions */
+#define PMU_CNTENSET_CNT0_ENABLE_Pos          0U                                           /*!< PMU CNTENCLR: Event Counter 0 Enable Clear Position */
+#define PMU_CNTENCLR_CNT0_ENABLE_Msk         (1UL /*<< PMU_CNTENCLR_CNT0_ENABLE_Pos*/)     /*!< PMU CNTENCLR: Event Counter 0 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT1_ENABLE_Pos          1U                                           /*!< PMU CNTENCLR: Event Counter 1 Enable Clear Position */
+#define PMU_CNTENCLR_CNT1_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT1_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 1 Enable Clear */
+
+#define PMU_CNTENCLR_CNT2_ENABLE_Pos          2U                                           /*!< PMU CNTENCLR: Event Counter 2 Enable Clear Position */
+#define PMU_CNTENCLR_CNT2_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT2_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 2 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT3_ENABLE_Pos          3U                                           /*!< PMU CNTENCLR: Event Counter 3 Enable Clear Position */
+#define PMU_CNTENCLR_CNT3_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT3_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 3 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT4_ENABLE_Pos          4U                                           /*!< PMU CNTENCLR: Event Counter 4 Enable Clear Position */
+#define PMU_CNTENCLR_CNT4_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT4_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 4 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT5_ENABLE_Pos          5U                                           /*!< PMU CNTENCLR: Event Counter 5 Enable Clear Position */
+#define PMU_CNTENCLR_CNT5_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT5_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 5 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT6_ENABLE_Pos          6U                                           /*!< PMU CNTENCLR: Event Counter 6 Enable Clear Position */
+#define PMU_CNTENCLR_CNT6_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT6_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 6 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT7_ENABLE_Pos          7U                                           /*!< PMU CNTENCLR: Event Counter 7 Enable Clear Position */
+#define PMU_CNTENCLR_CNT7_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT7_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 7 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT8_ENABLE_Pos          8U                                           /*!< PMU CNTENCLR: Event Counter 8 Enable Clear Position */
+#define PMU_CNTENCLR_CNT8_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT8_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 8 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT9_ENABLE_Pos          9U                                           /*!< PMU CNTENCLR: Event Counter 9 Enable Clear Position */
+#define PMU_CNTENCLR_CNT9_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT9_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 9 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT10_ENABLE_Pos         10U                                          /*!< PMU CNTENCLR: Event Counter 10 Enable Clear Position */
+#define PMU_CNTENCLR_CNT10_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT10_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 10 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT11_ENABLE_Pos         11U                                          /*!< PMU CNTENCLR: Event Counter 11 Enable Clear Position */
+#define PMU_CNTENCLR_CNT11_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT11_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 11 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT12_ENABLE_Pos         12U                                          /*!< PMU CNTENCLR: Event Counter 12 Enable Clear Position */
+#define PMU_CNTENCLR_CNT12_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT12_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 12 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT13_ENABLE_Pos         13U                                          /*!< PMU CNTENCLR: Event Counter 13 Enable Clear Position */
+#define PMU_CNTENCLR_CNT13_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT13_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 13 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT14_ENABLE_Pos         14U                                          /*!< PMU CNTENCLR: Event Counter 14 Enable Clear Position */
+#define PMU_CNTENCLR_CNT14_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT14_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 14 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT15_ENABLE_Pos         15U                                          /*!< PMU CNTENCLR: Event Counter 15 Enable Clear Position */
+#define PMU_CNTENCLR_CNT15_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT15_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 15 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT16_ENABLE_Pos         16U                                          /*!< PMU CNTENCLR: Event Counter 16 Enable Clear Position */
+#define PMU_CNTENCLR_CNT16_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT16_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 16 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT17_ENABLE_Pos         17U                                          /*!< PMU CNTENCLR: Event Counter 17 Enable Clear Position */
+#define PMU_CNTENCLR_CNT17_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT17_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 17 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT18_ENABLE_Pos         18U                                          /*!< PMU CNTENCLR: Event Counter 18 Enable Clear Position */
+#define PMU_CNTENCLR_CNT18_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT18_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 18 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT19_ENABLE_Pos         19U                                          /*!< PMU CNTENCLR: Event Counter 19 Enable Clear Position */
+#define PMU_CNTENCLR_CNT19_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT19_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 19 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT20_ENABLE_Pos         20U                                          /*!< PMU CNTENCLR: Event Counter 20 Enable Clear Position */
+#define PMU_CNTENCLR_CNT20_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT20_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 20 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT21_ENABLE_Pos         21U                                          /*!< PMU CNTENCLR: Event Counter 21 Enable Clear Position */
+#define PMU_CNTENCLR_CNT21_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT21_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 21 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT22_ENABLE_Pos         22U                                          /*!< PMU CNTENCLR: Event Counter 22 Enable Clear Position */
+#define PMU_CNTENCLR_CNT22_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT22_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 22 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT23_ENABLE_Pos         23U                                          /*!< PMU CNTENCLR: Event Counter 23 Enable Clear Position */
+#define PMU_CNTENCLR_CNT23_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT23_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 23 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT24_ENABLE_Pos         24U                                          /*!< PMU CNTENCLR: Event Counter 24 Enable Clear Position */
+#define PMU_CNTENCLR_CNT24_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT24_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 24 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT25_ENABLE_Pos         25U                                          /*!< PMU CNTENCLR: Event Counter 25 Enable Clear Position */
+#define PMU_CNTENCLR_CNT25_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT25_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 25 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT26_ENABLE_Pos         26U                                          /*!< PMU CNTENCLR: Event Counter 26 Enable Clear Position */
+#define PMU_CNTENCLR_CNT26_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT26_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 26 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT27_ENABLE_Pos         27U                                          /*!< PMU CNTENCLR: Event Counter 27 Enable Clear Position */
+#define PMU_CNTENCLR_CNT27_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT27_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 27 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT28_ENABLE_Pos         28U                                          /*!< PMU CNTENCLR: Event Counter 28 Enable Clear Position */
+#define PMU_CNTENCLR_CNT28_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT28_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 28 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT29_ENABLE_Pos         29U                                          /*!< PMU CNTENCLR: Event Counter 29 Enable Clear Position */
+#define PMU_CNTENCLR_CNT29_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT29_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 29 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT30_ENABLE_Pos         30U                                          /*!< PMU CNTENCLR: Event Counter 30 Enable Clear Position */
+#define PMU_CNTENCLR_CNT30_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT30_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 30 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CCNTR_ENABLE_Pos         31U                                          /*!< PMU CNTENCLR: Cycle Counter Enable Clear Position */
+#define PMU_CNTENCLR_CCNTR_ENABLE_Msk        (1UL << PMU_CNTENCLR_CCNTR_ENABLE_Pos)        /*!< PMU CNTENCLR: Cycle Counter Enable Clear Mask */
+
+/** \brief PMU Interrupt Enable Set Register Definitions */
+#define PMU_INTENSET_CNT0_ENABLE_Pos          0U                                           /*!< PMU INTENSET: Event Counter 0 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT0_ENABLE_Msk         (1UL /*<< PMU_INTENSET_CNT0_ENABLE_Pos*/)     /*!< PMU INTENSET: Event Counter 0 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT1_ENABLE_Pos          1U                                           /*!< PMU INTENSET: Event Counter 1 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT1_ENABLE_Msk         (1UL << PMU_INTENSET_CNT1_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 1 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT2_ENABLE_Pos          2U                                           /*!< PMU INTENSET: Event Counter 2 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT2_ENABLE_Msk         (1UL << PMU_INTENSET_CNT2_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 2 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT3_ENABLE_Pos          3U                                           /*!< PMU INTENSET: Event Counter 3 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT3_ENABLE_Msk         (1UL << PMU_INTENSET_CNT3_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 3 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT4_ENABLE_Pos          4U                                           /*!< PMU INTENSET: Event Counter 4 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT4_ENABLE_Msk         (1UL << PMU_INTENSET_CNT4_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 4 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT5_ENABLE_Pos          5U                                           /*!< PMU INTENSET: Event Counter 5 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT5_ENABLE_Msk         (1UL << PMU_INTENSET_CNT5_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 5 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT6_ENABLE_Pos          6U                                           /*!< PMU INTENSET: Event Counter 6 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT6_ENABLE_Msk         (1UL << PMU_INTENSET_CNT6_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 6 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT7_ENABLE_Pos          7U                                           /*!< PMU INTENSET: Event Counter 7 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT7_ENABLE_Msk         (1UL << PMU_INTENSET_CNT7_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 7 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT8_ENABLE_Pos          8U                                           /*!< PMU INTENSET: Event Counter 8 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT8_ENABLE_Msk         (1UL << PMU_INTENSET_CNT8_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 8 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT9_ENABLE_Pos          9U                                           /*!< PMU INTENSET: Event Counter 9 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT9_ENABLE_Msk         (1UL << PMU_INTENSET_CNT9_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 9 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT10_ENABLE_Pos         10U                                          /*!< PMU INTENSET: Event Counter 10 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT10_ENABLE_Msk        (1UL << PMU_INTENSET_CNT10_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 10 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT11_ENABLE_Pos         11U                                          /*!< PMU INTENSET: Event Counter 11 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT11_ENABLE_Msk        (1UL << PMU_INTENSET_CNT11_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 11 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT12_ENABLE_Pos         12U                                          /*!< PMU INTENSET: Event Counter 12 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT12_ENABLE_Msk        (1UL << PMU_INTENSET_CNT12_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 12 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT13_ENABLE_Pos         13U                                          /*!< PMU INTENSET: Event Counter 13 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT13_ENABLE_Msk        (1UL << PMU_INTENSET_CNT13_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 13 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT14_ENABLE_Pos         14U                                          /*!< PMU INTENSET: Event Counter 14 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT14_ENABLE_Msk        (1UL << PMU_INTENSET_CNT14_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 14 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT15_ENABLE_Pos         15U                                          /*!< PMU INTENSET: Event Counter 15 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT15_ENABLE_Msk        (1UL << PMU_INTENSET_CNT15_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 15 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT16_ENABLE_Pos         16U                                          /*!< PMU INTENSET: Event Counter 16 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT16_ENABLE_Msk        (1UL << PMU_INTENSET_CNT16_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 16 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT17_ENABLE_Pos         17U                                          /*!< PMU INTENSET: Event Counter 17 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT17_ENABLE_Msk        (1UL << PMU_INTENSET_CNT17_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 17 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT18_ENABLE_Pos         18U                                          /*!< PMU INTENSET: Event Counter 18 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT18_ENABLE_Msk        (1UL << PMU_INTENSET_CNT18_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 18 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT19_ENABLE_Pos         19U                                          /*!< PMU INTENSET: Event Counter 19 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT19_ENABLE_Msk        (1UL << PMU_INTENSET_CNT19_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 19 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT20_ENABLE_Pos         20U                                          /*!< PMU INTENSET: Event Counter 20 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT20_ENABLE_Msk        (1UL << PMU_INTENSET_CNT20_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 20 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT21_ENABLE_Pos         21U                                          /*!< PMU INTENSET: Event Counter 21 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT21_ENABLE_Msk        (1UL << PMU_INTENSET_CNT21_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 21 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT22_ENABLE_Pos         22U                                          /*!< PMU INTENSET: Event Counter 22 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT22_ENABLE_Msk        (1UL << PMU_INTENSET_CNT22_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 22 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT23_ENABLE_Pos         23U                                          /*!< PMU INTENSET: Event Counter 23 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT23_ENABLE_Msk        (1UL << PMU_INTENSET_CNT23_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 23 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT24_ENABLE_Pos         24U                                          /*!< PMU INTENSET: Event Counter 24 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT24_ENABLE_Msk        (1UL << PMU_INTENSET_CNT24_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 24 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT25_ENABLE_Pos         25U                                          /*!< PMU INTENSET: Event Counter 25 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT25_ENABLE_Msk        (1UL << PMU_INTENSET_CNT25_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 25 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT26_ENABLE_Pos         26U                                          /*!< PMU INTENSET: Event Counter 26 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT26_ENABLE_Msk        (1UL << PMU_INTENSET_CNT26_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 26 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT27_ENABLE_Pos         27U                                          /*!< PMU INTENSET: Event Counter 27 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT27_ENABLE_Msk        (1UL << PMU_INTENSET_CNT27_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 27 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT28_ENABLE_Pos         28U                                          /*!< PMU INTENSET: Event Counter 28 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT28_ENABLE_Msk        (1UL << PMU_INTENSET_CNT28_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 28 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT29_ENABLE_Pos         29U                                          /*!< PMU INTENSET: Event Counter 29 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT29_ENABLE_Msk        (1UL << PMU_INTENSET_CNT29_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 29 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT30_ENABLE_Pos         30U                                          /*!< PMU INTENSET: Event Counter 30 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT30_ENABLE_Msk        (1UL << PMU_INTENSET_CNT30_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 30 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CYCCNT_ENABLE_Pos        31U                                          /*!< PMU INTENSET: Cycle Counter Interrupt Enable Set Position */
+#define PMU_INTENSET_CCYCNT_ENABLE_Msk       (1UL << PMU_INTENSET_CYCCNT_ENABLE_Pos)       /*!< PMU INTENSET: Cycle Counter Interrupt Enable Set Mask */
+
+/** \brief PMU Interrupt Enable Clear Register Definitions */
+#define PMU_INTENSET_CNT0_ENABLE_Pos          0U                                           /*!< PMU INTENCLR: Event Counter 0 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT0_ENABLE_Msk         (1UL /*<< PMU_INTENCLR_CNT0_ENABLE_Pos*/)     /*!< PMU INTENCLR: Event Counter 0 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT1_ENABLE_Pos          1U                                           /*!< PMU INTENCLR: Event Counter 1 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT1_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT1_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 1 Interrupt Enable Clear */
+
+#define PMU_INTENCLR_CNT2_ENABLE_Pos          2U                                           /*!< PMU INTENCLR: Event Counter 2 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT2_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT2_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 2 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT3_ENABLE_Pos          3U                                           /*!< PMU INTENCLR: Event Counter 3 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT3_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT3_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 3 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT4_ENABLE_Pos          4U                                           /*!< PMU INTENCLR: Event Counter 4 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT4_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT4_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 4 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT5_ENABLE_Pos          5U                                           /*!< PMU INTENCLR: Event Counter 5 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT5_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT5_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 5 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT6_ENABLE_Pos          6U                                           /*!< PMU INTENCLR: Event Counter 6 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT6_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT6_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 6 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT7_ENABLE_Pos          7U                                           /*!< PMU INTENCLR: Event Counter 7 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT7_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT7_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 7 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT8_ENABLE_Pos          8U                                           /*!< PMU INTENCLR: Event Counter 8 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT8_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT8_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 8 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT9_ENABLE_Pos          9U                                           /*!< PMU INTENCLR: Event Counter 9 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT9_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT9_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 9 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT10_ENABLE_Pos         10U                                          /*!< PMU INTENCLR: Event Counter 10 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT10_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT10_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 10 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT11_ENABLE_Pos         11U                                          /*!< PMU INTENCLR: Event Counter 11 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT11_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT11_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 11 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT12_ENABLE_Pos         12U                                          /*!< PMU INTENCLR: Event Counter 12 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT12_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT12_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 12 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT13_ENABLE_Pos         13U                                          /*!< PMU INTENCLR: Event Counter 13 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT13_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT13_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 13 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT14_ENABLE_Pos         14U                                          /*!< PMU INTENCLR: Event Counter 14 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT14_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT14_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 14 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT15_ENABLE_Pos         15U                                          /*!< PMU INTENCLR: Event Counter 15 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT15_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT15_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 15 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT16_ENABLE_Pos         16U                                          /*!< PMU INTENCLR: Event Counter 16 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT16_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT16_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 16 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT17_ENABLE_Pos         17U                                          /*!< PMU INTENCLR: Event Counter 17 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT17_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT17_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 17 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT18_ENABLE_Pos         18U                                          /*!< PMU INTENCLR: Event Counter 18 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT18_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT18_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 18 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT19_ENABLE_Pos         19U                                          /*!< PMU INTENCLR: Event Counter 19 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT19_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT19_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 19 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT20_ENABLE_Pos         20U                                          /*!< PMU INTENCLR: Event Counter 20 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT20_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT20_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 20 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT21_ENABLE_Pos         21U                                          /*!< PMU INTENCLR: Event Counter 21 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT21_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT21_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 21 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT22_ENABLE_Pos         22U                                          /*!< PMU INTENCLR: Event Counter 22 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT22_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT22_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 22 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT23_ENABLE_Pos         23U                                          /*!< PMU INTENCLR: Event Counter 23 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT23_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT23_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 23 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT24_ENABLE_Pos         24U                                          /*!< PMU INTENCLR: Event Counter 24 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT24_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT24_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 24 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT25_ENABLE_Pos         25U                                          /*!< PMU INTENCLR: Event Counter 25 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT25_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT25_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 25 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT26_ENABLE_Pos         26U                                          /*!< PMU INTENCLR: Event Counter 26 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT26_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT26_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 26 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT27_ENABLE_Pos         27U                                          /*!< PMU INTENCLR: Event Counter 27 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT27_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT27_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 27 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT28_ENABLE_Pos         28U                                          /*!< PMU INTENCLR: Event Counter 28 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT28_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT28_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 28 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT29_ENABLE_Pos         29U                                          /*!< PMU INTENCLR: Event Counter 29 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT29_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT29_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 29 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT30_ENABLE_Pos         30U                                          /*!< PMU INTENCLR: Event Counter 30 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT30_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT30_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 30 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CYCCNT_ENABLE_Pos        31U                                          /*!< PMU INTENCLR: Cycle Counter Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CYCCNT_ENABLE_Msk       (1UL << PMU_INTENCLR_CYCCNT_ENABLE_Pos)       /*!< PMU INTENCLR: Cycle Counter Interrupt Enable Clear Mask */
+
+/** \brief PMU Overflow Flag Status Set Register Definitions */
+#define PMU_OVSSET_CNT0_STATUS_Pos            0U                                           /*!< PMU OVSSET: Event Counter 0 Overflow Set Position */
+#define PMU_OVSSET_CNT0_STATUS_Msk           (1UL /*<< PMU_OVSSET_CNT0_STATUS_Pos*/)       /*!< PMU OVSSET: Event Counter 0 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT1_STATUS_Pos            1U                                           /*!< PMU OVSSET: Event Counter 1 Overflow Set Position */
+#define PMU_OVSSET_CNT1_STATUS_Msk           (1UL << PMU_OVSSET_CNT1_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 1 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT2_STATUS_Pos            2U                                           /*!< PMU OVSSET: Event Counter 2 Overflow Set Position */
+#define PMU_OVSSET_CNT2_STATUS_Msk           (1UL << PMU_OVSSET_CNT2_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 2 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT3_STATUS_Pos            3U                                           /*!< PMU OVSSET: Event Counter 3 Overflow Set Position */
+#define PMU_OVSSET_CNT3_STATUS_Msk           (1UL << PMU_OVSSET_CNT3_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 3 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT4_STATUS_Pos            4U                                           /*!< PMU OVSSET: Event Counter 4 Overflow Set Position */
+#define PMU_OVSSET_CNT4_STATUS_Msk           (1UL << PMU_OVSSET_CNT4_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 4 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT5_STATUS_Pos            5U                                           /*!< PMU OVSSET: Event Counter 5 Overflow Set Position */
+#define PMU_OVSSET_CNT5_STATUS_Msk           (1UL << PMU_OVSSET_CNT5_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 5 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT6_STATUS_Pos            6U                                           /*!< PMU OVSSET: Event Counter 6 Overflow Set Position */
+#define PMU_OVSSET_CNT6_STATUS_Msk           (1UL << PMU_OVSSET_CNT6_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 6 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT7_STATUS_Pos            7U                                           /*!< PMU OVSSET: Event Counter 7 Overflow Set Position */
+#define PMU_OVSSET_CNT7_STATUS_Msk           (1UL << PMU_OVSSET_CNT7_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 7 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT8_STATUS_Pos            8U                                           /*!< PMU OVSSET: Event Counter 8 Overflow Set Position */
+#define PMU_OVSSET_CNT8_STATUS_Msk           (1UL << PMU_OVSSET_CNT8_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 8 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT9_STATUS_Pos            9U                                           /*!< PMU OVSSET: Event Counter 9 Overflow Set Position */
+#define PMU_OVSSET_CNT9_STATUS_Msk           (1UL << PMU_OVSSET_CNT9_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 9 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT10_STATUS_Pos           10U                                          /*!< PMU OVSSET: Event Counter 10 Overflow Set Position */
+#define PMU_OVSSET_CNT10_STATUS_Msk          (1UL << PMU_OVSSET_CNT10_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 10 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT11_STATUS_Pos           11U                                          /*!< PMU OVSSET: Event Counter 11 Overflow Set Position */
+#define PMU_OVSSET_CNT11_STATUS_Msk          (1UL << PMU_OVSSET_CNT11_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 11 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT12_STATUS_Pos           12U                                          /*!< PMU OVSSET: Event Counter 12 Overflow Set Position */
+#define PMU_OVSSET_CNT12_STATUS_Msk          (1UL << PMU_OVSSET_CNT12_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 12 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT13_STATUS_Pos           13U                                          /*!< PMU OVSSET: Event Counter 13 Overflow Set Position */
+#define PMU_OVSSET_CNT13_STATUS_Msk          (1UL << PMU_OVSSET_CNT13_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 13 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT14_STATUS_Pos           14U                                          /*!< PMU OVSSET: Event Counter 14 Overflow Set Position */
+#define PMU_OVSSET_CNT14_STATUS_Msk          (1UL << PMU_OVSSET_CNT14_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 14 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT15_STATUS_Pos           15U                                          /*!< PMU OVSSET: Event Counter 15 Overflow Set Position */
+#define PMU_OVSSET_CNT15_STATUS_Msk          (1UL << PMU_OVSSET_CNT15_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 15 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT16_STATUS_Pos           16U                                          /*!< PMU OVSSET: Event Counter 16 Overflow Set Position */
+#define PMU_OVSSET_CNT16_STATUS_Msk          (1UL << PMU_OVSSET_CNT16_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 16 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT17_STATUS_Pos           17U                                          /*!< PMU OVSSET: Event Counter 17 Overflow Set Position */
+#define PMU_OVSSET_CNT17_STATUS_Msk          (1UL << PMU_OVSSET_CNT17_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 17 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT18_STATUS_Pos           18U                                          /*!< PMU OVSSET: Event Counter 18 Overflow Set Position */
+#define PMU_OVSSET_CNT18_STATUS_Msk          (1UL << PMU_OVSSET_CNT18_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 18 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT19_STATUS_Pos           19U                                          /*!< PMU OVSSET: Event Counter 19 Overflow Set Position */
+#define PMU_OVSSET_CNT19_STATUS_Msk          (1UL << PMU_OVSSET_CNT19_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 19 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT20_STATUS_Pos           20U                                          /*!< PMU OVSSET: Event Counter 20 Overflow Set Position */
+#define PMU_OVSSET_CNT20_STATUS_Msk          (1UL << PMU_OVSSET_CNT20_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 20 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT21_STATUS_Pos           21U                                          /*!< PMU OVSSET: Event Counter 21 Overflow Set Position */
+#define PMU_OVSSET_CNT21_STATUS_Msk          (1UL << PMU_OVSSET_CNT21_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 21 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT22_STATUS_Pos           22U                                          /*!< PMU OVSSET: Event Counter 22 Overflow Set Position */
+#define PMU_OVSSET_CNT22_STATUS_Msk          (1UL << PMU_OVSSET_CNT22_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 22 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT23_STATUS_Pos           23U                                          /*!< PMU OVSSET: Event Counter 23 Overflow Set Position */
+#define PMU_OVSSET_CNT23_STATUS_Msk          (1UL << PMU_OVSSET_CNT23_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 23 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT24_STATUS_Pos           24U                                          /*!< PMU OVSSET: Event Counter 24 Overflow Set Position */
+#define PMU_OVSSET_CNT24_STATUS_Msk          (1UL << PMU_OVSSET_CNT24_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 24 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT25_STATUS_Pos           25U                                          /*!< PMU OVSSET: Event Counter 25 Overflow Set Position */
+#define PMU_OVSSET_CNT25_STATUS_Msk          (1UL << PMU_OVSSET_CNT25_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 25 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT26_STATUS_Pos           26U                                          /*!< PMU OVSSET: Event Counter 26 Overflow Set Position */
+#define PMU_OVSSET_CNT26_STATUS_Msk          (1UL << PMU_OVSSET_CNT26_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 26 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT27_STATUS_Pos           27U                                          /*!< PMU OVSSET: Event Counter 27 Overflow Set Position */
+#define PMU_OVSSET_CNT27_STATUS_Msk          (1UL << PMU_OVSSET_CNT27_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 27 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT28_STATUS_Pos           28U                                          /*!< PMU OVSSET: Event Counter 28 Overflow Set Position */
+#define PMU_OVSSET_CNT28_STATUS_Msk          (1UL << PMU_OVSSET_CNT28_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 28 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT29_STATUS_Pos           29U                                          /*!< PMU OVSSET: Event Counter 29 Overflow Set Position */
+#define PMU_OVSSET_CNT29_STATUS_Msk          (1UL << PMU_OVSSET_CNT29_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 29 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT30_STATUS_Pos           30U                                          /*!< PMU OVSSET: Event Counter 30 Overflow Set Position */
+#define PMU_OVSSET_CNT30_STATUS_Msk          (1UL << PMU_OVSSET_CNT30_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 30 Overflow Set Mask */
+
+#define PMU_OVSSET_CYCCNT_STATUS_Pos          31U                                          /*!< PMU OVSSET: Cycle Counter Overflow Set Position */
+#define PMU_OVSSET_CYCCNT_STATUS_Msk         (1UL << PMU_OVSSET_CYCCNT_STATUS_Pos)         /*!< PMU OVSSET: Cycle Counter Overflow Set Mask */
+
+/** \brief PMU Overflow Flag Status Clear Register Definitions */
+#define PMU_OVSCLR_CNT0_STATUS_Pos            0U                                           /*!< PMU OVSCLR: Event Counter 0 Overflow Clear Position */
+#define PMU_OVSCLR_CNT0_STATUS_Msk           (1UL /*<< PMU_OVSCLR_CNT0_STATUS_Pos*/)       /*!< PMU OVSCLR: Event Counter 0 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT1_STATUS_Pos            1U                                           /*!< PMU OVSCLR: Event Counter 1 Overflow Clear Position */
+#define PMU_OVSCLR_CNT1_STATUS_Msk           (1UL << PMU_OVSCLR_CNT1_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 1 Overflow Clear */
+
+#define PMU_OVSCLR_CNT2_STATUS_Pos            2U                                           /*!< PMU OVSCLR: Event Counter 2 Overflow Clear Position */
+#define PMU_OVSCLR_CNT2_STATUS_Msk           (1UL << PMU_OVSCLR_CNT2_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 2 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT3_STATUS_Pos            3U                                           /*!< PMU OVSCLR: Event Counter 3 Overflow Clear Position */
+#define PMU_OVSCLR_CNT3_STATUS_Msk           (1UL << PMU_OVSCLR_CNT3_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 3 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT4_STATUS_Pos            4U                                           /*!< PMU OVSCLR: Event Counter 4 Overflow Clear Position */
+#define PMU_OVSCLR_CNT4_STATUS_Msk           (1UL << PMU_OVSCLR_CNT4_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 4 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT5_STATUS_Pos            5U                                           /*!< PMU OVSCLR: Event Counter 5 Overflow Clear Position */
+#define PMU_OVSCLR_CNT5_STATUS_Msk           (1UL << PMU_OVSCLR_CNT5_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 5 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT6_STATUS_Pos            6U                                           /*!< PMU OVSCLR: Event Counter 6 Overflow Clear Position */
+#define PMU_OVSCLR_CNT6_STATUS_Msk           (1UL << PMU_OVSCLR_CNT6_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 6 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT7_STATUS_Pos            7U                                           /*!< PMU OVSCLR: Event Counter 7 Overflow Clear Position */
+#define PMU_OVSCLR_CNT7_STATUS_Msk           (1UL << PMU_OVSCLR_CNT7_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 7 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT8_STATUS_Pos            8U                                           /*!< PMU OVSCLR: Event Counter 8 Overflow Clear Position */
+#define PMU_OVSCLR_CNT8_STATUS_Msk           (1UL << PMU_OVSCLR_CNT8_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 8 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT9_STATUS_Pos            9U                                           /*!< PMU OVSCLR: Event Counter 9 Overflow Clear Position */
+#define PMU_OVSCLR_CNT9_STATUS_Msk           (1UL << PMU_OVSCLR_CNT9_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 9 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT10_STATUS_Pos           10U                                          /*!< PMU OVSCLR: Event Counter 10 Overflow Clear Position */
+#define PMU_OVSCLR_CNT10_STATUS_Msk          (1UL << PMU_OVSCLR_CNT10_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 10 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT11_STATUS_Pos           11U                                          /*!< PMU OVSCLR: Event Counter 11 Overflow Clear Position */
+#define PMU_OVSCLR_CNT11_STATUS_Msk          (1UL << PMU_OVSCLR_CNT11_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 11 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT12_STATUS_Pos           12U                                          /*!< PMU OVSCLR: Event Counter 12 Overflow Clear Position */
+#define PMU_OVSCLR_CNT12_STATUS_Msk          (1UL << PMU_OVSCLR_CNT12_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 12 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT13_STATUS_Pos           13U                                          /*!< PMU OVSCLR: Event Counter 13 Overflow Clear Position */
+#define PMU_OVSCLR_CNT13_STATUS_Msk          (1UL << PMU_OVSCLR_CNT13_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 13 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT14_STATUS_Pos           14U                                          /*!< PMU OVSCLR: Event Counter 14 Overflow Clear Position */
+#define PMU_OVSCLR_CNT14_STATUS_Msk          (1UL << PMU_OVSCLR_CNT14_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 14 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT15_STATUS_Pos           15U                                          /*!< PMU OVSCLR: Event Counter 15 Overflow Clear Position */
+#define PMU_OVSCLR_CNT15_STATUS_Msk          (1UL << PMU_OVSCLR_CNT15_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 15 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT16_STATUS_Pos           16U                                          /*!< PMU OVSCLR: Event Counter 16 Overflow Clear Position */
+#define PMU_OVSCLR_CNT16_STATUS_Msk          (1UL << PMU_OVSCLR_CNT16_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 16 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT17_STATUS_Pos           17U                                          /*!< PMU OVSCLR: Event Counter 17 Overflow Clear Position */
+#define PMU_OVSCLR_CNT17_STATUS_Msk          (1UL << PMU_OVSCLR_CNT17_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 17 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT18_STATUS_Pos           18U                                          /*!< PMU OVSCLR: Event Counter 18 Overflow Clear Position */
+#define PMU_OVSCLR_CNT18_STATUS_Msk          (1UL << PMU_OVSCLR_CNT18_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 18 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT19_STATUS_Pos           19U                                          /*!< PMU OVSCLR: Event Counter 19 Overflow Clear Position */
+#define PMU_OVSCLR_CNT19_STATUS_Msk          (1UL << PMU_OVSCLR_CNT19_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 19 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT20_STATUS_Pos           20U                                          /*!< PMU OVSCLR: Event Counter 20 Overflow Clear Position */
+#define PMU_OVSCLR_CNT20_STATUS_Msk          (1UL << PMU_OVSCLR_CNT20_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 20 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT21_STATUS_Pos           21U                                          /*!< PMU OVSCLR: Event Counter 21 Overflow Clear Position */
+#define PMU_OVSCLR_CNT21_STATUS_Msk          (1UL << PMU_OVSCLR_CNT21_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 21 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT22_STATUS_Pos           22U                                          /*!< PMU OVSCLR: Event Counter 22 Overflow Clear Position */
+#define PMU_OVSCLR_CNT22_STATUS_Msk          (1UL << PMU_OVSCLR_CNT22_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 22 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT23_STATUS_Pos           23U                                          /*!< PMU OVSCLR: Event Counter 23 Overflow Clear Position */
+#define PMU_OVSCLR_CNT23_STATUS_Msk          (1UL << PMU_OVSCLR_CNT23_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 23 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT24_STATUS_Pos           24U                                          /*!< PMU OVSCLR: Event Counter 24 Overflow Clear Position */
+#define PMU_OVSCLR_CNT24_STATUS_Msk          (1UL << PMU_OVSCLR_CNT24_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 24 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT25_STATUS_Pos           25U                                          /*!< PMU OVSCLR: Event Counter 25 Overflow Clear Position */
+#define PMU_OVSCLR_CNT25_STATUS_Msk          (1UL << PMU_OVSCLR_CNT25_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 25 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT26_STATUS_Pos           26U                                          /*!< PMU OVSCLR: Event Counter 26 Overflow Clear Position */
+#define PMU_OVSCLR_CNT26_STATUS_Msk          (1UL << PMU_OVSCLR_CNT26_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 26 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT27_STATUS_Pos           27U                                          /*!< PMU OVSCLR: Event Counter 27 Overflow Clear Position */
+#define PMU_OVSCLR_CNT27_STATUS_Msk          (1UL << PMU_OVSCLR_CNT27_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 27 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT28_STATUS_Pos           28U                                          /*!< PMU OVSCLR: Event Counter 28 Overflow Clear Position */
+#define PMU_OVSCLR_CNT28_STATUS_Msk          (1UL << PMU_OVSCLR_CNT28_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 28 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT29_STATUS_Pos           29U                                          /*!< PMU OVSCLR: Event Counter 29 Overflow Clear Position */
+#define PMU_OVSCLR_CNT29_STATUS_Msk          (1UL << PMU_OVSCLR_CNT29_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 29 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT30_STATUS_Pos           30U                                          /*!< PMU OVSCLR: Event Counter 30 Overflow Clear Position */
+#define PMU_OVSCLR_CNT30_STATUS_Msk          (1UL << PMU_OVSCLR_CNT30_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 30 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CYCCNT_STATUS_Pos          31U                                          /*!< PMU OVSCLR: Cycle Counter Overflow Clear Position */
+#define PMU_OVSCLR_CYCCNT_STATUS_Msk         (1UL << PMU_OVSCLR_CYCCNT_STATUS_Pos)         /*!< PMU OVSCLR: Cycle Counter Overflow Clear Mask */
+
+/** \brief PMU Software Increment Counter */
+#define PMU_SWINC_CNT0_Pos                    0U                                           /*!< PMU SWINC: Event Counter 0 Software Increment Position */
+#define PMU_SWINC_CNT0_Msk                   (1UL /*<< PMU_SWINC_CNT0_Pos */)              /*!< PMU SWINC: Event Counter 0 Software Increment Mask */
+
+#define PMU_SWINC_CNT1_Pos                    1U                                           /*!< PMU SWINC: Event Counter 1 Software Increment Position */
+#define PMU_SWINC_CNT1_Msk                   (1UL << PMU_SWINC_CNT1_Pos)                   /*!< PMU SWINC: Event Counter 1 Software Increment Mask */
+
+#define PMU_SWINC_CNT2_Pos                    2U                                           /*!< PMU SWINC: Event Counter 2 Software Increment Position */
+#define PMU_SWINC_CNT2_Msk                   (1UL << PMU_SWINC_CNT2_Pos)                   /*!< PMU SWINC: Event Counter 2 Software Increment Mask */
+
+#define PMU_SWINC_CNT3_Pos                    3U                                           /*!< PMU SWINC: Event Counter 3 Software Increment Position */
+#define PMU_SWINC_CNT3_Msk                   (1UL << PMU_SWINC_CNT3_Pos)                   /*!< PMU SWINC: Event Counter 3 Software Increment Mask */
+
+#define PMU_SWINC_CNT4_Pos                    4U                                           /*!< PMU SWINC: Event Counter 4 Software Increment Position */
+#define PMU_SWINC_CNT4_Msk                   (1UL << PMU_SWINC_CNT4_Pos)                   /*!< PMU SWINC: Event Counter 4 Software Increment Mask */
+
+#define PMU_SWINC_CNT5_Pos                    5U                                           /*!< PMU SWINC: Event Counter 5 Software Increment Position */
+#define PMU_SWINC_CNT5_Msk                   (1UL << PMU_SWINC_CNT5_Pos)                   /*!< PMU SWINC: Event Counter 5 Software Increment Mask */
+
+#define PMU_SWINC_CNT6_Pos                    6U                                           /*!< PMU SWINC: Event Counter 6 Software Increment Position */
+#define PMU_SWINC_CNT6_Msk                   (1UL << PMU_SWINC_CNT6_Pos)                   /*!< PMU SWINC: Event Counter 6 Software Increment Mask */
+
+#define PMU_SWINC_CNT7_Pos                    7U                                           /*!< PMU SWINC: Event Counter 7 Software Increment Position */
+#define PMU_SWINC_CNT7_Msk                   (1UL << PMU_SWINC_CNT7_Pos)                   /*!< PMU SWINC: Event Counter 7 Software Increment Mask */
+
+#define PMU_SWINC_CNT8_Pos                    8U                                           /*!< PMU SWINC: Event Counter 8 Software Increment Position */
+#define PMU_SWINC_CNT8_Msk                   (1UL << PMU_SWINC_CNT8_Pos)                   /*!< PMU SWINC: Event Counter 8 Software Increment Mask */
+
+#define PMU_SWINC_CNT9_Pos                    9U                                           /*!< PMU SWINC: Event Counter 9 Software Increment Position */
+#define PMU_SWINC_CNT9_Msk                   (1UL << PMU_SWINC_CNT9_Pos)                   /*!< PMU SWINC: Event Counter 9 Software Increment Mask */
+
+#define PMU_SWINC_CNT10_Pos                   10U                                          /*!< PMU SWINC: Event Counter 10 Software Increment Position */
+#define PMU_SWINC_CNT10_Msk                  (1UL << PMU_SWINC_CNT10_Pos)                  /*!< PMU SWINC: Event Counter 10 Software Increment Mask */
+
+#define PMU_SWINC_CNT11_Pos                   11U                                          /*!< PMU SWINC: Event Counter 11 Software Increment Position */
+#define PMU_SWINC_CNT11_Msk                  (1UL << PMU_SWINC_CNT11_Pos)                  /*!< PMU SWINC: Event Counter 11 Software Increment Mask */
+
+#define PMU_SWINC_CNT12_Pos                   12U                                          /*!< PMU SWINC: Event Counter 12 Software Increment Position */
+#define PMU_SWINC_CNT12_Msk                  (1UL << PMU_SWINC_CNT12_Pos)                  /*!< PMU SWINC: Event Counter 12 Software Increment Mask */
+
+#define PMU_SWINC_CNT13_Pos                   13U                                          /*!< PMU SWINC: Event Counter 13 Software Increment Position */
+#define PMU_SWINC_CNT13_Msk                  (1UL << PMU_SWINC_CNT13_Pos)                  /*!< PMU SWINC: Event Counter 13 Software Increment Mask */
+
+#define PMU_SWINC_CNT14_Pos                   14U                                          /*!< PMU SWINC: Event Counter 14 Software Increment Position */
+#define PMU_SWINC_CNT14_Msk                  (1UL << PMU_SWINC_CNT14_Pos)                  /*!< PMU SWINC: Event Counter 14 Software Increment Mask */
+
+#define PMU_SWINC_CNT15_Pos                   15U                                          /*!< PMU SWINC: Event Counter 15 Software Increment Position */
+#define PMU_SWINC_CNT15_Msk                  (1UL << PMU_SWINC_CNT15_Pos)                  /*!< PMU SWINC: Event Counter 15 Software Increment Mask */
+
+#define PMU_SWINC_CNT16_Pos                   16U                                          /*!< PMU SWINC: Event Counter 16 Software Increment Position */
+#define PMU_SWINC_CNT16_Msk                  (1UL << PMU_SWINC_CNT16_Pos)                  /*!< PMU SWINC: Event Counter 16 Software Increment Mask */
+
+#define PMU_SWINC_CNT17_Pos                   17U                                          /*!< PMU SWINC: Event Counter 17 Software Increment Position */
+#define PMU_SWINC_CNT17_Msk                  (1UL << PMU_SWINC_CNT17_Pos)                  /*!< PMU SWINC: Event Counter 17 Software Increment Mask */
+
+#define PMU_SWINC_CNT18_Pos                   18U                                          /*!< PMU SWINC: Event Counter 18 Software Increment Position */
+#define PMU_SWINC_CNT18_Msk                  (1UL << PMU_SWINC_CNT18_Pos)                  /*!< PMU SWINC: Event Counter 18 Software Increment Mask */
+
+#define PMU_SWINC_CNT19_Pos                   19U                                          /*!< PMU SWINC: Event Counter 19 Software Increment Position */
+#define PMU_SWINC_CNT19_Msk                  (1UL << PMU_SWINC_CNT19_Pos)                  /*!< PMU SWINC: Event Counter 19 Software Increment Mask */
+
+#define PMU_SWINC_CNT20_Pos                   20U                                          /*!< PMU SWINC: Event Counter 20 Software Increment Position */
+#define PMU_SWINC_CNT20_Msk                  (1UL << PMU_SWINC_CNT20_Pos)                  /*!< PMU SWINC: Event Counter 20 Software Increment Mask */
+
+#define PMU_SWINC_CNT21_Pos                   21U                                          /*!< PMU SWINC: Event Counter 21 Software Increment Position */
+#define PMU_SWINC_CNT21_Msk                  (1UL << PMU_SWINC_CNT21_Pos)                  /*!< PMU SWINC: Event Counter 21 Software Increment Mask */
+
+#define PMU_SWINC_CNT22_Pos                   22U                                          /*!< PMU SWINC: Event Counter 22 Software Increment Position */
+#define PMU_SWINC_CNT22_Msk                  (1UL << PMU_SWINC_CNT22_Pos)                  /*!< PMU SWINC: Event Counter 22 Software Increment Mask */
+
+#define PMU_SWINC_CNT23_Pos                   23U                                          /*!< PMU SWINC: Event Counter 23 Software Increment Position */
+#define PMU_SWINC_CNT23_Msk                  (1UL << PMU_SWINC_CNT23_Pos)                  /*!< PMU SWINC: Event Counter 23 Software Increment Mask */
+
+#define PMU_SWINC_CNT24_Pos                   24U                                          /*!< PMU SWINC: Event Counter 24 Software Increment Position */
+#define PMU_SWINC_CNT24_Msk                  (1UL << PMU_SWINC_CNT24_Pos)                  /*!< PMU SWINC: Event Counter 24 Software Increment Mask */
+
+#define PMU_SWINC_CNT25_Pos                   25U                                          /*!< PMU SWINC: Event Counter 25 Software Increment Position */
+#define PMU_SWINC_CNT25_Msk                  (1UL << PMU_SWINC_CNT25_Pos)                  /*!< PMU SWINC: Event Counter 25 Software Increment Mask */
+
+#define PMU_SWINC_CNT26_Pos                   26U                                          /*!< PMU SWINC: Event Counter 26 Software Increment Position */
+#define PMU_SWINC_CNT26_Msk                  (1UL << PMU_SWINC_CNT26_Pos)                  /*!< PMU SWINC: Event Counter 26 Software Increment Mask */
+
+#define PMU_SWINC_CNT27_Pos                   27U                                          /*!< PMU SWINC: Event Counter 27 Software Increment Position */
+#define PMU_SWINC_CNT27_Msk                  (1UL << PMU_SWINC_CNT27_Pos)                  /*!< PMU SWINC: Event Counter 27 Software Increment Mask */
+
+#define PMU_SWINC_CNT28_Pos                   28U                                          /*!< PMU SWINC: Event Counter 28 Software Increment Position */
+#define PMU_SWINC_CNT28_Msk                  (1UL << PMU_SWINC_CNT28_Pos)                  /*!< PMU SWINC: Event Counter 28 Software Increment Mask */
+
+#define PMU_SWINC_CNT29_Pos                   29U                                          /*!< PMU SWINC: Event Counter 29 Software Increment Position */
+#define PMU_SWINC_CNT29_Msk                  (1UL << PMU_SWINC_CNT29_Pos)                  /*!< PMU SWINC: Event Counter 29 Software Increment Mask */
+
+#define PMU_SWINC_CNT30_Pos                   30U                                          /*!< PMU SWINC: Event Counter 30 Software Increment Position */
+#define PMU_SWINC_CNT30_Msk                  (1UL << PMU_SWINC_CNT30_Pos)                  /*!< PMU SWINC: Event Counter 30 Software Increment Mask */
+
+/** \brief PMU Control Register Definitions */
+#define PMU_CTRL_ENABLE_Pos                   0U                                           /*!< PMU CTRL: ENABLE Position */
+#define PMU_CTRL_ENABLE_Msk                  (1UL /*<< PMU_CTRL_ENABLE_Pos*/)              /*!< PMU CTRL: ENABLE Mask */
+
+#define PMU_CTRL_EVENTCNT_RESET_Pos           1U                                           /*!< PMU CTRL: Event Counter Reset Position */
+#define PMU_CTRL_EVENTCNT_RESET_Msk          (1UL << PMU_CTRL_EVENTCNT_RESET_Pos)          /*!< PMU CTRL: Event Counter Reset Mask */
+
+#define PMU_CTRL_CYCCNT_RESET_Pos             2U                                           /*!< PMU CTRL: Cycle Counter Reset Position */
+#define PMU_CTRL_CYCCNT_RESET_Msk            (1UL << PMU_CTRL_CYCCNT_RESET_Pos)            /*!< PMU CTRL: Cycle Counter Reset Mask */
+
+#define PMU_CTRL_CYCCNT_DISABLE_Pos           5U                                           /*!< PMU CTRL: Disable Cycle Counter Position */
+#define PMU_CTRL_CYCCNT_DISABLE_Msk          (1UL << PMU_CTRL_CYCCNT_DISABLE_Pos)          /*!< PMU CTRL: Disable Cycle Counter Mask */
+
+#define PMU_CTRL_FRZ_ON_OV_Pos                9U                                           /*!< PMU CTRL: Freeze-on-overflow Position */
+#define PMU_CTRL_FRZ_ON_OV_Msk               (1UL << PMU_CTRL_FRZ_ON_OVERFLOW_Pos)         /*!< PMU CTRL: Freeze-on-overflow Mask */
+
+#define PMU_CTRL_TRACE_ON_OV_Pos              11U                                          /*!< PMU CTRL: Trace-on-overflow Position */
+#define PMU_CTRL_TRACE_ON_OV_Msk             (1UL << PMU_CTRL_TRACE_ON_OVERFLOW_Pos)       /*!< PMU CTRL: Trace-on-overflow Mask */
+
+/** \brief PMU Type Register Definitions */
+#define PMU_TYPE_NUM_CNTS_Pos                 0U                                           /*!< PMU TYPE: Number of Counters Position */
+#define PMU_TYPE_NUM_CNTS_Msk                (0xFFUL /*<< PMU_TYPE_NUM_CNTS_Pos*/)         /*!< PMU TYPE: Number of Counters Mask */
+
+#define PMU_TYPE_SIZE_CNTS_Pos                8U                                           /*!< PMU TYPE: Size of Counters Position */
+#define PMU_TYPE_SIZE_CNTS_Msk               (0x3FUL << PMU_TYPE_SIZE_CNTS_Pos)            /*!< PMU TYPE: Size of Counters Mask */
+
+#define PMU_TYPE_CYCCNT_PRESENT_Pos           14U                                          /*!< PMU TYPE: Cycle Counter Present Position */
+#define PMU_TYPE_CYCCNT_PRESENT_Msk          (1UL << PMU_TYPE_CYCCNT_PRESENT_Pos)          /*!< PMU TYPE: Cycle Counter Present Mask */
+
+#define PMU_TYPE_FRZ_OV_SUPPORT_Pos           21U                                          /*!< PMU TYPE: Freeze-on-overflow Support Position */
+#define PMU_TYPE_FRZ_OV_SUPPORT_Msk          (1UL << PMU_TYPE_FRZ_OV_SUPPORT_Pos)          /*!< PMU TYPE: Freeze-on-overflow Support Mask */
+
+#define PMU_TYPE_TRACE_ON_OV_SUPPORT_Pos      23U                                          /*!< PMU TYPE: Trace-on-overflow Support Position */
+#define PMU_TYPE_TRACE_ON_OV_SUPPORT_Msk     (1UL << PMU_TYPE_FRZ_OV_SUPPORT_Pos)          /*!< PMU TYPE: Trace-on-overflow Support Mask */
+
+/** \brief PMU Authentication Status Register Definitions */
+#define PMU_AUTHSTATUS_NSID_Pos               0U                                           /*!< PMU AUTHSTATUS: Non-secure Invasive Debug Position */
+#define PMU_AUTHSTATUS_NSID_Msk              (0x3UL /*<< PMU_AUTHSTATUS_NSID_Pos*/)        /*!< PMU AUTHSTATUS: Non-secure Invasive Debug Mask */
+
+#define PMU_AUTHSTATUS_NSNID_Pos              2U                                           /*!< PMU AUTHSTATUS: Non-secure Non-invasive Debug Position */
+#define PMU_AUTHSTATUS_NSNID_Msk             (0x3UL << PMU_AUTHSTATUS_NSNID_Pos)           /*!< PMU AUTHSTATUS: Non-secure Non-invasive Debug Mask */
+
+#define PMU_AUTHSTATUS_SID_Pos                4U                                           /*!< PMU AUTHSTATUS: Secure Invasive Debug Position */
+#define PMU_AUTHSTATUS_SID_Msk               (0x3UL << PMU_AUTHSTATUS_SID_Pos)             /*!< PMU AUTHSTATUS: Secure Invasive Debug Mask */
+
+#define PMU_AUTHSTATUS_SNID_Pos               6U                                           /*!< PMU AUTHSTATUS: Secure Non-invasive Debug Position */
+#define PMU_AUTHSTATUS_SNID_Msk              (0x3UL << PMU_AUTHSTATUS_SNID_Pos)            /*!< PMU AUTHSTATUS: Secure Non-invasive Debug Mask */
+
+#define PMU_AUTHSTATUS_NSUID_Pos              16U                                          /*!< PMU AUTHSTATUS: Non-secure Unprivileged Invasive Debug Position */
+#define PMU_AUTHSTATUS_NSUID_Msk             (0x3UL << PMU_AUTHSTATUS_NSUID_Pos)           /*!< PMU AUTHSTATUS: Non-secure Unprivileged Invasive Debug Mask */
+
+#define PMU_AUTHSTATUS_NSUNID_Pos             18U                                          /*!< PMU AUTHSTATUS: Non-secure Unprivileged Non-invasive Debug Position */
+#define PMU_AUTHSTATUS_NSUNID_Msk            (0x3UL << PMU_AUTHSTATUS_NSUNID_Pos)          /*!< PMU AUTHSTATUS: Non-secure Unprivileged Non-invasive Debug Mask */
+
+#define PMU_AUTHSTATUS_SUID_Pos               20U                                          /*!< PMU AUTHSTATUS: Secure Unprivileged Invasive Debug Position */
+#define PMU_AUTHSTATUS_SUID_Msk              (0x3UL << PMU_AUTHSTATUS_SUID_Pos)            /*!< PMU AUTHSTATUS: Secure Unprivileged Invasive Debug Mask */
+
+#define PMU_AUTHSTATUS_SUNID_Pos              22U                                          /*!< PMU AUTHSTATUS: Secure Unprivileged Non-invasive Debug Position */
+#define PMU_AUTHSTATUS_SUNID_Msk             (0x3UL << PMU_AUTHSTATUS_SUNID_Pos)           /*!< PMU AUTHSTATUS: Secure Unprivileged Non-invasive Debug Mask */
+
+/*@} end of group CMSIS_PMU */
+#endif
+
+
+#if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_MPU     Memory Protection Unit (MPU)
+  \brief    Type definitions for the Memory Protection Unit (MPU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Memory Protection Unit (MPU).
+ */
+typedef struct
+{
+  __IM  uint32_t TYPE;                   /*!< Offset: 0x000 (R/ )  MPU Type Register */
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x004 (R/W)  MPU Control Register */
+  __IOM uint32_t RNR;                    /*!< Offset: 0x008 (R/W)  MPU Region Number Register */
+  __IOM uint32_t RBAR;                   /*!< Offset: 0x00C (R/W)  MPU Region Base Address Register */
+  __IOM uint32_t RLAR;                   /*!< Offset: 0x010 (R/W)  MPU Region Limit Address Register */
+  __IOM uint32_t RBAR_A1;                /*!< Offset: 0x014 (R/W)  MPU Region Base Address Register Alias 1 */
+  __IOM uint32_t RLAR_A1;                /*!< Offset: 0x018 (R/W)  MPU Region Limit Address Register Alias 1 */
+  __IOM uint32_t RBAR_A2;                /*!< Offset: 0x01C (R/W)  MPU Region Base Address Register Alias 2 */
+  __IOM uint32_t RLAR_A2;                /*!< Offset: 0x020 (R/W)  MPU Region Limit Address Register Alias 2 */
+  __IOM uint32_t RBAR_A3;                /*!< Offset: 0x024 (R/W)  MPU Region Base Address Register Alias 3 */
+  __IOM uint32_t RLAR_A3;                /*!< Offset: 0x028 (R/W)  MPU Region Limit Address Register Alias 3 */
+        uint32_t RESERVED0[1];
+  union {
+  __IOM uint32_t MAIR[2];
+  struct {
+  __IOM uint32_t MAIR0;                  /*!< Offset: 0x030 (R/W)  MPU Memory Attribute Indirection Register 0 */
+  __IOM uint32_t MAIR1;                  /*!< Offset: 0x034 (R/W)  MPU Memory Attribute Indirection Register 1 */
+  };
+  };
+} MPU_Type;
+
+#define MPU_TYPE_RALIASES                  4U
+
+/** \brief MPU Type Register Definitions */
+#define MPU_TYPE_IREGION_Pos               16U                                            /*!< MPU TYPE: IREGION Position */
+#define MPU_TYPE_IREGION_Msk               (0xFFUL << MPU_TYPE_IREGION_Pos)               /*!< MPU TYPE: IREGION Mask */
+
+#define MPU_TYPE_DREGION_Pos                8U                                            /*!< MPU TYPE: DREGION Position */
+#define MPU_TYPE_DREGION_Msk               (0xFFUL << MPU_TYPE_DREGION_Pos)               /*!< MPU TYPE: DREGION Mask */
+
+#define MPU_TYPE_SEPARATE_Pos               0U                                            /*!< MPU TYPE: SEPARATE Position */
+#define MPU_TYPE_SEPARATE_Msk              (1UL /*<< MPU_TYPE_SEPARATE_Pos*/)             /*!< MPU TYPE: SEPARATE Mask */
+
+/** \brief MPU Control Register Definitions */
+#define MPU_CTRL_PRIVDEFENA_Pos             2U                                            /*!< MPU CTRL: PRIVDEFENA Position */
+#define MPU_CTRL_PRIVDEFENA_Msk            (1UL << MPU_CTRL_PRIVDEFENA_Pos)               /*!< MPU CTRL: PRIVDEFENA Mask */
+
+#define MPU_CTRL_HFNMIENA_Pos               1U                                            /*!< MPU CTRL: HFNMIENA Position */
+#define MPU_CTRL_HFNMIENA_Msk              (1UL << MPU_CTRL_HFNMIENA_Pos)                 /*!< MPU CTRL: HFNMIENA Mask */
+
+#define MPU_CTRL_ENABLE_Pos                 0U                                            /*!< MPU CTRL: ENABLE Position */
+#define MPU_CTRL_ENABLE_Msk                (1UL /*<< MPU_CTRL_ENABLE_Pos*/)               /*!< MPU CTRL: ENABLE Mask */
+
+/** \brief MPU Region Number Register Definitions */
+#define MPU_RNR_REGION_Pos                  0U                                            /*!< MPU RNR: REGION Position */
+#define MPU_RNR_REGION_Msk                 (0xFFUL /*<< MPU_RNR_REGION_Pos*/)             /*!< MPU RNR: REGION Mask */
+
+/** \brief MPU Region Base Address Register Definitions */
+#define MPU_RBAR_BASE_Pos                   5U                                            /*!< MPU RBAR: BASE Position */
+#define MPU_RBAR_BASE_Msk                  (0x7FFFFFFUL << MPU_RBAR_BASE_Pos)             /*!< MPU RBAR: BASE Mask */
+
+#define MPU_RBAR_SH_Pos                     3U                                            /*!< MPU RBAR: SH Position */
+#define MPU_RBAR_SH_Msk                    (0x3UL << MPU_RBAR_SH_Pos)                     /*!< MPU RBAR: SH Mask */
+
+#define MPU_RBAR_AP_Pos                     1U                                            /*!< MPU RBAR: AP Position */
+#define MPU_RBAR_AP_Msk                    (0x3UL << MPU_RBAR_AP_Pos)                     /*!< MPU RBAR: AP Mask */
+
+#define MPU_RBAR_XN_Pos                     0U                                            /*!< MPU RBAR: XN Position */
+#define MPU_RBAR_XN_Msk                    (01UL /*<< MPU_RBAR_XN_Pos*/)                  /*!< MPU RBAR: XN Mask */
+
+/** \brief MPU Region Limit Address Register Definitions */
+#define MPU_RLAR_LIMIT_Pos                  5U                                            /*!< MPU RLAR: LIMIT Position */
+#define MPU_RLAR_LIMIT_Msk                 (0x7FFFFFFUL << MPU_RLAR_LIMIT_Pos)            /*!< MPU RLAR: LIMIT Mask */
+
+#define MPU_RLAR_PXN_Pos                    4U                                            /*!< MPU RLAR: PXN Position */
+#define MPU_RLAR_PXN_Msk                   (1UL << MPU_RLAR_PXN_Pos)                      /*!< MPU RLAR: PXN Mask */
+
+#define MPU_RLAR_AttrIndx_Pos               1U                                            /*!< MPU RLAR: AttrIndx Position */
+#define MPU_RLAR_AttrIndx_Msk              (0x7UL << MPU_RLAR_AttrIndx_Pos)               /*!< MPU RLAR: AttrIndx Mask */
+
+#define MPU_RLAR_EN_Pos                     0U                                            /*!< MPU RLAR: Region enable bit Position */
+#define MPU_RLAR_EN_Msk                    (1UL /*<< MPU_RLAR_EN_Pos*/)                   /*!< MPU RLAR: Region enable bit Mask */
+
+/** \brief MPU Memory Attribute Indirection Register 0 Definitions */
+#define MPU_MAIR0_Attr3_Pos                24U                                            /*!< MPU MAIR0: Attr3 Position */
+#define MPU_MAIR0_Attr3_Msk                (0xFFUL << MPU_MAIR0_Attr3_Pos)                /*!< MPU MAIR0: Attr3 Mask */
+
+#define MPU_MAIR0_Attr2_Pos                16U                                            /*!< MPU MAIR0: Attr2 Position */
+#define MPU_MAIR0_Attr2_Msk                (0xFFUL << MPU_MAIR0_Attr2_Pos)                /*!< MPU MAIR0: Attr2 Mask */
+
+#define MPU_MAIR0_Attr1_Pos                 8U                                            /*!< MPU MAIR0: Attr1 Position */
+#define MPU_MAIR0_Attr1_Msk                (0xFFUL << MPU_MAIR0_Attr1_Pos)                /*!< MPU MAIR0: Attr1 Mask */
+
+#define MPU_MAIR0_Attr0_Pos                 0U                                            /*!< MPU MAIR0: Attr0 Position */
+#define MPU_MAIR0_Attr0_Msk                (0xFFUL /*<< MPU_MAIR0_Attr0_Pos*/)            /*!< MPU MAIR0: Attr0 Mask */
+
+/** \brief MPU Memory Attribute Indirection Register 1 Definitions */
+#define MPU_MAIR1_Attr7_Pos                24U                                            /*!< MPU MAIR1: Attr7 Position */
+#define MPU_MAIR1_Attr7_Msk                (0xFFUL << MPU_MAIR1_Attr7_Pos)                /*!< MPU MAIR1: Attr7 Mask */
+
+#define MPU_MAIR1_Attr6_Pos                16U                                            /*!< MPU MAIR1: Attr6 Position */
+#define MPU_MAIR1_Attr6_Msk                (0xFFUL << MPU_MAIR1_Attr6_Pos)                /*!< MPU MAIR1: Attr6 Mask */
+
+#define MPU_MAIR1_Attr5_Pos                 8U                                            /*!< MPU MAIR1: Attr5 Position */
+#define MPU_MAIR1_Attr5_Msk                (0xFFUL << MPU_MAIR1_Attr5_Pos)                /*!< MPU MAIR1: Attr5 Mask */
+
+#define MPU_MAIR1_Attr4_Pos                 0U                                            /*!< MPU MAIR1: Attr4 Position */
+#define MPU_MAIR1_Attr4_Msk                (0xFFUL /*<< MPU_MAIR1_Attr4_Pos*/)            /*!< MPU MAIR1: Attr4 Mask */
+
+/*@} end of group CMSIS_MPU */
+#endif
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SAU     Security Attribution Unit (SAU)
+  \brief    Type definitions for the Security Attribution Unit (SAU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Security Attribution Unit (SAU).
+ */
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  SAU Control Register */
+  __IM  uint32_t TYPE;                   /*!< Offset: 0x004 (R/ )  SAU Type Register */
+#if defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U)
+  __IOM uint32_t RNR;                    /*!< Offset: 0x008 (R/W)  SAU Region Number Register */
+  __IOM uint32_t RBAR;                   /*!< Offset: 0x00C (R/W)  SAU Region Base Address Register */
+  __IOM uint32_t RLAR;                   /*!< Offset: 0x010 (R/W)  SAU Region Limit Address Register */
+#else
+        uint32_t RESERVED0[3];
+#endif
+  __IOM uint32_t SFSR;                   /*!< Offset: 0x014 (R/W)  Secure Fault Status Register */
+  __IOM uint32_t SFAR;                   /*!< Offset: 0x018 (R/W)  Secure Fault Address Register */
+} SAU_Type;
+
+/** \brief SAU Control Register Definitions */
+#define SAU_CTRL_ALLNS_Pos                  1U                                            /*!< SAU CTRL: ALLNS Position */
+#define SAU_CTRL_ALLNS_Msk                 (1UL << SAU_CTRL_ALLNS_Pos)                    /*!< SAU CTRL: ALLNS Mask */
+
+#define SAU_CTRL_ENABLE_Pos                 0U                                            /*!< SAU CTRL: ENABLE Position */
+#define SAU_CTRL_ENABLE_Msk                (1UL /*<< SAU_CTRL_ENABLE_Pos*/)               /*!< SAU CTRL: ENABLE Mask */
+
+/** \brief SAU Type Register Definitions */
+#define SAU_TYPE_SREGION_Pos                0U                                            /*!< SAU TYPE: SREGION Position */
+#define SAU_TYPE_SREGION_Msk               (0xFFUL /*<< SAU_TYPE_SREGION_Pos*/)           /*!< SAU TYPE: SREGION Mask */
+
+#if defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U)
+/** \brief SAU Region Number Register Definitions */
+#define SAU_RNR_REGION_Pos                  0U                                            /*!< SAU RNR: REGION Position */
+#define SAU_RNR_REGION_Msk                 (0xFFUL /*<< SAU_RNR_REGION_Pos*/)             /*!< SAU RNR: REGION Mask */
+
+/** \brief SAU Region Base Address Register Definitions */
+#define SAU_RBAR_BADDR_Pos                  5U                                            /*!< SAU RBAR: BADDR Position */
+#define SAU_RBAR_BADDR_Msk                 (0x7FFFFFFUL << SAU_RBAR_BADDR_Pos)            /*!< SAU RBAR: BADDR Mask */
+
+/** \brief SAU Region Limit Address Register Definitions */
+#define SAU_RLAR_LADDR_Pos                  5U                                            /*!< SAU RLAR: LADDR Position */
+#define SAU_RLAR_LADDR_Msk                 (0x7FFFFFFUL << SAU_RLAR_LADDR_Pos)            /*!< SAU RLAR: LADDR Mask */
+
+#define SAU_RLAR_NSC_Pos                    1U                                            /*!< SAU RLAR: NSC Position */
+#define SAU_RLAR_NSC_Msk                   (1UL << SAU_RLAR_NSC_Pos)                      /*!< SAU RLAR: NSC Mask */
+
+#define SAU_RLAR_ENABLE_Pos                 0U                                            /*!< SAU RLAR: ENABLE Position */
+#define SAU_RLAR_ENABLE_Msk                (1UL /*<< SAU_RLAR_ENABLE_Pos*/)               /*!< SAU RLAR: ENABLE Mask */
+
+#endif /* defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U) */
+
+/** \brief SAU Secure Fault Status Register Definitions */
+#define SAU_SFSR_LSERR_Pos                  7U                                            /*!< SAU SFSR: LSERR Position */
+#define SAU_SFSR_LSERR_Msk                 (1UL << SAU_SFSR_LSERR_Pos)                    /*!< SAU SFSR: LSERR Mask */
+
+#define SAU_SFSR_SFARVALID_Pos              6U                                            /*!< SAU SFSR: SFARVALID Position */
+#define SAU_SFSR_SFARVALID_Msk             (1UL << SAU_SFSR_SFARVALID_Pos)                /*!< SAU SFSR: SFARVALID Mask */
+
+#define SAU_SFSR_LSPERR_Pos                 5U                                            /*!< SAU SFSR: LSPERR Position */
+#define SAU_SFSR_LSPERR_Msk                (1UL << SAU_SFSR_LSPERR_Pos)                   /*!< SAU SFSR: LSPERR Mask */
+
+#define SAU_SFSR_INVTRAN_Pos                4U                                            /*!< SAU SFSR: INVTRAN Position */
+#define SAU_SFSR_INVTRAN_Msk               (1UL << SAU_SFSR_INVTRAN_Pos)                  /*!< SAU SFSR: INVTRAN Mask */
+
+#define SAU_SFSR_AUVIOL_Pos                 3U                                            /*!< SAU SFSR: AUVIOL Position */
+#define SAU_SFSR_AUVIOL_Msk                (1UL << SAU_SFSR_AUVIOL_Pos)                   /*!< SAU SFSR: AUVIOL Mask */
+
+#define SAU_SFSR_INVER_Pos                  2U                                            /*!< SAU SFSR: INVER Position */
+#define SAU_SFSR_INVER_Msk                 (1UL << SAU_SFSR_INVER_Pos)                    /*!< SAU SFSR: INVER Mask */
+
+#define SAU_SFSR_INVIS_Pos                  1U                                            /*!< SAU SFSR: INVIS Position */
+#define SAU_SFSR_INVIS_Msk                 (1UL << SAU_SFSR_INVIS_Pos)                    /*!< SAU SFSR: INVIS Mask */
+
+#define SAU_SFSR_INVEP_Pos                  0U                                            /*!< SAU SFSR: INVEP Position */
+#define SAU_SFSR_INVEP_Msk                 (1UL /*<< SAU_SFSR_INVEP_Pos*/)                /*!< SAU SFSR: INVEP Mask */
+
+/*@} end of group CMSIS_SAU */
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_FPU     Floating Point Unit (FPU)
+  \brief    Type definitions for the Floating Point Unit (FPU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Floating Point Unit (FPU).
+ */
+typedef struct
+{
+        uint32_t RESERVED0[1U];
+  __IOM uint32_t FPCCR;                  /*!< Offset: 0x004 (R/W)  Floating-Point Context Control Register */
+  __IOM uint32_t FPCAR;                  /*!< Offset: 0x008 (R/W)  Floating-Point Context Address Register */
+  __IOM uint32_t FPDSCR;                 /*!< Offset: 0x00C (R/W)  Floating-Point Default Status Control Register */
+  __IM  uint32_t MVFR0;                  /*!< Offset: 0x010 (R/ )  Media and VFP Feature Register 0 */
+  __IM  uint32_t MVFR1;                  /*!< Offset: 0x014 (R/ )  Media and VFP Feature Register 1 */
+  __IM  uint32_t MVFR2;                  /*!< Offset: 0x018 (R/ )  Media and VFP Feature Register 2 */
+} FPU_Type;
+
+/** \brief FPU Floating-Point Context Control Register Definitions */
+#define FPU_FPCCR_ASPEN_Pos                31U                                            /*!< FPCCR: ASPEN bit Position */
+#define FPU_FPCCR_ASPEN_Msk                (1UL << FPU_FPCCR_ASPEN_Pos)                   /*!< FPCCR: ASPEN bit Mask */
+
+#define FPU_FPCCR_LSPEN_Pos                30U                                            /*!< FPCCR: LSPEN Position */
+#define FPU_FPCCR_LSPEN_Msk                (1UL << FPU_FPCCR_LSPEN_Pos)                   /*!< FPCCR: LSPEN bit Mask */
+
+#define FPU_FPCCR_LSPENS_Pos               29U                                            /*!< FPCCR: LSPENS Position */
+#define FPU_FPCCR_LSPENS_Msk               (1UL << FPU_FPCCR_LSPENS_Pos)                  /*!< FPCCR: LSPENS bit Mask */
+
+#define FPU_FPCCR_CLRONRET_Pos             28U                                            /*!< FPCCR: CLRONRET Position */
+#define FPU_FPCCR_CLRONRET_Msk             (1UL << FPU_FPCCR_CLRONRET_Pos)                /*!< FPCCR: CLRONRET bit Mask */
+
+#define FPU_FPCCR_CLRONRETS_Pos            27U                                            /*!< FPCCR: CLRONRETS Position */
+#define FPU_FPCCR_CLRONRETS_Msk            (1UL << FPU_FPCCR_CLRONRETS_Pos)               /*!< FPCCR: CLRONRETS bit Mask */
+
+#define FPU_FPCCR_TS_Pos                   26U                                            /*!< FPCCR: TS Position */
+#define FPU_FPCCR_TS_Msk                   (1UL << FPU_FPCCR_TS_Pos)                      /*!< FPCCR: TS bit Mask */
+
+#define FPU_FPCCR_UFRDY_Pos                10U                                            /*!< FPCCR: UFRDY Position */
+#define FPU_FPCCR_UFRDY_Msk                (1UL << FPU_FPCCR_UFRDY_Pos)                   /*!< FPCCR: UFRDY bit Mask */
+
+#define FPU_FPCCR_SPLIMVIOL_Pos             9U                                            /*!< FPCCR: SPLIMVIOL Position */
+#define FPU_FPCCR_SPLIMVIOL_Msk            (1UL << FPU_FPCCR_SPLIMVIOL_Pos)               /*!< FPCCR: SPLIMVIOL bit Mask */
+
+#define FPU_FPCCR_MONRDY_Pos                8U                                            /*!< FPCCR: MONRDY Position */
+#define FPU_FPCCR_MONRDY_Msk               (1UL << FPU_FPCCR_MONRDY_Pos)                  /*!< FPCCR: MONRDY bit Mask */
+
+#define FPU_FPCCR_SFRDY_Pos                 7U                                            /*!< FPCCR: SFRDY Position */
+#define FPU_FPCCR_SFRDY_Msk                (1UL << FPU_FPCCR_SFRDY_Pos)                   /*!< FPCCR: SFRDY bit Mask */
+
+#define FPU_FPCCR_BFRDY_Pos                 6U                                            /*!< FPCCR: BFRDY Position */
+#define FPU_FPCCR_BFRDY_Msk                (1UL << FPU_FPCCR_BFRDY_Pos)                   /*!< FPCCR: BFRDY bit Mask */
+
+#define FPU_FPCCR_MMRDY_Pos                 5U                                            /*!< FPCCR: MMRDY Position */
+#define FPU_FPCCR_MMRDY_Msk                (1UL << FPU_FPCCR_MMRDY_Pos)                   /*!< FPCCR: MMRDY bit Mask */
+
+#define FPU_FPCCR_HFRDY_Pos                 4U                                            /*!< FPCCR: HFRDY Position */
+#define FPU_FPCCR_HFRDY_Msk                (1UL << FPU_FPCCR_HFRDY_Pos)                   /*!< FPCCR: HFRDY bit Mask */
+
+#define FPU_FPCCR_THREAD_Pos                3U                                            /*!< FPCCR: processor mode bit Position */
+#define FPU_FPCCR_THREAD_Msk               (1UL << FPU_FPCCR_THREAD_Pos)                  /*!< FPCCR: processor mode active bit Mask */
+
+#define FPU_FPCCR_S_Pos                     2U                                            /*!< FPCCR: Security status of the FP context bit Position */
+#define FPU_FPCCR_S_Msk                    (1UL << FPU_FPCCR_S_Pos)                       /*!< FPCCR: Security status of the FP context bit Mask */
+
+#define FPU_FPCCR_USER_Pos                  1U                                            /*!< FPCCR: privilege level bit Position */
+#define FPU_FPCCR_USER_Msk                 (1UL << FPU_FPCCR_USER_Pos)                    /*!< FPCCR: privilege level bit Mask */
+
+#define FPU_FPCCR_LSPACT_Pos                0U                                            /*!< FPCCR: Lazy state preservation active bit Position */
+#define FPU_FPCCR_LSPACT_Msk               (1UL /*<< FPU_FPCCR_LSPACT_Pos*/)              /*!< FPCCR: Lazy state preservation active bit Mask */
+
+/** \brief FPU Floating-Point Context Address Register Definitions */
+#define FPU_FPCAR_ADDRESS_Pos               3U                                            /*!< FPCAR: ADDRESS bit Position */
+#define FPU_FPCAR_ADDRESS_Msk              (0x1FFFFFFFUL << FPU_FPCAR_ADDRESS_Pos)        /*!< FPCAR: ADDRESS bit Mask */
+
+/** \brief FPU Floating-Point Default Status Control Register Definitions */
+#define FPU_FPDSCR_AHP_Pos                 26U                                            /*!< FPDSCR: AHP bit Position */
+#define FPU_FPDSCR_AHP_Msk                 (1UL << FPU_FPDSCR_AHP_Pos)                    /*!< FPDSCR: AHP bit Mask */
+
+#define FPU_FPDSCR_DN_Pos                  25U                                            /*!< FPDSCR: DN bit Position */
+#define FPU_FPDSCR_DN_Msk                  (1UL << FPU_FPDSCR_DN_Pos)                     /*!< FPDSCR: DN bit Mask */
+
+#define FPU_FPDSCR_FZ_Pos                  24U                                            /*!< FPDSCR: FZ bit Position */
+#define FPU_FPDSCR_FZ_Msk                  (1UL << FPU_FPDSCR_FZ_Pos)                     /*!< FPDSCR: FZ bit Mask */
+
+#define FPU_FPDSCR_RMode_Pos               22U                                            /*!< FPDSCR: RMode bit Position */
+#define FPU_FPDSCR_RMode_Msk               (3UL << FPU_FPDSCR_RMode_Pos)                  /*!< FPDSCR: RMode bit Mask */
+
+#define FPU_FPDSCR_FZ16_Pos                19U                                            /*!< FPDSCR: FZ16 bit Position */
+#define FPU_FPDSCR_FZ16_Msk                (1UL << FPU_FPDSCR_FZ16_Pos)                   /*!< FPDSCR: FZ16 bit Mask */
+
+#define FPU_FPDSCR_LTPSIZE_Pos             16U                                            /*!< FPDSCR: LTPSIZE bit Position */
+#define FPU_FPDSCR_LTPSIZE_Msk             (7UL << FPU_FPDSCR_LTPSIZE_Pos)                /*!< FPDSCR: LTPSIZE bit Mask */
+
+/** \brief FPU Media and VFP Feature Register 0 Definitions */
+#define FPU_MVFR0_FPRound_Pos              28U                                            /*!< MVFR0: Rounding modes bits Position */
+#define FPU_MVFR0_FPRound_Msk              (0xFUL << FPU_MVFR0_FPRound_Pos)               /*!< MVFR0: Rounding modes bits Mask */
+
+#define FPU_MVFR0_FPSqrt_Pos               20U                                            /*!< MVFR0: Square root bits Position */
+#define FPU_MVFR0_FPSqrt_Msk               (0xFUL << FPU_MVFR0_FPSqrt_Pos)                /*!< MVFR0: Square root bits Mask */
+
+#define FPU_MVFR0_FPDivide_Pos             16U                                            /*!< MVFR0: Divide bits Position */
+#define FPU_MVFR0_FPDivide_Msk             (0xFUL << FPU_MVFR0_FPDivide_Pos)              /*!< MVFR0: Divide bits Mask */
+
+#define FPU_MVFR0_FPDP_Pos                  8U                                            /*!< MVFR0: Double-precision bits Position */
+#define FPU_MVFR0_FPDP_Msk                 (0xFUL << FPU_MVFR0_FPDP_Pos)                  /*!< MVFR0: Double-precision bits Mask */
+
+#define FPU_MVFR0_FPSP_Pos                  4U                                            /*!< MVFR0: Single-precision bits Position */
+#define FPU_MVFR0_FPSP_Msk                 (0xFUL << FPU_MVFR0_FPSP_Pos)                  /*!< MVFR0: Single-precision bits Mask */
+
+#define FPU_MVFR0_SIMDReg_Pos               0U                                            /*!< MVFR0: SIMD registers bits Position */
+#define FPU_MVFR0_SIMDReg_Msk              (0xFUL /*<< FPU_MVFR0_SIMDReg_Pos*/)           /*!< MVFR0: SIMD registers bits Mask */
+
+/** \brief FPU Media and VFP Feature Register 1 Definitions */
+#define FPU_MVFR1_FMAC_Pos                 28U                                            /*!< MVFR1: Fused MAC bits Position */
+#define FPU_MVFR1_FMAC_Msk                 (0xFUL << FPU_MVFR1_FMAC_Pos)                  /*!< MVFR1: Fused MAC bits Mask */
+
+#define FPU_MVFR1_FPHP_Pos                 24U                                            /*!< MVFR1: FP HPFP bits Position */
+#define FPU_MVFR1_FPHP_Msk                 (0xFUL << FPU_MVFR1_FPHP_Pos)                  /*!< MVFR1: FP HPFP bits Mask */
+
+#define FPU_MVFR1_FP16_Pos                 20U                                            /*!< MVFR1: FP16 bits Position */
+#define FPU_MVFR1_FP16_Msk                 (0xFUL << FPU_MVFR1_FP16_Pos)                  /*!< MVFR1: FP16 bits Mask */
+
+#define FPU_MVFR1_MVE_Pos                   8U                                            /*!< MVFR1: MVE bits Position */
+#define FPU_MVFR1_MVE_Msk                  (0xFUL << FPU_MVFR1_MVE_Pos)                   /*!< MVFR1: MVE bits Mask */
+
+#define FPU_MVFR1_FPDNaN_Pos                4U                                            /*!< MVFR1: D_NaN mode bits Position */
+#define FPU_MVFR1_FPDNaN_Msk               (0xFUL << FPU_MVFR1_FPDNaN_Pos)                /*!< MVFR1: D_NaN mode bits Mask */
+
+#define FPU_MVFR1_FPFtZ_Pos                 0U                                            /*!< MVFR1: FtZ mode bits Position */
+#define FPU_MVFR1_FPFtZ_Msk                (0xFUL /*<< FPU_MVFR1_FPFtZ_Pos*/)             /*!< MVFR1: FtZ mode bits Mask */
+
+/** \brief FPU Media and VFP Feature Register 2 Definitions */
+#define FPU_MVFR2_FPMisc_Pos                4U                                            /*!< MVFR2: VFP Misc bits Position */
+#define FPU_MVFR2_FPMisc_Msk               (0xFUL << FPU_MVFR2_FPMisc_Pos)                /*!< MVFR2: VFP Misc bits Mask */
+
+/*@} end of group CMSIS_FPU */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_DCB       Debug Control Block
+  \brief    Type definitions for the Debug Control Block Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Debug Control Block Registers (DCB).
+ */
+typedef struct
+{
+  __IOM uint32_t DHCSR;                  /*!< Offset: 0x000 (R/W)  Debug Halting Control and Status Register */
+  __OM  uint32_t DCRSR;                  /*!< Offset: 0x004 ( /W)  Debug Core Register Selector Register */
+  __IOM uint32_t DCRDR;                  /*!< Offset: 0x008 (R/W)  Debug Core Register Data Register */
+  __IOM uint32_t DEMCR;                  /*!< Offset: 0x00C (R/W)  Debug Exception and Monitor Control Register */
+  __OM  uint32_t DSCEMCR;                /*!< Offset: 0x010 ( /W)  Debug Set Clear Exception and Monitor Control Register */
+  __IOM uint32_t DAUTHCTRL;              /*!< Offset: 0x014 (R/W)  Debug Authentication Control Register */
+  __IOM uint32_t DSCSR;                  /*!< Offset: 0x018 (R/W)  Debug Security Control and Status Register */
+} DCB_Type;
+
+/** \brief DCB Debug Halting Control and Status Register Definitions */
+#define DCB_DHCSR_DBGKEY_Pos               16U                                            /*!< DCB DHCSR: Debug key Position */
+#define DCB_DHCSR_DBGKEY_Msk               (0xFFFFUL << DCB_DHCSR_DBGKEY_Pos)             /*!< DCB DHCSR: Debug key Mask */
+
+#define DCB_DHCSR_S_RESTART_ST_Pos         26U                                            /*!< DCB DHCSR: Restart sticky status Position */
+#define DCB_DHCSR_S_RESTART_ST_Msk         (1UL << DCB_DHCSR_S_RESTART_ST_Pos)            /*!< DCB DHCSR: Restart sticky status Mask */
+
+#define DCB_DHCSR_S_RESET_ST_Pos           25U                                            /*!< DCB DHCSR: Reset sticky status Position */
+#define DCB_DHCSR_S_RESET_ST_Msk           (1UL << DCB_DHCSR_S_RESET_ST_Pos)              /*!< DCB DHCSR: Reset sticky status Mask */
+
+#define DCB_DHCSR_S_RETIRE_ST_Pos          24U                                            /*!< DCB DHCSR: Retire sticky status Position */
+#define DCB_DHCSR_S_RETIRE_ST_Msk          (1UL << DCB_DHCSR_S_RETIRE_ST_Pos)             /*!< DCB DHCSR: Retire sticky status Mask */
+
+#define DCB_DHCSR_S_FPD_Pos                23U                                            /*!< DCB DHCSR: Floating-point registers Debuggable Position */
+#define DCB_DHCSR_S_FPD_Msk                (1UL << DCB_DHCSR_S_FPD_Pos)                   /*!< DCB DHCSR: Floating-point registers Debuggable Mask */
+
+#define DCB_DHCSR_S_SUIDE_Pos              22U                                            /*!< DCB DHCSR: Secure unprivileged halting debug enabled Position */
+#define DCB_DHCSR_S_SUIDE_Msk              (1UL << DCB_DHCSR_S_SUIDE_Pos)                 /*!< DCB DHCSR: Secure unprivileged halting debug enabled Mask */
+
+#define DCB_DHCSR_S_NSUIDE_Pos             21U                                            /*!< DCB DHCSR: Non-secure unprivileged halting debug enabled Position */
+#define DCB_DHCSR_S_NSUIDE_Msk             (1UL << DCB_DHCSR_S_NSUIDE_Pos)                /*!< DCB DHCSR: Non-secure unprivileged halting debug enabled Mask */
+
+#define DCB_DHCSR_S_SDE_Pos                20U                                            /*!< DCB DHCSR: Secure debug enabled Position */
+#define DCB_DHCSR_S_SDE_Msk                (1UL << DCB_DHCSR_S_SDE_Pos)                   /*!< DCB DHCSR: Secure debug enabled Mask */
+
+#define DCB_DHCSR_S_LOCKUP_Pos             19U                                            /*!< DCB DHCSR: Lockup status Position */
+#define DCB_DHCSR_S_LOCKUP_Msk             (1UL << DCB_DHCSR_S_LOCKUP_Pos)                /*!< DCB DHCSR: Lockup status Mask */
+
+#define DCB_DHCSR_S_SLEEP_Pos              18U                                            /*!< DCB DHCSR: Sleeping status Position */
+#define DCB_DHCSR_S_SLEEP_Msk              (1UL << DCB_DHCSR_S_SLEEP_Pos)                 /*!< DCB DHCSR: Sleeping status Mask */
+
+#define DCB_DHCSR_S_HALT_Pos               17U                                            /*!< DCB DHCSR: Halted status Position */
+#define DCB_DHCSR_S_HALT_Msk               (1UL << DCB_DHCSR_S_HALT_Pos)                  /*!< DCB DHCSR: Halted status Mask */
+
+#define DCB_DHCSR_S_REGRDY_Pos             16U                                            /*!< DCB DHCSR: Register ready status Position */
+#define DCB_DHCSR_S_REGRDY_Msk             (1UL << DCB_DHCSR_S_REGRDY_Pos)                /*!< DCB DHCSR: Register ready status Mask */
+
+#define DCB_DHCSR_C_PMOV_Pos                6U                                            /*!< DCB DHCSR: Halt on PMU overflow control Position */
+#define DCB_DHCSR_C_PMOV_Msk               (1UL << DCB_DHCSR_C_PMOV_Pos)                  /*!< DCB DHCSR: Halt on PMU overflow control Mask */
+
+#define DCB_DHCSR_C_SNAPSTALL_Pos           5U                                            /*!< DCB DHCSR: Snap stall control Position */
+#define DCB_DHCSR_C_SNAPSTALL_Msk          (1UL << DCB_DHCSR_C_SNAPSTALL_Pos)             /*!< DCB DHCSR: Snap stall control Mask */
+
+#define DCB_DHCSR_C_MASKINTS_Pos            3U                                            /*!< DCB DHCSR: Mask interrupts control Position */
+#define DCB_DHCSR_C_MASKINTS_Msk           (1UL << DCB_DHCSR_C_MASKINTS_Pos)              /*!< DCB DHCSR: Mask interrupts control Mask */
+
+#define DCB_DHCSR_C_STEP_Pos                2U                                            /*!< DCB DHCSR: Step control Position */
+#define DCB_DHCSR_C_STEP_Msk               (1UL << DCB_DHCSR_C_STEP_Pos)                  /*!< DCB DHCSR: Step control Mask */
+
+#define DCB_DHCSR_C_HALT_Pos                1U                                            /*!< DCB DHCSR: Halt control Position */
+#define DCB_DHCSR_C_HALT_Msk               (1UL << DCB_DHCSR_C_HALT_Pos)                  /*!< DCB DHCSR: Halt control Mask */
+
+#define DCB_DHCSR_C_DEBUGEN_Pos             0U                                            /*!< DCB DHCSR: Debug enable control Position */
+#define DCB_DHCSR_C_DEBUGEN_Msk            (1UL /*<< DCB_DHCSR_C_DEBUGEN_Pos*/)           /*!< DCB DHCSR: Debug enable control Mask */
+
+/** \brief DCB Debug Core Register Selector Register Definitions */
+#define DCB_DCRSR_REGWnR_Pos               16U                                            /*!< DCB DCRSR: Register write/not-read Position */
+#define DCB_DCRSR_REGWnR_Msk               (1UL << DCB_DCRSR_REGWnR_Pos)                  /*!< DCB DCRSR: Register write/not-read Mask */
+
+#define DCB_DCRSR_REGSEL_Pos                0U                                            /*!< DCB DCRSR: Register selector Position */
+#define DCB_DCRSR_REGSEL_Msk               (0x7FUL /*<< DCB_DCRSR_REGSEL_Pos*/)           /*!< DCB DCRSR: Register selector Mask */
+
+/** \brief DCB Debug Core Register Data Register Definitions */
+#define DCB_DCRDR_DBGTMP_Pos                0U                                            /*!< DCB DCRDR: Data temporary buffer Position */
+#define DCB_DCRDR_DBGTMP_Msk               (0xFFFFFFFFUL /*<< DCB_DCRDR_DBGTMP_Pos*/)     /*!< DCB DCRDR: Data temporary buffer Mask */
+
+/** \brief DCB Debug Exception and Monitor Control Register Definitions */
+#define DCB_DEMCR_TRCENA_Pos               24U                                            /*!< DCB DEMCR: Trace enable Position */
+#define DCB_DEMCR_TRCENA_Msk               (1UL << DCB_DEMCR_TRCENA_Pos)                  /*!< DCB DEMCR: Trace enable Mask */
+
+#define DCB_DEMCR_MONPRKEY_Pos             23U                                            /*!< DCB DEMCR: Monitor pend req key Position */
+#define DCB_DEMCR_MONPRKEY_Msk             (1UL << DCB_DEMCR_MONPRKEY_Pos)                /*!< DCB DEMCR: Monitor pend req key Mask */
+
+#define DCB_DEMCR_UMON_EN_Pos              21U                                            /*!< DCB DEMCR: Unprivileged monitor enable Position */
+#define DCB_DEMCR_UMON_EN_Msk              (1UL << DCB_DEMCR_UMON_EN_Pos)                 /*!< DCB DEMCR: Unprivileged monitor enable Mask */
+
+#define DCB_DEMCR_SDME_Pos                 20U                                            /*!< DCB DEMCR: Secure DebugMonitor enable Position */
+#define DCB_DEMCR_SDME_Msk                 (1UL << DCB_DEMCR_SDME_Pos)                    /*!< DCB DEMCR: Secure DebugMonitor enable Mask */
+
+#define DCB_DEMCR_MON_REQ_Pos              19U                                            /*!< DCB DEMCR: Monitor request Position */
+#define DCB_DEMCR_MON_REQ_Msk              (1UL << DCB_DEMCR_MON_REQ_Pos)                 /*!< DCB DEMCR: Monitor request Mask */
+
+#define DCB_DEMCR_MON_STEP_Pos             18U                                            /*!< DCB DEMCR: Monitor step Position */
+#define DCB_DEMCR_MON_STEP_Msk             (1UL << DCB_DEMCR_MON_STEP_Pos)                /*!< DCB DEMCR: Monitor step Mask */
+
+#define DCB_DEMCR_MON_PEND_Pos             17U                                            /*!< DCB DEMCR: Monitor pend Position */
+#define DCB_DEMCR_MON_PEND_Msk             (1UL << DCB_DEMCR_MON_PEND_Pos)                /*!< DCB DEMCR: Monitor pend Mask */
+
+#define DCB_DEMCR_MON_EN_Pos               16U                                            /*!< DCB DEMCR: Monitor enable Position */
+#define DCB_DEMCR_MON_EN_Msk               (1UL << DCB_DEMCR_MON_EN_Pos)                  /*!< DCB DEMCR: Monitor enable Mask */
+
+#define DCB_DEMCR_VC_SFERR_Pos             11U                                            /*!< DCB DEMCR: Vector Catch SecureFault Position */
+#define DCB_DEMCR_VC_SFERR_Msk             (1UL << DCB_DEMCR_VC_SFERR_Pos)                /*!< DCB DEMCR: Vector Catch SecureFault Mask */
+
+#define DCB_DEMCR_VC_HARDERR_Pos           10U                                            /*!< DCB DEMCR: Vector Catch HardFault errors Position */
+#define DCB_DEMCR_VC_HARDERR_Msk           (1UL << DCB_DEMCR_VC_HARDERR_Pos)              /*!< DCB DEMCR: Vector Catch HardFault errors Mask */
+
+#define DCB_DEMCR_VC_INTERR_Pos             9U                                            /*!< DCB DEMCR: Vector Catch interrupt errors Position */
+#define DCB_DEMCR_VC_INTERR_Msk            (1UL << DCB_DEMCR_VC_INTERR_Pos)               /*!< DCB DEMCR: Vector Catch interrupt errors Mask */
+
+#define DCB_DEMCR_VC_BUSERR_Pos             8U                                            /*!< DCB DEMCR: Vector Catch BusFault errors Position */
+#define DCB_DEMCR_VC_BUSERR_Msk            (1UL << DCB_DEMCR_VC_BUSERR_Pos)               /*!< DCB DEMCR: Vector Catch BusFault errors Mask */
+
+#define DCB_DEMCR_VC_STATERR_Pos            7U                                            /*!< DCB DEMCR: Vector Catch state errors Position */
+#define DCB_DEMCR_VC_STATERR_Msk           (1UL << DCB_DEMCR_VC_STATERR_Pos)              /*!< DCB DEMCR: Vector Catch state errors Mask */
+
+#define DCB_DEMCR_VC_CHKERR_Pos             6U                                            /*!< DCB DEMCR: Vector Catch check errors Position */
+#define DCB_DEMCR_VC_CHKERR_Msk            (1UL << DCB_DEMCR_VC_CHKERR_Pos)               /*!< DCB DEMCR: Vector Catch check errors Mask */
+
+#define DCB_DEMCR_VC_NOCPERR_Pos            5U                                            /*!< DCB DEMCR: Vector Catch NOCP errors Position */
+#define DCB_DEMCR_VC_NOCPERR_Msk           (1UL << DCB_DEMCR_VC_NOCPERR_Pos)              /*!< DCB DEMCR: Vector Catch NOCP errors Mask */
+
+#define DCB_DEMCR_VC_MMERR_Pos              4U                                            /*!< DCB DEMCR: Vector Catch MemManage errors Position */
+#define DCB_DEMCR_VC_MMERR_Msk             (1UL << DCB_DEMCR_VC_MMERR_Pos)                /*!< DCB DEMCR: Vector Catch MemManage errors Mask */
+
+#define DCB_DEMCR_VC_CORERESET_Pos          0U                                            /*!< DCB DEMCR: Vector Catch Core reset Position */
+#define DCB_DEMCR_VC_CORERESET_Msk         (1UL /*<< DCB_DEMCR_VC_CORERESET_Pos*/)        /*!< DCB DEMCR: Vector Catch Core reset Mask */
+
+/** \brief DCB Debug Set Clear Exception and Monitor Control Register Definitions */
+#define DCB_DSCEMCR_CLR_MON_REQ_Pos        19U                                            /*!< DCB DSCEMCR: Clear monitor request Position */
+#define DCB_DSCEMCR_CLR_MON_REQ_Msk        (1UL << DCB_DSCEMCR_CLR_MON_REQ_Pos)           /*!< DCB DSCEMCR: Clear monitor request Mask */
+
+#define DCB_DSCEMCR_CLR_MON_PEND_Pos       17U                                            /*!< DCB DSCEMCR: Clear monitor pend Position */
+#define DCB_DSCEMCR_CLR_MON_PEND_Msk       (1UL << DCB_DSCEMCR_CLR_MON_PEND_Pos)          /*!< DCB DSCEMCR: Clear monitor pend Mask */
+
+#define DCB_DSCEMCR_SET_MON_REQ_Pos         3U                                            /*!< DCB DSCEMCR: Set monitor request Position */
+#define DCB_DSCEMCR_SET_MON_REQ_Msk        (1UL << DCB_DSCEMCR_SET_MON_REQ_Pos)           /*!< DCB DSCEMCR: Set monitor request Mask */
+
+#define DCB_DSCEMCR_SET_MON_PEND_Pos        1U                                            /*!< DCB DSCEMCR: Set monitor pend Position */
+#define DCB_DSCEMCR_SET_MON_PEND_Msk       (1UL << DCB_DSCEMCR_SET_MON_PEND_Pos)          /*!< DCB DSCEMCR: Set monitor pend Mask */
+
+/** \brief DCB Debug Authentication Control Register Definitions */
+#define DCB_DAUTHCTRL_UIDEN_Pos            10U                                            /*!< DCB DAUTHCTRL: Unprivileged Invasive Debug Enable Position */
+#define DCB_DAUTHCTRL_UIDEN_Msk            (1UL << DCB_DAUTHCTRL_UIDEN_Pos)               /*!< DCB DAUTHCTRL: Unprivileged Invasive Debug Enable Mask */
+
+#define DCB_DAUTHCTRL_UIDAPEN_Pos           9U                                            /*!< DCB DAUTHCTRL: Unprivileged Invasive DAP Access Enable Position */
+#define DCB_DAUTHCTRL_UIDAPEN_Msk          (1UL << DCB_DAUTHCTRL_UIDAPEN_Pos)             /*!< DCB DAUTHCTRL: Unprivileged Invasive DAP Access Enable Mask */
+
+#define DCB_DAUTHCTRL_FSDMA_Pos             8U                                            /*!< DCB DAUTHCTRL: Force Secure DebugMonitor Allowed Position */
+#define DCB_DAUTHCTRL_FSDMA_Msk            (1UL << DCB_DAUTHCTRL_FSDMA_Pos)               /*!< DCB DAUTHCTRL: Force Secure DebugMonitor Allowed Mask */
+
+#define DCB_DAUTHCTRL_INTSPNIDEN_Pos        3U                                            /*!< DCB DAUTHCTRL: Internal Secure non-invasive debug enable Position */
+#define DCB_DAUTHCTRL_INTSPNIDEN_Msk       (1UL << DCB_DAUTHCTRL_INTSPNIDEN_Pos)          /*!< DCB DAUTHCTRL: Internal Secure non-invasive debug enable Mask */
+
+#define DCB_DAUTHCTRL_SPNIDENSEL_Pos        2U                                            /*!< DCB DAUTHCTRL: Secure non-invasive debug enable select Position */
+#define DCB_DAUTHCTRL_SPNIDENSEL_Msk       (1UL << DCB_DAUTHCTRL_SPNIDENSEL_Pos)          /*!< DCB DAUTHCTRL: Secure non-invasive debug enable select Mask */
+
+#define DCB_DAUTHCTRL_INTSPIDEN_Pos         1U                                            /*!< DCB DAUTHCTRL: Internal Secure invasive debug enable Position */
+#define DCB_DAUTHCTRL_INTSPIDEN_Msk        (1UL << DCB_DAUTHCTRL_INTSPIDEN_Pos)           /*!< DCB DAUTHCTRL: Internal Secure invasive debug enable Mask */
+
+#define DCB_DAUTHCTRL_SPIDENSEL_Pos         0U                                            /*!< DCB DAUTHCTRL: Secure invasive debug enable select Position */
+#define DCB_DAUTHCTRL_SPIDENSEL_Msk        (1UL /*<< DCB_DAUTHCTRL_SPIDENSEL_Pos*/)       /*!< DCB DAUTHCTRL: Secure invasive debug enable select Mask */
+
+/** \brief DCB Debug Security Control and Status Register Definitions */
+#define DCB_DSCSR_CDSKEY_Pos               17U                                            /*!< DCB DSCSR: CDS write-enable key Position */
+#define DCB_DSCSR_CDSKEY_Msk               (1UL << DCB_DSCSR_CDSKEY_Pos)                  /*!< DCB DSCSR: CDS write-enable key Mask */
+
+#define DCB_DSCSR_CDS_Pos                  16U                                            /*!< DCB DSCSR: Current domain Secure Position */
+#define DCB_DSCSR_CDS_Msk                  (1UL << DCB_DSCSR_CDS_Pos)                     /*!< DCB DSCSR: Current domain Secure Mask */
+
+#define DCB_DSCSR_SBRSEL_Pos                1U                                            /*!< DCB DSCSR: Secure banked register select Position */
+#define DCB_DSCSR_SBRSEL_Msk               (1UL << DCB_DSCSR_SBRSEL_Pos)                  /*!< DCB DSCSR: Secure banked register select Mask */
+
+#define DCB_DSCSR_SBRSELEN_Pos              0U                                            /*!< DCB DSCSR: Secure banked register select enable Position */
+#define DCB_DSCSR_SBRSELEN_Msk             (1UL /*<< DCB_DSCSR_SBRSELEN_Pos*/)            /*!< DCB DSCSR: Secure banked register select enable Mask */
+
+/*@} end of group CMSIS_DCB */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_DIB       Debug Identification Block
+  \brief    Type definitions for the Debug Identification Block Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Debug Identification Block Registers (DIB).
+ */
+typedef struct
+{
+        uint32_t RESERVED0[2U];
+  __IM  uint32_t DAUTHSTATUS;            /*!< Offset: 0x008 (R/ )  Debug Authentication Status Register */
+  __IM  uint32_t DDEVARCH;               /*!< Offset: 0x00C (R/ )  SCS Device Architecture Register */
+        uint32_t RESERVED1[3U];
+  __IM  uint32_t DDEVTYPE;               /*!< Offset: 0x01C (R/ )  SCS Device Type Register */
+} DIB_Type;
+
+/** \brief DIB Debug Authentication Status Register Definitions */
+#define DIB_DAUTHSTATUS_SUNID_Pos          22U                                            /*!< DIB DAUTHSTATUS: Secure Unprivileged Non-invasive Debug Allowed Position */
+#define DIB_DAUTHSTATUS_SUNID_Msk          (0x3UL << DIB_DAUTHSTATUS_SUNID_Pos )          /*!< DIB DAUTHSTATUS: Secure Unprivileged Non-invasive Debug Allowed Mask */
+
+#define DIB_DAUTHSTATUS_SUID_Pos           20U                                            /*!< DIB DAUTHSTATUS: Secure Unprivileged Invasive Debug Allowed Position */
+#define DIB_DAUTHSTATUS_SUID_Msk           (0x3UL << DIB_DAUTHSTATUS_SUID_Pos )           /*!< DIB DAUTHSTATUS: Secure Unprivileged Invasive Debug Allowed Mask */
+
+#define DIB_DAUTHSTATUS_NSUNID_Pos         18U                                            /*!< DIB DAUTHSTATUS: Non-secure Unprivileged Non-invasive Debug Allo Position */
+#define DIB_DAUTHSTATUS_NSUNID_Msk         (0x3UL << DIB_DAUTHSTATUS_NSUNID_Pos )         /*!< DIB DAUTHSTATUS: Non-secure Unprivileged Non-invasive Debug Allo Mask */
+
+#define DIB_DAUTHSTATUS_NSUID_Pos          16U                                            /*!< DIB DAUTHSTATUS: Non-secure Unprivileged Invasive Debug Allowed Position */
+#define DIB_DAUTHSTATUS_NSUID_Msk          (0x3UL << DIB_DAUTHSTATUS_NSUID_Pos )          /*!< DIB DAUTHSTATUS: Non-secure Unprivileged Invasive Debug Allowed Mask */
+
+#define DIB_DAUTHSTATUS_SNID_Pos            6U                                            /*!< DIB DAUTHSTATUS: Secure Non-invasive Debug Position */
+#define DIB_DAUTHSTATUS_SNID_Msk           (0x3UL << DIB_DAUTHSTATUS_SNID_Pos )           /*!< DIB DAUTHSTATUS: Secure Non-invasive Debug Mask */
+
+#define DIB_DAUTHSTATUS_SID_Pos             4U                                            /*!< DIB DAUTHSTATUS: Secure Invasive Debug Position */
+#define DIB_DAUTHSTATUS_SID_Msk            (0x3UL << DIB_DAUTHSTATUS_SID_Pos )            /*!< DIB DAUTHSTATUS: Secure Invasive Debug Mask */
+
+#define DIB_DAUTHSTATUS_NSNID_Pos           2U                                            /*!< DIB DAUTHSTATUS: Non-secure Non-invasive Debug Position */
+#define DIB_DAUTHSTATUS_NSNID_Msk          (0x3UL << DIB_DAUTHSTATUS_NSNID_Pos )          /*!< DIB DAUTHSTATUS: Non-secure Non-invasive Debug Mask */
+
+#define DIB_DAUTHSTATUS_NSID_Pos            0U                                            /*!< DIB DAUTHSTATUS: Non-secure Invasive Debug Position */
+#define DIB_DAUTHSTATUS_NSID_Msk           (0x3UL /*<< DIB_DAUTHSTATUS_NSID_Pos*/)        /*!< DIB DAUTHSTATUS: Non-secure Invasive Debug Mask */
+
+/** \brief DIB SCS Device Architecture Register Definitions */
+#define DIB_DDEVARCH_ARCHITECT_Pos         21U                                            /*!< DIB DDEVARCH: Architect Position */
+#define DIB_DDEVARCH_ARCHITECT_Msk         (0x7FFUL << DIB_DDEVARCH_ARCHITECT_Pos )       /*!< DIB DDEVARCH: Architect Mask */
+
+#define DIB_DDEVARCH_PRESENT_Pos           20U                                            /*!< DIB DDEVARCH: DEVARCH Present Position */
+#define DIB_DDEVARCH_PRESENT_Msk           (0x1FUL << DIB_DDEVARCH_PRESENT_Pos )          /*!< DIB DDEVARCH: DEVARCH Present Mask */
+
+#define DIB_DDEVARCH_REVISION_Pos          16U                                            /*!< DIB DDEVARCH: Revision Position */
+#define DIB_DDEVARCH_REVISION_Msk          (0xFUL << DIB_DDEVARCH_REVISION_Pos )          /*!< DIB DDEVARCH: Revision Mask */
+
+#define DIB_DDEVARCH_ARCHVER_Pos           12U                                            /*!< DIB DDEVARCH: Architecture Version Position */
+#define DIB_DDEVARCH_ARCHVER_Msk           (0xFUL << DIB_DDEVARCH_ARCHVER_Pos )           /*!< DIB DDEVARCH: Architecture Version Mask */
+
+#define DIB_DDEVARCH_ARCHPART_Pos           0U                                            /*!< DIB DDEVARCH: Architecture Part Position */
+#define DIB_DDEVARCH_ARCHPART_Msk          (0xFFFUL /*<< DIB_DDEVARCH_ARCHPART_Pos*/)     /*!< DIB DDEVARCH: Architecture Part Mask */
+
+/** \brief DIB SCS Device Type Register Definitions */
+#define DIB_DDEVTYPE_SUB_Pos                4U                                            /*!< DIB DDEVTYPE: Sub-type Position */
+#define DIB_DDEVTYPE_SUB_Msk               (0xFUL << DIB_DDEVTYPE_SUB_Pos )               /*!< DIB DDEVTYPE: Sub-type Mask */
+
+#define DIB_DDEVTYPE_MAJOR_Pos              0U                                            /*!< DIB DDEVTYPE: Major type Position */
+#define DIB_DDEVTYPE_MAJOR_Msk             (0xFUL /*<< DIB_DDEVTYPE_MAJOR_Pos*/)          /*!< DIB DDEVTYPE: Major type Mask */
+
+/*@} end of group CMSIS_DIB */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_core_bitfield     Core register bit field macros
+  \brief      Macros for use with bit field definitions (xxx_Pos, xxx_Msk).
+  @{
+ */
+
+/**
+  \brief   Mask and shift a bit field value for use in a register bit range.
+  \param[in] field  Name of the register bit field.
+  \param[in] value  Value of the bit field. This parameter is interpreted as an uint32_t type.
+  \return           Masked and shifted value.
+*/
+#define _VAL2FLD(field, value)    (((uint32_t)(value) << field ## _Pos) & field ## _Msk)
+
+/**
+  \brief     Mask and shift a register value to extract a bit filed value.
+  \param[in] field  Name of the register bit field.
+  \param[in] value  Value of register. This parameter is interpreted as an uint32_t type.
+  \return           Masked and shifted bit field value.
+*/
+#define _FLD2VAL(field, value)    (((uint32_t)(value) & field ## _Msk) >> field ## _Pos)
+
+/*@} end of group CMSIS_core_bitfield */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_core_base     Core Definitions
+  \brief      Definitions for base addresses, unions, and structures.
+  @{
+ */
+
+/* Memory mapping of Core Hardware */
+  #define SCS_BASE            (0xE000E000UL)                             /*!< System Control Space Base Address */
+  #define ITM_BASE            (0xE0000000UL)                             /*!< ITM Base Address */
+  #define DWT_BASE            (0xE0001000UL)                             /*!< DWT Base Address */
+  #define MEMSYSCTL_BASE      (0xE001E000UL)                             /*!< Memory System Control Base Address */
+  #define ERRBNK_BASE         (0xE001E100UL)                             /*!< Error Banking Base Address */
+  #define PWRMODCTL_BASE      (0xE001E300UL)                             /*!< Power Mode Control Base Address */
+  #define EWIC_ISA_BASE       (0xE001E400UL)                             /*!< External Wakeup Interrupt Controller interrupt status access Base Address */
+  #define PRCCFGINF_BASE      (0xE001E700UL)                             /*!< Processor Configuration Information Base Address */
+  #define STL_BASE            (0xE001E800UL)                             /*!< Software Test Library Base Address */
+  #define TPIU_BASE           (0xE0040000UL)                             /*!< TPIU Base Address */
+  #define EWIC_BASE           (0xE0047000UL)                             /*!< External Wakeup Interrupt Controller Base Address */
+  #define DCB_BASE            (0xE000EDF0UL)                             /*!< DCB Base Address */
+  #define DIB_BASE            (0xE000EFB0UL)                             /*!< DIB Base Address */
+  #define SysTick_BASE        (SCS_BASE +  0x0010UL)                     /*!< SysTick Base Address */
+  #define NVIC_BASE           (SCS_BASE +  0x0100UL)                     /*!< NVIC Base Address */
+  #define SCB_BASE            (SCS_BASE +  0x0D00UL)                     /*!< System Control Block Base Address */
+
+  #define ICB                 ((ICB_Type       *)     SCS_BASE         ) /*!< System control Register not in SCB */
+  #define SCB                 ((SCB_Type       *)     SCB_BASE         ) /*!< SCB configuration struct */
+  #define SysTick             ((SysTick_Type   *)     SysTick_BASE     ) /*!< SysTick configuration struct */
+  #define NVIC                ((NVIC_Type      *)     NVIC_BASE        ) /*!< NVIC configuration struct */
+  #define ITM                 ((ITM_Type       *)     ITM_BASE         ) /*!< ITM configuration struct */
+  #define DWT                 ((DWT_Type       *)     DWT_BASE         ) /*!< DWT configuration struct */
+  #define TPIU                ((TPIU_Type      *)     TPIU_BASE        ) /*!< TPIU configuration struct */
+  #define MEMSYSCTL           ((MemSysCtl_Type *)     MEMSYSCTL_BASE   ) /*!< Memory System Control configuration struct */
+  #define ERRBNK              ((ErrBnk_Type    *)     ERRBNK_BASE      ) /*!< Error Banking configuration struct */
+  #define PWRMODCTL           ((PwrModCtl_Type *)     PWRMODCTL_BASE   ) /*!< Power Mode Control configuration struct */
+  #define EWIC_ISA            ((EWIC_ISA_Type  *)     EWIC_ISA_BASE    ) /*!< EWIC interrupt status access struct */
+  #define EWIC                ((EWIC_Type      *)     EWIC_BASE        ) /*!< EWIC configuration struct */
+  #define PRCCFGINF           ((PrcCfgInf_Type *)     PRCCFGINF_BASE   ) /*!< Processor Configuration Information configuration struct */
+  #define STL                 ((STL_Type       *)     STL_BASE         ) /*!< Software Test Library configuration struct */
+  #define DCB                 ((DCB_Type       *)     DCB_BASE         ) /*!< DCB configuration struct */
+  #define DIB                 ((DIB_Type       *)     DIB_BASE         ) /*!< DIB configuration struct */
+
+  #if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+    #define MPU_BASE          (SCS_BASE +  0x0D90UL)                     /*!< Memory Protection Unit */
+    #define MPU               ((MPU_Type       *)     MPU_BASE         ) /*!< Memory Protection Unit */
+  #endif
+
+  #if defined (__PMU_PRESENT) && (__PMU_PRESENT == 1U)
+    #define PMU_BASE          (0xE0003000UL)                             /*!< PMU Base Address */
+    #define PMU               ((PMU_Type       *)     PMU_BASE         ) /*!< PMU configuration struct */
+  #endif
+
+  #if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+    #define SAU_BASE          (SCS_BASE +  0x0DD0UL)                     /*!< Security Attribution Unit */
+    #define SAU               ((SAU_Type       *)     SAU_BASE         ) /*!< Security Attribution Unit */
+  #endif
+
+  #define FPU_BASE            (SCS_BASE +  0x0F30UL)                     /*!< Floating Point Unit */
+  #define FPU                 ((FPU_Type       *)     FPU_BASE         ) /*!< Floating Point Unit */
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  #define SCS_BASE_NS         (0xE002E000UL)                             /*!< System Control Space Base Address (non-secure address space) */
+  #define DCB_BASE_NS         (0xE002EDF0UL)                             /*!< DCB Base Address                  (non-secure address space) */
+  #define DIB_BASE_NS         (0xE002EFB0UL)                             /*!< DIB Base Address                  (non-secure address space) */
+  #define SysTick_BASE_NS     (SCS_BASE_NS +  0x0010UL)                  /*!< SysTick Base Address              (non-secure address space) */
+  #define NVIC_BASE_NS        (SCS_BASE_NS +  0x0100UL)                  /*!< NVIC Base Address                 (non-secure address space) */
+  #define SCB_BASE_NS         (SCS_BASE_NS +  0x0D00UL)                  /*!< System Control Block Base Address (non-secure address space) */
+
+  #define ICB_NS              ((ICB_Type       *)     SCS_BASE_NS      ) /*!< System control Register not in SCB(non-secure address space) */
+  #define SCB_NS              ((SCB_Type       *)     SCB_BASE_NS      ) /*!< SCB configuration struct          (non-secure address space) */
+  #define SysTick_NS          ((SysTick_Type   *)     SysTick_BASE_NS  ) /*!< SysTick configuration struct      (non-secure address space) */
+  #define NVIC_NS             ((NVIC_Type      *)     NVIC_BASE_NS     ) /*!< NVIC configuration struct         (non-secure address space) */
+  #define DCB_NS              ((DCB_Type       *)     DCB_BASE_NS      ) /*!< DCB configuration struct          (non-secure address space) */
+  #define DIB_NS              ((DIB_Type       *)     DIB_BASE_NS      ) /*!< DIB configuration struct          (non-secure address space) */
+
+  #if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+    #define MPU_BASE_NS       (SCS_BASE_NS +  0x0D90UL)                  /*!< Memory Protection Unit            (non-secure address space) */
+    #define MPU_NS            ((MPU_Type       *)     MPU_BASE_NS      ) /*!< Memory Protection Unit            (non-secure address space) */
+  #endif
+
+  #define FPU_BASE_NS         (SCS_BASE_NS +  0x0F30UL)                  /*!< Floating Point Unit               (non-secure address space) */
+  #define FPU_NS              ((FPU_Type       *)     FPU_BASE_NS      ) /*!< Floating Point Unit               (non-secure address space) */
+
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+/*@} */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_register_aliases     Backwards Compatibility Aliases
+  \brief      Register alias definitions for backwards compatibility.
+  @{
+ */
+
+/*@} */
+
+
+/*******************************************************************************
+ *                Hardware Abstraction Layer
+  Core Function Interface contains:
+  - Core NVIC Functions
+  - Core SysTick Functions
+  - Core Debug Functions
+  - Core Register Access Functions
+ ******************************************************************************/
+/**
+  \defgroup CMSIS_Core_FunctionInterface Functions and Instructions Reference
+*/
+
+
+
+/* ##########################   NVIC functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_NVICFunctions NVIC Functions
+  \brief    Functions that manage interrupts and exceptions via the NVIC.
+  @{
+ */
+
+#ifdef CMSIS_NVIC_VIRTUAL
+  #ifndef CMSIS_NVIC_VIRTUAL_HEADER_FILE
+    #define CMSIS_NVIC_VIRTUAL_HEADER_FILE "cmsis_nvic_virtual.h"
+  #endif
+  #include CMSIS_NVIC_VIRTUAL_HEADER_FILE
+#else
+  #define NVIC_SetPriorityGrouping    __NVIC_SetPriorityGrouping
+  #define NVIC_GetPriorityGrouping    __NVIC_GetPriorityGrouping
+  #define NVIC_EnableIRQ              __NVIC_EnableIRQ
+  #define NVIC_GetEnableIRQ           __NVIC_GetEnableIRQ
+  #define NVIC_DisableIRQ             __NVIC_DisableIRQ
+  #define NVIC_GetPendingIRQ          __NVIC_GetPendingIRQ
+  #define NVIC_SetPendingIRQ          __NVIC_SetPendingIRQ
+  #define NVIC_ClearPendingIRQ        __NVIC_ClearPendingIRQ
+  #define NVIC_GetActive              __NVIC_GetActive
+  #define NVIC_SetPriority            __NVIC_SetPriority
+  #define NVIC_GetPriority            __NVIC_GetPriority
+  #define NVIC_SystemReset            __NVIC_SystemReset
+#endif /* CMSIS_NVIC_VIRTUAL */
+
+#ifdef CMSIS_VECTAB_VIRTUAL
+  #ifndef CMSIS_VECTAB_VIRTUAL_HEADER_FILE
+    #define CMSIS_VECTAB_VIRTUAL_HEADER_FILE "cmsis_vectab_virtual.h"
+  #endif
+  #include CMSIS_VECTAB_VIRTUAL_HEADER_FILE
+#else
+  #define NVIC_SetVector              __NVIC_SetVector
+  #define NVIC_GetVector              __NVIC_GetVector
+#endif  /* (CMSIS_VECTAB_VIRTUAL) */
+
+#define NVIC_USER_IRQ_OFFSET          16
+
+
+/* Special LR values for Secure/Non-Secure call handling and exception handling                                               */
+
+/* Function Return Payload (from ARMv8-M Architecture Reference Manual) LR value on entry from Secure BLXNS                   */
+#define FNC_RETURN                 (0xFEFFFFFFUL)     /* bit [0] ignored when processing a branch                             */
+
+/* The following EXC_RETURN mask values are used to evaluate the LR on exception entry */
+#define EXC_RETURN_PREFIX          (0xFF000000UL)     /* bits [31:24] set to indicate an EXC_RETURN value                     */
+#define EXC_RETURN_S               (0x00000040UL)     /* bit [6] stack used to push registers: 0=Non-secure 1=Secure          */
+#define EXC_RETURN_DCRS            (0x00000020UL)     /* bit [5] stacking rules for called registers: 0=skipped 1=saved       */
+#define EXC_RETURN_FTYPE           (0x00000010UL)     /* bit [4] allocate stack for floating-point context: 0=done 1=skipped  */
+#define EXC_RETURN_MODE            (0x00000008UL)     /* bit [3] processor mode for return: 0=Handler mode 1=Thread mode      */
+#define EXC_RETURN_SPSEL           (0x00000004UL)     /* bit [2] stack pointer used to restore context: 0=MSP 1=PSP           */
+#define EXC_RETURN_ES              (0x00000001UL)     /* bit [0] security state exception was taken to: 0=Non-secure 1=Secure */
+
+/* Integrity Signature (from ARMv8-M Architecture Reference Manual) for exception context stacking                            */
+#if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)  /* Value for processors with floating-point extension:                  */
+#define EXC_INTEGRITY_SIGNATURE     (0xFEFA125AUL)     /* bit [0] SFTC must match LR bit[4] EXC_RETURN_FTYPE                   */
+#else
+#define EXC_INTEGRITY_SIGNATURE     (0xFEFA125BUL)     /* Value for processors without floating-point extension                */
+#endif
+
+
+/**
+  \brief   Set Priority Grouping
+  \details Sets the priority grouping field using the required unlock sequence.
+           The parameter PriorityGroup is assigned to the field SCB->AIRCR [10:8] PRIGROUP field.
+           Only values from 0..7 are used.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+  \param [in]      PriorityGroup  Priority grouping field.
+ */
+__STATIC_INLINE void __NVIC_SetPriorityGrouping(uint32_t PriorityGroup)
+{
+  uint32_t reg_value;
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);             /* only values 0..7 are used          */
+
+  reg_value  =  SCB->AIRCR;                                                   /* read old register configuration    */
+  reg_value &= ~((uint32_t)(SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk)); /* clear bits to change               */
+  reg_value  =  (reg_value                                   |
+                ((uint32_t)0x5FAUL << SCB_AIRCR_VECTKEY_Pos) |
+                (PriorityGroupTmp << SCB_AIRCR_PRIGROUP_Pos)  );              /* Insert write key and priority group */
+  SCB->AIRCR =  reg_value;
+}
+
+
+/**
+  \brief   Get Priority Grouping
+  \details Reads the priority grouping field from the NVIC Interrupt Controller.
+  \return                Priority grouping field (SCB->AIRCR [10:8] PRIGROUP field).
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPriorityGrouping(void)
+{
+  return ((uint32_t)((SCB->AIRCR & SCB_AIRCR_PRIGROUP_Msk) >> SCB_AIRCR_PRIGROUP_Pos));
+}
+
+
+/**
+  \brief   Enable Interrupt
+  \details Enables a device specific interrupt in the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_EnableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    __COMPILER_BARRIER();
+    NVIC->ISER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+    __COMPILER_BARRIER();
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Enable status
+  \details Returns a device specific interrupt enable status from the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt is not enabled.
+  \return             1  Interrupt is enabled.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetEnableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ISER[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Disable Interrupt
+  \details Disables a device specific interrupt in the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_DisableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ICER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+    __DSB();
+    __ISB();
+  }
+}
+
+
+/**
+  \brief   Get Pending Interrupt
+  \details Reads the NVIC pending register and returns the pending bit for the specified device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not pending.
+  \return             1  Interrupt status is pending.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ISPR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Pending Interrupt
+  \details Sets the pending bit of a device specific interrupt in the NVIC pending register.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_SetPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ISPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Clear Pending Interrupt
+  \details Clears the pending bit of a device specific interrupt in the NVIC pending register.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_ClearPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ICPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Active Interrupt
+  \details Reads the active register in the NVIC and returns the active bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not active.
+  \return             1  Interrupt status is active.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetActive(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->IABR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   Get Interrupt Target State
+  \details Reads the interrupt target field in the NVIC and returns the interrupt target bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  if interrupt is assigned to Secure
+  \return             1  if interrupt is assigned to Non Secure
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t NVIC_GetTargetState(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Interrupt Target State
+  \details Sets the interrupt target field in the NVIC and returns the interrupt target bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  if interrupt is assigned to Secure
+                      1  if interrupt is assigned to Non Secure
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t NVIC_SetTargetState(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] |=  ((uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL)));
+    return((uint32_t)(((NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Clear Interrupt Target State
+  \details Clears the interrupt target field in the NVIC and returns the interrupt target bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  if interrupt is assigned to Secure
+                      1  if interrupt is assigned to Non Secure
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t NVIC_ClearTargetState(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] &= ~((uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL)));
+    return((uint32_t)(((NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+
+/**
+  \brief   Set Interrupt Priority
+  \details Sets the priority of a device specific interrupt or a processor exception.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]      IRQn  Interrupt number.
+  \param [in]  priority  Priority to set.
+  \note    The priority cannot be set for every processor exception.
+ */
+__STATIC_INLINE void __NVIC_SetPriority(IRQn_Type IRQn, uint32_t priority)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->IPR[((uint32_t)IRQn)]               = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+  else
+  {
+    SCB->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Priority
+  \details Reads the priority of a device specific interrupt or a processor exception.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn  Interrupt number.
+  \return             Interrupt Priority.
+                      Value is aligned automatically to the implemented priority bits of the microcontroller.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPriority(IRQn_Type IRQn)
+{
+
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return(((uint32_t)NVIC->IPR[((uint32_t)IRQn)]               >> (8U - __NVIC_PRIO_BITS)));
+  }
+  else
+  {
+    return(((uint32_t)SCB->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] >> (8U - __NVIC_PRIO_BITS)));
+  }
+}
+
+
+/**
+  \brief   Encode Priority
+  \details Encodes the priority for an interrupt with the given priority group,
+           preemptive priority value, and subpriority value.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+  \param [in]     PriorityGroup  Used priority group.
+  \param [in]   PreemptPriority  Preemptive priority value (starting from 0).
+  \param [in]       SubPriority  Subpriority value (starting from 0).
+  \return                        Encoded priority. Value can be used in the function \ref NVIC_SetPriority().
+ */
+__STATIC_INLINE uint32_t NVIC_EncodePriority (uint32_t PriorityGroup, uint32_t PreemptPriority, uint32_t SubPriority)
+{
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);   /* only values 0..7 are used          */
+  uint32_t PreemptPriorityBits;
+  uint32_t SubPriorityBits;
+
+  PreemptPriorityBits = ((7UL - PriorityGroupTmp) > (uint32_t)(__NVIC_PRIO_BITS)) ? (uint32_t)(__NVIC_PRIO_BITS) : (uint32_t)(7UL - PriorityGroupTmp);
+  SubPriorityBits     = ((PriorityGroupTmp + (uint32_t)(__NVIC_PRIO_BITS)) < (uint32_t)7UL) ? (uint32_t)0UL : (uint32_t)((PriorityGroupTmp - 7UL) + (uint32_t)(__NVIC_PRIO_BITS));
+
+  return (
+           ((PreemptPriority & (uint32_t)((1UL << (PreemptPriorityBits)) - 1UL)) << SubPriorityBits) |
+           ((SubPriority     & (uint32_t)((1UL << (SubPriorityBits    )) - 1UL)))
+         );
+}
+
+
+/**
+  \brief   Decode Priority
+  \details Decodes an interrupt priority value with a given priority group to
+           preemptive priority value and subpriority value.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS) the smallest possible priority group is set.
+  \param [in]         Priority   Priority value, which can be retrieved with the function \ref NVIC_GetPriority().
+  \param [in]     PriorityGroup  Used priority group.
+  \param [out] pPreemptPriority  Preemptive priority value (starting from 0).
+  \param [out]     pSubPriority  Subpriority value (starting from 0).
+ */
+__STATIC_INLINE void NVIC_DecodePriority (uint32_t Priority, uint32_t PriorityGroup, uint32_t* const pPreemptPriority, uint32_t* const pSubPriority)
+{
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);   /* only values 0..7 are used          */
+  uint32_t PreemptPriorityBits;
+  uint32_t SubPriorityBits;
+
+  PreemptPriorityBits = ((7UL - PriorityGroupTmp) > (uint32_t)(__NVIC_PRIO_BITS)) ? (uint32_t)(__NVIC_PRIO_BITS) : (uint32_t)(7UL - PriorityGroupTmp);
+  SubPriorityBits     = ((PriorityGroupTmp + (uint32_t)(__NVIC_PRIO_BITS)) < (uint32_t)7UL) ? (uint32_t)0UL : (uint32_t)((PriorityGroupTmp - 7UL) + (uint32_t)(__NVIC_PRIO_BITS));
+
+  *pPreemptPriority = (Priority >> SubPriorityBits) & (uint32_t)((1UL << (PreemptPriorityBits)) - 1UL);
+  *pSubPriority     = (Priority                   ) & (uint32_t)((1UL << (SubPriorityBits    )) - 1UL);
+}
+
+
+/**
+  \brief   Set Interrupt Vector
+  \details Sets an interrupt vector in SRAM based interrupt vector table.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+           VTOR must been relocated to SRAM before.
+  \param [in]   IRQn      Interrupt number
+  \param [in]   vector    Address of interrupt handler function
+ */
+__STATIC_INLINE void __NVIC_SetVector(IRQn_Type IRQn, uint32_t vector)
+{
+  uint32_t *vectors = (uint32_t *) ((uintptr_t) SCB->VTOR);
+  vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET] = vector;
+  __DSB();
+}
+
+
+/**
+  \brief   Get Interrupt Vector
+  \details Reads an interrupt vector from interrupt vector table.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn      Interrupt number.
+  \return                 Address of interrupt handler function
+ */
+__STATIC_INLINE uint32_t __NVIC_GetVector(IRQn_Type IRQn)
+{
+  uint32_t *vectors = (uint32_t *) ((uintptr_t) SCB->VTOR);
+  return vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET];
+}
+
+
+/**
+  \brief   System Reset
+  \details Initiates a system reset request to reset the MCU.
+ */
+__NO_RETURN __STATIC_INLINE void __NVIC_SystemReset(void)
+{
+  __DSB();                                                          /* Ensure all outstanding memory accesses included
+                                                                       buffered write are completed before reset */
+  SCB->AIRCR  = (uint32_t)((0x5FAUL << SCB_AIRCR_VECTKEY_Pos)    |
+                           (SCB->AIRCR & SCB_AIRCR_PRIGROUP_Msk) |
+                            SCB_AIRCR_SYSRESETREQ_Msk    );         /* Keep priority group unchanged */
+  __DSB();                                                          /* Ensure completion of memory access */
+
+  for(;;)                                                           /* wait until reset */
+  {
+    __NOP();
+  }
+}
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   Set Priority Grouping (non-secure)
+  \details Sets the non-secure priority grouping field when in secure state using the required unlock sequence.
+           The parameter PriorityGroup is assigned to the field SCB->AIRCR [10:8] PRIGROUP field.
+           Only values from 0..7 are used.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+  \param [in]      PriorityGroup  Priority grouping field.
+ */
+__STATIC_INLINE void TZ_NVIC_SetPriorityGrouping_NS(uint32_t PriorityGroup)
+{
+  uint32_t reg_value;
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);             /* only values 0..7 are used          */
+
+  reg_value  =  SCB_NS->AIRCR;                                                /* read old register configuration    */
+  reg_value &= ~((uint32_t)(SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk)); /* clear bits to change               */
+  reg_value  =  (reg_value                                   |
+                ((uint32_t)0x5FAUL << SCB_AIRCR_VECTKEY_Pos) |
+                (PriorityGroupTmp << SCB_AIRCR_PRIGROUP_Pos)  );              /* Insert write key and priority group */
+  SCB_NS->AIRCR =  reg_value;
+}
+
+
+/**
+  \brief   Get Priority Grouping (non-secure)
+  \details Reads the priority grouping field from the non-secure NVIC when in secure state.
+  \return                Priority grouping field (SCB->AIRCR [10:8] PRIGROUP field).
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetPriorityGrouping_NS(void)
+{
+  return ((uint32_t)((SCB_NS->AIRCR & SCB_AIRCR_PRIGROUP_Msk) >> SCB_AIRCR_PRIGROUP_Pos));
+}
+
+
+/**
+  \brief   Enable Interrupt (non-secure)
+  \details Enables a device specific interrupt in the non-secure NVIC interrupt controller when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void TZ_NVIC_EnableIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->ISER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Enable status (non-secure)
+  \details Returns a device specific interrupt enable status from the non-secure NVIC interrupt controller when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt is not enabled.
+  \return             1  Interrupt is enabled.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetEnableIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC_NS->ISER[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Disable Interrupt (non-secure)
+  \details Disables a device specific interrupt in the non-secure NVIC interrupt controller when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void TZ_NVIC_DisableIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->ICER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Pending Interrupt (non-secure)
+  \details Reads the NVIC pending register in the non-secure NVIC when in secure state and returns the pending bit for the specified device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not pending.
+  \return             1  Interrupt status is pending.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetPendingIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC_NS->ISPR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Pending Interrupt (non-secure)
+  \details Sets the pending bit of a device specific interrupt in the non-secure NVIC pending register when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void TZ_NVIC_SetPendingIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->ISPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Clear Pending Interrupt (non-secure)
+  \details Clears the pending bit of a device specific interrupt in the non-secure NVIC pending register when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void TZ_NVIC_ClearPendingIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->ICPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Active Interrupt (non-secure)
+  \details Reads the active register in non-secure NVIC when in secure state and returns the active bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not active.
+  \return             1  Interrupt status is active.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetActive_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC_NS->IABR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Interrupt Priority (non-secure)
+  \details Sets the priority of a non-secure device specific interrupt or a non-secure processor exception when in secure state.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]      IRQn  Interrupt number.
+  \param [in]  priority  Priority to set.
+  \note    The priority cannot be set for every non-secure processor exception.
+ */
+__STATIC_INLINE void TZ_NVIC_SetPriority_NS(IRQn_Type IRQn, uint32_t priority)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->IPR[((uint32_t)IRQn)]               = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+  else
+  {
+    SCB_NS->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Priority (non-secure)
+  \details Reads the priority of a non-secure device specific interrupt or a non-secure processor exception when in secure state.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn  Interrupt number.
+  \return             Interrupt Priority. Value is aligned automatically to the implemented priority bits of the microcontroller.
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetPriority_NS(IRQn_Type IRQn)
+{
+
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return(((uint32_t)NVIC_NS->IPR[((uint32_t)IRQn)]               >> (8U - __NVIC_PRIO_BITS)));
+  }
+  else
+  {
+    return(((uint32_t)SCB_NS->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] >> (8U - __NVIC_PRIO_BITS)));
+  }
+}
+#endif /*  defined (__ARM_FEATURE_CMSE) &&(__ARM_FEATURE_CMSE == 3U) */
+
+/*@} end of CMSIS_Core_NVICFunctions */
+
+/* ##########################  MPU functions  #################################### */
+
+#if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+
+  #include "m-profile/armv8m_mpu.h"
+
+#endif
+
+/* ##########################  PMU functions and events  #################################### */
+
+#if defined (__PMU_PRESENT) && (__PMU_PRESENT == 1U)
+
+#include "m-profile/armv8m_pmu.h"
+
+/**
+  \brief   Cortex-M55 PMU events
+  \note    Architectural PMU events can be found in armv8m_pmu.h
+*/
+
+#define ARMCM55_PMU_ECC_ERR                          0xC000             /*!< Any ECC error */
+#define ARMCM55_PMU_ECC_ERR_FATAL                    0xC001             /*!< Any fatal ECC error */
+#define ARMCM55_PMU_ECC_ERR_DCACHE                   0xC010             /*!< Any ECC error in the data cache */
+#define ARMCM55_PMU_ECC_ERR_ICACHE                   0xC011             /*!< Any ECC error in the instruction cache */
+#define ARMCM55_PMU_ECC_ERR_FATAL_DCACHE             0xC012             /*!< Any fatal ECC error in the data cache */
+#define ARMCM55_PMU_ECC_ERR_FATAL_ICACHE             0xC013             /*!< Any fatal ECC error in the instruction cache*/
+#define ARMCM55_PMU_ECC_ERR_DTCM                     0xC020             /*!< Any ECC error in the DTCM */
+#define ARMCM55_PMU_ECC_ERR_ITCM                     0xC021             /*!< Any ECC error in the ITCM */
+#define ARMCM55_PMU_ECC_ERR_FATAL_DTCM               0xC022             /*!< Any fatal ECC error in the DTCM */
+#define ARMCM55_PMU_ECC_ERR_FATAL_ITCM               0xC023             /*!< Any fatal ECC error in the ITCM */
+#define ARMCM55_PMU_PF_LINEFILL                      0xC100             /*!< A prefetcher starts a line-fill */
+#define ARMCM55_PMU_PF_CANCEL                        0xC101             /*!< A prefetcher stops prefetching */
+#define ARMCM55_PMU_PF_DROP_LINEFILL                 0xC102             /*!< A linefill triggered by a prefetcher has been dropped because of lack of buffering */
+#define ARMCM55_PMU_NWAMODE_ENTER                    0xC200             /*!< No write-allocate mode entry */
+#define ARMCM55_PMU_NWAMODE                          0xC201             /*!< Write-allocate store is not allocated into the data cache due to no-write-allocate mode */
+#define ARMCM55_PMU_SAHB_ACCESS                      0xC300             /*!< Read or write access on the S-AHB interface to the TCM */
+#define ARMCM55_PMU_PAHB_ACCESS                      0xC301             /*!< Read or write access to the P-AHB write interface */
+#define ARMCM55_PMU_AXI_WRITE_ACCESS                 0xC302             /*!< Any beat access to M-AXI write interface */
+#define ARMCM55_PMU_AXI_READ_ACCESS                  0xC303             /*!< Any beat access to M-AXI read interface */
+#define ARMCM55_PMU_DOSTIMEOUT_DOUBLE                0xC400             /*!< Denial of Service timeout has fired twice and caused buffers to drain to allow forward progress */
+#define ARMCM55_PMU_DOSTIMEOUT_TRIPLE                0xC401             /*!< Denial of Service timeout has fired three times and blocked the LSU to force forward progress */
+#define ARMCM55_PMU_CDE_INST_RETIRED                 0xC402             /*!< CDE instruction architecturally executed. */
+#define ARMCM55_PMU_CDE_CX1_INST_RETIRED             0xC404             /*!< CDE CX1 instruction architecturally executed. */
+#define ARMCM55_PMU_CDE_CX2_INST_RETIRED             0xC406             /*!< CDE CX2 instruction architecturally executed. */
+#define ARMCM55_PMU_CDE_CX3_INST_RETIRED             0xC408             /*!< CDE CX3 instruction architecturally executed. */
+#define ARMCM55_PMU_CDE_VCX1_INST_RETIRED            0xC40A             /*!< CDE VCX1 instruction architecturally executed. */
+#define ARMCM55_PMU_CDE_VCX2_INST_RETIRED            0xC40C             /*!< CDE VCX2 instruction architecturally executed. */
+#define ARMCM55_PMU_CDE_VCX3_INST_RETIRED            0xC40E             /*!< CDE VCX3 instruction architecturally executed. */
+#define ARMCM55_PMU_CDE_VCX1_VEC_INST_RETIRED        0xC410             /*!< CDE VCX1 Vector instruction architecturally executed. */
+#define ARMCM55_PMU_CDE_VCX2_VEC_INST_RETIRED        0xC412             /*!< CDE VCX2 Vector instruction architecturally executed. */
+#define ARMCM55_PMU_CDE_VCX3_VEC_INST_RETIRED        0xC414             /*!< CDE VCX3 Vector instruction architecturally executed. */
+#define ARMCM55_PMU_CDE_PRED                         0xC416             /*!< Cycles where one or more predicated beats of a CDE instruction architecturally executed. */
+#define ARMCM55_PMU_CDE_STALL                        0xC417             /*!< Stall cycles caused by a CDE instruction. */
+#define ARMCM55_PMU_CDE_STALL_RESOURCE               0xC418             /*!< Stall cycles caused by a CDE instruction because of resource conflicts */
+#define ARMCM55_PMU_CDE_STALL_DEPENDENCY             0xC419             /*!< Stall cycles caused by a CDE register dependency. */
+#define ARMCM55_PMU_CDE_STALL_CUSTOM                 0xC41A             /*!< Stall cycles caused by a CDE instruction are generated by the custom hardware. */
+#define ARMCM55_PMU_CDE_STALL_OTHER                  0xC41B             /*!< Stall cycles caused by a CDE instruction are not covered by the other counters. */
+#define ARMCM55_PMU_PF_LF_LA_1                       0xC41C             /*!< A data prefetcher line-fill request is made while the lookahead distance is 1. */
+#define ARMCM55_PMU_PF_LF_LA_2                       0xC41D             /*!< A data prefetcher line-fill request is made while the lookahead distance is 2. */
+#define ARMCM55_PMU_PF_LF_LA_3                       0xC41E             /*!< A data prefetcher line-fill request is made while the lookahead distance is 3. */
+#define ARMCM55_PMU_PF_LF_LA_4                       0xC41F             /*!< A data prefetcher line-fill request is made while the lookahead distance is 4. */
+#define ARMCM55_PMU_PF_LF_LA_5                       0xC420             /*!< A data prefetcher line-fill request is made while the lookahead distance is 5. */
+#define ARMCM55_PMU_PF_LF_LA_6                       0xC421             /*!< A data prefetcher line-fill request is made while the lookahead distance is 6. */
+#define ARMCM55_PMU_PF_BUFFER_FULL                   0xC422             /*!< A data prefetcher request is made while the buffer is full. */
+#define ARMCM55_PMU_PF_BUFFER_MISS                   0xC423             /*!< A load requires a line-fill which misses in the data prefetcher buffer. */
+#define ARMCM55_PMU_PF_BUFFER_HIT                    0xC424             /*!< A load access hits in the data prefetcher buffer. */
+
+#endif
+
+/* ##########################  FPU functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_FpuFunctions FPU Functions
+  \brief    Function that provides FPU type.
+  @{
+ */
+
+/**
+  \brief   get FPU type
+  \details returns the FPU type
+  \returns
+   - \b  0: No FPU
+   - \b  1: Single precision FPU
+   - \b  2: Double + Single precision FPU
+ */
+__STATIC_INLINE uint32_t SCB_GetFPUType(void)
+{
+  uint32_t mvfr0;
+
+  mvfr0 = FPU->MVFR0;
+  if      ((mvfr0 & (FPU_MVFR0_FPSP_Msk | FPU_MVFR0_FPDP_Msk)) == 0x220U)
+  {
+    return 2U;           /* Double + Single precision FPU */
+  }
+  else if ((mvfr0 & (FPU_MVFR0_FPSP_Msk | FPU_MVFR0_FPDP_Msk)) == 0x020U)
+  {
+    return 1U;           /* Single precision FPU */
+  }
+  else
+  {
+    return 0U;           /* No FPU */
+  }
+}
+
+
+/*@} end of CMSIS_Core_FpuFunctions */
+
+/* ##########################  MVE functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_MveFunctions MVE Functions
+  \brief    Function that provides MVE type.
+  @{
+ */
+
+/**
+  \brief   get MVE type
+  \details returns the MVE type
+  \returns
+   - \b  0: No Vector Extension (MVE)
+   - \b  1: Integer Vector Extension (MVE-I)
+   - \b  2: Floating-point Vector Extension (MVE-F)
+ */
+__STATIC_INLINE uint32_t SCB_GetMVEType(void)
+{
+  const uint32_t mvfr1 = FPU->MVFR1;
+  if      ((mvfr1 & FPU_MVFR1_MVE_Msk) == (0x2U << FPU_MVFR1_MVE_Pos))
+  {
+    return 2U;
+  }
+  else if ((mvfr1 & FPU_MVFR1_MVE_Msk) == (0x1U << FPU_MVFR1_MVE_Pos))
+  {
+    return 1U;
+  }
+  else
+  {
+    return 0U;
+  }
+}
+
+
+/*@} end of CMSIS_Core_MveFunctions */
+
+
+/* ##########################  Cache functions  #################################### */
+
+#if ((defined (__ICACHE_PRESENT) && (__ICACHE_PRESENT == 1U)) || \
+     (defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)))
+  #include "m-profile/armv7m_cachel1.h"
+#endif
+
+
+/* ##########################   SAU functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_SAUFunctions SAU Functions
+  \brief    Functions that configure the SAU.
+  @{
+ */
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+
+/**
+  \brief   Enable SAU
+  \details Enables the Security Attribution Unit (SAU).
+ */
+__STATIC_INLINE void TZ_SAU_Enable(void)
+{
+    SAU->CTRL |=  (SAU_CTRL_ENABLE_Msk);
+}
+
+
+
+/**
+  \brief   Disable SAU
+  \details Disables the Security Attribution Unit (SAU).
+ */
+__STATIC_INLINE void TZ_SAU_Disable(void)
+{
+    SAU->CTRL &= ~(SAU_CTRL_ENABLE_Msk);
+}
+
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+/*@} end of CMSIS_Core_SAUFunctions */
+
+
+
+
+/* ##################################    Debug Control function  ############################################ */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_DCBFunctions Debug Control Functions
+  \brief    Functions that access the Debug Control Block.
+  @{
+ */
+
+
+/**
+  \brief   Set Debug Authentication Control Register
+  \details writes to Debug Authentication Control register.
+  \param [in]  value  value to be writen.
+ */
+__STATIC_INLINE void DCB_SetAuthCtrl(uint32_t value)
+{
+    __DSB();
+    __ISB();
+    DCB->DAUTHCTRL = value;
+    __DSB();
+    __ISB();
+}
+
+
+/**
+  \brief   Get Debug Authentication Control Register
+  \details Reads Debug Authentication Control register.
+  \return             Debug Authentication Control Register.
+ */
+__STATIC_INLINE uint32_t DCB_GetAuthCtrl(void)
+{
+    return (DCB->DAUTHCTRL);
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   Set Debug Authentication Control Register (non-secure)
+  \details writes to non-secure Debug Authentication Control register when in secure state.
+  \param [in]  value  value to be writen
+ */
+__STATIC_INLINE void TZ_DCB_SetAuthCtrl_NS(uint32_t value)
+{
+    __DSB();
+    __ISB();
+    DCB_NS->DAUTHCTRL = value;
+    __DSB();
+    __ISB();
+}
+
+
+/**
+  \brief   Get Debug Authentication Control Register (non-secure)
+  \details Reads non-secure Debug Authentication Control register when in secure state.
+  \return             Debug Authentication Control Register.
+ */
+__STATIC_INLINE uint32_t TZ_DCB_GetAuthCtrl_NS(void)
+{
+    return (DCB_NS->DAUTHCTRL);
+}
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+/*@} end of CMSIS_Core_DCBFunctions */
+
+
+
+
+/* ##################################    Debug Identification function  ############################################ */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_DIBFunctions Debug Identification Functions
+  \brief    Functions that access the Debug Identification Block.
+  @{
+ */
+
+
+/**
+  \brief   Get Debug Authentication Status Register
+  \details Reads Debug Authentication Status register.
+  \return             Debug Authentication Status Register.
+ */
+__STATIC_INLINE uint32_t DIB_GetAuthStatus(void)
+{
+    return (DIB->DAUTHSTATUS);
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   Get Debug Authentication Status Register (non-secure)
+  \details Reads non-secure Debug Authentication Status register when in secure state.
+  \return             Debug Authentication Status Register.
+ */
+__STATIC_INLINE uint32_t TZ_DIB_GetAuthStatus_NS(void)
+{
+    return (DIB_NS->DAUTHSTATUS);
+}
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+/*@} end of CMSIS_Core_DCBFunctions */
+
+
+
+
+/* ##################################    SysTick function  ############################################ */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_SysTickFunctions SysTick Functions
+  \brief    Functions that configure the System.
+  @{
+ */
+
+#if defined (__Vendor_SysTickConfig) && (__Vendor_SysTickConfig == 0U)
+
+/**
+  \brief   System Tick Configuration
+  \details Initializes the System Timer and its interrupt, and starts the System Tick Timer.
+           Counter is in free running mode to generate periodic interrupts.
+  \param [in]  ticks  Number of ticks between two interrupts.
+  \return          0  Function succeeded.
+  \return          1  Function failed.
+  \note    When the variable <b>__Vendor_SysTickConfig</b> is set to 1, then the
+           function <b>SysTick_Config</b> is not included. In this case, the file <b><i>device</i>.h</b>
+           must contain a vendor-specific implementation of this function.
+ */
+__STATIC_INLINE uint32_t SysTick_Config(uint32_t ticks)
+{
+  if ((ticks - 1UL) > SysTick_LOAD_RELOAD_Msk)
+  {
+    return (1UL);                                                   /* Reload value impossible */
+  }
+
+  SysTick->LOAD  = (uint32_t)(ticks - 1UL);                         /* set reload register */
+  NVIC_SetPriority (SysTick_IRQn, (1UL << __NVIC_PRIO_BITS) - 1UL); /* set Priority for Systick Interrupt */
+  SysTick->VAL   = 0UL;                                             /* Load the SysTick Counter Value */
+  SysTick->CTRL  = SysTick_CTRL_CLKSOURCE_Msk |
+                   SysTick_CTRL_TICKINT_Msk   |
+                   SysTick_CTRL_ENABLE_Msk;                         /* Enable SysTick IRQ and SysTick Timer */
+  return (0UL);                                                     /* Function successful */
+}
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   System Tick Configuration (non-secure)
+  \details Initializes the non-secure System Timer and its interrupt when in secure state, and starts the System Tick Timer.
+           Counter is in free running mode to generate periodic interrupts.
+  \param [in]  ticks  Number of ticks between two interrupts.
+  \return          0  Function succeeded.
+  \return          1  Function failed.
+  \note    When the variable <b>__Vendor_SysTickConfig</b> is set to 1, then the
+           function <b>TZ_SysTick_Config_NS</b> is not included. In this case, the file <b><i>device</i>.h</b>
+           must contain a vendor-specific implementation of this function.
+
+ */
+__STATIC_INLINE uint32_t TZ_SysTick_Config_NS(uint32_t ticks)
+{
+  if ((ticks - 1UL) > SysTick_LOAD_RELOAD_Msk)
+  {
+    return (1UL);                                                         /* Reload value impossible */
+  }
+
+  SysTick_NS->LOAD  = (uint32_t)(ticks - 1UL);                            /* set reload register */
+  TZ_NVIC_SetPriority_NS (SysTick_IRQn, (1UL << __NVIC_PRIO_BITS) - 1UL); /* set Priority for Systick Interrupt */
+  SysTick_NS->VAL   = 0UL;                                                /* Load the SysTick Counter Value */
+  SysTick_NS->CTRL  = SysTick_CTRL_CLKSOURCE_Msk |
+                      SysTick_CTRL_TICKINT_Msk   |
+                      SysTick_CTRL_ENABLE_Msk;                            /* Enable SysTick IRQ and SysTick Timer */
+  return (0UL);                                                           /* Function successful */
+}
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+#endif
+
+/*@} end of CMSIS_Core_SysTickFunctions */
+
+
+
+/* ##################################### Debug In/Output function ########################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_core_DebugFunctions ITM Functions
+  \brief    Functions that access the ITM debug interface.
+  @{
+ */
+
+extern volatile int32_t ITM_RxBuffer;                              /*!< External variable to receive characters. */
+#define                 ITM_RXBUFFER_EMPTY  ((int32_t)0x5AA55AA5U) /*!< Value identifying \ref ITM_RxBuffer is ready for next character. */
+
+
+/**
+  \brief   ITM Send Character
+  \details Transmits a character via the ITM channel 0, and
+           \li Just returns when no debugger is connected that has booked the output.
+           \li Is blocking when a debugger is connected, but the previous character sent has not been transmitted.
+  \param [in]     ch  Character to transmit.
+  \returns            Character to transmit.
+ */
+__STATIC_INLINE uint32_t ITM_SendChar (uint32_t ch)
+{
+  if (((ITM->TCR & ITM_TCR_ITMENA_Msk) != 0UL) &&      /* ITM enabled */
+      ((ITM->TER & 1UL               ) != 0UL)   )     /* ITM Port #0 enabled */
+  {
+    while (ITM->PORT[0U].u32 == 0UL)
+    {
+      __NOP();
+    }
+    ITM->PORT[0U].u8 = (uint8_t)ch;
+  }
+  return (ch);
+}
+
+
+/**
+  \brief   ITM Receive Character
+  \details Inputs a character via the external variable \ref ITM_RxBuffer.
+  \return             Received character.
+  \return         -1  No character pending.
+ */
+__STATIC_INLINE int32_t ITM_ReceiveChar (void)
+{
+  int32_t ch = -1;                           /* no character available */
+
+  if (ITM_RxBuffer != ITM_RXBUFFER_EMPTY)
+  {
+    ch = ITM_RxBuffer;
+    ITM_RxBuffer = ITM_RXBUFFER_EMPTY;       /* ready for next character */
+  }
+
+  return (ch);
+}
+
+
+/**
+  \brief   ITM Check Character
+  \details Checks whether a character is pending for reading in the variable \ref ITM_RxBuffer.
+  \return          0  No character available.
+  \return          1  Character available.
+ */
+__STATIC_INLINE int32_t ITM_CheckChar (void)
+{
+
+  if (ITM_RxBuffer == ITM_RXBUFFER_EMPTY)
+  {
+    return (0);                              /* no character available */
+  }
+  else
+  {
+    return (1);                              /*    character available */
+  }
+}
+
+/*@} end of CMSIS_core_DebugFunctions */
+
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_CM55_H_DEPENDANT */
+
+#endif /* __CMSIS_GENERIC */

--- a/platform/ext/cmsis/CMSIS/Core/Include/core_cm7.h
+++ b/platform/ext/cmsis/CMSIS/Core/Include/core_cm7.h
@@ -1,0 +1,2367 @@
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS Cortex-M7 Core Peripheral Access Layer Header File
+ */
+
+#if   defined ( __ICCARM__ )
+  #pragma system_include                        /* treat file as system include file for MISRA check */
+#elif defined (__clang__)
+  #pragma clang system_header                   /* treat file as system include file */
+#elif defined ( __GNUC__ )
+  #pragma GCC diagnostic ignored "-Wpedantic"   /* disable pedantic warning due to unnamed structs/unions */
+#endif
+
+#ifndef __CORE_CM7_H_GENERIC
+#define __CORE_CM7_H_GENERIC
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/**
+  \page CMSIS_MISRA_Exceptions  MISRA-C:2004 Compliance Exceptions
+  CMSIS violates the following MISRA-C:2004 rules:
+
+   \li Required Rule 8.5, object/function definition in header file.<br>
+     Function definitions in header files are used to allow 'inlining'.
+
+   \li Required Rule 18.4, declaration of union type or object of union type: '{...}'.<br>
+     Unions are used for effective representation of core registers.
+
+   \li Advisory Rule 19.7, Function-like macro defined.<br>
+     Function-like macros are used to allow more efficient code.
+ */
+
+
+/*******************************************************************************
+ *                 CMSIS definitions
+ ******************************************************************************/
+/**
+  \ingroup Cortex_M7
+  @{
+ */
+
+#include "cmsis_version.h"
+
+/* CMSIS CM7 definitions */
+
+#define __CORTEX_M                (7U)                                /*!< Cortex-M Core */
+
+/** __FPU_USED indicates whether an FPU is used or not.
+    For this, __FPU_PRESENT has to be checked prior to making use of FPU specific registers and functions.
+*/
+#if defined ( __CC_ARM )
+  #if defined (__TARGET_FPU_VFP)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #if defined (__ARM_FP)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#elif defined (__ti__)
+  #if defined (__ARM_FP)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#elif defined ( __GNUC__ )
+  #if defined (__VFP_FP__) && !defined(__SOFTFP__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#elif defined ( __ICCARM__ )
+  #if defined (__ARMVFP__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#elif defined ( __TI_ARM__ )
+  #if defined (__TI_VFP_SUPPORT__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#elif defined ( __TASKING__ )
+  #if defined (__FPU_VFP__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#elif defined ( __CSMC__ )
+  #if ( __CSMC__ & 0x400U)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#endif
+
+#include "cmsis_compiler.h"               /* CMSIS compiler specific defines */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_CM7_H_GENERIC */
+
+#ifndef __CMSIS_GENERIC
+
+#ifndef __CORE_CM7_H_DEPENDANT
+#define __CORE_CM7_H_DEPENDANT
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* check device defines and use defaults */
+#if defined __CHECK_DEVICE_DEFINES
+  #ifndef __CM7_REV
+    #define __CM7_REV               0x0000U
+    #warning "__CM7_REV not defined in device header file; using default!"
+  #endif
+
+  #ifndef __FPU_PRESENT
+    #define __FPU_PRESENT             0U
+    #warning "__FPU_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __MPU_PRESENT
+    #define __MPU_PRESENT             0U
+    #warning "__MPU_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __ICACHE_PRESENT
+    #define __ICACHE_PRESENT          0U
+    #warning "__ICACHE_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __DCACHE_PRESENT
+    #define __DCACHE_PRESENT          0U
+    #warning "__DCACHE_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __DTCM_PRESENT
+    #define __DTCM_PRESENT            0U
+    #warning "__DTCM_PRESENT        not defined in device header file; using default!"
+  #endif
+
+  #ifndef __VTOR_PRESENT
+    #define __VTOR_PRESENT            1U
+    #warning "__VTOR_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __NVIC_PRIO_BITS
+    #define __NVIC_PRIO_BITS          3U
+    #warning "__NVIC_PRIO_BITS not defined in device header file; using default!"
+  #endif
+
+  #ifndef __Vendor_SysTickConfig
+    #define __Vendor_SysTickConfig    0U
+    #warning "__Vendor_SysTickConfig not defined in device header file; using default!"
+  #endif
+#endif
+
+/* IO definitions (access restrictions to peripheral registers) */
+/**
+    \defgroup CMSIS_glob_defs CMSIS Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+*/
+#ifdef __cplusplus
+  #define   __I     volatile             /*!< Defines 'read only' permissions */
+#else
+  #define   __I     volatile const       /*!< Defines 'read only' permissions */
+#endif
+#define     __O     volatile             /*!< Defines 'write only' permissions */
+#define     __IO    volatile             /*!< Defines 'read / write' permissions */
+
+/* following defines should be used for structure members */
+#define     __IM     volatile const      /*! Defines 'read only' structure member permissions */
+#define     __OM     volatile            /*! Defines 'write only' structure member permissions */
+#define     __IOM    volatile            /*! Defines 'read / write' structure member permissions */
+
+/*@} end of group Cortex_M7 */
+
+
+
+/*******************************************************************************
+ *                 Register Abstraction
+  Core Register contain:
+  - Core Register
+  - Core NVIC Register
+  - Core SCB Register
+  - Core SysTick Register
+  - Core Debug Register
+  - Core MPU Register
+  - Core FPU Register
+ ******************************************************************************/
+/**
+  \defgroup CMSIS_core_register Defines and Type Definitions
+  \brief Type definitions and defines for Cortex-M processor based devices.
+*/
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_CORE  Status and Control Registers
+  \brief      Core Register type definitions.
+  @{
+ */
+
+/**
+  \brief  Union type to access the Application Program Status Register (APSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t _reserved0:16;              /*!< bit:  0..15  Reserved */
+    uint32_t GE:4;                       /*!< bit: 16..19  Greater than or Equal flags */
+    uint32_t _reserved1:7;               /*!< bit: 20..26  Reserved */
+    uint32_t Q:1;                        /*!< bit:     27  Saturation condition flag */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} APSR_Type;
+
+/** \brief APSR Register Definitions */
+#define APSR_N_Pos                         31U                                            /*!< APSR: N Position */
+#define APSR_N_Msk                         (1UL << APSR_N_Pos)                            /*!< APSR: N Mask */
+
+#define APSR_Z_Pos                         30U                                            /*!< APSR: Z Position */
+#define APSR_Z_Msk                         (1UL << APSR_Z_Pos)                            /*!< APSR: Z Mask */
+
+#define APSR_C_Pos                         29U                                            /*!< APSR: C Position */
+#define APSR_C_Msk                         (1UL << APSR_C_Pos)                            /*!< APSR: C Mask */
+
+#define APSR_V_Pos                         28U                                            /*!< APSR: V Position */
+#define APSR_V_Msk                         (1UL << APSR_V_Pos)                            /*!< APSR: V Mask */
+
+#define APSR_Q_Pos                         27U                                            /*!< APSR: Q Position */
+#define APSR_Q_Msk                         (1UL << APSR_Q_Pos)                            /*!< APSR: Q Mask */
+
+#define APSR_GE_Pos                        16U                                            /*!< APSR: GE Position */
+#define APSR_GE_Msk                        (0xFUL << APSR_GE_Pos)                         /*!< APSR: GE Mask */
+
+
+/**
+  \brief  Union type to access the Interrupt Program Status Register (IPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number */
+    uint32_t _reserved0:23;              /*!< bit:  9..31  Reserved */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} IPSR_Type;
+
+/** \brief IPSR Register Definitions */
+#define IPSR_ISR_Pos                        0U                                            /*!< IPSR: ISR Position */
+#define IPSR_ISR_Msk                       (0x1FFUL /*<< IPSR_ISR_Pos*/)                  /*!< IPSR: ISR Mask */
+
+
+/**
+  \brief  Union type to access the Special-Purpose Program Status Registers (xPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number */
+    uint32_t _reserved0:1;               /*!< bit:      9  Reserved */
+    uint32_t ICI_IT_1:6;                 /*!< bit: 10..15  ICI/IT part 1 */
+    uint32_t GE:4;                       /*!< bit: 16..19  Greater than or Equal flags */
+    uint32_t _reserved1:4;               /*!< bit: 20..23  Reserved */
+    uint32_t T:1;                        /*!< bit:     24  Thumb bit */
+    uint32_t ICI_IT_2:2;                 /*!< bit: 25..26  ICI/IT part 2 */
+    uint32_t Q:1;                        /*!< bit:     27  Saturation condition flag */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} xPSR_Type;
+
+/** \brief xPSR Register Definitions */
+#define xPSR_N_Pos                         31U                                            /*!< xPSR: N Position */
+#define xPSR_N_Msk                         (1UL << xPSR_N_Pos)                            /*!< xPSR: N Mask */
+
+#define xPSR_Z_Pos                         30U                                            /*!< xPSR: Z Position */
+#define xPSR_Z_Msk                         (1UL << xPSR_Z_Pos)                            /*!< xPSR: Z Mask */
+
+#define xPSR_C_Pos                         29U                                            /*!< xPSR: C Position */
+#define xPSR_C_Msk                         (1UL << xPSR_C_Pos)                            /*!< xPSR: C Mask */
+
+#define xPSR_V_Pos                         28U                                            /*!< xPSR: V Position */
+#define xPSR_V_Msk                         (1UL << xPSR_V_Pos)                            /*!< xPSR: V Mask */
+
+#define xPSR_Q_Pos                         27U                                            /*!< xPSR: Q Position */
+#define xPSR_Q_Msk                         (1UL << xPSR_Q_Pos)                            /*!< xPSR: Q Mask */
+
+#define xPSR_ICI_IT_2_Pos                  25U                                            /*!< xPSR: ICI/IT part 2 Position */
+#define xPSR_ICI_IT_2_Msk                  (3UL << xPSR_ICI_IT_2_Pos)                     /*!< xPSR: ICI/IT part 2 Mask */
+
+#define xPSR_T_Pos                         24U                                            /*!< xPSR: T Position */
+#define xPSR_T_Msk                         (1UL << xPSR_T_Pos)                            /*!< xPSR: T Mask */
+
+#define xPSR_GE_Pos                        16U                                            /*!< xPSR: GE Position */
+#define xPSR_GE_Msk                        (0xFUL << xPSR_GE_Pos)                         /*!< xPSR: GE Mask */
+
+#define xPSR_ICI_IT_1_Pos                  10U                                            /*!< xPSR: ICI/IT part 1 Position */
+#define xPSR_ICI_IT_1_Msk                  (0x3FUL << xPSR_ICI_IT_1_Pos)                  /*!< xPSR: ICI/IT part 1 Mask */
+
+#define xPSR_ISR_Pos                        0U                                            /*!< xPSR: ISR Position */
+#define xPSR_ISR_Msk                       (0x1FFUL /*<< xPSR_ISR_Pos*/)                  /*!< xPSR: ISR Mask */
+
+
+/**
+  \brief  Union type to access the Control Registers (CONTROL).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t nPRIV:1;                    /*!< bit:      0  Execution privilege in Thread mode */
+    uint32_t SPSEL:1;                    /*!< bit:      1  Stack to be used */
+    uint32_t FPCA:1;                     /*!< bit:      2  FP extension active flag */
+    uint32_t _reserved0:29;              /*!< bit:  3..31  Reserved */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} CONTROL_Type;
+
+/** \brief CONTROL Register Definitions */
+#define CONTROL_FPCA_Pos                    2U                                            /*!< CONTROL: FPCA Position */
+#define CONTROL_FPCA_Msk                   (1UL << CONTROL_FPCA_Pos)                      /*!< CONTROL: FPCA Mask */
+
+#define CONTROL_SPSEL_Pos                   1U                                            /*!< CONTROL: SPSEL Position */
+#define CONTROL_SPSEL_Msk                  (1UL << CONTROL_SPSEL_Pos)                     /*!< CONTROL: SPSEL Mask */
+
+#define CONTROL_nPRIV_Pos                   0U                                            /*!< CONTROL: nPRIV Position */
+#define CONTROL_nPRIV_Msk                  (1UL /*<< CONTROL_nPRIV_Pos*/)                 /*!< CONTROL: nPRIV Mask */
+
+/*@} end of group CMSIS_CORE */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_NVIC  Nested Vectored Interrupt Controller (NVIC)
+  \brief      Type definitions for the NVIC Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Nested Vectored Interrupt Controller (NVIC).
+ */
+typedef struct
+{
+  __IOM uint32_t ISER[8U];               /*!< Offset: 0x000 (R/W)  Interrupt Set Enable Register */
+        uint32_t RESERVED0[24U];
+  __IOM uint32_t ICER[8U];               /*!< Offset: 0x080 (R/W)  Interrupt Clear Enable Register */
+        uint32_t RESERVED1[24U];
+  __IOM uint32_t ISPR[8U];               /*!< Offset: 0x100 (R/W)  Interrupt Set Pending Register */
+        uint32_t RESERVED2[24U];
+  __IOM uint32_t ICPR[8U];               /*!< Offset: 0x180 (R/W)  Interrupt Clear Pending Register */
+        uint32_t RESERVED3[24U];
+  __IOM uint32_t IABR[8U];               /*!< Offset: 0x200 (R/W)  Interrupt Active bit Register */
+        uint32_t RESERVED4[56U];
+  __IOM uint8_t  IPR[240U];              /*!< Offset: 0x300 (R/W)  Interrupt Priority Register (8Bit wide) */
+        uint32_t RESERVED5[644U];
+  __OM  uint32_t STIR;                   /*!< Offset: 0xE00 ( /W)  Software Trigger Interrupt Register */
+}  NVIC_Type;
+
+/** \brief NVIC Software Triggered Interrupt Register Definitions */
+#define NVIC_STIR_INTID_Pos                 0U                                         /*!< STIR: INTLINESNUM Position */
+#define NVIC_STIR_INTID_Msk                (0x1FFUL /*<< NVIC_STIR_INTID_Pos*/)        /*!< STIR: INTLINESNUM Mask */
+
+/*@} end of group CMSIS_NVIC */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SCB     System Control Block (SCB)
+  \brief    Type definitions for the System Control Block Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Control Block (SCB).
+ */
+typedef struct
+{
+  __IM  uint32_t CPUID;                  /*!< Offset: 0x000 (R/ )  CPUID Base Register */
+  __IOM uint32_t ICSR;                   /*!< Offset: 0x004 (R/W)  Interrupt Control and State Register */
+  __IOM uint32_t VTOR;                   /*!< Offset: 0x008 (R/W)  Vector Table Offset Register */
+  __IOM uint32_t AIRCR;                  /*!< Offset: 0x00C (R/W)  Application Interrupt and Reset Control Register */
+  __IOM uint32_t SCR;                    /*!< Offset: 0x010 (R/W)  System Control Register */
+  __IOM uint32_t CCR;                    /*!< Offset: 0x014 (R/W)  Configuration Control Register */
+  __IOM uint8_t  SHPR[12U];              /*!< Offset: 0x018 (R/W)  System Handlers Priority Registers (4-7, 8-11, 12-15) */
+  __IOM uint32_t SHCSR;                  /*!< Offset: 0x024 (R/W)  System Handler Control and State Register */
+  __IOM uint32_t CFSR;                   /*!< Offset: 0x028 (R/W)  Configurable Fault Status Register */
+  __IOM uint32_t HFSR;                   /*!< Offset: 0x02C (R/W)  HardFault Status Register */
+  __IOM uint32_t DFSR;                   /*!< Offset: 0x030 (R/W)  Debug Fault Status Register */
+  __IOM uint32_t MMFAR;                  /*!< Offset: 0x034 (R/W)  MemManage Fault Address Register */
+  __IOM uint32_t BFAR;                   /*!< Offset: 0x038 (R/W)  BusFault Address Register */
+  __IOM uint32_t AFSR;                   /*!< Offset: 0x03C (R/W)  Auxiliary Fault Status Register */
+  __IM  uint32_t ID_PFR[2U];             /*!< Offset: 0x040 (R/ )  Processor Feature Register */
+  __IM  uint32_t ID_DFR;                 /*!< Offset: 0x048 (R/ )  Debug Feature Register */
+  __IM  uint32_t ID_AFR;                 /*!< Offset: 0x04C (R/ )  Auxiliary Feature Register */
+  __IM  uint32_t ID_MMFR[4U];            /*!< Offset: 0x050 (R/ )  Memory Model Feature Register */
+  __IM  uint32_t ID_ISAR[5U];            /*!< Offset: 0x060 (R/ )  Instruction Set Attributes Register */
+        uint32_t RESERVED0[1U];
+  __IM  uint32_t CLIDR;                  /*!< Offset: 0x078 (R/ )  Cache Level ID register */
+  __IM  uint32_t CTR;                    /*!< Offset: 0x07C (R/ )  Cache Type register */
+  __IM  uint32_t CCSIDR;                 /*!< Offset: 0x080 (R/ )  Cache Size ID Register */
+  __IOM uint32_t CSSELR;                 /*!< Offset: 0x084 (R/W)  Cache Size Selection Register */
+  __IOM uint32_t CPACR;                  /*!< Offset: 0x088 (R/W)  Coprocessor Access Control Register */
+        uint32_t RESERVED3[93U];
+  __OM  uint32_t STIR;                   /*!< Offset: 0x200 ( /W)  Software Triggered Interrupt Register */
+        uint32_t RESERVED4[15U];
+  __IM  uint32_t MVFR0;                  /*!< Offset: 0x240 (R/ )  Media and VFP Feature Register 0 */
+  __IM  uint32_t MVFR1;                  /*!< Offset: 0x244 (R/ )  Media and VFP Feature Register 1 */
+  __IM  uint32_t MVFR2;                  /*!< Offset: 0x248 (R/ )  Media and VFP Feature Register 2 */
+        uint32_t RESERVED5[1U];
+  __OM  uint32_t ICIALLU;                /*!< Offset: 0x250 ( /W)  I-Cache Invalidate All to PoU */
+        uint32_t RESERVED6[1U];
+  __OM  uint32_t ICIMVAU;                /*!< Offset: 0x258 ( /W)  I-Cache Invalidate by MVA to PoU */
+  __OM  uint32_t DCIMVAC;                /*!< Offset: 0x25C ( /W)  D-Cache Invalidate by MVA to PoC */
+  __OM  uint32_t DCISW;                  /*!< Offset: 0x260 ( /W)  D-Cache Invalidate by Set-way */
+  __OM  uint32_t DCCMVAU;                /*!< Offset: 0x264 ( /W)  D-Cache Clean by MVA to PoU */
+  __OM  uint32_t DCCMVAC;                /*!< Offset: 0x268 ( /W)  D-Cache Clean by MVA to PoC */
+  __OM  uint32_t DCCSW;                  /*!< Offset: 0x26C ( /W)  D-Cache Clean by Set-way */
+  __OM  uint32_t DCCIMVAC;               /*!< Offset: 0x270 ( /W)  D-Cache Clean and Invalidate by MVA to PoC */
+  __OM  uint32_t DCCISW;                 /*!< Offset: 0x274 ( /W)  D-Cache Clean and Invalidate by Set-way */
+  __OM  uint32_t BPIALL;                 /*!< Offset: 0x278 ( /W)  Branch Predictor Invalidate All */
+        uint32_t RESERVED7[5U];
+  __IOM uint32_t ITCMCR;                 /*!< Offset: 0x290 (R/W)  Instruction Tightly-Coupled Memory Control Register */
+  __IOM uint32_t DTCMCR;                 /*!< Offset: 0x294 (R/W)  Data Tightly-Coupled Memory Control Registers */
+  __IOM uint32_t AHBPCR;                 /*!< Offset: 0x298 (R/W)  AHBP Control Register */
+  __IOM uint32_t CACR;                   /*!< Offset: 0x29C (R/W)  L1 Cache Control Register */
+  __IOM uint32_t AHBSCR;                 /*!< Offset: 0x2A0 (R/W)  AHB Slave Control Register */
+        uint32_t RESERVED8[1U];
+  __IOM uint32_t ABFSR;                  /*!< Offset: 0x2A8 (R/W)  Auxiliary Bus Fault Status Register */
+} SCB_Type;
+
+/** \brief SCB CPUID Register Definitions */
+#define SCB_CPUID_IMPLEMENTER_Pos          24U                                            /*!< SCB CPUID: IMPLEMENTER Position */
+#define SCB_CPUID_IMPLEMENTER_Msk          (0xFFUL << SCB_CPUID_IMPLEMENTER_Pos)          /*!< SCB CPUID: IMPLEMENTER Mask */
+
+#define SCB_CPUID_VARIANT_Pos              20U                                            /*!< SCB CPUID: VARIANT Position */
+#define SCB_CPUID_VARIANT_Msk              (0xFUL << SCB_CPUID_VARIANT_Pos)               /*!< SCB CPUID: VARIANT Mask */
+
+#define SCB_CPUID_ARCHITECTURE_Pos         16U                                            /*!< SCB CPUID: ARCHITECTURE Position */
+#define SCB_CPUID_ARCHITECTURE_Msk         (0xFUL << SCB_CPUID_ARCHITECTURE_Pos)          /*!< SCB CPUID: ARCHITECTURE Mask */
+
+#define SCB_CPUID_PARTNO_Pos                4U                                            /*!< SCB CPUID: PARTNO Position */
+#define SCB_CPUID_PARTNO_Msk               (0xFFFUL << SCB_CPUID_PARTNO_Pos)              /*!< SCB CPUID: PARTNO Mask */
+
+#define SCB_CPUID_REVISION_Pos              0U                                            /*!< SCB CPUID: REVISION Position */
+#define SCB_CPUID_REVISION_Msk             (0xFUL /*<< SCB_CPUID_REVISION_Pos*/)          /*!< SCB CPUID: REVISION Mask */
+
+/** \brief SCB Interrupt Control State Register Definitions */
+#define SCB_ICSR_NMIPENDSET_Pos            31U                                            /*!< SCB ICSR: NMIPENDSET Position */
+#define SCB_ICSR_NMIPENDSET_Msk            (1UL << SCB_ICSR_NMIPENDSET_Pos)               /*!< SCB ICSR: NMIPENDSET Mask */
+
+#define SCB_ICSR_PENDSVSET_Pos             28U                                            /*!< SCB ICSR: PENDSVSET Position */
+#define SCB_ICSR_PENDSVSET_Msk             (1UL << SCB_ICSR_PENDSVSET_Pos)                /*!< SCB ICSR: PENDSVSET Mask */
+
+#define SCB_ICSR_PENDSVCLR_Pos             27U                                            /*!< SCB ICSR: PENDSVCLR Position */
+#define SCB_ICSR_PENDSVCLR_Msk             (1UL << SCB_ICSR_PENDSVCLR_Pos)                /*!< SCB ICSR: PENDSVCLR Mask */
+
+#define SCB_ICSR_PENDSTSET_Pos             26U                                            /*!< SCB ICSR: PENDSTSET Position */
+#define SCB_ICSR_PENDSTSET_Msk             (1UL << SCB_ICSR_PENDSTSET_Pos)                /*!< SCB ICSR: PENDSTSET Mask */
+
+#define SCB_ICSR_PENDSTCLR_Pos             25U                                            /*!< SCB ICSR: PENDSTCLR Position */
+#define SCB_ICSR_PENDSTCLR_Msk             (1UL << SCB_ICSR_PENDSTCLR_Pos)                /*!< SCB ICSR: PENDSTCLR Mask */
+
+#define SCB_ICSR_ISRPREEMPT_Pos            23U                                            /*!< SCB ICSR: ISRPREEMPT Position */
+#define SCB_ICSR_ISRPREEMPT_Msk            (1UL << SCB_ICSR_ISRPREEMPT_Pos)               /*!< SCB ICSR: ISRPREEMPT Mask */
+
+#define SCB_ICSR_ISRPENDING_Pos            22U                                            /*!< SCB ICSR: ISRPENDING Position */
+#define SCB_ICSR_ISRPENDING_Msk            (1UL << SCB_ICSR_ISRPENDING_Pos)               /*!< SCB ICSR: ISRPENDING Mask */
+
+#define SCB_ICSR_VECTPENDING_Pos           12U                                            /*!< SCB ICSR: VECTPENDING Position */
+#define SCB_ICSR_VECTPENDING_Msk           (0x1FFUL << SCB_ICSR_VECTPENDING_Pos)          /*!< SCB ICSR: VECTPENDING Mask */
+
+#define SCB_ICSR_RETTOBASE_Pos             11U                                            /*!< SCB ICSR: RETTOBASE Position */
+#define SCB_ICSR_RETTOBASE_Msk             (1UL << SCB_ICSR_RETTOBASE_Pos)                /*!< SCB ICSR: RETTOBASE Mask */
+
+#define SCB_ICSR_VECTACTIVE_Pos             0U                                            /*!< SCB ICSR: VECTACTIVE Position */
+#define SCB_ICSR_VECTACTIVE_Msk            (0x1FFUL /*<< SCB_ICSR_VECTACTIVE_Pos*/)       /*!< SCB ICSR: VECTACTIVE Mask */
+
+/** \brief SCB Vector Table Offset Register Definitions */
+#define SCB_VTOR_TBLOFF_Pos                 7U                                            /*!< SCB VTOR: TBLOFF Position */
+#define SCB_VTOR_TBLOFF_Msk                (0x1FFFFFFUL << SCB_VTOR_TBLOFF_Pos)           /*!< SCB VTOR: TBLOFF Mask */
+
+/** \brief SCB Application Interrupt and Reset Control Register Definitions */
+#define SCB_AIRCR_VECTKEY_Pos              16U                                            /*!< SCB AIRCR: VECTKEY Position */
+#define SCB_AIRCR_VECTKEY_Msk              (0xFFFFUL << SCB_AIRCR_VECTKEY_Pos)            /*!< SCB AIRCR: VECTKEY Mask */
+
+#define SCB_AIRCR_VECTKEYSTAT_Pos          16U                                            /*!< SCB AIRCR: VECTKEYSTAT Position */
+#define SCB_AIRCR_VECTKEYSTAT_Msk          (0xFFFFUL << SCB_AIRCR_VECTKEYSTAT_Pos)        /*!< SCB AIRCR: VECTKEYSTAT Mask */
+
+#define SCB_AIRCR_ENDIANESS_Pos            15U                                            /*!< SCB AIRCR: ENDIANESS Position */
+#define SCB_AIRCR_ENDIANESS_Msk            (1UL << SCB_AIRCR_ENDIANESS_Pos)               /*!< SCB AIRCR: ENDIANESS Mask */
+
+#define SCB_AIRCR_PRIGROUP_Pos              8U                                            /*!< SCB AIRCR: PRIGROUP Position */
+#define SCB_AIRCR_PRIGROUP_Msk             (7UL << SCB_AIRCR_PRIGROUP_Pos)                /*!< SCB AIRCR: PRIGROUP Mask */
+
+#define SCB_AIRCR_SYSRESETREQ_Pos           2U                                            /*!< SCB AIRCR: SYSRESETREQ Position */
+#define SCB_AIRCR_SYSRESETREQ_Msk          (1UL << SCB_AIRCR_SYSRESETREQ_Pos)             /*!< SCB AIRCR: SYSRESETREQ Mask */
+
+#define SCB_AIRCR_VECTCLRACTIVE_Pos         1U                                            /*!< SCB AIRCR: VECTCLRACTIVE Position */
+#define SCB_AIRCR_VECTCLRACTIVE_Msk        (1UL << SCB_AIRCR_VECTCLRACTIVE_Pos)           /*!< SCB AIRCR: VECTCLRACTIVE Mask */
+
+#define SCB_AIRCR_VECTRESET_Pos             0U                                            /*!< SCB AIRCR: VECTRESET Position */
+#define SCB_AIRCR_VECTRESET_Msk            (1UL /*<< SCB_AIRCR_VECTRESET_Pos*/)           /*!< SCB AIRCR: VECTRESET Mask */
+
+/** \brief SCB System Control Register Definitions */
+#define SCB_SCR_SEVONPEND_Pos               4U                                            /*!< SCB SCR: SEVONPEND Position */
+#define SCB_SCR_SEVONPEND_Msk              (1UL << SCB_SCR_SEVONPEND_Pos)                 /*!< SCB SCR: SEVONPEND Mask */
+
+#define SCB_SCR_SLEEPDEEP_Pos               2U                                            /*!< SCB SCR: SLEEPDEEP Position */
+#define SCB_SCR_SLEEPDEEP_Msk              (1UL << SCB_SCR_SLEEPDEEP_Pos)                 /*!< SCB SCR: SLEEPDEEP Mask */
+
+#define SCB_SCR_SLEEPONEXIT_Pos             1U                                            /*!< SCB SCR: SLEEPONEXIT Position */
+#define SCB_SCR_SLEEPONEXIT_Msk            (1UL << SCB_SCR_SLEEPONEXIT_Pos)               /*!< SCB SCR: SLEEPONEXIT Mask */
+
+/** \brief SCB Configuration Control Register Definitions */
+#define SCB_CCR_BP_Pos                      18U                                           /*!< SCB CCR: Branch prediction enable bit Position */
+#define SCB_CCR_BP_Msk                     (1UL << SCB_CCR_BP_Pos)                        /*!< SCB CCR: Branch prediction enable bit Mask */
+
+#define SCB_CCR_IC_Pos                      17U                                           /*!< SCB CCR: Instruction cache enable bit Position */
+#define SCB_CCR_IC_Msk                     (1UL << SCB_CCR_IC_Pos)                        /*!< SCB CCR: Instruction cache enable bit Mask */
+
+#define SCB_CCR_DC_Pos                      16U                                           /*!< SCB CCR: Cache enable bit Position */
+#define SCB_CCR_DC_Msk                     (1UL << SCB_CCR_DC_Pos)                        /*!< SCB CCR: Cache enable bit Mask */
+
+#define SCB_CCR_STKALIGN_Pos                9U                                            /*!< SCB CCR: STKALIGN Position */
+#define SCB_CCR_STKALIGN_Msk               (1UL << SCB_CCR_STKALIGN_Pos)                  /*!< SCB CCR: STKALIGN Mask */
+
+#define SCB_CCR_BFHFNMIGN_Pos               8U                                            /*!< SCB CCR: BFHFNMIGN Position */
+#define SCB_CCR_BFHFNMIGN_Msk              (1UL << SCB_CCR_BFHFNMIGN_Pos)                 /*!< SCB CCR: BFHFNMIGN Mask */
+
+#define SCB_CCR_DIV_0_TRP_Pos               4U                                            /*!< SCB CCR: DIV_0_TRP Position */
+#define SCB_CCR_DIV_0_TRP_Msk              (1UL << SCB_CCR_DIV_0_TRP_Pos)                 /*!< SCB CCR: DIV_0_TRP Mask */
+
+#define SCB_CCR_UNALIGN_TRP_Pos             3U                                            /*!< SCB CCR: UNALIGN_TRP Position */
+#define SCB_CCR_UNALIGN_TRP_Msk            (1UL << SCB_CCR_UNALIGN_TRP_Pos)               /*!< SCB CCR: UNALIGN_TRP Mask */
+
+#define SCB_CCR_USERSETMPEND_Pos            1U                                            /*!< SCB CCR: USERSETMPEND Position */
+#define SCB_CCR_USERSETMPEND_Msk           (1UL << SCB_CCR_USERSETMPEND_Pos)              /*!< SCB CCR: USERSETMPEND Mask */
+
+#define SCB_CCR_NONBASETHRDENA_Pos          0U                                            /*!< SCB CCR: NONBASETHRDENA Position */
+#define SCB_CCR_NONBASETHRDENA_Msk         (1UL /*<< SCB_CCR_NONBASETHRDENA_Pos*/)        /*!< SCB CCR: NONBASETHRDENA Mask */
+
+/** \brief SCB System Handler Control and State Register Definitions */
+#define SCB_SHCSR_USGFAULTENA_Pos          18U                                            /*!< SCB SHCSR: USGFAULTENA Position */
+#define SCB_SHCSR_USGFAULTENA_Msk          (1UL << SCB_SHCSR_USGFAULTENA_Pos)             /*!< SCB SHCSR: USGFAULTENA Mask */
+
+#define SCB_SHCSR_BUSFAULTENA_Pos          17U                                            /*!< SCB SHCSR: BUSFAULTENA Position */
+#define SCB_SHCSR_BUSFAULTENA_Msk          (1UL << SCB_SHCSR_BUSFAULTENA_Pos)             /*!< SCB SHCSR: BUSFAULTENA Mask */
+
+#define SCB_SHCSR_MEMFAULTENA_Pos          16U                                            /*!< SCB SHCSR: MEMFAULTENA Position */
+#define SCB_SHCSR_MEMFAULTENA_Msk          (1UL << SCB_SHCSR_MEMFAULTENA_Pos)             /*!< SCB SHCSR: MEMFAULTENA Mask */
+
+#define SCB_SHCSR_SVCALLPENDED_Pos         15U                                            /*!< SCB SHCSR: SVCALLPENDED Position */
+#define SCB_SHCSR_SVCALLPENDED_Msk         (1UL << SCB_SHCSR_SVCALLPENDED_Pos)            /*!< SCB SHCSR: SVCALLPENDED Mask */
+
+#define SCB_SHCSR_BUSFAULTPENDED_Pos       14U                                            /*!< SCB SHCSR: BUSFAULTPENDED Position */
+#define SCB_SHCSR_BUSFAULTPENDED_Msk       (1UL << SCB_SHCSR_BUSFAULTPENDED_Pos)          /*!< SCB SHCSR: BUSFAULTPENDED Mask */
+
+#define SCB_SHCSR_MEMFAULTPENDED_Pos       13U                                            /*!< SCB SHCSR: MEMFAULTPENDED Position */
+#define SCB_SHCSR_MEMFAULTPENDED_Msk       (1UL << SCB_SHCSR_MEMFAULTPENDED_Pos)          /*!< SCB SHCSR: MEMFAULTPENDED Mask */
+
+#define SCB_SHCSR_USGFAULTPENDED_Pos       12U                                            /*!< SCB SHCSR: USGFAULTPENDED Position */
+#define SCB_SHCSR_USGFAULTPENDED_Msk       (1UL << SCB_SHCSR_USGFAULTPENDED_Pos)          /*!< SCB SHCSR: USGFAULTPENDED Mask */
+
+#define SCB_SHCSR_SYSTICKACT_Pos           11U                                            /*!< SCB SHCSR: SYSTICKACT Position */
+#define SCB_SHCSR_SYSTICKACT_Msk           (1UL << SCB_SHCSR_SYSTICKACT_Pos)              /*!< SCB SHCSR: SYSTICKACT Mask */
+
+#define SCB_SHCSR_PENDSVACT_Pos            10U                                            /*!< SCB SHCSR: PENDSVACT Position */
+#define SCB_SHCSR_PENDSVACT_Msk            (1UL << SCB_SHCSR_PENDSVACT_Pos)               /*!< SCB SHCSR: PENDSVACT Mask */
+
+#define SCB_SHCSR_MONITORACT_Pos            8U                                            /*!< SCB SHCSR: MONITORACT Position */
+#define SCB_SHCSR_MONITORACT_Msk           (1UL << SCB_SHCSR_MONITORACT_Pos)              /*!< SCB SHCSR: MONITORACT Mask */
+
+#define SCB_SHCSR_SVCALLACT_Pos             7U                                            /*!< SCB SHCSR: SVCALLACT Position */
+#define SCB_SHCSR_SVCALLACT_Msk            (1UL << SCB_SHCSR_SVCALLACT_Pos)               /*!< SCB SHCSR: SVCALLACT Mask */
+
+#define SCB_SHCSR_USGFAULTACT_Pos           3U                                            /*!< SCB SHCSR: USGFAULTACT Position */
+#define SCB_SHCSR_USGFAULTACT_Msk          (1UL << SCB_SHCSR_USGFAULTACT_Pos)             /*!< SCB SHCSR: USGFAULTACT Mask */
+
+#define SCB_SHCSR_BUSFAULTACT_Pos           1U                                            /*!< SCB SHCSR: BUSFAULTACT Position */
+#define SCB_SHCSR_BUSFAULTACT_Msk          (1UL << SCB_SHCSR_BUSFAULTACT_Pos)             /*!< SCB SHCSR: BUSFAULTACT Mask */
+
+#define SCB_SHCSR_MEMFAULTACT_Pos           0U                                            /*!< SCB SHCSR: MEMFAULTACT Position */
+#define SCB_SHCSR_MEMFAULTACT_Msk          (1UL /*<< SCB_SHCSR_MEMFAULTACT_Pos*/)         /*!< SCB SHCSR: MEMFAULTACT Mask */
+
+/** \brief SCB Configurable Fault Status Register Definitions */
+#define SCB_CFSR_USGFAULTSR_Pos            16U                                            /*!< SCB CFSR: Usage Fault Status Register Position */
+#define SCB_CFSR_USGFAULTSR_Msk            (0xFFFFUL << SCB_CFSR_USGFAULTSR_Pos)          /*!< SCB CFSR: Usage Fault Status Register Mask */
+
+#define SCB_CFSR_BUSFAULTSR_Pos             8U                                            /*!< SCB CFSR: Bus Fault Status Register Position */
+#define SCB_CFSR_BUSFAULTSR_Msk            (0xFFUL << SCB_CFSR_BUSFAULTSR_Pos)            /*!< SCB CFSR: Bus Fault Status Register Mask */
+
+#define SCB_CFSR_MEMFAULTSR_Pos             0U                                            /*!< SCB CFSR: Memory Manage Fault Status Register Position */
+#define SCB_CFSR_MEMFAULTSR_Msk            (0xFFUL /*<< SCB_CFSR_MEMFAULTSR_Pos*/)        /*!< SCB CFSR: Memory Manage Fault Status Register Mask */
+
+/** \brief SCB MemManage Fault Status Register Definitions (part of SCB Configurable Fault Status Register) */
+#define SCB_CFSR_MMARVALID_Pos             (SCB_CFSR_MEMFAULTSR_Pos + 7U)                 /*!< SCB CFSR (MMFSR): MMARVALID Position */
+#define SCB_CFSR_MMARVALID_Msk             (1UL << SCB_CFSR_MMARVALID_Pos)                /*!< SCB CFSR (MMFSR): MMARVALID Mask */
+
+#define SCB_CFSR_MLSPERR_Pos               (SCB_CFSR_MEMFAULTSR_Pos + 5U)                 /*!< SCB CFSR (MMFSR): MLSPERR Position */
+#define SCB_CFSR_MLSPERR_Msk               (1UL << SCB_CFSR_MLSPERR_Pos)                  /*!< SCB CFSR (MMFSR): MLSPERR Mask */
+
+#define SCB_CFSR_MSTKERR_Pos               (SCB_CFSR_MEMFAULTSR_Pos + 4U)                 /*!< SCB CFSR (MMFSR): MSTKERR Position */
+#define SCB_CFSR_MSTKERR_Msk               (1UL << SCB_CFSR_MSTKERR_Pos)                  /*!< SCB CFSR (MMFSR): MSTKERR Mask */
+
+#define SCB_CFSR_MUNSTKERR_Pos             (SCB_CFSR_MEMFAULTSR_Pos + 3U)                 /*!< SCB CFSR (MMFSR): MUNSTKERR Position */
+#define SCB_CFSR_MUNSTKERR_Msk             (1UL << SCB_CFSR_MUNSTKERR_Pos)                /*!< SCB CFSR (MMFSR): MUNSTKERR Mask */
+
+#define SCB_CFSR_DACCVIOL_Pos              (SCB_CFSR_MEMFAULTSR_Pos + 1U)                 /*!< SCB CFSR (MMFSR): DACCVIOL Position */
+#define SCB_CFSR_DACCVIOL_Msk              (1UL << SCB_CFSR_DACCVIOL_Pos)                 /*!< SCB CFSR (MMFSR): DACCVIOL Mask */
+
+#define SCB_CFSR_IACCVIOL_Pos              (SCB_CFSR_MEMFAULTSR_Pos + 0U)                 /*!< SCB CFSR (MMFSR): IACCVIOL Position */
+#define SCB_CFSR_IACCVIOL_Msk              (1UL /*<< SCB_CFSR_IACCVIOL_Pos*/)             /*!< SCB CFSR (MMFSR): IACCVIOL Mask */
+
+/** \brief SCB BusFault Status Register Definitions (part of SCB Configurable Fault Status Register) */
+#define SCB_CFSR_BFARVALID_Pos            (SCB_CFSR_BUSFAULTSR_Pos + 7U)                  /*!< SCB CFSR (BFSR): BFARVALID Position */
+#define SCB_CFSR_BFARVALID_Msk            (1UL << SCB_CFSR_BFARVALID_Pos)                 /*!< SCB CFSR (BFSR): BFARVALID Mask */
+
+#define SCB_CFSR_LSPERR_Pos               (SCB_CFSR_BUSFAULTSR_Pos + 5U)                  /*!< SCB CFSR (BFSR): LSPERR Position */
+#define SCB_CFSR_LSPERR_Msk               (1UL << SCB_CFSR_LSPERR_Pos)                    /*!< SCB CFSR (BFSR): LSPERR Mask */
+
+#define SCB_CFSR_STKERR_Pos               (SCB_CFSR_BUSFAULTSR_Pos + 4U)                  /*!< SCB CFSR (BFSR): STKERR Position */
+#define SCB_CFSR_STKERR_Msk               (1UL << SCB_CFSR_STKERR_Pos)                    /*!< SCB CFSR (BFSR): STKERR Mask */
+
+#define SCB_CFSR_UNSTKERR_Pos             (SCB_CFSR_BUSFAULTSR_Pos + 3U)                  /*!< SCB CFSR (BFSR): UNSTKERR Position */
+#define SCB_CFSR_UNSTKERR_Msk             (1UL << SCB_CFSR_UNSTKERR_Pos)                  /*!< SCB CFSR (BFSR): UNSTKERR Mask */
+
+#define SCB_CFSR_IMPRECISERR_Pos          (SCB_CFSR_BUSFAULTSR_Pos + 2U)                  /*!< SCB CFSR (BFSR): IMPRECISERR Position */
+#define SCB_CFSR_IMPRECISERR_Msk          (1UL << SCB_CFSR_IMPRECISERR_Pos)               /*!< SCB CFSR (BFSR): IMPRECISERR Mask */
+
+#define SCB_CFSR_PRECISERR_Pos            (SCB_CFSR_BUSFAULTSR_Pos + 1U)                  /*!< SCB CFSR (BFSR): PRECISERR Position */
+#define SCB_CFSR_PRECISERR_Msk            (1UL << SCB_CFSR_PRECISERR_Pos)                 /*!< SCB CFSR (BFSR): PRECISERR Mask */
+
+#define SCB_CFSR_IBUSERR_Pos              (SCB_CFSR_BUSFAULTSR_Pos + 0U)                  /*!< SCB CFSR (BFSR): IBUSERR Position */
+#define SCB_CFSR_IBUSERR_Msk              (1UL << SCB_CFSR_IBUSERR_Pos)                   /*!< SCB CFSR (BFSR): IBUSERR Mask */
+
+/** \brief SCB UsageFault Status Register Definitions (part of SCB Configurable Fault Status Register) */
+#define SCB_CFSR_DIVBYZERO_Pos            (SCB_CFSR_USGFAULTSR_Pos + 9U)                  /*!< SCB CFSR (UFSR): DIVBYZERO Position */
+#define SCB_CFSR_DIVBYZERO_Msk            (1UL << SCB_CFSR_DIVBYZERO_Pos)                 /*!< SCB CFSR (UFSR): DIVBYZERO Mask */
+
+#define SCB_CFSR_UNALIGNED_Pos            (SCB_CFSR_USGFAULTSR_Pos + 8U)                  /*!< SCB CFSR (UFSR): UNALIGNED Position */
+#define SCB_CFSR_UNALIGNED_Msk            (1UL << SCB_CFSR_UNALIGNED_Pos)                 /*!< SCB CFSR (UFSR): UNALIGNED Mask */
+
+#define SCB_CFSR_NOCP_Pos                 (SCB_CFSR_USGFAULTSR_Pos + 3U)                  /*!< SCB CFSR (UFSR): NOCP Position */
+#define SCB_CFSR_NOCP_Msk                 (1UL << SCB_CFSR_NOCP_Pos)                      /*!< SCB CFSR (UFSR): NOCP Mask */
+
+#define SCB_CFSR_INVPC_Pos                (SCB_CFSR_USGFAULTSR_Pos + 2U)                  /*!< SCB CFSR (UFSR): INVPC Position */
+#define SCB_CFSR_INVPC_Msk                (1UL << SCB_CFSR_INVPC_Pos)                     /*!< SCB CFSR (UFSR): INVPC Mask */
+
+#define SCB_CFSR_INVSTATE_Pos             (SCB_CFSR_USGFAULTSR_Pos + 1U)                  /*!< SCB CFSR (UFSR): INVSTATE Position */
+#define SCB_CFSR_INVSTATE_Msk             (1UL << SCB_CFSR_INVSTATE_Pos)                  /*!< SCB CFSR (UFSR): INVSTATE Mask */
+
+#define SCB_CFSR_UNDEFINSTR_Pos           (SCB_CFSR_USGFAULTSR_Pos + 0U)                  /*!< SCB CFSR (UFSR): UNDEFINSTR Position */
+#define SCB_CFSR_UNDEFINSTR_Msk           (1UL << SCB_CFSR_UNDEFINSTR_Pos)                /*!< SCB CFSR (UFSR): UNDEFINSTR Mask */
+
+/** \brief SCB Hard Fault Status Register Definitions */
+#define SCB_HFSR_DEBUGEVT_Pos              31U                                            /*!< SCB HFSR: DEBUGEVT Position */
+#define SCB_HFSR_DEBUGEVT_Msk              (1UL << SCB_HFSR_DEBUGEVT_Pos)                 /*!< SCB HFSR: DEBUGEVT Mask */
+
+#define SCB_HFSR_FORCED_Pos                30U                                            /*!< SCB HFSR: FORCED Position */
+#define SCB_HFSR_FORCED_Msk                (1UL << SCB_HFSR_FORCED_Pos)                   /*!< SCB HFSR: FORCED Mask */
+
+#define SCB_HFSR_VECTTBL_Pos                1U                                            /*!< SCB HFSR: VECTTBL Position */
+#define SCB_HFSR_VECTTBL_Msk               (1UL << SCB_HFSR_VECTTBL_Pos)                  /*!< SCB HFSR: VECTTBL Mask */
+
+/** \brief SCB Debug Fault Status Register Definitions */
+#define SCB_DFSR_EXTERNAL_Pos               4U                                            /*!< SCB DFSR: EXTERNAL Position */
+#define SCB_DFSR_EXTERNAL_Msk              (1UL << SCB_DFSR_EXTERNAL_Pos)                 /*!< SCB DFSR: EXTERNAL Mask */
+
+#define SCB_DFSR_VCATCH_Pos                 3U                                            /*!< SCB DFSR: VCATCH Position */
+#define SCB_DFSR_VCATCH_Msk                (1UL << SCB_DFSR_VCATCH_Pos)                   /*!< SCB DFSR: VCATCH Mask */
+
+#define SCB_DFSR_DWTTRAP_Pos                2U                                            /*!< SCB DFSR: DWTTRAP Position */
+#define SCB_DFSR_DWTTRAP_Msk               (1UL << SCB_DFSR_DWTTRAP_Pos)                  /*!< SCB DFSR: DWTTRAP Mask */
+
+#define SCB_DFSR_BKPT_Pos                   1U                                            /*!< SCB DFSR: BKPT Position */
+#define SCB_DFSR_BKPT_Msk                  (1UL << SCB_DFSR_BKPT_Pos)                     /*!< SCB DFSR: BKPT Mask */
+
+#define SCB_DFSR_HALTED_Pos                 0U                                            /*!< SCB DFSR: HALTED Position */
+#define SCB_DFSR_HALTED_Msk                (1UL /*<< SCB_DFSR_HALTED_Pos*/)               /*!< SCB DFSR: HALTED Mask */
+
+/** \brief SCB Cache Level ID Register Definitions */
+#define SCB_CLIDR_LOUU_Pos                 27U                                            /*!< SCB CLIDR: LoUU Position */
+#define SCB_CLIDR_LOUU_Msk                 (7UL << SCB_CLIDR_LOUU_Pos)                    /*!< SCB CLIDR: LoUU Mask */
+
+#define SCB_CLIDR_LOC_Pos                  24U                                            /*!< SCB CLIDR: LoC Position */
+#define SCB_CLIDR_LOC_Msk                  (7UL << SCB_CLIDR_LOC_Pos)                     /*!< SCB CLIDR: LoC Mask */
+
+/** \brief SCB Cache Type Register Definitions */
+#define SCB_CTR_FORMAT_Pos                 29U                                            /*!< SCB CTR: Format Position */
+#define SCB_CTR_FORMAT_Msk                 (7UL << SCB_CTR_FORMAT_Pos)                    /*!< SCB CTR: Format Mask */
+
+#define SCB_CTR_CWG_Pos                    24U                                            /*!< SCB CTR: CWG Position */
+#define SCB_CTR_CWG_Msk                    (0xFUL << SCB_CTR_CWG_Pos)                     /*!< SCB CTR: CWG Mask */
+
+#define SCB_CTR_ERG_Pos                    20U                                            /*!< SCB CTR: ERG Position */
+#define SCB_CTR_ERG_Msk                    (0xFUL << SCB_CTR_ERG_Pos)                     /*!< SCB CTR: ERG Mask */
+
+#define SCB_CTR_DMINLINE_Pos               16U                                            /*!< SCB CTR: DminLine Position */
+#define SCB_CTR_DMINLINE_Msk               (0xFUL << SCB_CTR_DMINLINE_Pos)                /*!< SCB CTR: DminLine Mask */
+
+#define SCB_CTR_IMINLINE_Pos                0U                                            /*!< SCB CTR: ImInLine Position */
+#define SCB_CTR_IMINLINE_Msk               (0xFUL /*<< SCB_CTR_IMINLINE_Pos*/)            /*!< SCB CTR: ImInLine Mask */
+
+/** \brief SCB Cache Size ID Register Definitions */
+#define SCB_CCSIDR_WT_Pos                  31U                                            /*!< SCB CCSIDR: WT Position */
+#define SCB_CCSIDR_WT_Msk                  (1UL << SCB_CCSIDR_WT_Pos)                     /*!< SCB CCSIDR: WT Mask */
+
+#define SCB_CCSIDR_WB_Pos                  30U                                            /*!< SCB CCSIDR: WB Position */
+#define SCB_CCSIDR_WB_Msk                  (1UL << SCB_CCSIDR_WB_Pos)                     /*!< SCB CCSIDR: WB Mask */
+
+#define SCB_CCSIDR_RA_Pos                  29U                                            /*!< SCB CCSIDR: RA Position */
+#define SCB_CCSIDR_RA_Msk                  (1UL << SCB_CCSIDR_RA_Pos)                     /*!< SCB CCSIDR: RA Mask */
+
+#define SCB_CCSIDR_WA_Pos                  28U                                            /*!< SCB CCSIDR: WA Position */
+#define SCB_CCSIDR_WA_Msk                  (1UL << SCB_CCSIDR_WA_Pos)                     /*!< SCB CCSIDR: WA Mask */
+
+#define SCB_CCSIDR_NUMSETS_Pos             13U                                            /*!< SCB CCSIDR: NumSets Position */
+#define SCB_CCSIDR_NUMSETS_Msk             (0x7FFFUL << SCB_CCSIDR_NUMSETS_Pos)           /*!< SCB CCSIDR: NumSets Mask */
+
+#define SCB_CCSIDR_ASSOCIATIVITY_Pos        3U                                            /*!< SCB CCSIDR: Associativity Position */
+#define SCB_CCSIDR_ASSOCIATIVITY_Msk       (0x3FFUL << SCB_CCSIDR_ASSOCIATIVITY_Pos)      /*!< SCB CCSIDR: Associativity Mask */
+
+#define SCB_CCSIDR_LINESIZE_Pos             0U                                            /*!< SCB CCSIDR: LineSize Position */
+#define SCB_CCSIDR_LINESIZE_Msk            (7UL /*<< SCB_CCSIDR_LINESIZE_Pos*/)           /*!< SCB CCSIDR: LineSize Mask */
+
+/** \brief SCB Cache Size Selection Register Definitions */
+#define SCB_CSSELR_LEVEL_Pos                1U                                            /*!< SCB CSSELR: Level Position */
+#define SCB_CSSELR_LEVEL_Msk               (7UL << SCB_CSSELR_LEVEL_Pos)                  /*!< SCB CSSELR: Level Mask */
+
+#define SCB_CSSELR_IND_Pos                  0U                                            /*!< SCB CSSELR: InD Position */
+#define SCB_CSSELR_IND_Msk                 (1UL /*<< SCB_CSSELR_IND_Pos*/)                /*!< SCB CSSELR: InD Mask */
+
+/** \brief SCB Software Triggered Interrupt Register Definitions */
+#define SCB_STIR_INTID_Pos                  0U                                            /*!< SCB STIR: INTID Position */
+#define SCB_STIR_INTID_Msk                 (0x1FFUL /*<< SCB_STIR_INTID_Pos*/)            /*!< SCB STIR: INTID Mask */
+
+/** \brief SCB D-Cache Invalidate by Set-way Register Definitions */
+#define SCB_DCISW_WAY_Pos                  30U                                            /*!< SCB DCISW: Way Position */
+#define SCB_DCISW_WAY_Msk                  (3UL << SCB_DCISW_WAY_Pos)                     /*!< SCB DCISW: Way Mask */
+
+#define SCB_DCISW_SET_Pos                   5U                                            /*!< SCB DCISW: Set Position */
+#define SCB_DCISW_SET_Msk                  (0x1FFUL << SCB_DCISW_SET_Pos)                 /*!< SCB DCISW: Set Mask */
+
+/** \brief SCB D-Cache Clean by Set-way Register Definitions */
+#define SCB_DCCSW_WAY_Pos                  30U                                            /*!< SCB DCCSW: Way Position */
+#define SCB_DCCSW_WAY_Msk                  (3UL << SCB_DCCSW_WAY_Pos)                     /*!< SCB DCCSW: Way Mask */
+
+#define SCB_DCCSW_SET_Pos                   5U                                            /*!< SCB DCCSW: Set Position */
+#define SCB_DCCSW_SET_Msk                  (0x1FFUL << SCB_DCCSW_SET_Pos)                 /*!< SCB DCCSW: Set Mask */
+
+/** \brief SCB D-Cache Clean and Invalidate by Set-way Register Definitions */
+#define SCB_DCCISW_WAY_Pos                 30U                                            /*!< SCB DCCISW: Way Position */
+#define SCB_DCCISW_WAY_Msk                 (3UL << SCB_DCCISW_WAY_Pos)                    /*!< SCB DCCISW: Way Mask */
+
+#define SCB_DCCISW_SET_Pos                  5U                                            /*!< SCB DCCISW: Set Position */
+#define SCB_DCCISW_SET_Msk                 (0x1FFUL << SCB_DCCISW_SET_Pos)                /*!< SCB DCCISW: Set Mask */
+
+/** \brief SCB Instruction Tightly-Coupled Memory Control Register Definitions */
+#define SCB_ITCMCR_SZ_Pos                   3U                                            /*!< SCB ITCMCR: SZ Position */
+#define SCB_ITCMCR_SZ_Msk                  (0xFUL << SCB_ITCMCR_SZ_Pos)                   /*!< SCB ITCMCR: SZ Mask */
+
+#define SCB_ITCMCR_RETEN_Pos                2U                                            /*!< SCB ITCMCR: RETEN Position */
+#define SCB_ITCMCR_RETEN_Msk               (1UL << SCB_ITCMCR_RETEN_Pos)                  /*!< SCB ITCMCR: RETEN Mask */
+
+#define SCB_ITCMCR_RMW_Pos                  1U                                            /*!< SCB ITCMCR: RMW Position */
+#define SCB_ITCMCR_RMW_Msk                 (1UL << SCB_ITCMCR_RMW_Pos)                    /*!< SCB ITCMCR: RMW Mask */
+
+#define SCB_ITCMCR_EN_Pos                   0U                                            /*!< SCB ITCMCR: EN Position */
+#define SCB_ITCMCR_EN_Msk                  (1UL /*<< SCB_ITCMCR_EN_Pos*/)                 /*!< SCB ITCMCR: EN Mask */
+
+/** \brief SCB Data Tightly-Coupled Memory Control Register Definitions */
+#define SCB_DTCMCR_SZ_Pos                   3U                                            /*!< SCB DTCMCR: SZ Position */
+#define SCB_DTCMCR_SZ_Msk                  (0xFUL << SCB_DTCMCR_SZ_Pos)                   /*!< SCB DTCMCR: SZ Mask */
+
+#define SCB_DTCMCR_RETEN_Pos                2U                                            /*!< SCB DTCMCR: RETEN Position */
+#define SCB_DTCMCR_RETEN_Msk               (1UL << SCB_DTCMCR_RETEN_Pos)                   /*!< SCB DTCMCR: RETEN Mask */
+
+#define SCB_DTCMCR_RMW_Pos                  1U                                            /*!< SCB DTCMCR: RMW Position */
+#define SCB_DTCMCR_RMW_Msk                 (1UL << SCB_DTCMCR_RMW_Pos)                    /*!< SCB DTCMCR: RMW Mask */
+
+#define SCB_DTCMCR_EN_Pos                   0U                                            /*!< SCB DTCMCR: EN Position */
+#define SCB_DTCMCR_EN_Msk                  (1UL /*<< SCB_DTCMCR_EN_Pos*/)                 /*!< SCB DTCMCR: EN Mask */
+
+/** \brief SCB AHBP Control Register Definitions */
+#define SCB_AHBPCR_SZ_Pos                   1U                                            /*!< SCB AHBPCR: SZ Position */
+#define SCB_AHBPCR_SZ_Msk                  (7UL << SCB_AHBPCR_SZ_Pos)                     /*!< SCB AHBPCR: SZ Mask */
+
+#define SCB_AHBPCR_EN_Pos                   0U                                            /*!< SCB AHBPCR: EN Position */
+#define SCB_AHBPCR_EN_Msk                  (1UL /*<< SCB_AHBPCR_EN_Pos*/)                 /*!< SCB AHBPCR: EN Mask */
+
+/** \brief SCB L1 Cache Control Register Definitions */
+#define SCB_CACR_FORCEWT_Pos                2U                                            /*!< SCB CACR: FORCEWT Position */
+#define SCB_CACR_FORCEWT_Msk               (1UL << SCB_CACR_FORCEWT_Pos)                  /*!< SCB CACR: FORCEWT Mask */
+
+#define SCB_CACR_ECCDIS_Pos                 1U                                            /*!< SCB CACR: ECCDIS Position */
+#define SCB_CACR_ECCDIS_Msk                (1UL << SCB_CACR_ECCDIS_Pos)                   /*!< SCB CACR: ECCDIS Mask */
+
+#define SCB_CACR_SIWT_Pos                   0U                                            /*!< SCB CACR: SIWT Position */
+#define SCB_CACR_SIWT_Msk                  (1UL /*<< SCB_CACR_SIWT_Pos*/)                 /*!< SCB CACR: SIWT Mask */
+
+/** \brief SCB AHBS Control Register Definitions */
+#define SCB_AHBSCR_INITCOUNT_Pos           11U                                            /*!< SCB AHBSCR: INITCOUNT Position */
+#define SCB_AHBSCR_INITCOUNT_Msk           (0x1FUL << SCB_AHBSCR_INITCOUNT_Pos)           /*!< SCB AHBSCR: INITCOUNT Mask */
+
+#define SCB_AHBSCR_TPRI_Pos                 2U                                            /*!< SCB AHBSCR: TPRI Position */
+#define SCB_AHBSCR_TPRI_Msk                (0x1FFUL << SCB_AHBSCR_TPRI_Pos)               /*!< SCB AHBSCR: TPRI Mask */
+
+#define SCB_AHBSCR_CTL_Pos                  0U                                            /*!< SCB AHBSCR: CTL Position*/
+#define SCB_AHBSCR_CTL_Msk                 (3UL /*<< SCB_AHBSCR_CTL_Pos*/)                /*!< SCB AHBSCR: CTL Mask */
+
+/** \brief SCB Auxiliary Bus Fault Status Register Definitions */
+#define SCB_ABFSR_AXIMTYPE_Pos              8U                                            /*!< SCB ABFSR: AXIMTYPE Position*/
+#define SCB_ABFSR_AXIMTYPE_Msk             (3UL << SCB_ABFSR_AXIMTYPE_Pos)                /*!< SCB ABFSR: AXIMTYPE Mask */
+
+#define SCB_ABFSR_EPPB_Pos                  4U                                            /*!< SCB ABFSR: EPPB Position*/
+#define SCB_ABFSR_EPPB_Msk                 (1UL << SCB_ABFSR_EPPB_Pos)                    /*!< SCB ABFSR: EPPB Mask */
+
+#define SCB_ABFSR_AXIM_Pos                  3U                                            /*!< SCB ABFSR: AXIM Position*/
+#define SCB_ABFSR_AXIM_Msk                 (1UL << SCB_ABFSR_AXIM_Pos)                    /*!< SCB ABFSR: AXIM Mask */
+
+#define SCB_ABFSR_AHBP_Pos                  2U                                            /*!< SCB ABFSR: AHBP Position*/
+#define SCB_ABFSR_AHBP_Msk                 (1UL << SCB_ABFSR_AHBP_Pos)                    /*!< SCB ABFSR: AHBP Mask */
+
+#define SCB_ABFSR_DTCM_Pos                  1U                                            /*!< SCB ABFSR: DTCM Position*/
+#define SCB_ABFSR_DTCM_Msk                 (1UL << SCB_ABFSR_DTCM_Pos)                    /*!< SCB ABFSR: DTCM Mask */
+
+#define SCB_ABFSR_ITCM_Pos                  0U                                            /*!< SCB ABFSR: ITCM Position*/
+#define SCB_ABFSR_ITCM_Msk                 (1UL /*<< SCB_ABFSR_ITCM_Pos*/)                /*!< SCB ABFSR: ITCM Mask */
+
+/*@} end of group CMSIS_SCB */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SCnSCB System Controls not in SCB (SCnSCB)
+  \brief    Type definitions for the System Control and ID Register not in the SCB
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Control and ID Register not in the SCB.
+ */
+typedef struct
+{
+        uint32_t RESERVED0[1U];
+  __IM  uint32_t ICTR;                   /*!< Offset: 0x004 (R/ )  Interrupt Controller Type Register */
+  __IOM uint32_t ACTLR;                  /*!< Offset: 0x008 (R/W)  Auxiliary Control Register */
+} SCnSCB_Type;
+
+/** \brief SCnSCB Interrupt Controller Type Register Definitions */
+#define SCnSCB_ICTR_INTLINESNUM_Pos         0U                                         /*!< ICTR: INTLINESNUM Position */
+#define SCnSCB_ICTR_INTLINESNUM_Msk        (0xFUL /*<< SCnSCB_ICTR_INTLINESNUM_Pos*/)  /*!< ICTR: INTLINESNUM Mask */
+
+/** \brief SCnSCB Auxiliary Control Register Definitions */
+#define SCnSCB_ACTLR_DISDYNADD_Pos         26U                                         /*!< ACTLR: DISDYNADD Position */
+#define SCnSCB_ACTLR_DISDYNADD_Msk         (1UL << SCnSCB_ACTLR_DISDYNADD_Pos)         /*!< ACTLR: DISDYNADD Mask */
+
+#define SCnSCB_ACTLR_DISISSCH1_Pos         21U                                         /*!< ACTLR: DISISSCH1 Position */
+#define SCnSCB_ACTLR_DISISSCH1_Msk         (0x1FUL << SCnSCB_ACTLR_DISISSCH1_Pos)      /*!< ACTLR: DISISSCH1 Mask */
+
+#define SCnSCB_ACTLR_DISDI_Pos             16U                                         /*!< ACTLR: DISDI Position */
+#define SCnSCB_ACTLR_DISDI_Msk             (0x1FUL << SCnSCB_ACTLR_DISDI_Pos)          /*!< ACTLR: DISDI Mask */
+
+#define SCnSCB_ACTLR_DISCRITAXIRUR_Pos     15U                                         /*!< ACTLR: DISCRITAXIRUR Position */
+#define SCnSCB_ACTLR_DISCRITAXIRUR_Msk     (1UL << SCnSCB_ACTLR_DISCRITAXIRUR_Pos)     /*!< ACTLR: DISCRITAXIRUR Mask */
+
+#define SCnSCB_ACTLR_DISBTACALLOC_Pos      14U                                         /*!< ACTLR: DISBTACALLOC Position */
+#define SCnSCB_ACTLR_DISBTACALLOC_Msk      (1UL << SCnSCB_ACTLR_DISBTACALLOC_Pos)      /*!< ACTLR: DISBTACALLOC Mask */
+
+#define SCnSCB_ACTLR_DISBTACREAD_Pos       13U                                         /*!< ACTLR: DISBTACREAD Position */
+#define SCnSCB_ACTLR_DISBTACREAD_Msk       (1UL << SCnSCB_ACTLR_DISBTACREAD_Pos)       /*!< ACTLR: DISBTACREAD Mask */
+
+#define SCnSCB_ACTLR_DISITMATBFLUSH_Pos    12U                                         /*!< ACTLR: DISITMATBFLUSH Position */
+#define SCnSCB_ACTLR_DISITMATBFLUSH_Msk    (1UL << SCnSCB_ACTLR_DISITMATBFLUSH_Pos)    /*!< ACTLR: DISITMATBFLUSH Mask */
+
+#define SCnSCB_ACTLR_DISRAMODE_Pos         11U                                         /*!< ACTLR: DISRAMODE Position */
+#define SCnSCB_ACTLR_DISRAMODE_Msk         (1UL << SCnSCB_ACTLR_DISRAMODE_Pos)         /*!< ACTLR: DISRAMODE Mask */
+
+#define SCnSCB_ACTLR_FPEXCODIS_Pos         10U                                         /*!< ACTLR: FPEXCODIS Position */
+#define SCnSCB_ACTLR_FPEXCODIS_Msk         (1UL << SCnSCB_ACTLR_FPEXCODIS_Pos)         /*!< ACTLR: FPEXCODIS Mask */
+
+#define SCnSCB_ACTLR_DISFOLD_Pos            2U                                         /*!< ACTLR: DISFOLD Position */
+#define SCnSCB_ACTLR_DISFOLD_Msk           (1UL << SCnSCB_ACTLR_DISFOLD_Pos)           /*!< ACTLR: DISFOLD Mask */
+
+#define SCnSCB_ACTLR_DISMCYCINT_Pos         0U                                         /*!< ACTLR: DISMCYCINT Position */
+#define SCnSCB_ACTLR_DISMCYCINT_Msk        (1UL /*<< SCnSCB_ACTLR_DISMCYCINT_Pos*/)    /*!< ACTLR: DISMCYCINT Mask */
+
+/*@} end of group CMSIS_SCnotSCB */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SysTick     System Tick Timer (SysTick)
+  \brief    Type definitions for the System Timer Registers.
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Timer (SysTick).
+ */
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  SysTick Control and Status Register */
+  __IOM uint32_t LOAD;                   /*!< Offset: 0x004 (R/W)  SysTick Reload Value Register */
+  __IOM uint32_t VAL;                    /*!< Offset: 0x008 (R/W)  SysTick Current Value Register */
+  __IM  uint32_t CALIB;                  /*!< Offset: 0x00C (R/ )  SysTick Calibration Register */
+} SysTick_Type;
+
+/** \brief SysTick Control / Status Register Definitions */
+#define SysTick_CTRL_COUNTFLAG_Pos         16U                                            /*!< SysTick CTRL: COUNTFLAG Position */
+#define SysTick_CTRL_COUNTFLAG_Msk         (1UL << SysTick_CTRL_COUNTFLAG_Pos)            /*!< SysTick CTRL: COUNTFLAG Mask */
+
+#define SysTick_CTRL_CLKSOURCE_Pos          2U                                            /*!< SysTick CTRL: CLKSOURCE Position */
+#define SysTick_CTRL_CLKSOURCE_Msk         (1UL << SysTick_CTRL_CLKSOURCE_Pos)            /*!< SysTick CTRL: CLKSOURCE Mask */
+
+#define SysTick_CTRL_TICKINT_Pos            1U                                            /*!< SysTick CTRL: TICKINT Position */
+#define SysTick_CTRL_TICKINT_Msk           (1UL << SysTick_CTRL_TICKINT_Pos)              /*!< SysTick CTRL: TICKINT Mask */
+
+#define SysTick_CTRL_ENABLE_Pos             0U                                            /*!< SysTick CTRL: ENABLE Position */
+#define SysTick_CTRL_ENABLE_Msk            (1UL /*<< SysTick_CTRL_ENABLE_Pos*/)           /*!< SysTick CTRL: ENABLE Mask */
+
+/** \brief SysTick Reload Register Definitions */
+#define SysTick_LOAD_RELOAD_Pos             0U                                            /*!< SysTick LOAD: RELOAD Position */
+#define SysTick_LOAD_RELOAD_Msk            (0xFFFFFFUL /*<< SysTick_LOAD_RELOAD_Pos*/)    /*!< SysTick LOAD: RELOAD Mask */
+
+/** \brief SysTick Current Register Definitions */
+#define SysTick_VAL_CURRENT_Pos             0U                                            /*!< SysTick VAL: CURRENT Position */
+#define SysTick_VAL_CURRENT_Msk            (0xFFFFFFUL /*<< SysTick_VAL_CURRENT_Pos*/)    /*!< SysTick VAL: CURRENT Mask */
+
+/** \brief SysTick Calibration Register Definitions */
+#define SysTick_CALIB_NOREF_Pos            31U                                            /*!< SysTick CALIB: NOREF Position */
+#define SysTick_CALIB_NOREF_Msk            (1UL << SysTick_CALIB_NOREF_Pos)               /*!< SysTick CALIB: NOREF Mask */
+
+#define SysTick_CALIB_SKEW_Pos             30U                                            /*!< SysTick CALIB: SKEW Position */
+#define SysTick_CALIB_SKEW_Msk             (1UL << SysTick_CALIB_SKEW_Pos)                /*!< SysTick CALIB: SKEW Mask */
+
+#define SysTick_CALIB_TENMS_Pos             0U                                            /*!< SysTick CALIB: TENMS Position */
+#define SysTick_CALIB_TENMS_Msk            (0xFFFFFFUL /*<< SysTick_CALIB_TENMS_Pos*/)    /*!< SysTick CALIB: TENMS Mask */
+
+/*@} end of group CMSIS_SysTick */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_ITM     Instrumentation Trace Macrocell (ITM)
+  \brief    Type definitions for the Instrumentation Trace Macrocell (ITM)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Instrumentation Trace Macrocell Register (ITM).
+ */
+typedef struct
+{
+  __OM  union
+  {
+    __OM  uint8_t    u8;                 /*!< Offset: 0x000 ( /W)  Stimulus Port 8-bit */
+    __OM  uint16_t   u16;                /*!< Offset: 0x000 ( /W)  Stimulus Port 16-bit */
+    __OM  uint32_t   u32;                /*!< Offset: 0x000 ( /W)  Stimulus Port 32-bit */
+  }  PORT [32U];                         /*!< Offset: 0x000 ( /W)  Stimulus Port Registers */
+        uint32_t RESERVED0[864U];
+  __IOM uint32_t TER;                    /*!< Offset: 0xE00 (R/W)  Trace Enable Register */
+        uint32_t RESERVED1[15U];
+  __IOM uint32_t TPR;                    /*!< Offset: 0xE40 (R/W)  Trace Privilege Register */
+        uint32_t RESERVED2[15U];
+  __IOM uint32_t TCR;                    /*!< Offset: 0xE80 (R/W)  Trace Control Register */
+        uint32_t RESERVED3[32U];
+        uint32_t RESERVED4[43U];
+  __OM  uint32_t LAR;                    /*!< Offset: 0xFB0 ( /W)  Lock Access Register */
+  __IM  uint32_t LSR;                    /*!< Offset: 0xFB4 (R/ )  Lock Status Register */
+} ITM_Type;
+
+/** \brief ITM Trace Privilege Register Definitions */
+#define ITM_TPR_PRIVMASK_Pos                0U                                            /*!< ITM TPR: PRIVMASK Position */
+#define ITM_TPR_PRIVMASK_Msk               (0xFFFFFFFFUL /*<< ITM_TPR_PRIVMASK_Pos*/)     /*!< ITM TPR: PRIVMASK Mask */
+
+/** \brief ITM Trace Control Register Definitions */
+#define ITM_TCR_BUSY_Pos                   23U                                            /*!< ITM TCR: BUSY Position */
+#define ITM_TCR_BUSY_Msk                   (1UL << ITM_TCR_BUSY_Pos)                      /*!< ITM TCR: BUSY Mask */
+
+#define ITM_TCR_TRACEBUSID_Pos             16U                                            /*!< ITM TCR: ATBID Position */
+#define ITM_TCR_TRACEBUSID_Msk             (0x7FUL << ITM_TCR_TRACEBUSID_Pos)             /*!< ITM TCR: ATBID Mask */
+
+#define ITM_TCR_GTSFREQ_Pos                10U                                            /*!< ITM TCR: Global timestamp frequency Position */
+#define ITM_TCR_GTSFREQ_Msk                (3UL << ITM_TCR_GTSFREQ_Pos)                   /*!< ITM TCR: Global timestamp frequency Mask */
+
+#define ITM_TCR_TSPRESCALE_Pos              8U                                            /*!< ITM TCR: TSPrescale Position */
+#define ITM_TCR_TSPRESCALE_Msk             (3UL << ITM_TCR_TSPRESCALE_Pos)                /*!< ITM TCR: TSPrescale Mask */
+
+#define ITM_TCR_SWOENA_Pos                  4U                                            /*!< ITM TCR: SWOENA Position */
+#define ITM_TCR_SWOENA_Msk                 (1UL << ITM_TCR_SWOENA_Pos)                    /*!< ITM TCR: SWOENA Mask */
+
+#define ITM_TCR_DWTENA_Pos                  3U                                            /*!< ITM TCR: DWTENA Position */
+#define ITM_TCR_DWTENA_Msk                 (1UL << ITM_TCR_DWTENA_Pos)                    /*!< ITM TCR: DWTENA Mask */
+
+#define ITM_TCR_SYNCENA_Pos                 2U                                            /*!< ITM TCR: SYNCENA Position */
+#define ITM_TCR_SYNCENA_Msk                (1UL << ITM_TCR_SYNCENA_Pos)                   /*!< ITM TCR: SYNCENA Mask */
+
+#define ITM_TCR_TSENA_Pos                   1U                                            /*!< ITM TCR: TSENA Position */
+#define ITM_TCR_TSENA_Msk                  (1UL << ITM_TCR_TSENA_Pos)                     /*!< ITM TCR: TSENA Mask */
+
+#define ITM_TCR_ITMENA_Pos                  0U                                            /*!< ITM TCR: ITM Enable bit Position */
+#define ITM_TCR_ITMENA_Msk                 (1UL /*<< ITM_TCR_ITMENA_Pos*/)                /*!< ITM TCR: ITM Enable bit Mask */
+
+/** \brief ITM Lock Status Register Definitions */
+#define ITM_LSR_BYTEACC_Pos                 2U                                            /*!< ITM LSR: ByteAcc Position */
+#define ITM_LSR_BYTEACC_Msk                (1UL << ITM_LSR_BYTEACC_Pos)                   /*!< ITM LSR: ByteAcc Mask */
+
+#define ITM_LSR_ACCESS_Pos                  1U                                            /*!< ITM LSR: Access Position */
+#define ITM_LSR_ACCESS_Msk                 (1UL << ITM_LSR_ACCESS_Pos)                    /*!< ITM LSR: Access Mask */
+
+#define ITM_LSR_PRESENT_Pos                 0U                                            /*!< ITM LSR: Present Position */
+#define ITM_LSR_PRESENT_Msk                (1UL /*<< ITM_LSR_PRESENT_Pos*/)               /*!< ITM LSR: Present Mask */
+
+/*@}*/ /* end of group CMSIS_ITM */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_DWT     Data Watchpoint and Trace (DWT)
+  \brief    Type definitions for the Data Watchpoint and Trace (DWT)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Data Watchpoint and Trace Register (DWT).
+ */
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  Control Register */
+  __IOM uint32_t CYCCNT;                 /*!< Offset: 0x004 (R/W)  Cycle Count Register */
+  __IOM uint32_t CPICNT;                 /*!< Offset: 0x008 (R/W)  CPI Count Register */
+  __IOM uint32_t EXCCNT;                 /*!< Offset: 0x00C (R/W)  Exception Overhead Count Register */
+  __IOM uint32_t SLEEPCNT;               /*!< Offset: 0x010 (R/W)  Sleep Count Register */
+  __IOM uint32_t LSUCNT;                 /*!< Offset: 0x014 (R/W)  LSU Count Register */
+  __IOM uint32_t FOLDCNT;                /*!< Offset: 0x018 (R/W)  Folded-instruction Count Register */
+  __IM  uint32_t PCSR;                   /*!< Offset: 0x01C (R/ )  Program Counter Sample Register */
+  __IOM uint32_t COMP0;                  /*!< Offset: 0x020 (R/W)  Comparator Register 0 */
+  __IOM uint32_t MASK0;                  /*!< Offset: 0x024 (R/W)  Mask Register 0 */
+  __IOM uint32_t FUNCTION0;              /*!< Offset: 0x028 (R/W)  Function Register 0 */
+        uint32_t RESERVED0[1U];
+  __IOM uint32_t COMP1;                  /*!< Offset: 0x030 (R/W)  Comparator Register 1 */
+  __IOM uint32_t MASK1;                  /*!< Offset: 0x034 (R/W)  Mask Register 1 */
+  __IOM uint32_t FUNCTION1;              /*!< Offset: 0x038 (R/W)  Function Register 1 */
+        uint32_t RESERVED1[1U];
+  __IOM uint32_t COMP2;                  /*!< Offset: 0x040 (R/W)  Comparator Register 2 */
+  __IOM uint32_t MASK2;                  /*!< Offset: 0x044 (R/W)  Mask Register 2 */
+  __IOM uint32_t FUNCTION2;              /*!< Offset: 0x048 (R/W)  Function Register 2 */
+        uint32_t RESERVED2[1U];
+  __IOM uint32_t COMP3;                  /*!< Offset: 0x050 (R/W)  Comparator Register 3 */
+  __IOM uint32_t MASK3;                  /*!< Offset: 0x054 (R/W)  Mask Register 3 */
+  __IOM uint32_t FUNCTION3;              /*!< Offset: 0x058 (R/W)  Function Register 3 */
+} DWT_Type;
+
+/** \brief DWT Control Register Definitions */
+#define DWT_CTRL_NUMCOMP_Pos               28U                                         /*!< DWT CTRL: NUMCOMP Position */
+#define DWT_CTRL_NUMCOMP_Msk               (0xFUL << DWT_CTRL_NUMCOMP_Pos)             /*!< DWT CTRL: NUMCOMP Mask */
+
+#define DWT_CTRL_NOTRCPKT_Pos              27U                                         /*!< DWT CTRL: NOTRCPKT Position */
+#define DWT_CTRL_NOTRCPKT_Msk              (1UL << DWT_CTRL_NOTRCPKT_Pos)              /*!< DWT CTRL: NOTRCPKT Mask */
+
+#define DWT_CTRL_NOEXTTRIG_Pos             26U                                         /*!< DWT CTRL: NOEXTTRIG Position */
+#define DWT_CTRL_NOEXTTRIG_Msk             (1UL << DWT_CTRL_NOEXTTRIG_Pos)             /*!< DWT CTRL: NOEXTTRIG Mask */
+
+#define DWT_CTRL_NOCYCCNT_Pos              25U                                         /*!< DWT CTRL: NOCYCCNT Position */
+#define DWT_CTRL_NOCYCCNT_Msk              (1UL << DWT_CTRL_NOCYCCNT_Pos)              /*!< DWT CTRL: NOCYCCNT Mask */
+
+#define DWT_CTRL_NOPRFCNT_Pos              24U                                         /*!< DWT CTRL: NOPRFCNT Position */
+#define DWT_CTRL_NOPRFCNT_Msk              (1UL << DWT_CTRL_NOPRFCNT_Pos)              /*!< DWT CTRL: NOPRFCNT Mask */
+
+#define DWT_CTRL_CYCEVTENA_Pos             22U                                         /*!< DWT CTRL: CYCEVTENA Position */
+#define DWT_CTRL_CYCEVTENA_Msk             (1UL << DWT_CTRL_CYCEVTENA_Pos)             /*!< DWT CTRL: CYCEVTENA Mask */
+
+#define DWT_CTRL_FOLDEVTENA_Pos            21U                                         /*!< DWT CTRL: FOLDEVTENA Position */
+#define DWT_CTRL_FOLDEVTENA_Msk            (1UL << DWT_CTRL_FOLDEVTENA_Pos)            /*!< DWT CTRL: FOLDEVTENA Mask */
+
+#define DWT_CTRL_LSUEVTENA_Pos             20U                                         /*!< DWT CTRL: LSUEVTENA Position */
+#define DWT_CTRL_LSUEVTENA_Msk             (1UL << DWT_CTRL_LSUEVTENA_Pos)             /*!< DWT CTRL: LSUEVTENA Mask */
+
+#define DWT_CTRL_SLEEPEVTENA_Pos           19U                                         /*!< DWT CTRL: SLEEPEVTENA Position */
+#define DWT_CTRL_SLEEPEVTENA_Msk           (1UL << DWT_CTRL_SLEEPEVTENA_Pos)           /*!< DWT CTRL: SLEEPEVTENA Mask */
+
+#define DWT_CTRL_EXCEVTENA_Pos             18U                                         /*!< DWT CTRL: EXCEVTENA Position */
+#define DWT_CTRL_EXCEVTENA_Msk             (1UL << DWT_CTRL_EXCEVTENA_Pos)             /*!< DWT CTRL: EXCEVTENA Mask */
+
+#define DWT_CTRL_CPIEVTENA_Pos             17U                                         /*!< DWT CTRL: CPIEVTENA Position */
+#define DWT_CTRL_CPIEVTENA_Msk             (1UL << DWT_CTRL_CPIEVTENA_Pos)             /*!< DWT CTRL: CPIEVTENA Mask */
+
+#define DWT_CTRL_EXCTRCENA_Pos             16U                                         /*!< DWT CTRL: EXCTRCENA Position */
+#define DWT_CTRL_EXCTRCENA_Msk             (1UL << DWT_CTRL_EXCTRCENA_Pos)             /*!< DWT CTRL: EXCTRCENA Mask */
+
+#define DWT_CTRL_PCSAMPLENA_Pos            12U                                         /*!< DWT CTRL: PCSAMPLENA Position */
+#define DWT_CTRL_PCSAMPLENA_Msk            (1UL << DWT_CTRL_PCSAMPLENA_Pos)            /*!< DWT CTRL: PCSAMPLENA Mask */
+
+#define DWT_CTRL_SYNCTAP_Pos               10U                                         /*!< DWT CTRL: SYNCTAP Position */
+#define DWT_CTRL_SYNCTAP_Msk               (0x3UL << DWT_CTRL_SYNCTAP_Pos)             /*!< DWT CTRL: SYNCTAP Mask */
+
+#define DWT_CTRL_CYCTAP_Pos                 9U                                         /*!< DWT CTRL: CYCTAP Position */
+#define DWT_CTRL_CYCTAP_Msk                (1UL << DWT_CTRL_CYCTAP_Pos)                /*!< DWT CTRL: CYCTAP Mask */
+
+#define DWT_CTRL_POSTINIT_Pos               5U                                         /*!< DWT CTRL: POSTINIT Position */
+#define DWT_CTRL_POSTINIT_Msk              (0xFUL << DWT_CTRL_POSTINIT_Pos)            /*!< DWT CTRL: POSTINIT Mask */
+
+#define DWT_CTRL_POSTPRESET_Pos             1U                                         /*!< DWT CTRL: POSTPRESET Position */
+#define DWT_CTRL_POSTPRESET_Msk            (0xFUL << DWT_CTRL_POSTPRESET_Pos)          /*!< DWT CTRL: POSTPRESET Mask */
+
+#define DWT_CTRL_CYCCNTENA_Pos              0U                                         /*!< DWT CTRL: CYCCNTENA Position */
+#define DWT_CTRL_CYCCNTENA_Msk             (1UL /*<< DWT_CTRL_CYCCNTENA_Pos*/)         /*!< DWT CTRL: CYCCNTENA Mask */
+
+/** \brief DWT CPI Count Register Definitions */
+#define DWT_CPICNT_CPICNT_Pos               0U                                         /*!< DWT CPICNT: CPICNT Position */
+#define DWT_CPICNT_CPICNT_Msk              (0xFFUL /*<< DWT_CPICNT_CPICNT_Pos*/)       /*!< DWT CPICNT: CPICNT Mask */
+
+/** \brief DWT Exception Overhead Count Register Definitions */
+#define DWT_EXCCNT_EXCCNT_Pos               0U                                         /*!< DWT EXCCNT: EXCCNT Position */
+#define DWT_EXCCNT_EXCCNT_Msk              (0xFFUL /*<< DWT_EXCCNT_EXCCNT_Pos*/)       /*!< DWT EXCCNT: EXCCNT Mask */
+
+/** \brief DWT Sleep Count Register Definitions */
+#define DWT_SLEEPCNT_SLEEPCNT_Pos           0U                                         /*!< DWT SLEEPCNT: SLEEPCNT Position */
+#define DWT_SLEEPCNT_SLEEPCNT_Msk          (0xFFUL /*<< DWT_SLEEPCNT_SLEEPCNT_Pos*/)   /*!< DWT SLEEPCNT: SLEEPCNT Mask */
+
+/** \brief DWT LSU Count Register Definitions */
+#define DWT_LSUCNT_LSUCNT_Pos               0U                                         /*!< DWT LSUCNT: LSUCNT Position */
+#define DWT_LSUCNT_LSUCNT_Msk              (0xFFUL /*<< DWT_LSUCNT_LSUCNT_Pos*/)       /*!< DWT LSUCNT: LSUCNT Mask */
+
+/** \brief DWT Folded-instruction Count Register Definitions */
+#define DWT_FOLDCNT_FOLDCNT_Pos             0U                                         /*!< DWT FOLDCNT: FOLDCNT Position */
+#define DWT_FOLDCNT_FOLDCNT_Msk            (0xFFUL /*<< DWT_FOLDCNT_FOLDCNT_Pos*/)     /*!< DWT FOLDCNT: FOLDCNT Mask */
+
+/** \brief DWT Comparator Mask Register Definitions */
+#define DWT_MASK_MASK_Pos                   0U                                         /*!< DWT MASK: MASK Position */
+#define DWT_MASK_MASK_Msk                  (0x1FUL /*<< DWT_MASK_MASK_Pos*/)           /*!< DWT MASK: MASK Mask */
+
+/** \brief DWT Comparator Function Register Definitions */
+#define DWT_FUNCTION_MATCHED_Pos           24U                                         /*!< DWT FUNCTION: MATCHED Position */
+#define DWT_FUNCTION_MATCHED_Msk           (1UL << DWT_FUNCTION_MATCHED_Pos)           /*!< DWT FUNCTION: MATCHED Mask */
+
+#define DWT_FUNCTION_DATAVADDR1_Pos        16U                                         /*!< DWT FUNCTION: DATAVADDR1 Position */
+#define DWT_FUNCTION_DATAVADDR1_Msk        (0xFUL << DWT_FUNCTION_DATAVADDR1_Pos)      /*!< DWT FUNCTION: DATAVADDR1 Mask */
+
+#define DWT_FUNCTION_DATAVADDR0_Pos        12U                                         /*!< DWT FUNCTION: DATAVADDR0 Position */
+#define DWT_FUNCTION_DATAVADDR0_Msk        (0xFUL << DWT_FUNCTION_DATAVADDR0_Pos)      /*!< DWT FUNCTION: DATAVADDR0 Mask */
+
+#define DWT_FUNCTION_DATAVSIZE_Pos         10U                                         /*!< DWT FUNCTION: DATAVSIZE Position */
+#define DWT_FUNCTION_DATAVSIZE_Msk         (0x3UL << DWT_FUNCTION_DATAVSIZE_Pos)       /*!< DWT FUNCTION: DATAVSIZE Mask */
+
+#define DWT_FUNCTION_LNK1ENA_Pos            9U                                         /*!< DWT FUNCTION: LNK1ENA Position */
+#define DWT_FUNCTION_LNK1ENA_Msk           (1UL << DWT_FUNCTION_LNK1ENA_Pos)           /*!< DWT FUNCTION: LNK1ENA Mask */
+
+#define DWT_FUNCTION_DATAVMATCH_Pos         8U                                         /*!< DWT FUNCTION: DATAVMATCH Position */
+#define DWT_FUNCTION_DATAVMATCH_Msk        (1UL << DWT_FUNCTION_DATAVMATCH_Pos)        /*!< DWT FUNCTION: DATAVMATCH Mask */
+
+#define DWT_FUNCTION_CYCMATCH_Pos           7U                                         /*!< DWT FUNCTION: CYCMATCH Position */
+#define DWT_FUNCTION_CYCMATCH_Msk          (1UL << DWT_FUNCTION_CYCMATCH_Pos)          /*!< DWT FUNCTION: CYCMATCH Mask */
+
+#define DWT_FUNCTION_EMITRANGE_Pos          5U                                         /*!< DWT FUNCTION: EMITRANGE Position */
+#define DWT_FUNCTION_EMITRANGE_Msk         (1UL << DWT_FUNCTION_EMITRANGE_Pos)         /*!< DWT FUNCTION: EMITRANGE Mask */
+
+#define DWT_FUNCTION_FUNCTION_Pos           0U                                         /*!< DWT FUNCTION: FUNCTION Position */
+#define DWT_FUNCTION_FUNCTION_Msk          (0xFUL /*<< DWT_FUNCTION_FUNCTION_Pos*/)    /*!< DWT FUNCTION: FUNCTION Mask */
+
+/*@}*/ /* end of group CMSIS_DWT */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_TPIU    Trace Port Interface Unit (TPIU)
+  \brief    Type definitions for the Trace Port Interface Unit (TPIU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Trace Port Interface Unit Register (TPIU).
+ */
+typedef struct
+{
+  __IM  uint32_t SSPSR;                  /*!< Offset: 0x000 (R/ )  Supported Parallel Port Size Register */
+  __IOM uint32_t CSPSR;                  /*!< Offset: 0x004 (R/W)  Current Parallel Port Size Register */
+        uint32_t RESERVED0[2U];
+  __IOM uint32_t ACPR;                   /*!< Offset: 0x010 (R/W)  Asynchronous Clock Prescaler Register */
+        uint32_t RESERVED1[55U];
+  __IOM uint32_t SPPR;                   /*!< Offset: 0x0F0 (R/W)  Selected Pin Protocol Register */
+        uint32_t RESERVED2[131U];
+  __IM  uint32_t FFSR;                   /*!< Offset: 0x300 (R/ )  Formatter and Flush Status Register */
+  __IOM uint32_t FFCR;                   /*!< Offset: 0x304 (R/W)  Formatter and Flush Control Register */
+  __IM  uint32_t FSCR;                   /*!< Offset: 0x308 (R/ )  Formatter Synchronization Counter Register */
+        uint32_t RESERVED3[759U];
+  __IM  uint32_t TRIGGER;                /*!< Offset: 0xEE8 (R/ )  TRIGGER Register */
+  __IM  uint32_t FIFO0;                  /*!< Offset: 0xEEC (R/ )  Integration ETM Data */
+  __IM  uint32_t ITATBCTR2;              /*!< Offset: 0xEF0 (R/ )  ITATBCTR2 */
+        uint32_t RESERVED4[1U];
+  __IM  uint32_t ITATBCTR0;              /*!< Offset: 0xEF8 (R/ )  ITATBCTR0 */
+  __IM  uint32_t FIFO1;                  /*!< Offset: 0xEFC (R/ )  Integration ITM Data */
+  __IOM uint32_t ITCTRL;                 /*!< Offset: 0xF00 (R/W)  Integration Mode Control */
+        uint32_t RESERVED5[39U];
+  __IOM uint32_t CLAIMSET;               /*!< Offset: 0xFA0 (R/W)  Claim tag set */
+  __IOM uint32_t CLAIMCLR;               /*!< Offset: 0xFA4 (R/W)  Claim tag clear */
+        uint32_t RESERVED7[8U];
+  __IM  uint32_t DEVID;                  /*!< Offset: 0xFC8 (R/ )  Device Configuration Register */
+  __IM  uint32_t DEVTYPE;                /*!< Offset: 0xFCC (R/ )  Device Type Identifier Register */
+} TPIU_Type;
+
+/** \brief TPIU Asynchronous Clock Prescaler Register Definitions */
+#define TPIU_ACPR_PRESCALER_Pos             0U                                         /*!< TPIU ACPR: PRESCALER Position */
+#define TPIU_ACPR_PRESCALER_Msk            (0x1FFFUL /*<< TPIU_ACPR_PRESCALER_Pos*/)   /*!< TPIU ACPR: PRESCALER Mask */
+
+/** \brief TPIU Selected Pin Protocol Register Definitions */
+#define TPIU_SPPR_TXMODE_Pos                0U                                         /*!< TPIU SPPR: TXMODE Position */
+#define TPIU_SPPR_TXMODE_Msk               (0x3UL /*<< TPIU_SPPR_TXMODE_Pos*/)         /*!< TPIU SPPR: TXMODE Mask */
+
+/** \brief TPIU Formatter and Flush Status Register Definitions */
+#define TPIU_FFSR_FtNonStop_Pos             3U                                         /*!< TPIU FFSR: FtNonStop Position */
+#define TPIU_FFSR_FtNonStop_Msk            (1UL << TPIU_FFSR_FtNonStop_Pos)            /*!< TPIU FFSR: FtNonStop Mask */
+
+#define TPIU_FFSR_TCPresent_Pos             2U                                         /*!< TPIU FFSR: TCPresent Position */
+#define TPIU_FFSR_TCPresent_Msk            (1UL << TPIU_FFSR_TCPresent_Pos)            /*!< TPIU FFSR: TCPresent Mask */
+
+#define TPIU_FFSR_FtStopped_Pos             1U                                         /*!< TPIU FFSR: FtStopped Position */
+#define TPIU_FFSR_FtStopped_Msk            (1UL << TPIU_FFSR_FtStopped_Pos)            /*!< TPIU FFSR: FtStopped Mask */
+
+#define TPIU_FFSR_FlInProg_Pos              0U                                         /*!< TPIU FFSR: FlInProg Position */
+#define TPIU_FFSR_FlInProg_Msk             (1UL /*<< TPIU_FFSR_FlInProg_Pos*/)         /*!< TPIU FFSR: FlInProg Mask */
+
+/** \brief TPIU Formatter and Flush Control Register Definitions */
+#define TPIU_FFCR_TrigIn_Pos                8U                                         /*!< TPIU FFCR: TrigIn Position */
+#define TPIU_FFCR_TrigIn_Msk               (1UL << TPIU_FFCR_TrigIn_Pos)               /*!< TPIU FFCR: TrigIn Mask */
+
+#define TPIU_FFCR_EnFCont_Pos               1U                                         /*!< TPIU FFCR: EnFCont Position */
+#define TPIU_FFCR_EnFCont_Msk              (1UL << TPIU_FFCR_EnFCont_Pos)              /*!< TPIU FFCR: EnFCont Mask */
+
+/** \brief TPIU TRIGGER Register Definitions */
+#define TPIU_TRIGGER_TRIGGER_Pos            0U                                         /*!< TPIU TRIGGER: TRIGGER Position */
+#define TPIU_TRIGGER_TRIGGER_Msk           (1UL /*<< TPIU_TRIGGER_TRIGGER_Pos*/)       /*!< TPIU TRIGGER: TRIGGER Mask */
+
+/** \brief TPIU Integration ETM Data Register Definitions (FIFO0) */
+#define TPIU_FIFO0_ITM_ATVALID_Pos         29U                                         /*!< TPIU FIFO0: ITM_ATVALID Position */
+#define TPIU_FIFO0_ITM_ATVALID_Msk         (1UL << TPIU_FIFO0_ITM_ATVALID_Pos)         /*!< TPIU FIFO0: ITM_ATVALID Mask */
+
+#define TPIU_FIFO0_ITM_bytecount_Pos       27U                                         /*!< TPIU FIFO0: ITM_bytecount Position */
+#define TPIU_FIFO0_ITM_bytecount_Msk       (0x3UL << TPIU_FIFO0_ITM_bytecount_Pos)     /*!< TPIU FIFO0: ITM_bytecount Mask */
+
+#define TPIU_FIFO0_ETM_ATVALID_Pos         26U                                         /*!< TPIU FIFO0: ETM_ATVALID Position */
+#define TPIU_FIFO0_ETM_ATVALID_Msk         (1UL << TPIU_FIFO0_ETM_ATVALID_Pos)         /*!< TPIU FIFO0: ETM_ATVALID Mask */
+
+#define TPIU_FIFO0_ETM_bytecount_Pos       24U                                         /*!< TPIU FIFO0: ETM_bytecount Position */
+#define TPIU_FIFO0_ETM_bytecount_Msk       (0x3UL << TPIU_FIFO0_ETM_bytecount_Pos)     /*!< TPIU FIFO0: ETM_bytecount Mask */
+
+#define TPIU_FIFO0_ETM2_Pos                16U                                         /*!< TPIU FIFO0: ETM2 Position */
+#define TPIU_FIFO0_ETM2_Msk                (0xFFUL << TPIU_FIFO0_ETM2_Pos)             /*!< TPIU FIFO0: ETM2 Mask */
+
+#define TPIU_FIFO0_ETM1_Pos                 8U                                         /*!< TPIU FIFO0: ETM1 Position */
+#define TPIU_FIFO0_ETM1_Msk                (0xFFUL << TPIU_FIFO0_ETM1_Pos)             /*!< TPIU FIFO0: ETM1 Mask */
+
+#define TPIU_FIFO0_ETM0_Pos                 0U                                         /*!< TPIU FIFO0: ETM0 Position */
+#define TPIU_FIFO0_ETM0_Msk                (0xFFUL /*<< TPIU_FIFO0_ETM0_Pos*/)         /*!< TPIU FIFO0: ETM0 Mask */
+
+/** \brief TPIU ITATBCTR2 Register Definitions */
+#define TPIU_ITATBCTR2_ATREADY2_Pos         0U                                         /*!< TPIU ITATBCTR2: ATREADY2 Position */
+#define TPIU_ITATBCTR2_ATREADY2_Msk        (1UL /*<< TPIU_ITATBCTR2_ATREADY2_Pos*/)    /*!< TPIU ITATBCTR2: ATREADY2 Mask */
+
+#define TPIU_ITATBCTR2_ATREADY1_Pos         0U                                         /*!< TPIU ITATBCTR2: ATREADY1 Position */
+#define TPIU_ITATBCTR2_ATREADY1_Msk        (1UL /*<< TPIU_ITATBCTR2_ATREADY1_Pos*/)    /*!< TPIU ITATBCTR2: ATREADY1 Mask */
+
+/** \brief TPIU Integration ITM Data Register Definitions (FIFO1) */
+#define TPIU_FIFO1_ITM_ATVALID_Pos         29U                                         /*!< TPIU FIFO1: ITM_ATVALID Position */
+#define TPIU_FIFO1_ITM_ATVALID_Msk         (1UL << TPIU_FIFO1_ITM_ATVALID_Pos)         /*!< TPIU FIFO1: ITM_ATVALID Mask */
+
+#define TPIU_FIFO1_ITM_bytecount_Pos       27U                                         /*!< TPIU FIFO1: ITM_bytecount Position */
+#define TPIU_FIFO1_ITM_bytecount_Msk       (0x3UL << TPIU_FIFO1_ITM_bytecount_Pos)     /*!< TPIU FIFO1: ITM_bytecount Mask */
+
+#define TPIU_FIFO1_ETM_ATVALID_Pos         26U                                         /*!< TPIU FIFO1: ETM_ATVALID Position */
+#define TPIU_FIFO1_ETM_ATVALID_Msk         (1UL << TPIU_FIFO1_ETM_ATVALID_Pos)         /*!< TPIU FIFO1: ETM_ATVALID Mask */
+
+#define TPIU_FIFO1_ETM_bytecount_Pos       24U                                         /*!< TPIU FIFO1: ETM_bytecount Position */
+#define TPIU_FIFO1_ETM_bytecount_Msk       (0x3UL << TPIU_FIFO1_ETM_bytecount_Pos)     /*!< TPIU FIFO1: ETM_bytecount Mask */
+
+#define TPIU_FIFO1_ITM2_Pos                16U                                         /*!< TPIU FIFO1: ITM2 Position */
+#define TPIU_FIFO1_ITM2_Msk                (0xFFUL << TPIU_FIFO1_ITM2_Pos)             /*!< TPIU FIFO1: ITM2 Mask */
+
+#define TPIU_FIFO1_ITM1_Pos                 8U                                         /*!< TPIU FIFO1: ITM1 Position */
+#define TPIU_FIFO1_ITM1_Msk                (0xFFUL << TPIU_FIFO1_ITM1_Pos)             /*!< TPIU FIFO1: ITM1 Mask */
+
+#define TPIU_FIFO1_ITM0_Pos                 0U                                         /*!< TPIU FIFO1: ITM0 Position */
+#define TPIU_FIFO1_ITM0_Msk                (0xFFUL /*<< TPIU_FIFO1_ITM0_Pos*/)         /*!< TPIU FIFO1: ITM0 Mask */
+
+/** \brief TPIU ITATBCTR0 Register Definitions */
+#define TPIU_ITATBCTR0_ATREADY2_Pos         0U                                         /*!< TPIU ITATBCTR0: ATREADY2 Position */
+#define TPIU_ITATBCTR0_ATREADY2_Msk        (1UL /*<< TPIU_ITATBCTR0_ATREADY2_Pos*/)    /*!< TPIU ITATBCTR0: ATREADY2 Mask */
+
+#define TPIU_ITATBCTR0_ATREADY1_Pos         0U                                         /*!< TPIU ITATBCTR0: ATREADY1 Position */
+#define TPIU_ITATBCTR0_ATREADY1_Msk        (1UL /*<< TPIU_ITATBCTR0_ATREADY1_Pos*/)    /*!< TPIU ITATBCTR0: ATREADY1 Mask */
+
+/** \brief TPIU Integration Mode Control Register Definitions */
+#define TPIU_ITCTRL_Mode_Pos                0U                                         /*!< TPIU ITCTRL: Mode Position */
+#define TPIU_ITCTRL_Mode_Msk               (0x3UL /*<< TPIU_ITCTRL_Mode_Pos*/)         /*!< TPIU ITCTRL: Mode Mask */
+
+/** \brief TPIU DEVID Register Definitions */
+#define TPIU_DEVID_NRZVALID_Pos            11U                                         /*!< TPIU DEVID: NRZVALID Position */
+#define TPIU_DEVID_NRZVALID_Msk            (1UL << TPIU_DEVID_NRZVALID_Pos)            /*!< TPIU DEVID: NRZVALID Mask */
+
+#define TPIU_DEVID_MANCVALID_Pos           10U                                         /*!< TPIU DEVID: MANCVALID Position */
+#define TPIU_DEVID_MANCVALID_Msk           (1UL << TPIU_DEVID_MANCVALID_Pos)           /*!< TPIU DEVID: MANCVALID Mask */
+
+#define TPIU_DEVID_PTINVALID_Pos            9U                                         /*!< TPIU DEVID: PTINVALID Position */
+#define TPIU_DEVID_PTINVALID_Msk           (1UL << TPIU_DEVID_PTINVALID_Pos)           /*!< TPIU DEVID: PTINVALID Mask */
+
+#define TPIU_DEVID_MinBufSz_Pos             6U                                         /*!< TPIU DEVID: MinBufSz Position */
+#define TPIU_DEVID_MinBufSz_Msk            (0x7UL << TPIU_DEVID_MinBufSz_Pos)          /*!< TPIU DEVID: MinBufSz Mask */
+
+#define TPIU_DEVID_AsynClkIn_Pos            5U                                         /*!< TPIU DEVID: AsynClkIn Position */
+#define TPIU_DEVID_AsynClkIn_Msk           (1UL << TPIU_DEVID_AsynClkIn_Pos)           /*!< TPIU DEVID: AsynClkIn Mask */
+
+#define TPIU_DEVID_NrTraceInput_Pos         0U                                         /*!< TPIU DEVID: NrTraceInput Position */
+#define TPIU_DEVID_NrTraceInput_Msk        (0x3FUL /*<< TPIU_DEVID_NrTraceInput_Pos*/) /*!< TPIU DEVID: NrTraceInput Mask */
+
+/** \brief TPIU DEVTYPE Register Definitions */
+#define TPIU_DEVTYPE_SubType_Pos            4U                                         /*!< TPIU DEVTYPE: SubType Position */
+#define TPIU_DEVTYPE_SubType_Msk           (0xFUL /*<< TPIU_DEVTYPE_SubType_Pos*/)     /*!< TPIU DEVTYPE: SubType Mask */
+
+#define TPIU_DEVTYPE_MajorType_Pos          0U                                         /*!< TPIU DEVTYPE: MajorType Position */
+#define TPIU_DEVTYPE_MajorType_Msk         (0xFUL << TPIU_DEVTYPE_MajorType_Pos)       /*!< TPIU DEVTYPE: MajorType Mask */
+
+/*@}*/ /* end of group CMSIS_TPIU */
+
+
+#if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_MPU     Memory Protection Unit (MPU)
+  \brief    Type definitions for the Memory Protection Unit (MPU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Memory Protection Unit (MPU).
+ */
+typedef struct
+{
+  __IM  uint32_t TYPE;                   /*!< Offset: 0x000 (R/ )  MPU Type Register */
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x004 (R/W)  MPU Control Register */
+  __IOM uint32_t RNR;                    /*!< Offset: 0x008 (R/W)  MPU Region Number Register */
+  __IOM uint32_t RBAR;                   /*!< Offset: 0x00C (R/W)  MPU Region Base Address Register */
+  __IOM uint32_t RASR;                   /*!< Offset: 0x010 (R/W)  MPU Region Attribute and Size Register */
+  __IOM uint32_t RBAR_A1;                /*!< Offset: 0x014 (R/W)  MPU Alias 1 Region Base Address Register */
+  __IOM uint32_t RASR_A1;                /*!< Offset: 0x018 (R/W)  MPU Alias 1 Region Attribute and Size Register */
+  __IOM uint32_t RBAR_A2;                /*!< Offset: 0x01C (R/W)  MPU Alias 2 Region Base Address Register */
+  __IOM uint32_t RASR_A2;                /*!< Offset: 0x020 (R/W)  MPU Alias 2 Region Attribute and Size Register */
+  __IOM uint32_t RBAR_A3;                /*!< Offset: 0x024 (R/W)  MPU Alias 3 Region Base Address Register */
+  __IOM uint32_t RASR_A3;                /*!< Offset: 0x028 (R/W)  MPU Alias 3 Region Attribute and Size Register */
+} MPU_Type;
+
+#define MPU_TYPE_RALIASES                  4U
+
+/** \brief MPU Type Register Definitions */
+#define MPU_TYPE_IREGION_Pos               16U                                            /*!< MPU TYPE: IREGION Position */
+#define MPU_TYPE_IREGION_Msk               (0xFFUL << MPU_TYPE_IREGION_Pos)               /*!< MPU TYPE: IREGION Mask */
+
+#define MPU_TYPE_DREGION_Pos                8U                                            /*!< MPU TYPE: DREGION Position */
+#define MPU_TYPE_DREGION_Msk               (0xFFUL << MPU_TYPE_DREGION_Pos)               /*!< MPU TYPE: DREGION Mask */
+
+#define MPU_TYPE_SEPARATE_Pos               0U                                            /*!< MPU TYPE: SEPARATE Position */
+#define MPU_TYPE_SEPARATE_Msk              (1UL /*<< MPU_TYPE_SEPARATE_Pos*/)             /*!< MPU TYPE: SEPARATE Mask */
+
+/** \brief MPU Control Register Definitions */
+#define MPU_CTRL_PRIVDEFENA_Pos             2U                                            /*!< MPU CTRL: PRIVDEFENA Position */
+#define MPU_CTRL_PRIVDEFENA_Msk            (1UL << MPU_CTRL_PRIVDEFENA_Pos)               /*!< MPU CTRL: PRIVDEFENA Mask */
+
+#define MPU_CTRL_HFNMIENA_Pos               1U                                            /*!< MPU CTRL: HFNMIENA Position */
+#define MPU_CTRL_HFNMIENA_Msk              (1UL << MPU_CTRL_HFNMIENA_Pos)                 /*!< MPU CTRL: HFNMIENA Mask */
+
+#define MPU_CTRL_ENABLE_Pos                 0U                                            /*!< MPU CTRL: ENABLE Position */
+#define MPU_CTRL_ENABLE_Msk                (1UL /*<< MPU_CTRL_ENABLE_Pos*/)               /*!< MPU CTRL: ENABLE Mask */
+
+/** \brief MPU Region Number Register Definitions */
+#define MPU_RNR_REGION_Pos                  0U                                            /*!< MPU RNR: REGION Position */
+#define MPU_RNR_REGION_Msk                 (0xFFUL /*<< MPU_RNR_REGION_Pos*/)             /*!< MPU RNR: REGION Mask */
+
+/** \brief MPU Region Base Address Register Definitions */
+#define MPU_RBAR_ADDR_Pos                   5U                                            /*!< MPU RBAR: ADDR Position */
+#define MPU_RBAR_ADDR_Msk                  (0x7FFFFFFUL << MPU_RBAR_ADDR_Pos)             /*!< MPU RBAR: ADDR Mask */
+
+#define MPU_RBAR_VALID_Pos                  4U                                            /*!< MPU RBAR: VALID Position */
+#define MPU_RBAR_VALID_Msk                 (1UL << MPU_RBAR_VALID_Pos)                    /*!< MPU RBAR: VALID Mask */
+
+#define MPU_RBAR_REGION_Pos                 0U                                            /*!< MPU RBAR: REGION Position */
+#define MPU_RBAR_REGION_Msk                (0xFUL /*<< MPU_RBAR_REGION_Pos*/)             /*!< MPU RBAR: REGION Mask */
+
+/** \brief MPU Region Attribute and Size Register Definitions */
+#define MPU_RASR_ATTRS_Pos                 16U                                            /*!< MPU RASR: MPU Region Attribute field Position */
+#define MPU_RASR_ATTRS_Msk                 (0xFFFFUL << MPU_RASR_ATTRS_Pos)               /*!< MPU RASR: MPU Region Attribute field Mask */
+
+#define MPU_RASR_XN_Pos                    28U                                            /*!< MPU RASR: ATTRS.XN Position */
+#define MPU_RASR_XN_Msk                    (1UL << MPU_RASR_XN_Pos)                       /*!< MPU RASR: ATTRS.XN Mask */
+
+#define MPU_RASR_AP_Pos                    24U                                            /*!< MPU RASR: ATTRS.AP Position */
+#define MPU_RASR_AP_Msk                    (0x7UL << MPU_RASR_AP_Pos)                     /*!< MPU RASR: ATTRS.AP Mask */
+
+#define MPU_RASR_TEX_Pos                   19U                                            /*!< MPU RASR: ATTRS.TEX Position */
+#define MPU_RASR_TEX_Msk                   (0x7UL << MPU_RASR_TEX_Pos)                    /*!< MPU RASR: ATTRS.TEX Mask */
+
+#define MPU_RASR_S_Pos                     18U                                            /*!< MPU RASR: ATTRS.S Position */
+#define MPU_RASR_S_Msk                     (1UL << MPU_RASR_S_Pos)                        /*!< MPU RASR: ATTRS.S Mask */
+
+#define MPU_RASR_C_Pos                     17U                                            /*!< MPU RASR: ATTRS.C Position */
+#define MPU_RASR_C_Msk                     (1UL << MPU_RASR_C_Pos)                        /*!< MPU RASR: ATTRS.C Mask */
+
+#define MPU_RASR_B_Pos                     16U                                            /*!< MPU RASR: ATTRS.B Position */
+#define MPU_RASR_B_Msk                     (1UL << MPU_RASR_B_Pos)                        /*!< MPU RASR: ATTRS.B Mask */
+
+#define MPU_RASR_SRD_Pos                    8U                                            /*!< MPU RASR: Sub-Region Disable Position */
+#define MPU_RASR_SRD_Msk                   (0xFFUL << MPU_RASR_SRD_Pos)                   /*!< MPU RASR: Sub-Region Disable Mask */
+
+#define MPU_RASR_SIZE_Pos                   1U                                            /*!< MPU RASR: Region Size Field Position */
+#define MPU_RASR_SIZE_Msk                  (0x1FUL << MPU_RASR_SIZE_Pos)                  /*!< MPU RASR: Region Size Field Mask */
+
+#define MPU_RASR_ENABLE_Pos                 0U                                            /*!< MPU RASR: Region enable bit Position */
+#define MPU_RASR_ENABLE_Msk                (1UL /*<< MPU_RASR_ENABLE_Pos*/)               /*!< MPU RASR: Region enable bit Disable Mask */
+
+/*@} end of group CMSIS_MPU */
+#endif /* defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U) */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_FPU     Floating Point Unit (FPU)
+  \brief    Type definitions for the Floating Point Unit (FPU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Floating Point Unit (FPU).
+ */
+typedef struct
+{
+        uint32_t RESERVED0[1U];
+  __IOM uint32_t FPCCR;                  /*!< Offset: 0x004 (R/W)  Floating-Point Context Control Register */
+  __IOM uint32_t FPCAR;                  /*!< Offset: 0x008 (R/W)  Floating-Point Context Address Register */
+  __IOM uint32_t FPDSCR;                 /*!< Offset: 0x00C (R/W)  Floating-Point Default Status Control Register */
+  __IM  uint32_t MVFR0;                  /*!< Offset: 0x010 (R/ )  Media and VFP Feature Register 0 */
+  __IM  uint32_t MVFR1;                  /*!< Offset: 0x014 (R/ )  Media and VFP Feature Register 1 */
+  __IM  uint32_t MVFR2;                  /*!< Offset: 0x018 (R/ )  Media and VFP Feature Register 2 */
+} FPU_Type;
+
+/** \brief FPU Floating-Point Context Control Register Definitions */
+#define FPU_FPCCR_ASPEN_Pos                31U                                            /*!< FPCCR: ASPEN bit Position */
+#define FPU_FPCCR_ASPEN_Msk                (1UL << FPU_FPCCR_ASPEN_Pos)                   /*!< FPCCR: ASPEN bit Mask */
+
+#define FPU_FPCCR_LSPEN_Pos                30U                                            /*!< FPCCR: LSPEN Position */
+#define FPU_FPCCR_LSPEN_Msk                (1UL << FPU_FPCCR_LSPEN_Pos)                   /*!< FPCCR: LSPEN bit Mask */
+
+#define FPU_FPCCR_MONRDY_Pos                8U                                            /*!< FPCCR: MONRDY Position */
+#define FPU_FPCCR_MONRDY_Msk               (1UL << FPU_FPCCR_MONRDY_Pos)                  /*!< FPCCR: MONRDY bit Mask */
+
+#define FPU_FPCCR_BFRDY_Pos                 6U                                            /*!< FPCCR: BFRDY Position */
+#define FPU_FPCCR_BFRDY_Msk                (1UL << FPU_FPCCR_BFRDY_Pos)                   /*!< FPCCR: BFRDY bit Mask */
+
+#define FPU_FPCCR_MMRDY_Pos                 5U                                            /*!< FPCCR: MMRDY Position */
+#define FPU_FPCCR_MMRDY_Msk                (1UL << FPU_FPCCR_MMRDY_Pos)                   /*!< FPCCR: MMRDY bit Mask */
+
+#define FPU_FPCCR_HFRDY_Pos                 4U                                            /*!< FPCCR: HFRDY Position */
+#define FPU_FPCCR_HFRDY_Msk                (1UL << FPU_FPCCR_HFRDY_Pos)                   /*!< FPCCR: HFRDY bit Mask */
+
+#define FPU_FPCCR_THREAD_Pos                3U                                            /*!< FPCCR: processor mode bit Position */
+#define FPU_FPCCR_THREAD_Msk               (1UL << FPU_FPCCR_THREAD_Pos)                  /*!< FPCCR: processor mode active bit Mask */
+
+#define FPU_FPCCR_USER_Pos                  1U                                            /*!< FPCCR: privilege level bit Position */
+#define FPU_FPCCR_USER_Msk                 (1UL << FPU_FPCCR_USER_Pos)                    /*!< FPCCR: privilege level bit Mask */
+
+#define FPU_FPCCR_LSPACT_Pos                0U                                            /*!< FPCCR: Lazy state preservation active bit Position */
+#define FPU_FPCCR_LSPACT_Msk               (1UL /*<< FPU_FPCCR_LSPACT_Pos*/)              /*!< FPCCR: Lazy state preservation active bit Mask */
+
+/** \brief FPU Floating-Point Context Address Register Definitions */
+#define FPU_FPCAR_ADDRESS_Pos               3U                                            /*!< FPCAR: ADDRESS bit Position */
+#define FPU_FPCAR_ADDRESS_Msk              (0x1FFFFFFFUL << FPU_FPCAR_ADDRESS_Pos)        /*!< FPCAR: ADDRESS bit Mask */
+
+/** \brief FPU Floating-Point Default Status Control Register Definitions */
+#define FPU_FPDSCR_AHP_Pos                 26U                                            /*!< FPDSCR: AHP bit Position */
+#define FPU_FPDSCR_AHP_Msk                 (1UL << FPU_FPDSCR_AHP_Pos)                    /*!< FPDSCR: AHP bit Mask */
+
+#define FPU_FPDSCR_DN_Pos                  25U                                            /*!< FPDSCR: DN bit Position */
+#define FPU_FPDSCR_DN_Msk                  (1UL << FPU_FPDSCR_DN_Pos)                     /*!< FPDSCR: DN bit Mask */
+
+#define FPU_FPDSCR_FZ_Pos                  24U                                            /*!< FPDSCR: FZ bit Position */
+#define FPU_FPDSCR_FZ_Msk                  (1UL << FPU_FPDSCR_FZ_Pos)                     /*!< FPDSCR: FZ bit Mask */
+
+#define FPU_FPDSCR_RMode_Pos               22U                                            /*!< FPDSCR: RMode bit Position */
+#define FPU_FPDSCR_RMode_Msk               (3UL << FPU_FPDSCR_RMode_Pos)                  /*!< FPDSCR: RMode bit Mask */
+
+/** \brief FPU Media and VFP Feature Register 0 Definitions */
+#define FPU_MVFR0_FPRound_Pos              28U                                            /*!< MVFR0: Rounding modes bits Position */
+#define FPU_MVFR0_FPRound_Msk              (0xFUL << FPU_MVFR0_FPRound_Pos)               /*!< MVFR0: Rounding modes bits Mask */
+
+#define FPU_MVFR0_FPShortvec_Pos           24U                                            /*!< MVFR0: Short vectors bits Position */
+#define FPU_MVFR0_FPShortvec_Msk          (0xFUL << FPU_MVFR0_FPShortvec_Pos)             /*!< MVFR0: Short vectors bits Mask */
+
+#define FPU_MVFR0_FPSqrt_Pos               20U                                            /*!< MVFR0: Square root bits Position */
+#define FPU_MVFR0_FPSqrt_Msk               (0xFUL << FPU_MVFR0_FPSqrt_Pos)                /*!< MVFR0: Square root bits Mask */
+
+#define FPU_MVFR0_FPDivide_Pos             16U                                            /*!< MVFR0: Divide bits Position */
+#define FPU_MVFR0_FPDivide_Msk             (0xFUL << FPU_MVFR0_FPDivide_Pos)              /*!< MVFR0: Divide bits Mask */
+
+#define FPU_MVFR0_FPExceptrap_Pos    12U                                                  /*!< MVFR0: Exception trapping bits Position */
+#define FPU_MVFR0_FPExceptrap_Msk    (0xFUL << FPU_MVFR0_FPExceptrap_Pos)                 /*!< MVFR0: Exception trapping bits Mask */
+
+#define FPU_MVFR0_FPDP_Pos                  8U                                            /*!< MVFR0: Double-precision bits Position */
+#define FPU_MVFR0_FPDP_Msk                 (0xFUL << FPU_MVFR0_FPDP_Pos)                  /*!< MVFR0: Double-precision bits Mask */
+
+#define FPU_MVFR0_FPSP_Pos                  4U                                            /*!< MVFR0: Single-precision bits Position */
+#define FPU_MVFR0_FPSP_Msk                 (0xFUL << FPU_MVFR0_FPSP_Pos)                  /*!< MVFR0: Single-precision bits Mask */
+
+#define FPU_MVFR0_SIMDReg_Pos               0U                                            /*!< MVFR0: SIMD registers bits Position */
+#define FPU_MVFR0_SIMDReg_Msk              (0xFUL /*<< FPU_MVFR0_SIMDReg_Pos*/)           /*!< MVFR0: SIMD registers bits Mask */
+
+/** \brief FPU Media and VFP Feature Register 1 Definitions */
+#define FPU_MVFR1_FMAC_Pos                 28U                                            /*!< MVFR1: Fused MAC bits Position */
+#define FPU_MVFR1_FMAC_Msk                 (0xFUL << FPU_MVFR1_FMAC_Pos)                  /*!< MVFR1: Fused MAC bits Mask */
+
+#define FPU_MVFR1_FPHP_Pos                 24U                                            /*!< MVFR1: FP HPFP bits Position */
+#define FPU_MVFR1_FPHP_Msk                 (0xFUL << FPU_MVFR1_FPHP_Pos)                  /*!< MVFR1: FP HPFP bits Mask */
+
+#define FPU_MVFR1_FPDNaN_Pos                4U                                            /*!< MVFR1: D_NaN mode bits Position */
+#define FPU_MVFR1_FPDNaN_Msk               (0xFUL << FPU_MVFR1_FPDNaN_Pos)                /*!< MVFR1: D_NaN mode bits Mask */
+
+#define FPU_MVFR1_FPFtZ_Pos                 0U                                            /*!< MVFR1: FtZ mode bits Position */
+#define FPU_MVFR1_FPFtZ_Msk                (0xFUL /*<< FPU_MVFR1_FPFtZ_Pos*/)             /*!< MVFR1: FtZ mode bits Mask */
+
+/** \brief FPU Media and VFP Feature Register 2 Definitions */
+#define FPU_MVFR2_FPMisc_Pos                4U                                            /*!< MVFR2: VFP Misc bits Position */
+#define FPU_MVFR2_FPMisc_Msk               (0xFUL << FPU_MVFR2_FPMisc_Pos)                /*!< MVFR2: VFP Misc bits Mask */
+
+/*@} end of group CMSIS_FPU */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_DCB       Debug Control Block
+  \brief    Type definitions for the Debug Control Block Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Debug Control Block Registers (DCB).
+ */
+typedef struct
+{
+  __IOM uint32_t DHCSR;                  /*!< Offset: 0x000 (R/W)  Debug Halting Control and Status Register */
+  __OM  uint32_t DCRSR;                  /*!< Offset: 0x004 ( /W)  Debug Core Register Selector Register */
+  __IOM uint32_t DCRDR;                  /*!< Offset: 0x008 (R/W)  Debug Core Register Data Register */
+  __IOM uint32_t DEMCR;                  /*!< Offset: 0x00C (R/W)  Debug Exception and Monitor Control Register */
+} DCB_Type;
+
+/** \brief DCB Debug Halting Control and Status Register Definitions */
+#define DCB_DHCSR_DBGKEY_Pos               16U                                            /*!< DCB DHCSR: Debug key Position */
+#define DCB_DHCSR_DBGKEY_Msk               (0xFFFFUL << DCB_DHCSR_DBGKEY_Pos)             /*!< DCB DHCSR: Debug key Mask */
+
+#define DCB_DHCSR_S_RESET_ST_Pos           25U                                            /*!< DCB DHCSR: Reset sticky status Position */
+#define DCB_DHCSR_S_RESET_ST_Msk           (1UL << DCB_DHCSR_S_RESET_ST_Pos)              /*!< DCB DHCSR: Reset sticky status Mask */
+
+#define DCB_DHCSR_S_RETIRE_ST_Pos          24U                                            /*!< DCB DHCSR: Retire sticky status Position */
+#define DCB_DHCSR_S_RETIRE_ST_Msk          (1UL << DCB_DHCSR_S_RETIRE_ST_Pos)             /*!< DCB DHCSR: Retire sticky status Mask */
+
+#define DCB_DHCSR_S_LOCKUP_Pos             19U                                            /*!< DCB DHCSR: Lockup status Position */
+#define DCB_DHCSR_S_LOCKUP_Msk             (1UL << DCB_DHCSR_S_LOCKUP_Pos)                /*!< DCB DHCSR: Lockup status Mask */
+
+#define DCB_DHCSR_S_SLEEP_Pos              18U                                            /*!< DCB DHCSR: Sleeping status Position */
+#define DCB_DHCSR_S_SLEEP_Msk              (1UL << DCB_DHCSR_S_SLEEP_Pos)                 /*!< DCB DHCSR: Sleeping status Mask */
+
+#define DCB_DHCSR_S_HALT_Pos               17U                                            /*!< DCB DHCSR: Halted status Position */
+#define DCB_DHCSR_S_HALT_Msk               (1UL << DCB_DHCSR_S_HALT_Pos)                  /*!< DCB DHCSR: Halted status Mask */
+
+#define DCB_DHCSR_S_REGRDY_Pos             16U                                            /*!< DCB DHCSR: Register ready status Position */
+#define DCB_DHCSR_S_REGRDY_Msk             (1UL << DCB_DHCSR_S_REGRDY_Pos)                /*!< DCB DHCSR: Register ready status Mask */
+
+#define DCB_DHCSR_C_SNAPSTALL_Pos           5U                                            /*!< DCB DHCSR: Snap stall control Position */
+#define DCB_DHCSR_C_SNAPSTALL_Msk          (1UL << DCB_DHCSR_C_SNAPSTALL_Pos)             /*!< DCB DHCSR: Snap stall control Mask */
+
+#define DCB_DHCSR_C_MASKINTS_Pos            3U                                            /*!< DCB DHCSR: Mask interrupts control Position */
+#define DCB_DHCSR_C_MASKINTS_Msk           (1UL << DCB_DHCSR_C_MASKINTS_Pos)              /*!< DCB DHCSR: Mask interrupts control Mask */
+
+#define DCB_DHCSR_C_STEP_Pos                2U                                            /*!< DCB DHCSR: Step control Position */
+#define DCB_DHCSR_C_STEP_Msk               (1UL << DCB_DHCSR_C_STEP_Pos)                  /*!< DCB DHCSR: Step control Mask */
+
+#define DCB_DHCSR_C_HALT_Pos                1U                                            /*!< DCB DHCSR: Halt control Position */
+#define DCB_DHCSR_C_HALT_Msk               (1UL << DCB_DHCSR_C_HALT_Pos)                  /*!< DCB DHCSR: Halt control Mask */
+
+#define DCB_DHCSR_C_DEBUGEN_Pos             0U                                            /*!< DCB DHCSR: Debug enable control Position */
+#define DCB_DHCSR_C_DEBUGEN_Msk            (1UL /*<< DCB_DHCSR_C_DEBUGEN_Pos*/)           /*!< DCB DHCSR: Debug enable control Mask */
+
+/** \brief DCB Debug Core Register Selector Register Definitions */
+#define DCB_DCRSR_REGWnR_Pos               16U                                            /*!< DCB DCRSR: Register write/not-read Position */
+#define DCB_DCRSR_REGWnR_Msk               (1UL << DCB_DCRSR_REGWnR_Pos)                  /*!< DCB DCRSR: Register write/not-read Mask */
+
+#define DCB_DCRSR_REGSEL_Pos                0U                                            /*!< DCB DCRSR: Register selector Position */
+#define DCB_DCRSR_REGSEL_Msk               (0x7FUL /*<< DCB_DCRSR_REGSEL_Pos*/)           /*!< DCB DCRSR: Register selector Mask */
+
+/** \brief DCB Debug Core Register Data Register Definitions */
+#define DCB_DCRDR_DBGTMP_Pos                0U                                            /*!< DCB DCRDR: Data temporary buffer Position */
+#define DCB_DCRDR_DBGTMP_Msk               (0xFFFFFFFFUL /*<< DCB_DCRDR_DBGTMP_Pos*/)     /*!< DCB DCRDR: Data temporary buffer Mask */
+
+/** \brief DCB Debug Exception and Monitor Control Register Definitions */
+#define DCB_DEMCR_TRCENA_Pos               24U                                            /*!< DCB DEMCR: Trace enable Position */
+#define DCB_DEMCR_TRCENA_Msk               (1UL << DCB_DEMCR_TRCENA_Pos)                  /*!< DCB DEMCR: Trace enable Mask */
+
+#define DCB_DEMCR_MON_REQ_Pos              19U                                            /*!< DCB DEMCR: Monitor request Position */
+#define DCB_DEMCR_MON_REQ_Msk              (1UL << DCB_DEMCR_MON_REQ_Pos)                 /*!< DCB DEMCR: Monitor request Mask */
+
+#define DCB_DEMCR_MON_STEP_Pos             18U                                            /*!< DCB DEMCR: Monitor step Position */
+#define DCB_DEMCR_MON_STEP_Msk             (1UL << DCB_DEMCR_MON_STEP_Pos)                /*!< DCB DEMCR: Monitor step Mask */
+
+#define DCB_DEMCR_MON_PEND_Pos             17U                                            /*!< DCB DEMCR: Monitor pend Position */
+#define DCB_DEMCR_MON_PEND_Msk             (1UL << DCB_DEMCR_MON_PEND_Pos)                /*!< DCB DEMCR: Monitor pend Mask */
+
+#define DCB_DEMCR_MON_EN_Pos               16U                                            /*!< DCB DEMCR: Monitor enable Position */
+#define DCB_DEMCR_MON_EN_Msk               (1UL << DCB_DEMCR_MON_EN_Pos)                  /*!< DCB DEMCR: Monitor enable Mask */
+
+#define DCB_DEMCR_VC_HARDERR_Pos           10U                                            /*!< DCB DEMCR: Vector Catch HardFault errors Position */
+#define DCB_DEMCR_VC_HARDERR_Msk           (1UL << DCB_DEMCR_VC_HARDERR_Pos)              /*!< DCB DEMCR: Vector Catch HardFault errors Mask */
+
+#define DCB_DEMCR_VC_INTERR_Pos             9U                                            /*!< DCB DEMCR: Vector Catch interrupt errors Position */
+#define DCB_DEMCR_VC_INTERR_Msk            (1UL << DCB_DEMCR_VC_INTERR_Pos)               /*!< DCB DEMCR: Vector Catch interrupt errors Mask */
+
+#define DCB_DEMCR_VC_BUSERR_Pos             8U                                            /*!< DCB DEMCR: Vector Catch BusFault errors Position */
+#define DCB_DEMCR_VC_BUSERR_Msk            (1UL << DCB_DEMCR_VC_BUSERR_Pos)               /*!< DCB DEMCR: Vector Catch BusFault errors Mask */
+
+#define DCB_DEMCR_VC_STATERR_Pos            7U                                            /*!< DCB DEMCR: Vector Catch state errors Position */
+#define DCB_DEMCR_VC_STATERR_Msk           (1UL << DCB_DEMCR_VC_STATERR_Pos)              /*!< DCB DEMCR: Vector Catch state errors Mask */
+
+#define DCB_DEMCR_VC_CHKERR_Pos             6U                                            /*!< DCB DEMCR: Vector Catch check errors Position */
+#define DCB_DEMCR_VC_CHKERR_Msk            (1UL << DCB_DEMCR_VC_CHKERR_Pos)               /*!< DCB DEMCR: Vector Catch check errors Mask */
+
+#define DCB_DEMCR_VC_NOCPERR_Pos            5U                                            /*!< DCB DEMCR: Vector Catch NOCP errors Position */
+#define DCB_DEMCR_VC_NOCPERR_Msk           (1UL << DCB_DEMCR_VC_NOCPERR_Pos)              /*!< DCB DEMCR: Vector Catch NOCP errors Mask */
+
+#define DCB_DEMCR_VC_MMERR_Pos              4U                                            /*!< DCB DEMCR: Vector Catch MemManage errors Position */
+#define DCB_DEMCR_VC_MMERR_Msk             (1UL << DCB_DEMCR_VC_MMERR_Pos)                /*!< DCB DEMCR: Vector Catch MemManage errors Mask */
+
+#define DCB_DEMCR_VC_CORERESET_Pos          0U                                            /*!< DCB DEMCR: Vector Catch Core reset Position */
+#define DCB_DEMCR_VC_CORERESET_Msk         (1UL /*<< DCB_DEMCR_VC_CORERESET_Pos*/)        /*!< DCB DEMCR: Vector Catch Core reset Mask */
+
+/*@} end of group CMSIS_DCB */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_core_bitfield     Core register bit field macros
+  \brief      Macros for use with bit field definitions (xxx_Pos, xxx_Msk).
+  @{
+ */
+
+/**
+  \brief   Mask and shift a bit field value for use in a register bit range.
+  \param[in] field  Name of the register bit field.
+  \param[in] value  Value of the bit field. This parameter is interpreted as an uint32_t type.
+  \return           Masked and shifted value.
+*/
+#define _VAL2FLD(field, value)    (((uint32_t)(value) << field ## _Pos) & field ## _Msk)
+
+/**
+  \brief     Mask and shift a register value to extract a bit filed value.
+  \param[in] field  Name of the register bit field.
+  \param[in] value  Value of register. This parameter is interpreted as an uint32_t type.
+  \return           Masked and shifted bit field value.
+*/
+#define _FLD2VAL(field, value)    (((uint32_t)(value) & field ## _Msk) >> field ## _Pos)
+
+/*@} end of group CMSIS_core_bitfield */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_core_base     Core Definitions
+  \brief      Definitions for base addresses, unions, and structures.
+  @{
+ */
+
+/* Memory mapping of Core Hardware */
+#define SCS_BASE            (0xE000E000UL)                            /*!< System Control Space Base Address */
+#define ITM_BASE            (0xE0000000UL)                            /*!< ITM Base Address */
+#define DWT_BASE            (0xE0001000UL)                            /*!< DWT Base Address */
+#define TPIU_BASE           (0xE0040000UL)                            /*!< TPIU Base Address */
+#define DCB_BASE            (0xE000EDF0UL)                            /*!< Core Debug Base Address */
+#define SysTick_BASE        (SCS_BASE +  0x0010UL)                    /*!< SysTick Base Address */
+#define NVIC_BASE           (SCS_BASE +  0x0100UL)                    /*!< NVIC Base Address */
+#define SCB_BASE            (SCS_BASE +  0x0D00UL)                    /*!< System Control Block Base Address */
+
+#define SCnSCB              ((SCnSCB_Type    *)     SCS_BASE      )   /*!< System control Register not in SCB */
+#define SCB                 ((SCB_Type       *)     SCB_BASE      )   /*!< SCB configuration struct */
+#define SysTick             ((SysTick_Type   *)     SysTick_BASE  )   /*!< SysTick configuration struct */
+#define NVIC                ((NVIC_Type      *)     NVIC_BASE     )   /*!< NVIC configuration struct */
+#define ITM                 ((ITM_Type       *)     ITM_BASE      )   /*!< ITM configuration struct */
+#define DWT                 ((DWT_Type       *)     DWT_BASE      )   /*!< DWT configuration struct */
+#define TPIU                ((TPIU_Type      *)     TPIU_BASE     )   /*!< TPIU configuration struct */
+#define DCB                 ((DCB_Type       *)     DCB_BASE      )   /*!< DCB configuration struct */
+
+#if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+  #define MPU_BASE          (SCS_BASE +  0x0D90UL)                    /*!< Memory Protection Unit */
+  #define MPU               ((MPU_Type       *)     MPU_BASE      )   /*!< Memory Protection Unit */
+#endif
+
+#define FPU_BASE            (SCS_BASE +  0x0F30UL)                    /*!< Floating Point Unit */
+#define FPU                 ((FPU_Type       *)     FPU_BASE      )   /*!< Floating Point Unit */
+
+/*@} */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_register_aliases     Backwards Compatibility Aliases
+  \brief      Register alias definitions for backwards compatibility.
+  @{
+ */
+
+/*@} */
+
+
+/*******************************************************************************
+ *                Hardware Abstraction Layer
+  Core Function Interface contains:
+  - Core NVIC Functions
+  - Core SysTick Functions
+  - Core Debug Functions
+  - Core Register Access Functions
+ ******************************************************************************/
+/**
+  \defgroup CMSIS_Core_FunctionInterface Functions and Instructions Reference
+*/
+
+
+
+/* ##########################   NVIC functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_NVICFunctions NVIC Functions
+  \brief    Functions that manage interrupts and exceptions via the NVIC.
+  @{
+ */
+
+#ifdef CMSIS_NVIC_VIRTUAL
+  #ifndef CMSIS_NVIC_VIRTUAL_HEADER_FILE
+    #define CMSIS_NVIC_VIRTUAL_HEADER_FILE "cmsis_nvic_virtual.h"
+  #endif
+  #include CMSIS_NVIC_VIRTUAL_HEADER_FILE
+#else
+  #define NVIC_SetPriorityGrouping    __NVIC_SetPriorityGrouping
+  #define NVIC_GetPriorityGrouping    __NVIC_GetPriorityGrouping
+  #define NVIC_EnableIRQ              __NVIC_EnableIRQ
+  #define NVIC_GetEnableIRQ           __NVIC_GetEnableIRQ
+  #define NVIC_DisableIRQ             __NVIC_DisableIRQ
+  #define NVIC_GetPendingIRQ          __NVIC_GetPendingIRQ
+  #define NVIC_SetPendingIRQ          __NVIC_SetPendingIRQ
+  #define NVIC_ClearPendingIRQ        __NVIC_ClearPendingIRQ
+  #define NVIC_GetActive              __NVIC_GetActive
+  #define NVIC_SetPriority            __NVIC_SetPriority
+  #define NVIC_GetPriority            __NVIC_GetPriority
+  #define NVIC_SystemReset            __NVIC_SystemReset
+#endif /* CMSIS_NVIC_VIRTUAL */
+
+#ifdef CMSIS_VECTAB_VIRTUAL
+  #ifndef CMSIS_VECTAB_VIRTUAL_HEADER_FILE
+    #define CMSIS_VECTAB_VIRTUAL_HEADER_FILE "cmsis_vectab_virtual.h"
+  #endif
+  #include CMSIS_VECTAB_VIRTUAL_HEADER_FILE
+#else
+  #define NVIC_SetVector              __NVIC_SetVector
+  #define NVIC_GetVector              __NVIC_GetVector
+#endif  /* (CMSIS_VECTAB_VIRTUAL) */
+
+#define NVIC_USER_IRQ_OFFSET          16
+
+
+/* The following EXC_RETURN values are saved the LR on exception entry */
+#define EXC_RETURN_HANDLER         (0xFFFFFFF1UL)     /* return to Handler mode, uses MSP after return                               */
+#define EXC_RETURN_THREAD_MSP      (0xFFFFFFF9UL)     /* return to Thread mode, uses MSP after return                                */
+#define EXC_RETURN_THREAD_PSP      (0xFFFFFFFDUL)     /* return to Thread mode, uses PSP after return                                */
+#define EXC_RETURN_HANDLER_FPU     (0xFFFFFFE1UL)     /* return to Handler mode, uses MSP after return, restore floating-point state */
+#define EXC_RETURN_THREAD_MSP_FPU  (0xFFFFFFE9UL)     /* return to Thread mode, uses MSP after return, restore floating-point state  */
+#define EXC_RETURN_THREAD_PSP_FPU  (0xFFFFFFEDUL)     /* return to Thread mode, uses PSP after return, restore floating-point state  */
+
+
+/**
+  \brief   Set Priority Grouping
+  \details Sets the priority grouping field using the required unlock sequence.
+           The parameter PriorityGroup is assigned to the field SCB->AIRCR [10:8] PRIGROUP field.
+           Only values from 0..7 are used.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+  \param [in]      PriorityGroup  Priority grouping field.
+ */
+__STATIC_INLINE void __NVIC_SetPriorityGrouping(uint32_t PriorityGroup)
+{
+  uint32_t reg_value;
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);             /* only values 0..7 are used          */
+
+  reg_value  =  SCB->AIRCR;                                                   /* read old register configuration    */
+  reg_value &= ~((uint32_t)(SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk)); /* clear bits to change               */
+  reg_value  =  (reg_value                                   |
+                ((uint32_t)0x5FAUL << SCB_AIRCR_VECTKEY_Pos) |
+                (PriorityGroupTmp << SCB_AIRCR_PRIGROUP_Pos)  );              /* Insert write key and priority group */
+  SCB->AIRCR =  reg_value;
+}
+
+
+/**
+  \brief   Get Priority Grouping
+  \details Reads the priority grouping field from the NVIC Interrupt Controller.
+  \return                Priority grouping field (SCB->AIRCR [10:8] PRIGROUP field).
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPriorityGrouping(void)
+{
+  return ((uint32_t)((SCB->AIRCR & SCB_AIRCR_PRIGROUP_Msk) >> SCB_AIRCR_PRIGROUP_Pos));
+}
+
+
+/**
+  \brief   Enable Interrupt
+  \details Enables a device specific interrupt in the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_EnableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    __COMPILER_BARRIER();
+    NVIC->ISER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+    __COMPILER_BARRIER();
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Enable status
+  \details Returns a device specific interrupt enable status from the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt is not enabled.
+  \return             1  Interrupt is enabled.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetEnableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ISER[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Disable Interrupt
+  \details Disables a device specific interrupt in the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_DisableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ICER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+    __DSB();
+    __ISB();
+  }
+}
+
+
+/**
+  \brief   Get Pending Interrupt
+  \details Reads the NVIC pending register and returns the pending bit for the specified device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not pending.
+  \return             1  Interrupt status is pending.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ISPR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Pending Interrupt
+  \details Sets the pending bit of a device specific interrupt in the NVIC pending register.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_SetPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ISPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Clear Pending Interrupt
+  \details Clears the pending bit of a device specific interrupt in the NVIC pending register.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_ClearPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ICPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Active Interrupt
+  \details Reads the active register in the NVIC and returns the active bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not active.
+  \return             1  Interrupt status is active.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetActive(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->IABR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Interrupt Priority
+  \details Sets the priority of a device specific interrupt or a processor exception.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]      IRQn  Interrupt number.
+  \param [in]  priority  Priority to set.
+  \note    The priority cannot be set for every processor exception.
+ */
+__STATIC_INLINE void __NVIC_SetPriority(IRQn_Type IRQn, uint32_t priority)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->IPR[((uint32_t)IRQn)]               = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+  else
+  {
+    SCB->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Priority
+  \details Reads the priority of a device specific interrupt or a processor exception.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn  Interrupt number.
+  \return             Interrupt Priority.
+                      Value is aligned automatically to the implemented priority bits of the microcontroller.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPriority(IRQn_Type IRQn)
+{
+
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return(((uint32_t)NVIC->IPR[((uint32_t)IRQn)]               >> (8U - __NVIC_PRIO_BITS)));
+  }
+  else
+  {
+    return(((uint32_t)SCB->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] >> (8U - __NVIC_PRIO_BITS)));
+  }
+}
+
+
+/**
+  \brief   Encode Priority
+  \details Encodes the priority for an interrupt with the given priority group,
+           preemptive priority value, and subpriority value.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+  \param [in]     PriorityGroup  Used priority group.
+  \param [in]   PreemptPriority  Preemptive priority value (starting from 0).
+  \param [in]       SubPriority  Subpriority value (starting from 0).
+  \return                        Encoded priority. Value can be used in the function \ref NVIC_SetPriority().
+ */
+__STATIC_INLINE uint32_t NVIC_EncodePriority (uint32_t PriorityGroup, uint32_t PreemptPriority, uint32_t SubPriority)
+{
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);   /* only values 0..7 are used          */
+  uint32_t PreemptPriorityBits;
+  uint32_t SubPriorityBits;
+
+  PreemptPriorityBits = ((7UL - PriorityGroupTmp) > (uint32_t)(__NVIC_PRIO_BITS)) ? (uint32_t)(__NVIC_PRIO_BITS) : (uint32_t)(7UL - PriorityGroupTmp);
+  SubPriorityBits     = ((PriorityGroupTmp + (uint32_t)(__NVIC_PRIO_BITS)) < (uint32_t)7UL) ? (uint32_t)0UL : (uint32_t)((PriorityGroupTmp - 7UL) + (uint32_t)(__NVIC_PRIO_BITS));
+
+  return (
+           ((PreemptPriority & (uint32_t)((1UL << (PreemptPriorityBits)) - 1UL)) << SubPriorityBits) |
+           ((SubPriority     & (uint32_t)((1UL << (SubPriorityBits    )) - 1UL)))
+         );
+}
+
+
+/**
+  \brief   Decode Priority
+  \details Decodes an interrupt priority value with a given priority group to
+           preemptive priority value and subpriority value.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS) the smallest possible priority group is set.
+  \param [in]         Priority   Priority value, which can be retrieved with the function \ref NVIC_GetPriority().
+  \param [in]     PriorityGroup  Used priority group.
+  \param [out] pPreemptPriority  Preemptive priority value (starting from 0).
+  \param [out]     pSubPriority  Subpriority value (starting from 0).
+ */
+__STATIC_INLINE void NVIC_DecodePriority (uint32_t Priority, uint32_t PriorityGroup, uint32_t* const pPreemptPriority, uint32_t* const pSubPriority)
+{
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);   /* only values 0..7 are used          */
+  uint32_t PreemptPriorityBits;
+  uint32_t SubPriorityBits;
+
+  PreemptPriorityBits = ((7UL - PriorityGroupTmp) > (uint32_t)(__NVIC_PRIO_BITS)) ? (uint32_t)(__NVIC_PRIO_BITS) : (uint32_t)(7UL - PriorityGroupTmp);
+  SubPriorityBits     = ((PriorityGroupTmp + (uint32_t)(__NVIC_PRIO_BITS)) < (uint32_t)7UL) ? (uint32_t)0UL : (uint32_t)((PriorityGroupTmp - 7UL) + (uint32_t)(__NVIC_PRIO_BITS));
+
+  *pPreemptPriority = (Priority >> SubPriorityBits) & (uint32_t)((1UL << (PreemptPriorityBits)) - 1UL);
+  *pSubPriority     = (Priority                   ) & (uint32_t)((1UL << (SubPriorityBits    )) - 1UL);
+}
+
+
+/**
+  \brief   Set Interrupt Vector
+  \details Sets an interrupt vector in SRAM based interrupt vector table.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+           VTOR must been relocated to SRAM before.
+  \param [in]   IRQn      Interrupt number
+  \param [in]   vector    Address of interrupt handler function
+ */
+__STATIC_INLINE void __NVIC_SetVector(IRQn_Type IRQn, uint32_t vector)
+{
+  uint32_t *vectors = (uint32_t *) ((uintptr_t) SCB->VTOR);
+  vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET] = vector;
+  __DSB();
+}
+
+
+/**
+  \brief   Get Interrupt Vector
+  \details Reads an interrupt vector from interrupt vector table.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn      Interrupt number.
+  \return                 Address of interrupt handler function
+ */
+__STATIC_INLINE uint32_t __NVIC_GetVector(IRQn_Type IRQn)
+{
+  uint32_t *vectors = (uint32_t *) ((uintptr_t) SCB->VTOR);
+  return vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET];
+}
+
+
+/**
+  \brief   System Reset
+  \details Initiates a system reset request to reset the MCU.
+ */
+__NO_RETURN __STATIC_INLINE void __NVIC_SystemReset(void)
+{
+  __DSB();                                                          /* Ensure all outstanding memory accesses included
+                                                                       buffered write are completed before reset */
+  SCB->AIRCR  = (uint32_t)((0x5FAUL << SCB_AIRCR_VECTKEY_Pos)    |
+                           (SCB->AIRCR & SCB_AIRCR_PRIGROUP_Msk) |
+                            SCB_AIRCR_SYSRESETREQ_Msk    );         /* Keep priority group unchanged */
+  __DSB();                                                          /* Ensure completion of memory access */
+
+  for(;;)                                                           /* wait until reset */
+  {
+    __NOP();
+  }
+}
+
+/*@} end of CMSIS_Core_NVICFunctions */
+
+
+/* ##########################  MPU functions  #################################### */
+
+#if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+
+#include "m-profile/armv7m_mpu.h"
+
+#endif
+
+
+/* ##########################  FPU functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_FpuFunctions FPU Functions
+  \brief    Function that provides FPU type.
+  @{
+ */
+
+/**
+  \brief   get FPU type
+  \details returns the FPU type
+  \returns
+   - \b  0: No FPU
+   - \b  1: Single precision FPU
+   - \b  2: Double + Single precision FPU
+ */
+__STATIC_INLINE uint32_t SCB_GetFPUType(void)
+{
+  uint32_t mvfr0;
+
+  mvfr0 = FPU->MVFR0;
+  if      ((mvfr0 & (FPU_MVFR0_FPSP_Msk | FPU_MVFR0_FPDP_Msk)) == 0x220U)
+  {
+    return 2U;           /* Double + Single precision FPU */
+  }
+  else if ((mvfr0 & (FPU_MVFR0_FPSP_Msk | FPU_MVFR0_FPDP_Msk)) == 0x020U)
+  {
+    return 1U;           /* Single precision FPU */
+  }
+  else
+  {
+    return 0U;           /* No FPU */
+  }
+}
+
+/*@} end of CMSIS_Core_FpuFunctions */
+
+
+/* ##########################  Cache functions  #################################### */
+
+#if ((defined (__ICACHE_PRESENT) && (__ICACHE_PRESENT == 1U)) || \
+     (defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)))
+  #include "m-profile/armv7m_cachel1.h"
+#endif
+
+
+/* ##################################    SysTick function  ############################################ */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_SysTickFunctions SysTick Functions
+  \brief    Functions that configure the System.
+  @{
+ */
+
+#if defined (__Vendor_SysTickConfig) && (__Vendor_SysTickConfig == 0U)
+
+/**
+  \brief   System Tick Configuration
+  \details Initializes the System Timer and its interrupt, and starts the System Tick Timer.
+           Counter is in free running mode to generate periodic interrupts.
+  \param [in]  ticks  Number of ticks between two interrupts.
+  \return          0  Function succeeded.
+  \return          1  Function failed.
+  \note    When the variable <b>__Vendor_SysTickConfig</b> is set to 1, then the
+           function <b>SysTick_Config</b> is not included. In this case, the file <b><i>device</i>.h</b>
+           must contain a vendor-specific implementation of this function.
+ */
+__STATIC_INLINE uint32_t SysTick_Config(uint32_t ticks)
+{
+  if ((ticks - 1UL) > SysTick_LOAD_RELOAD_Msk)
+  {
+    return (1UL);                                                   /* Reload value impossible */
+  }
+
+  SysTick->LOAD  = (uint32_t)(ticks - 1UL);                         /* set reload register */
+  NVIC_SetPriority (SysTick_IRQn, (1UL << __NVIC_PRIO_BITS) - 1UL); /* set Priority for Systick Interrupt */
+  SysTick->VAL   = 0UL;                                             /* Load the SysTick Counter Value */
+  SysTick->CTRL  = SysTick_CTRL_CLKSOURCE_Msk |
+                   SysTick_CTRL_TICKINT_Msk   |
+                   SysTick_CTRL_ENABLE_Msk;                         /* Enable SysTick IRQ and SysTick Timer */
+  return (0UL);                                                     /* Function successful */
+}
+
+#endif
+
+/*@} end of CMSIS_Core_SysTickFunctions */
+
+
+
+/* ##################################### Debug In/Output function ########################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_core_DebugFunctions ITM Functions
+  \brief    Functions that access the ITM debug interface.
+  @{
+ */
+
+extern volatile int32_t ITM_RxBuffer;                              /*!< External variable to receive characters. */
+#define                 ITM_RXBUFFER_EMPTY  ((int32_t)0x5AA55AA5U) /*!< Value identifying \ref ITM_RxBuffer is ready for next character. */
+
+
+/**
+  \brief   ITM Send Character
+  \details Transmits a character via the ITM channel 0, and
+           \li Just returns when no debugger is connected that has booked the output.
+           \li Is blocking when a debugger is connected, but the previous character sent has not been transmitted.
+  \param [in]     ch  Character to transmit.
+  \returns            Character to transmit.
+ */
+__STATIC_INLINE uint32_t ITM_SendChar (uint32_t ch)
+{
+  if (((ITM->TCR & ITM_TCR_ITMENA_Msk) != 0UL) &&      /* ITM enabled */
+      ((ITM->TER & 1UL               ) != 0UL)   )     /* ITM Port #0 enabled */
+  {
+    while (ITM->PORT[0U].u32 == 0UL)
+    {
+      __NOP();
+    }
+    ITM->PORT[0U].u8 = (uint8_t)ch;
+  }
+  return (ch);
+}
+
+
+/**
+  \brief   ITM Receive Character
+  \details Inputs a character via the external variable \ref ITM_RxBuffer.
+  \return             Received character.
+  \return         -1  No character pending.
+ */
+__STATIC_INLINE int32_t ITM_ReceiveChar (void)
+{
+  int32_t ch = -1;                           /* no character available */
+
+  if (ITM_RxBuffer != ITM_RXBUFFER_EMPTY)
+  {
+    ch = ITM_RxBuffer;
+    ITM_RxBuffer = ITM_RXBUFFER_EMPTY;       /* ready for next character */
+  }
+
+  return (ch);
+}
+
+
+/**
+  \brief   ITM Check Character
+  \details Checks whether a character is pending for reading in the variable \ref ITM_RxBuffer.
+  \return          0  No character available.
+  \return          1  Character available.
+ */
+__STATIC_INLINE int32_t ITM_CheckChar (void)
+{
+
+  if (ITM_RxBuffer == ITM_RXBUFFER_EMPTY)
+  {
+    return (0);                              /* no character available */
+  }
+  else
+  {
+    return (1);                              /*    character available */
+  }
+}
+
+/*@} end of CMSIS_core_DebugFunctions */
+
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_CM7_H_DEPENDANT */
+
+#endif /* __CMSIS_GENERIC */

--- a/platform/ext/cmsis/CMSIS/Core/Include/core_cm85.h
+++ b/platform/ext/cmsis/CMSIS/Core/Include/core_cm85.h
@@ -1,0 +1,4765 @@
+/*
+ * Copyright (c) 2022-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS Cortex-M85 Core Peripheral Access Layer Header File
+ */
+
+#if   defined ( __ICCARM__ )
+  #pragma system_include                        /* treat file as system include file for MISRA check */
+#elif defined (__clang__)
+  #pragma clang system_header                   /* treat file as system include file */
+#elif defined ( __GNUC__ )
+  #pragma GCC diagnostic ignored "-Wpedantic"   /* disable pedantic warning due to unnamed structs/unions */
+#endif
+
+#ifndef __CORE_CM85_H_GENERIC
+#define __CORE_CM85_H_GENERIC
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/**
+  \page CMSIS_MISRA_Exceptions  MISRA-C:2004 Compliance Exceptions
+  CMSIS violates the following MISRA-C:2004 rules:
+
+   \li Required Rule 8.5, object/function definition in header file.<br>
+     Function definitions in header files are used to allow 'inlining'.
+
+   \li Required Rule 18.4, declaration of union type or object of union type: '{...}'.<br>
+     Unions are used for effective representation of core registers.
+
+   \li Advisory Rule 19.7, Function-like macro defined.<br>
+     Function-like macros are used to allow more efficient code.
+ */
+
+
+/*******************************************************************************
+ *                 CMSIS definitions
+ ******************************************************************************/
+/**
+  \ingroup Cortex_M85
+  @{
+ */
+
+#include "cmsis_version.h"
+
+/* CMSIS CM85 definitions */
+
+#define __CORTEX_M                (85U)                               /*!< Cortex-M Core */
+
+#if defined ( __CC_ARM )
+  #error Legacy Arm Compiler does not support Armv8.1-M target architecture.
+#elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #if defined (__ARM_FP)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+  #if defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1U)
+    #if defined (__DSP_PRESENT) && (__DSP_PRESENT == 1U)
+      #define __DSP_USED       1U
+    #else
+      #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
+      #define __DSP_USED       0U
+    #endif
+  #else
+    #define __DSP_USED         0U
+  #endif
+
+#elif defined (__ti__)
+  #if defined (__ARM_FP)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+  #if defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1U)
+    #if defined (__DSP_PRESENT) && (__DSP_PRESENT == 1U)
+      #define __DSP_USED       1U
+    #else
+      #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
+      #define __DSP_USED       0U
+    #endif
+  #else
+    #define __DSP_USED         0U
+  #endif
+
+#elif defined ( __GNUC__ )
+  #if defined (__VFP_FP__) && !defined(__SOFTFP__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+  #if defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1U)
+    #if defined (__DSP_PRESENT) && (__DSP_PRESENT == 1U)
+      #define __DSP_USED       1U
+    #else
+      #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
+      #define __DSP_USED         0U
+    #endif
+  #else
+    #define __DSP_USED         0U
+  #endif
+
+#elif defined ( __ICCARM__ )
+  #if defined (__ARMVFP__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+  #if defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1U)
+    #if defined (__DSP_PRESENT) && (__DSP_PRESENT == 1U)
+      #define __DSP_USED       1U
+    #else
+      #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
+      #define __DSP_USED         0U
+    #endif
+  #else
+    #define __DSP_USED         0U
+  #endif
+
+#elif defined ( __TI_ARM__ )
+  #if defined (__TI_VFP_SUPPORT__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#elif defined ( __TASKING__ )
+  #if defined (__FPU_VFP__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#elif defined ( __CSMC__ )
+  #if ( __CSMC__ & 0x400U)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#endif
+
+#include "cmsis_compiler.h"               /* CMSIS compiler specific defines */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_CM85_H_GENERIC */
+
+#ifndef __CMSIS_GENERIC
+
+#ifndef __CORE_CM85_H_DEPENDANT
+#define __CORE_CM85_H_DEPENDANT
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* check device defines and use defaults */
+#if defined __CHECK_DEVICE_DEFINES
+  #ifndef __CM85_REV
+    #define __CM85_REV               0x0001U
+    #warning "__CM85_REV not defined in device header file; using default!"
+  #endif
+
+  #ifndef __FPU_PRESENT
+    #define __FPU_PRESENT             0U
+    #warning "__FPU_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #if __FPU_PRESENT != 0U
+    #ifndef __FPU_DP
+      #define __FPU_DP             0U
+      #warning "__FPU_DP not defined in device header file; using default!"
+    #endif
+  #endif
+
+  #ifndef __MPU_PRESENT
+    #define __MPU_PRESENT             0U
+    #warning "__MPU_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __ICACHE_PRESENT
+    #define __ICACHE_PRESENT          0U
+    #warning "__ICACHE_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __DCACHE_PRESENT
+    #define __DCACHE_PRESENT          0U
+    #warning "__DCACHE_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __VTOR_PRESENT
+    #define __VTOR_PRESENT             1U
+    #warning "__VTOR_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __PMU_PRESENT
+    #define __PMU_PRESENT             0U
+    #warning "__PMU_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #if __PMU_PRESENT != 0U
+    #ifndef __PMU_NUM_EVENTCNT
+      #define __PMU_NUM_EVENTCNT      8U
+      #warning "__PMU_NUM_EVENTCNT not defined in device header file; using default!"
+    #elif (__PMU_NUM_EVENTCNT > 8 || __PMU_NUM_EVENTCNT < 2)
+    #error "__PMU_NUM_EVENTCNT is out of range in device header file!" */
+    #endif
+  #endif
+
+  #ifndef __SAUREGION_PRESENT
+    #define __SAUREGION_PRESENT       0U
+    #warning "__SAUREGION_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __DSP_PRESENT
+    #define __DSP_PRESENT             0U
+    #warning "__DSP_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __NVIC_PRIO_BITS
+    #define __NVIC_PRIO_BITS          3U
+    #warning "__NVIC_PRIO_BITS not defined in device header file; using default!"
+  #endif
+
+  #ifndef __Vendor_SysTickConfig
+    #define __Vendor_SysTickConfig    0U
+    #warning "__Vendor_SysTickConfig not defined in device header file; using default!"
+  #endif
+#endif
+
+/* IO definitions (access restrictions to peripheral registers) */
+/**
+    \defgroup CMSIS_glob_defs CMSIS Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+*/
+#ifdef __cplusplus
+  #define   __I     volatile             /*!< Defines 'read only' permissions */
+#else
+  #define   __I     volatile const       /*!< Defines 'read only' permissions */
+#endif
+#define     __O     volatile             /*!< Defines 'write only' permissions */
+#define     __IO    volatile             /*!< Defines 'read / write' permissions */
+
+/* following defines should be used for structure members */
+#define     __IM     volatile const      /*! Defines 'read only' structure member permissions */
+#define     __OM     volatile            /*! Defines 'write only' structure member permissions */
+#define     __IOM    volatile            /*! Defines 'read / write' structure member permissions */
+
+/*@} end of group Cortex_M85 */
+
+
+
+/*******************************************************************************
+ *                 Register Abstraction
+  Core Register contain:
+  - Core Register
+  - Core NVIC Register
+  - Core EWIC Register
+  - Core EWIC Interrupt Status Access Register
+  - Core SCB Register
+  - Core SysTick Register
+  - Core Debug Register
+  - Core PMU Register
+  - Core MPU Register
+  - Core SAU Register
+  - Core FPU Register
+ ******************************************************************************/
+/**
+  \defgroup CMSIS_core_register Defines and Type Definitions
+  \brief Type definitions and defines for Cortex-M processor based devices.
+*/
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_CORE  Status and Control Registers
+  \brief      Core Register type definitions.
+  @{
+ */
+
+/**
+  \brief  Union type to access the Application Program Status Register (APSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t _reserved0:16;              /*!< bit:  0..15  Reserved */
+    uint32_t GE:4;                       /*!< bit: 16..19  Greater than or Equal flags */
+    uint32_t _reserved1:7;               /*!< bit: 20..26  Reserved */
+    uint32_t Q:1;                        /*!< bit:     27  Saturation condition flag */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} APSR_Type;
+
+/** \brief APSR Register Definitions */
+#define APSR_N_Pos                         31U                                            /*!< APSR: N Position */
+#define APSR_N_Msk                         (1UL << APSR_N_Pos)                            /*!< APSR: N Mask */
+
+#define APSR_Z_Pos                         30U                                            /*!< APSR: Z Position */
+#define APSR_Z_Msk                         (1UL << APSR_Z_Pos)                            /*!< APSR: Z Mask */
+
+#define APSR_C_Pos                         29U                                            /*!< APSR: C Position */
+#define APSR_C_Msk                         (1UL << APSR_C_Pos)                            /*!< APSR: C Mask */
+
+#define APSR_V_Pos                         28U                                            /*!< APSR: V Position */
+#define APSR_V_Msk                         (1UL << APSR_V_Pos)                            /*!< APSR: V Mask */
+
+#define APSR_Q_Pos                         27U                                            /*!< APSR: Q Position */
+#define APSR_Q_Msk                         (1UL << APSR_Q_Pos)                            /*!< APSR: Q Mask */
+
+#define APSR_GE_Pos                        16U                                            /*!< APSR: GE Position */
+#define APSR_GE_Msk                        (0xFUL << APSR_GE_Pos)                         /*!< APSR: GE Mask */
+
+
+/**
+  \brief  Union type to access the Interrupt Program Status Register (IPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number */
+    uint32_t _reserved0:23;              /*!< bit:  9..31  Reserved */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} IPSR_Type;
+
+/** \brief IPSR Register Definitions */
+#define IPSR_ISR_Pos                        0U                                            /*!< IPSR: ISR Position */
+#define IPSR_ISR_Msk                       (0x1FFUL /*<< IPSR_ISR_Pos*/)                  /*!< IPSR: ISR Mask */
+
+
+/**
+  \brief  Union type to access the Special-Purpose Program Status Registers (xPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number */
+    uint32_t _reserved0:7;               /*!< bit:  9..15  Reserved */
+    uint32_t GE:4;                       /*!< bit: 16..19  Greater than or Equal flags */
+    uint32_t _reserved1:1;               /*!< bit:     20  Reserved */
+    uint32_t B:1;                        /*!< bit:     21  BTI active       (read 0) */
+    uint32_t _reserved2:2;               /*!< bit: 22..23  Reserved */
+    uint32_t T:1;                        /*!< bit:     24  Thumb bit        (read 0) */
+    uint32_t IT:2;                       /*!< bit: 25..26  saved IT state   (read 0) */
+    uint32_t Q:1;                        /*!< bit:     27  Saturation condition flag */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} xPSR_Type;
+
+/** \brief xPSR Register Definitions */
+#define xPSR_N_Pos                         31U                                            /*!< xPSR: N Position */
+#define xPSR_N_Msk                         (1UL << xPSR_N_Pos)                            /*!< xPSR: N Mask */
+
+#define xPSR_Z_Pos                         30U                                            /*!< xPSR: Z Position */
+#define xPSR_Z_Msk                         (1UL << xPSR_Z_Pos)                            /*!< xPSR: Z Mask */
+
+#define xPSR_C_Pos                         29U                                            /*!< xPSR: C Position */
+#define xPSR_C_Msk                         (1UL << xPSR_C_Pos)                            /*!< xPSR: C Mask */
+
+#define xPSR_V_Pos                         28U                                            /*!< xPSR: V Position */
+#define xPSR_V_Msk                         (1UL << xPSR_V_Pos)                            /*!< xPSR: V Mask */
+
+#define xPSR_Q_Pos                         27U                                            /*!< xPSR: Q Position */
+#define xPSR_Q_Msk                         (1UL << xPSR_Q_Pos)                            /*!< xPSR: Q Mask */
+
+#define xPSR_IT_Pos                        25U                                            /*!< xPSR: IT Position */
+#define xPSR_IT_Msk                        (3UL << xPSR_IT_Pos)                           /*!< xPSR: IT Mask */
+
+#define xPSR_T_Pos                         24U                                            /*!< xPSR: T Position */
+#define xPSR_T_Msk                         (1UL << xPSR_T_Pos)                            /*!< xPSR: T Mask */
+
+#define xPSR_B_Pos                         21U                                            /*!< xPSR: B Position */
+#define xPSR_B_Msk                         (1UL << xPSR_B_Pos)                            /*!< xPSR: B Mask */
+
+#define xPSR_GE_Pos                        16U                                            /*!< xPSR: GE Position */
+#define xPSR_GE_Msk                        (0xFUL << xPSR_GE_Pos)                         /*!< xPSR: GE Mask */
+
+#define xPSR_ISR_Pos                        0U                                            /*!< xPSR: ISR Position */
+#define xPSR_ISR_Msk                       (0x1FFUL /*<< xPSR_ISR_Pos*/)                  /*!< xPSR: ISR Mask */
+
+
+/**
+  \brief  Union type to access the Control Registers (CONTROL).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t nPRIV:1;                    /*!< bit:      0  Execution privilege in Thread mode */
+    uint32_t SPSEL:1;                    /*!< bit:      1  Stack-pointer select */
+    uint32_t FPCA:1;                     /*!< bit:      2  Floating-point context active */
+    uint32_t SFPA:1;                     /*!< bit:      3  Secure floating-point active */
+    uint32_t BTI_EN:1;                   /*!< bit:      4  Privileged branch target identification enable */
+    uint32_t UBTI_EN:1;                  /*!< bit:      5  Unprivileged branch target identification enable */
+    uint32_t PAC_EN:1;                   /*!< bit:      6  Privileged pointer authentication enable */
+    uint32_t UPAC_EN:1;                  /*!< bit:      7  Unprivileged pointer authentication enable */
+    uint32_t _reserved1:24;              /*!< bit:  8..31  Reserved */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} CONTROL_Type;
+
+/** \brief CONTROL Register Definitions */
+#define CONTROL_UPAC_EN_Pos                 7U                                            /*!< CONTROL: UPAC_EN Position */
+#define CONTROL_UPAC_EN_Msk                (1UL << CONTROL_UPAC_EN_Pos)                   /*!< CONTROL: UPAC_EN Mask */
+
+#define CONTROL_PAC_EN_Pos                  6U                                            /*!< CONTROL: PAC_EN Position */
+#define CONTROL_PAC_EN_Msk                 (1UL << CONTROL_PAC_EN_Pos)                    /*!< CONTROL: PAC_EN Mask */
+
+#define CONTROL_UBTI_EN_Pos                 5U                                            /*!< CONTROL: UBTI_EN Position */
+#define CONTROL_UBTI_EN_Msk                (1UL << CONTROL_UBTI_EN_Pos)                   /*!< CONTROL: UBTI_EN Mask */
+
+#define CONTROL_BTI_EN_Pos                  4U                                            /*!< CONTROL: BTI_EN Position */
+#define CONTROL_BTI_EN_Msk                 (1UL << CONTROL_BTI_EN_Pos)                    /*!< CONTROL: BTI_EN Mask */
+
+#define CONTROL_SFPA_Pos                    3U                                            /*!< CONTROL: SFPA Position */
+#define CONTROL_SFPA_Msk                   (1UL << CONTROL_SFPA_Pos)                      /*!< CONTROL: SFPA Mask */
+
+#define CONTROL_FPCA_Pos                    2U                                            /*!< CONTROL: FPCA Position */
+#define CONTROL_FPCA_Msk                   (1UL << CONTROL_FPCA_Pos)                      /*!< CONTROL: FPCA Mask */
+
+#define CONTROL_SPSEL_Pos                   1U                                            /*!< CONTROL: SPSEL Position */
+#define CONTROL_SPSEL_Msk                  (1UL << CONTROL_SPSEL_Pos)                     /*!< CONTROL: SPSEL Mask */
+
+#define CONTROL_nPRIV_Pos                   0U                                            /*!< CONTROL: nPRIV Position */
+#define CONTROL_nPRIV_Msk                  (1UL /*<< CONTROL_nPRIV_Pos*/)                 /*!< CONTROL: nPRIV Mask */
+
+/*@} end of group CMSIS_CORE */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_NVIC  Nested Vectored Interrupt Controller (NVIC)
+  \brief      Type definitions for the NVIC Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Nested Vectored Interrupt Controller (NVIC).
+ */
+typedef struct
+{
+  __IOM uint32_t ISER[16U];              /*!< Offset: 0x000 (R/W)  Interrupt Set Enable Register */
+        uint32_t RESERVED0[16U];
+  __IOM uint32_t ICER[16U];              /*!< Offset: 0x080 (R/W)  Interrupt Clear Enable Register */
+        uint32_t RESERVED1[16U];
+  __IOM uint32_t ISPR[16U];              /*!< Offset: 0x100 (R/W)  Interrupt Set Pending Register */
+        uint32_t RESERVED2[16U];
+  __IOM uint32_t ICPR[16U];              /*!< Offset: 0x180 (R/W)  Interrupt Clear Pending Register */
+        uint32_t RESERVED3[16U];
+  __IOM uint32_t IABR[16U];              /*!< Offset: 0x200 (R/W)  Interrupt Active bit Register */
+        uint32_t RESERVED4[16U];
+  __IOM uint32_t ITNS[16U];              /*!< Offset: 0x280 (R/W)  Interrupt Non-Secure State Register */
+        uint32_t RESERVED5[16U];
+  __IOM uint8_t  IPR[496U];              /*!< Offset: 0x300 (R/W)  Interrupt Priority Register (8Bit wide) */
+        uint32_t RESERVED6[580U];
+  __OM  uint32_t STIR;                   /*!< Offset: 0xE00 ( /W)  Software Trigger Interrupt Register */
+}  NVIC_Type;
+
+/** \brief NVIC Software Triggered Interrupt Register Definitions */
+#define NVIC_STIR_INTID_Pos                 0U                                         /*!< STIR: INTLINESNUM Position */
+#define NVIC_STIR_INTID_Msk                (0x1FFUL /*<< NVIC_STIR_INTID_Pos*/)        /*!< STIR: INTLINESNUM Mask */
+
+/*@} end of group CMSIS_NVIC */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SCB     System Control Block (SCB)
+  \brief    Type definitions for the System Control Block Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Control Block (SCB).
+ */
+typedef struct
+{
+  __IM  uint32_t CPUID;                  /*!< Offset: 0x000 (R/ )  CPUID Base Register */
+  __IOM uint32_t ICSR;                   /*!< Offset: 0x004 (R/W)  Interrupt Control and State Register */
+  __IOM uint32_t VTOR;                   /*!< Offset: 0x008 (R/W)  Vector Table Offset Register */
+  __IOM uint32_t AIRCR;                  /*!< Offset: 0x00C (R/W)  Application Interrupt and Reset Control Register */
+  __IOM uint32_t SCR;                    /*!< Offset: 0x010 (R/W)  System Control Register */
+  __IOM uint32_t CCR;                    /*!< Offset: 0x014 (R/W)  Configuration Control Register */
+  __IOM uint8_t  SHPR[12U];              /*!< Offset: 0x018 (R/W)  System Handlers Priority Registers (4-7, 8-11, 12-15) */
+  __IOM uint32_t SHCSR;                  /*!< Offset: 0x024 (R/W)  System Handler Control and State Register */
+  __IOM uint32_t CFSR;                   /*!< Offset: 0x028 (R/W)  Configurable Fault Status Register */
+  __IOM uint32_t HFSR;                   /*!< Offset: 0x02C (R/W)  HardFault Status Register */
+  __IOM uint32_t DFSR;                   /*!< Offset: 0x030 (R/W)  Debug Fault Status Register */
+  __IOM uint32_t MMFAR;                  /*!< Offset: 0x034 (R/W)  MemManage Fault Address Register */
+  __IOM uint32_t BFAR;                   /*!< Offset: 0x038 (R/W)  BusFault Address Register */
+  __IOM uint32_t AFSR;                   /*!< Offset: 0x03C (R/W)  Auxiliary Fault Status Register */
+  __IM  uint32_t ID_PFR[2U];             /*!< Offset: 0x040 (R/ )  Processor Feature Register */
+  __IM  uint32_t ID_DFR;                 /*!< Offset: 0x048 (R/ )  Debug Feature Register */
+  __IM  uint32_t ID_AFR;                 /*!< Offset: 0x04C (R/ )  Auxiliary Feature Register */
+  __IM  uint32_t ID_MMFR[4U];            /*!< Offset: 0x050 (R/ )  Memory Model Feature Register */
+  __IM  uint32_t ID_ISAR[6U];            /*!< Offset: 0x060 (R/ )  Instruction Set Attributes Register */
+  __IM  uint32_t CLIDR;                  /*!< Offset: 0x078 (R/ )  Cache Level ID register */
+  __IM  uint32_t CTR;                    /*!< Offset: 0x07C (R/ )  Cache Type register */
+  __IM  uint32_t CCSIDR;                 /*!< Offset: 0x080 (R/ )  Cache Size ID Register */
+  __IOM uint32_t CSSELR;                 /*!< Offset: 0x084 (R/W)  Cache Size Selection Register */
+  __IOM uint32_t CPACR;                  /*!< Offset: 0x088 (R/W)  Coprocessor Access Control Register */
+  __IOM uint32_t NSACR;                  /*!< Offset: 0x08C (R/W)  Non-Secure Access Control Register */
+        uint32_t RESERVED7[21U];
+  __IOM uint32_t SFSR;                   /*!< Offset: 0x0E4 (R/W)  Secure Fault Status Register */
+  __IOM uint32_t SFAR;                   /*!< Offset: 0x0E8 (R/W)  Secure Fault Address Register */
+        uint32_t RESERVED3[69U];
+  __OM  uint32_t STIR;                   /*!< Offset: 0x200 ( /W)  Software Triggered Interrupt Register */
+  __IOM uint32_t RFSR;                   /*!< Offset: 0x204 (R/W)  RAS Fault Status Register */
+        uint32_t RESERVED4[14U];
+  __IM  uint32_t MVFR0;                  /*!< Offset: 0x240 (R/ )  Media and VFP Feature Register 0 */
+  __IM  uint32_t MVFR1;                  /*!< Offset: 0x244 (R/ )  Media and VFP Feature Register 1 */
+  __IM  uint32_t MVFR2;                  /*!< Offset: 0x248 (R/ )  Media and VFP Feature Register 2 */
+        uint32_t RESERVED5[1U];
+  __OM  uint32_t ICIALLU;                /*!< Offset: 0x250 ( /W)  I-Cache Invalidate All to PoU */
+        uint32_t RESERVED6[1U];
+  __OM  uint32_t ICIMVAU;                /*!< Offset: 0x258 ( /W)  I-Cache Invalidate by MVA to PoU */
+  __OM  uint32_t DCIMVAC;                /*!< Offset: 0x25C ( /W)  D-Cache Invalidate by MVA to PoC */
+  __OM  uint32_t DCISW;                  /*!< Offset: 0x260 ( /W)  D-Cache Invalidate by Set-way */
+  __OM  uint32_t DCCMVAU;                /*!< Offset: 0x264 ( /W)  D-Cache Clean by MVA to PoU */
+  __OM  uint32_t DCCMVAC;                /*!< Offset: 0x268 ( /W)  D-Cache Clean by MVA to PoC */
+  __OM  uint32_t DCCSW;                  /*!< Offset: 0x26C ( /W)  D-Cache Clean by Set-way */
+  __OM  uint32_t DCCIMVAC;               /*!< Offset: 0x270 ( /W)  D-Cache Clean and Invalidate by MVA to PoC */
+  __OM  uint32_t DCCISW;                 /*!< Offset: 0x274 ( /W)  D-Cache Clean and Invalidate by Set-way */
+  __OM  uint32_t BPIALL;                 /*!< Offset: 0x278 ( /W)  Branch Predictor Invalidate All */
+} SCB_Type;
+
+/** \brief SCB CPUID Register Definitions */
+#define SCB_CPUID_IMPLEMENTER_Pos          24U                                            /*!< SCB CPUID: IMPLEMENTER Position */
+#define SCB_CPUID_IMPLEMENTER_Msk          (0xFFUL << SCB_CPUID_IMPLEMENTER_Pos)          /*!< SCB CPUID: IMPLEMENTER Mask */
+
+#define SCB_CPUID_VARIANT_Pos              20U                                            /*!< SCB CPUID: VARIANT Position */
+#define SCB_CPUID_VARIANT_Msk              (0xFUL << SCB_CPUID_VARIANT_Pos)               /*!< SCB CPUID: VARIANT Mask */
+
+#define SCB_CPUID_ARCHITECTURE_Pos         16U                                            /*!< SCB CPUID: ARCHITECTURE Position */
+#define SCB_CPUID_ARCHITECTURE_Msk         (0xFUL << SCB_CPUID_ARCHITECTURE_Pos)          /*!< SCB CPUID: ARCHITECTURE Mask */
+
+#define SCB_CPUID_PARTNO_Pos                4U                                            /*!< SCB CPUID: PARTNO Position */
+#define SCB_CPUID_PARTNO_Msk               (0xFFFUL << SCB_CPUID_PARTNO_Pos)              /*!< SCB CPUID: PARTNO Mask */
+
+#define SCB_CPUID_REVISION_Pos              0U                                            /*!< SCB CPUID: REVISION Position */
+#define SCB_CPUID_REVISION_Msk             (0xFUL /*<< SCB_CPUID_REVISION_Pos*/)          /*!< SCB CPUID: REVISION Mask */
+
+/** \brief SCB Interrupt Control State Register Definitions */
+#define SCB_ICSR_PENDNMISET_Pos            31U                                            /*!< SCB ICSR: PENDNMISET Position */
+#define SCB_ICSR_PENDNMISET_Msk            (1UL << SCB_ICSR_PENDNMISET_Pos)               /*!< SCB ICSR: PENDNMISET Mask */
+
+#define SCB_ICSR_PENDNMICLR_Pos            30U                                            /*!< SCB ICSR: PENDNMICLR Position */
+#define SCB_ICSR_PENDNMICLR_Msk            (1UL << SCB_ICSR_PENDNMICLR_Pos)               /*!< SCB ICSR: PENDNMICLR Mask */
+
+#define SCB_ICSR_PENDSVSET_Pos             28U                                            /*!< SCB ICSR: PENDSVSET Position */
+#define SCB_ICSR_PENDSVSET_Msk             (1UL << SCB_ICSR_PENDSVSET_Pos)                /*!< SCB ICSR: PENDSVSET Mask */
+
+#define SCB_ICSR_PENDSVCLR_Pos             27U                                            /*!< SCB ICSR: PENDSVCLR Position */
+#define SCB_ICSR_PENDSVCLR_Msk             (1UL << SCB_ICSR_PENDSVCLR_Pos)                /*!< SCB ICSR: PENDSVCLR Mask */
+
+#define SCB_ICSR_PENDSTSET_Pos             26U                                            /*!< SCB ICSR: PENDSTSET Position */
+#define SCB_ICSR_PENDSTSET_Msk             (1UL << SCB_ICSR_PENDSTSET_Pos)                /*!< SCB ICSR: PENDSTSET Mask */
+
+#define SCB_ICSR_PENDSTCLR_Pos             25U                                            /*!< SCB ICSR: PENDSTCLR Position */
+#define SCB_ICSR_PENDSTCLR_Msk             (1UL << SCB_ICSR_PENDSTCLR_Pos)                /*!< SCB ICSR: PENDSTCLR Mask */
+
+#define SCB_ICSR_STTNS_Pos                 24U                                            /*!< SCB ICSR: STTNS Position (Security Extension) */
+#define SCB_ICSR_STTNS_Msk                 (1UL << SCB_ICSR_STTNS_Pos)                    /*!< SCB ICSR: STTNS Mask (Security Extension) */
+
+#define SCB_ICSR_ISRPREEMPT_Pos            23U                                            /*!< SCB ICSR: ISRPREEMPT Position */
+#define SCB_ICSR_ISRPREEMPT_Msk            (1UL << SCB_ICSR_ISRPREEMPT_Pos)               /*!< SCB ICSR: ISRPREEMPT Mask */
+
+#define SCB_ICSR_ISRPENDING_Pos            22U                                            /*!< SCB ICSR: ISRPENDING Position */
+#define SCB_ICSR_ISRPENDING_Msk            (1UL << SCB_ICSR_ISRPENDING_Pos)               /*!< SCB ICSR: ISRPENDING Mask */
+
+#define SCB_ICSR_VECTPENDING_Pos           12U                                            /*!< SCB ICSR: VECTPENDING Position */
+#define SCB_ICSR_VECTPENDING_Msk           (0x1FFUL << SCB_ICSR_VECTPENDING_Pos)          /*!< SCB ICSR: VECTPENDING Mask */
+
+#define SCB_ICSR_RETTOBASE_Pos             11U                                            /*!< SCB ICSR: RETTOBASE Position */
+#define SCB_ICSR_RETTOBASE_Msk             (1UL << SCB_ICSR_RETTOBASE_Pos)                /*!< SCB ICSR: RETTOBASE Mask */
+
+#define SCB_ICSR_VECTACTIVE_Pos             0U                                            /*!< SCB ICSR: VECTACTIVE Position */
+#define SCB_ICSR_VECTACTIVE_Msk            (0x1FFUL /*<< SCB_ICSR_VECTACTIVE_Pos*/)       /*!< SCB ICSR: VECTACTIVE Mask */
+
+/** \brief SCB Vector Table Offset Register Definitions */
+#define SCB_VTOR_TBLOFF_Pos                 7U                                            /*!< SCB VTOR: TBLOFF Position */
+#define SCB_VTOR_TBLOFF_Msk                (0x1FFFFFFUL << SCB_VTOR_TBLOFF_Pos)           /*!< SCB VTOR: TBLOFF Mask */
+
+/** \brief SCB Application Interrupt and Reset Control Register Definitions */
+#define SCB_AIRCR_VECTKEY_Pos              16U                                            /*!< SCB AIRCR: VECTKEY Position */
+#define SCB_AIRCR_VECTKEY_Msk              (0xFFFFUL << SCB_AIRCR_VECTKEY_Pos)            /*!< SCB AIRCR: VECTKEY Mask */
+
+#define SCB_AIRCR_VECTKEYSTAT_Pos          16U                                            /*!< SCB AIRCR: VECTKEYSTAT Position */
+#define SCB_AIRCR_VECTKEYSTAT_Msk          (0xFFFFUL << SCB_AIRCR_VECTKEYSTAT_Pos)        /*!< SCB AIRCR: VECTKEYSTAT Mask */
+
+#define SCB_AIRCR_ENDIANESS_Pos            15U                                            /*!< SCB AIRCR: ENDIANESS Position */
+#define SCB_AIRCR_ENDIANESS_Msk            (1UL << SCB_AIRCR_ENDIANESS_Pos)               /*!< SCB AIRCR: ENDIANESS Mask */
+
+#define SCB_AIRCR_PRIS_Pos                 14U                                            /*!< SCB AIRCR: PRIS Position */
+#define SCB_AIRCR_PRIS_Msk                 (1UL << SCB_AIRCR_PRIS_Pos)                    /*!< SCB AIRCR: PRIS Mask */
+
+#define SCB_AIRCR_BFHFNMINS_Pos            13U                                            /*!< SCB AIRCR: BFHFNMINS Position */
+#define SCB_AIRCR_BFHFNMINS_Msk            (1UL << SCB_AIRCR_BFHFNMINS_Pos)               /*!< SCB AIRCR: BFHFNMINS Mask */
+
+#define SCB_AIRCR_PRIGROUP_Pos              8U                                            /*!< SCB AIRCR: PRIGROUP Position */
+#define SCB_AIRCR_PRIGROUP_Msk             (7UL << SCB_AIRCR_PRIGROUP_Pos)                /*!< SCB AIRCR: PRIGROUP Mask */
+
+#define SCB_AIRCR_IESB_Pos                  5U                                            /*!< SCB AIRCR: Implicit ESB Enable Position */
+#define SCB_AIRCR_IESB_Msk                 (1UL << SCB_AIRCR_IESB_Pos)                    /*!< SCB AIRCR: Implicit ESB Enable Mask */
+
+#define SCB_AIRCR_DIT_Pos                   4U                                            /*!< SCB AIRCR: Data Independent Timing Position */
+#define SCB_AIRCR_DIT_Msk                  (1UL << SCB_AIRCR_DIT_Pos)                     /*!< SCB AIRCR: Data Independent Timing Mask */
+
+#define SCB_AIRCR_SYSRESETREQS_Pos          3U                                            /*!< SCB AIRCR: SYSRESETREQS Position */
+#define SCB_AIRCR_SYSRESETREQS_Msk         (1UL << SCB_AIRCR_SYSRESETREQS_Pos)            /*!< SCB AIRCR: SYSRESETREQS Mask */
+
+#define SCB_AIRCR_SYSRESETREQ_Pos           2U                                            /*!< SCB AIRCR: SYSRESETREQ Position */
+#define SCB_AIRCR_SYSRESETREQ_Msk          (1UL << SCB_AIRCR_SYSRESETREQ_Pos)             /*!< SCB AIRCR: SYSRESETREQ Mask */
+
+#define SCB_AIRCR_VECTCLRACTIVE_Pos         1U                                            /*!< SCB AIRCR: VECTCLRACTIVE Position */
+#define SCB_AIRCR_VECTCLRACTIVE_Msk        (1UL << SCB_AIRCR_VECTCLRACTIVE_Pos)           /*!< SCB AIRCR: VECTCLRACTIVE Mask */
+
+/** \brief SCB System Control Register Definitions */
+#define SCB_SCR_SEVONPEND_Pos               4U                                            /*!< SCB SCR: SEVONPEND Position */
+#define SCB_SCR_SEVONPEND_Msk              (1UL << SCB_SCR_SEVONPEND_Pos)                 /*!< SCB SCR: SEVONPEND Mask */
+
+#define SCB_SCR_SLEEPDEEPS_Pos              3U                                            /*!< SCB SCR: SLEEPDEEPS Position */
+#define SCB_SCR_SLEEPDEEPS_Msk             (1UL << SCB_SCR_SLEEPDEEPS_Pos)                /*!< SCB SCR: SLEEPDEEPS Mask */
+
+#define SCB_SCR_SLEEPDEEP_Pos               2U                                            /*!< SCB SCR: SLEEPDEEP Position */
+#define SCB_SCR_SLEEPDEEP_Msk              (1UL << SCB_SCR_SLEEPDEEP_Pos)                 /*!< SCB SCR: SLEEPDEEP Mask */
+
+#define SCB_SCR_SLEEPONEXIT_Pos             1U                                            /*!< SCB SCR: SLEEPONEXIT Position */
+#define SCB_SCR_SLEEPONEXIT_Msk            (1UL << SCB_SCR_SLEEPONEXIT_Pos)               /*!< SCB SCR: SLEEPONEXIT Mask */
+
+/** \brief SCB Configuration Control Register Definitions */
+#define SCB_CCR_TRD_Pos                    20U                                            /*!< SCB CCR: TRD Position */
+#define SCB_CCR_TRD_Msk                    (1UL << SCB_CCR_TRD_Pos)                       /*!< SCB CCR: TRD Mask */
+
+#define SCB_CCR_LOB_Pos                    19U                                            /*!< SCB CCR: LOB Position */
+#define SCB_CCR_LOB_Msk                    (1UL << SCB_CCR_LOB_Pos)                       /*!< SCB CCR: LOB Mask */
+
+#define SCB_CCR_BP_Pos                     18U                                            /*!< SCB CCR: BP Position */
+#define SCB_CCR_BP_Msk                     (1UL << SCB_CCR_BP_Pos)                        /*!< SCB CCR: BP Mask */
+
+#define SCB_CCR_IC_Pos                     17U                                            /*!< SCB CCR: IC Position */
+#define SCB_CCR_IC_Msk                     (1UL << SCB_CCR_IC_Pos)                        /*!< SCB CCR: IC Mask */
+
+#define SCB_CCR_DC_Pos                     16U                                            /*!< SCB CCR: DC Position */
+#define SCB_CCR_DC_Msk                     (1UL << SCB_CCR_DC_Pos)                        /*!< SCB CCR: DC Mask */
+
+#define SCB_CCR_STKOFHFNMIGN_Pos           10U                                            /*!< SCB CCR: STKOFHFNMIGN Position */
+#define SCB_CCR_STKOFHFNMIGN_Msk           (1UL << SCB_CCR_STKOFHFNMIGN_Pos)              /*!< SCB CCR: STKOFHFNMIGN Mask */
+
+#define SCB_CCR_BFHFNMIGN_Pos               8U                                            /*!< SCB CCR: BFHFNMIGN Position */
+#define SCB_CCR_BFHFNMIGN_Msk              (1UL << SCB_CCR_BFHFNMIGN_Pos)                 /*!< SCB CCR: BFHFNMIGN Mask */
+
+#define SCB_CCR_DIV_0_TRP_Pos               4U                                            /*!< SCB CCR: DIV_0_TRP Position */
+#define SCB_CCR_DIV_0_TRP_Msk              (1UL << SCB_CCR_DIV_0_TRP_Pos)                 /*!< SCB CCR: DIV_0_TRP Mask */
+
+#define SCB_CCR_UNALIGN_TRP_Pos             3U                                            /*!< SCB CCR: UNALIGN_TRP Position */
+#define SCB_CCR_UNALIGN_TRP_Msk            (1UL << SCB_CCR_UNALIGN_TRP_Pos)               /*!< SCB CCR: UNALIGN_TRP Mask */
+
+#define SCB_CCR_USERSETMPEND_Pos            1U                                            /*!< SCB CCR: USERSETMPEND Position */
+#define SCB_CCR_USERSETMPEND_Msk           (1UL << SCB_CCR_USERSETMPEND_Pos)              /*!< SCB CCR: USERSETMPEND Mask */
+
+/** \brief SCB System Handler Control and State Register Definitions */
+#define SCB_SHCSR_HARDFAULTPENDED_Pos      21U                                            /*!< SCB SHCSR: HARDFAULTPENDED Position */
+#define SCB_SHCSR_HARDFAULTPENDED_Msk      (1UL << SCB_SHCSR_HARDFAULTPENDED_Pos)         /*!< SCB SHCSR: HARDFAULTPENDED Mask */
+
+#define SCB_SHCSR_SECUREFAULTPENDED_Pos    20U                                            /*!< SCB SHCSR: SECUREFAULTPENDED Position */
+#define SCB_SHCSR_SECUREFAULTPENDED_Msk    (1UL << SCB_SHCSR_SECUREFAULTPENDED_Pos)       /*!< SCB SHCSR: SECUREFAULTPENDED Mask */
+
+#define SCB_SHCSR_SECUREFAULTENA_Pos       19U                                            /*!< SCB SHCSR: SECUREFAULTENA Position */
+#define SCB_SHCSR_SECUREFAULTENA_Msk       (1UL << SCB_SHCSR_SECUREFAULTENA_Pos)          /*!< SCB SHCSR: SECUREFAULTENA Mask */
+
+#define SCB_SHCSR_USGFAULTENA_Pos          18U                                            /*!< SCB SHCSR: USGFAULTENA Position */
+#define SCB_SHCSR_USGFAULTENA_Msk          (1UL << SCB_SHCSR_USGFAULTENA_Pos)             /*!< SCB SHCSR: USGFAULTENA Mask */
+
+#define SCB_SHCSR_BUSFAULTENA_Pos          17U                                            /*!< SCB SHCSR: BUSFAULTENA Position */
+#define SCB_SHCSR_BUSFAULTENA_Msk          (1UL << SCB_SHCSR_BUSFAULTENA_Pos)             /*!< SCB SHCSR: BUSFAULTENA Mask */
+
+#define SCB_SHCSR_MEMFAULTENA_Pos          16U                                            /*!< SCB SHCSR: MEMFAULTENA Position */
+#define SCB_SHCSR_MEMFAULTENA_Msk          (1UL << SCB_SHCSR_MEMFAULTENA_Pos)             /*!< SCB SHCSR: MEMFAULTENA Mask */
+
+#define SCB_SHCSR_SVCALLPENDED_Pos         15U                                            /*!< SCB SHCSR: SVCALLPENDED Position */
+#define SCB_SHCSR_SVCALLPENDED_Msk         (1UL << SCB_SHCSR_SVCALLPENDED_Pos)            /*!< SCB SHCSR: SVCALLPENDED Mask */
+
+#define SCB_SHCSR_BUSFAULTPENDED_Pos       14U                                            /*!< SCB SHCSR: BUSFAULTPENDED Position */
+#define SCB_SHCSR_BUSFAULTPENDED_Msk       (1UL << SCB_SHCSR_BUSFAULTPENDED_Pos)          /*!< SCB SHCSR: BUSFAULTPENDED Mask */
+
+#define SCB_SHCSR_MEMFAULTPENDED_Pos       13U                                            /*!< SCB SHCSR: MEMFAULTPENDED Position */
+#define SCB_SHCSR_MEMFAULTPENDED_Msk       (1UL << SCB_SHCSR_MEMFAULTPENDED_Pos)          /*!< SCB SHCSR: MEMFAULTPENDED Mask */
+
+#define SCB_SHCSR_USGFAULTPENDED_Pos       12U                                            /*!< SCB SHCSR: USGFAULTPENDED Position */
+#define SCB_SHCSR_USGFAULTPENDED_Msk       (1UL << SCB_SHCSR_USGFAULTPENDED_Pos)          /*!< SCB SHCSR: USGFAULTPENDED Mask */
+
+#define SCB_SHCSR_SYSTICKACT_Pos           11U                                            /*!< SCB SHCSR: SYSTICKACT Position */
+#define SCB_SHCSR_SYSTICKACT_Msk           (1UL << SCB_SHCSR_SYSTICKACT_Pos)              /*!< SCB SHCSR: SYSTICKACT Mask */
+
+#define SCB_SHCSR_PENDSVACT_Pos            10U                                            /*!< SCB SHCSR: PENDSVACT Position */
+#define SCB_SHCSR_PENDSVACT_Msk            (1UL << SCB_SHCSR_PENDSVACT_Pos)               /*!< SCB SHCSR: PENDSVACT Mask */
+
+#define SCB_SHCSR_MONITORACT_Pos            8U                                            /*!< SCB SHCSR: MONITORACT Position */
+#define SCB_SHCSR_MONITORACT_Msk           (1UL << SCB_SHCSR_MONITORACT_Pos)              /*!< SCB SHCSR: MONITORACT Mask */
+
+#define SCB_SHCSR_SVCALLACT_Pos             7U                                            /*!< SCB SHCSR: SVCALLACT Position */
+#define SCB_SHCSR_SVCALLACT_Msk            (1UL << SCB_SHCSR_SVCALLACT_Pos)               /*!< SCB SHCSR: SVCALLACT Mask */
+
+#define SCB_SHCSR_NMIACT_Pos                5U                                            /*!< SCB SHCSR: NMIACT Position */
+#define SCB_SHCSR_NMIACT_Msk               (1UL << SCB_SHCSR_NMIACT_Pos)                  /*!< SCB SHCSR: NMIACT Mask */
+
+#define SCB_SHCSR_SECUREFAULTACT_Pos        4U                                            /*!< SCB SHCSR: SECUREFAULTACT Position */
+#define SCB_SHCSR_SECUREFAULTACT_Msk       (1UL << SCB_SHCSR_SECUREFAULTACT_Pos)          /*!< SCB SHCSR: SECUREFAULTACT Mask */
+
+#define SCB_SHCSR_USGFAULTACT_Pos           3U                                            /*!< SCB SHCSR: USGFAULTACT Position */
+#define SCB_SHCSR_USGFAULTACT_Msk          (1UL << SCB_SHCSR_USGFAULTACT_Pos)             /*!< SCB SHCSR: USGFAULTACT Mask */
+
+#define SCB_SHCSR_HARDFAULTACT_Pos          2U                                            /*!< SCB SHCSR: HARDFAULTACT Position */
+#define SCB_SHCSR_HARDFAULTACT_Msk         (1UL << SCB_SHCSR_HARDFAULTACT_Pos)            /*!< SCB SHCSR: HARDFAULTACT Mask */
+
+#define SCB_SHCSR_BUSFAULTACT_Pos           1U                                            /*!< SCB SHCSR: BUSFAULTACT Position */
+#define SCB_SHCSR_BUSFAULTACT_Msk          (1UL << SCB_SHCSR_BUSFAULTACT_Pos)             /*!< SCB SHCSR: BUSFAULTACT Mask */
+
+#define SCB_SHCSR_MEMFAULTACT_Pos           0U                                            /*!< SCB SHCSR: MEMFAULTACT Position */
+#define SCB_SHCSR_MEMFAULTACT_Msk          (1UL /*<< SCB_SHCSR_MEMFAULTACT_Pos*/)         /*!< SCB SHCSR: MEMFAULTACT Mask */
+
+/** \brief SCB Configurable Fault Status Register Definitions */
+#define SCB_CFSR_USGFAULTSR_Pos            16U                                            /*!< SCB CFSR: Usage Fault Status Register Position */
+#define SCB_CFSR_USGFAULTSR_Msk            (0xFFFFUL << SCB_CFSR_USGFAULTSR_Pos)          /*!< SCB CFSR: Usage Fault Status Register Mask */
+
+#define SCB_CFSR_BUSFAULTSR_Pos             8U                                            /*!< SCB CFSR: Bus Fault Status Register Position */
+#define SCB_CFSR_BUSFAULTSR_Msk            (0xFFUL << SCB_CFSR_BUSFAULTSR_Pos)            /*!< SCB CFSR: Bus Fault Status Register Mask */
+
+#define SCB_CFSR_MEMFAULTSR_Pos             0U                                            /*!< SCB CFSR: Memory Manage Fault Status Register Position */
+#define SCB_CFSR_MEMFAULTSR_Msk            (0xFFUL /*<< SCB_CFSR_MEMFAULTSR_Pos*/)        /*!< SCB CFSR: Memory Manage Fault Status Register Mask */
+
+/** \brief SCB MemManage Fault Status Register Definitions (part of SCB Configurable Fault Status Register) */
+#define SCB_CFSR_MMARVALID_Pos             (SCB_CFSR_MEMFAULTSR_Pos + 7U)                 /*!< SCB CFSR (MMFSR): MMARVALID Position */
+#define SCB_CFSR_MMARVALID_Msk             (1UL << SCB_CFSR_MMARVALID_Pos)                /*!< SCB CFSR (MMFSR): MMARVALID Mask */
+
+#define SCB_CFSR_MLSPERR_Pos               (SCB_CFSR_MEMFAULTSR_Pos + 5U)                 /*!< SCB CFSR (MMFSR): MLSPERR Position */
+#define SCB_CFSR_MLSPERR_Msk               (1UL << SCB_CFSR_MLSPERR_Pos)                  /*!< SCB CFSR (MMFSR): MLSPERR Mask */
+
+#define SCB_CFSR_MSTKERR_Pos               (SCB_CFSR_MEMFAULTSR_Pos + 4U)                 /*!< SCB CFSR (MMFSR): MSTKERR Position */
+#define SCB_CFSR_MSTKERR_Msk               (1UL << SCB_CFSR_MSTKERR_Pos)                  /*!< SCB CFSR (MMFSR): MSTKERR Mask */
+
+#define SCB_CFSR_MUNSTKERR_Pos             (SCB_CFSR_MEMFAULTSR_Pos + 3U)                 /*!< SCB CFSR (MMFSR): MUNSTKERR Position */
+#define SCB_CFSR_MUNSTKERR_Msk             (1UL << SCB_CFSR_MUNSTKERR_Pos)                /*!< SCB CFSR (MMFSR): MUNSTKERR Mask */
+
+#define SCB_CFSR_DACCVIOL_Pos              (SCB_CFSR_MEMFAULTSR_Pos + 1U)                 /*!< SCB CFSR (MMFSR): DACCVIOL Position */
+#define SCB_CFSR_DACCVIOL_Msk              (1UL << SCB_CFSR_DACCVIOL_Pos)                 /*!< SCB CFSR (MMFSR): DACCVIOL Mask */
+
+#define SCB_CFSR_IACCVIOL_Pos              (SCB_CFSR_MEMFAULTSR_Pos + 0U)                 /*!< SCB CFSR (MMFSR): IACCVIOL Position */
+#define SCB_CFSR_IACCVIOL_Msk              (1UL /*<< SCB_CFSR_IACCVIOL_Pos*/)             /*!< SCB CFSR (MMFSR): IACCVIOL Mask */
+
+/** \brief SCB BusFault Status Register Definitions (part of SCB Configurable Fault Status Register) */
+#define SCB_CFSR_BFARVALID_Pos            (SCB_CFSR_BUSFAULTSR_Pos + 7U)                  /*!< SCB CFSR (BFSR): BFARVALID Position */
+#define SCB_CFSR_BFARVALID_Msk            (1UL << SCB_CFSR_BFARVALID_Pos)                 /*!< SCB CFSR (BFSR): BFARVALID Mask */
+
+#define SCB_CFSR_LSPERR_Pos               (SCB_CFSR_BUSFAULTSR_Pos + 5U)                  /*!< SCB CFSR (BFSR): LSPERR Position */
+#define SCB_CFSR_LSPERR_Msk               (1UL << SCB_CFSR_LSPERR_Pos)                    /*!< SCB CFSR (BFSR): LSPERR Mask */
+
+#define SCB_CFSR_STKERR_Pos               (SCB_CFSR_BUSFAULTSR_Pos + 4U)                  /*!< SCB CFSR (BFSR): STKERR Position */
+#define SCB_CFSR_STKERR_Msk               (1UL << SCB_CFSR_STKERR_Pos)                    /*!< SCB CFSR (BFSR): STKERR Mask */
+
+#define SCB_CFSR_UNSTKERR_Pos             (SCB_CFSR_BUSFAULTSR_Pos + 3U)                  /*!< SCB CFSR (BFSR): UNSTKERR Position */
+#define SCB_CFSR_UNSTKERR_Msk             (1UL << SCB_CFSR_UNSTKERR_Pos)                  /*!< SCB CFSR (BFSR): UNSTKERR Mask */
+
+#define SCB_CFSR_IMPRECISERR_Pos          (SCB_CFSR_BUSFAULTSR_Pos + 2U)                  /*!< SCB CFSR (BFSR): IMPRECISERR Position */
+#define SCB_CFSR_IMPRECISERR_Msk          (1UL << SCB_CFSR_IMPRECISERR_Pos)               /*!< SCB CFSR (BFSR): IMPRECISERR Mask */
+
+#define SCB_CFSR_PRECISERR_Pos            (SCB_CFSR_BUSFAULTSR_Pos + 1U)                  /*!< SCB CFSR (BFSR): PRECISERR Position */
+#define SCB_CFSR_PRECISERR_Msk            (1UL << SCB_CFSR_PRECISERR_Pos)                 /*!< SCB CFSR (BFSR): PRECISERR Mask */
+
+#define SCB_CFSR_IBUSERR_Pos              (SCB_CFSR_BUSFAULTSR_Pos + 0U)                  /*!< SCB CFSR (BFSR): IBUSERR Position */
+#define SCB_CFSR_IBUSERR_Msk              (1UL << SCB_CFSR_IBUSERR_Pos)                   /*!< SCB CFSR (BFSR): IBUSERR Mask */
+
+/** \brief SCB UsageFault Status Register Definitions (part of SCB Configurable Fault Status Register) */
+#define SCB_CFSR_DIVBYZERO_Pos            (SCB_CFSR_USGFAULTSR_Pos + 9U)                  /*!< SCB CFSR (UFSR): DIVBYZERO Position */
+#define SCB_CFSR_DIVBYZERO_Msk            (1UL << SCB_CFSR_DIVBYZERO_Pos)                 /*!< SCB CFSR (UFSR): DIVBYZERO Mask */
+
+#define SCB_CFSR_UNALIGNED_Pos            (SCB_CFSR_USGFAULTSR_Pos + 8U)                  /*!< SCB CFSR (UFSR): UNALIGNED Position */
+#define SCB_CFSR_UNALIGNED_Msk            (1UL << SCB_CFSR_UNALIGNED_Pos)                 /*!< SCB CFSR (UFSR): UNALIGNED Mask */
+
+#define SCB_CFSR_STKOF_Pos                (SCB_CFSR_USGFAULTSR_Pos + 4U)                  /*!< SCB CFSR (UFSR): STKOF Position */
+#define SCB_CFSR_STKOF_Msk                (1UL << SCB_CFSR_STKOF_Pos)                     /*!< SCB CFSR (UFSR): STKOF Mask */
+
+#define SCB_CFSR_NOCP_Pos                 (SCB_CFSR_USGFAULTSR_Pos + 3U)                  /*!< SCB CFSR (UFSR): NOCP Position */
+#define SCB_CFSR_NOCP_Msk                 (1UL << SCB_CFSR_NOCP_Pos)                      /*!< SCB CFSR (UFSR): NOCP Mask */
+
+#define SCB_CFSR_INVPC_Pos                (SCB_CFSR_USGFAULTSR_Pos + 2U)                  /*!< SCB CFSR (UFSR): INVPC Position */
+#define SCB_CFSR_INVPC_Msk                (1UL << SCB_CFSR_INVPC_Pos)                     /*!< SCB CFSR (UFSR): INVPC Mask */
+
+#define SCB_CFSR_INVSTATE_Pos             (SCB_CFSR_USGFAULTSR_Pos + 1U)                  /*!< SCB CFSR (UFSR): INVSTATE Position */
+#define SCB_CFSR_INVSTATE_Msk             (1UL << SCB_CFSR_INVSTATE_Pos)                  /*!< SCB CFSR (UFSR): INVSTATE Mask */
+
+#define SCB_CFSR_UNDEFINSTR_Pos           (SCB_CFSR_USGFAULTSR_Pos + 0U)                  /*!< SCB CFSR (UFSR): UNDEFINSTR Position */
+#define SCB_CFSR_UNDEFINSTR_Msk           (1UL << SCB_CFSR_UNDEFINSTR_Pos)                /*!< SCB CFSR (UFSR): UNDEFINSTR Mask */
+
+/** \brief SCB Hard Fault Status Register Definitions */
+#define SCB_HFSR_DEBUGEVT_Pos              31U                                            /*!< SCB HFSR: DEBUGEVT Position */
+#define SCB_HFSR_DEBUGEVT_Msk              (1UL << SCB_HFSR_DEBUGEVT_Pos)                 /*!< SCB HFSR: DEBUGEVT Mask */
+
+#define SCB_HFSR_FORCED_Pos                30U                                            /*!< SCB HFSR: FORCED Position */
+#define SCB_HFSR_FORCED_Msk                (1UL << SCB_HFSR_FORCED_Pos)                   /*!< SCB HFSR: FORCED Mask */
+
+#define SCB_HFSR_VECTTBL_Pos                1U                                            /*!< SCB HFSR: VECTTBL Position */
+#define SCB_HFSR_VECTTBL_Msk               (1UL << SCB_HFSR_VECTTBL_Pos)                  /*!< SCB HFSR: VECTTBL Mask */
+
+/** \brief SCB Debug Fault Status Register Definitions */
+#define SCB_DFSR_PMU_Pos                    5U                                            /*!< SCB DFSR: PMU Position */
+#define SCB_DFSR_PMU_Msk                   (1UL << SCB_DFSR_PMU_Pos)                      /*!< SCB DFSR: PMU Mask */
+
+#define SCB_DFSR_EXTERNAL_Pos               4U                                            /*!< SCB DFSR: EXTERNAL Position */
+#define SCB_DFSR_EXTERNAL_Msk              (1UL << SCB_DFSR_EXTERNAL_Pos)                 /*!< SCB DFSR: EXTERNAL Mask */
+
+#define SCB_DFSR_VCATCH_Pos                 3U                                            /*!< SCB DFSR: VCATCH Position */
+#define SCB_DFSR_VCATCH_Msk                (1UL << SCB_DFSR_VCATCH_Pos)                   /*!< SCB DFSR: VCATCH Mask */
+
+#define SCB_DFSR_DWTTRAP_Pos                2U                                            /*!< SCB DFSR: DWTTRAP Position */
+#define SCB_DFSR_DWTTRAP_Msk               (1UL << SCB_DFSR_DWTTRAP_Pos)                  /*!< SCB DFSR: DWTTRAP Mask */
+
+#define SCB_DFSR_BKPT_Pos                   1U                                            /*!< SCB DFSR: BKPT Position */
+#define SCB_DFSR_BKPT_Msk                  (1UL << SCB_DFSR_BKPT_Pos)                     /*!< SCB DFSR: BKPT Mask */
+
+#define SCB_DFSR_HALTED_Pos                 0U                                            /*!< SCB DFSR: HALTED Position */
+#define SCB_DFSR_HALTED_Msk                (1UL /*<< SCB_DFSR_HALTED_Pos*/)               /*!< SCB DFSR: HALTED Mask */
+
+/** \brief SCB Non-Secure Access Control Register Definitions */
+#define SCB_NSACR_CP11_Pos                 11U                                            /*!< SCB NSACR: CP11 Position */
+#define SCB_NSACR_CP11_Msk                 (1UL << SCB_NSACR_CP11_Pos)                    /*!< SCB NSACR: CP11 Mask */
+
+#define SCB_NSACR_CP10_Pos                 10U                                            /*!< SCB NSACR: CP10 Position */
+#define SCB_NSACR_CP10_Msk                 (1UL << SCB_NSACR_CP10_Pos)                    /*!< SCB NSACR: CP10 Mask */
+
+#define SCB_NSACR_CP7_Pos                   7U                                            /*!< SCB NSACR: CP7 Position */
+#define SCB_NSACR_CP7_Msk                  (1UL << SCB_NSACR_CP7_Pos)                     /*!< SCB NSACR: CP7 Mask */
+
+#define SCB_NSACR_CP6_Pos                   6U                                            /*!< SCB NSACR: CP6 Position */
+#define SCB_NSACR_CP6_Msk                  (1UL << SCB_NSACR_CP6_Pos)                     /*!< SCB NSACR: CP6 Mask */
+
+#define SCB_NSACR_CP5_Pos                   5U                                            /*!< SCB NSACR: CP5 Position */
+#define SCB_NSACR_CP5_Msk                  (1UL << SCB_NSACR_CP5_Pos)                     /*!< SCB NSACR: CP5 Mask */
+
+#define SCB_NSACR_CP4_Pos                   4U                                            /*!< SCB NSACR: CP4 Position */
+#define SCB_NSACR_CP4_Msk                  (1UL << SCB_NSACR_CP4_Pos)                     /*!< SCB NSACR: CP4 Mask */
+
+#define SCB_NSACR_CP3_Pos                   3U                                            /*!< SCB NSACR: CP3 Position */
+#define SCB_NSACR_CP3_Msk                  (1UL << SCB_NSACR_CP3_Pos)                     /*!< SCB NSACR: CP3 Mask */
+
+#define SCB_NSACR_CP2_Pos                   2U                                            /*!< SCB NSACR: CP2 Position */
+#define SCB_NSACR_CP2_Msk                  (1UL << SCB_NSACR_CP2_Pos)                     /*!< SCB NSACR: CP2 Mask */
+
+#define SCB_NSACR_CP1_Pos                   1U                                            /*!< SCB NSACR: CP1 Position */
+#define SCB_NSACR_CP1_Msk                  (1UL << SCB_NSACR_CP1_Pos)                     /*!< SCB NSACR: CP1 Mask */
+
+#define SCB_NSACR_CP0_Pos                   0U                                            /*!< SCB NSACR: CP0 Position */
+#define SCB_NSACR_CP0_Msk                  (1UL /*<< SCB_NSACR_CP0_Pos*/)                 /*!< SCB NSACR: CP0 Mask */
+
+/** \brief SCB Debug Feature Register 0 Definitions */
+#define SCB_ID_DFR_UDE_Pos                 28U                                            /*!< SCB ID_DFR: UDE Position */
+#define SCB_ID_DFR_UDE_Msk                 (0xFUL << SCB_ID_DFR_UDE_Pos)                  /*!< SCB ID_DFR: UDE Mask */
+
+#define SCB_ID_DFR_MProfDbg_Pos            20U                                            /*!< SCB ID_DFR: MProfDbg Position */
+#define SCB_ID_DFR_MProfDbg_Msk            (0xFUL << SCB_ID_DFR_MProfDbg_Pos)             /*!< SCB ID_DFR: MProfDbg Mask */
+
+/** \brief SCB Cache Level ID Register Definitions */
+#define SCB_CLIDR_LOUU_Pos                 27U                                            /*!< SCB CLIDR: LoUU Position */
+#define SCB_CLIDR_LOUU_Msk                 (7UL << SCB_CLIDR_LOUU_Pos)                    /*!< SCB CLIDR: LoUU Mask */
+
+#define SCB_CLIDR_LOC_Pos                  24U                                            /*!< SCB CLIDR: LoC Position */
+#define SCB_CLIDR_LOC_Msk                  (7UL << SCB_CLIDR_LOC_Pos)                     /*!< SCB CLIDR: LoC Mask */
+
+/** \brief SCB Cache Type Register Definitions */
+#define SCB_CTR_FORMAT_Pos                 29U                                            /*!< SCB CTR: Format Position */
+#define SCB_CTR_FORMAT_Msk                 (7UL << SCB_CTR_FORMAT_Pos)                    /*!< SCB CTR: Format Mask */
+
+#define SCB_CTR_CWG_Pos                    24U                                            /*!< SCB CTR: CWG Position */
+#define SCB_CTR_CWG_Msk                    (0xFUL << SCB_CTR_CWG_Pos)                     /*!< SCB CTR: CWG Mask */
+
+#define SCB_CTR_ERG_Pos                    20U                                            /*!< SCB CTR: ERG Position */
+#define SCB_CTR_ERG_Msk                    (0xFUL << SCB_CTR_ERG_Pos)                     /*!< SCB CTR: ERG Mask */
+
+#define SCB_CTR_DMINLINE_Pos               16U                                            /*!< SCB CTR: DminLine Position */
+#define SCB_CTR_DMINLINE_Msk               (0xFUL << SCB_CTR_DMINLINE_Pos)                /*!< SCB CTR: DminLine Mask */
+
+#define SCB_CTR_IMINLINE_Pos                0U                                            /*!< SCB CTR: ImInLine Position */
+#define SCB_CTR_IMINLINE_Msk               (0xFUL /*<< SCB_CTR_IMINLINE_Pos*/)            /*!< SCB CTR: ImInLine Mask */
+
+/** \brief SCB Cache Size ID Register Definitions */
+#define SCB_CCSIDR_WT_Pos                  31U                                            /*!< SCB CCSIDR: WT Position */
+#define SCB_CCSIDR_WT_Msk                  (1UL << SCB_CCSIDR_WT_Pos)                     /*!< SCB CCSIDR: WT Mask */
+
+#define SCB_CCSIDR_WB_Pos                  30U                                            /*!< SCB CCSIDR: WB Position */
+#define SCB_CCSIDR_WB_Msk                  (1UL << SCB_CCSIDR_WB_Pos)                     /*!< SCB CCSIDR: WB Mask */
+
+#define SCB_CCSIDR_RA_Pos                  29U                                            /*!< SCB CCSIDR: RA Position */
+#define SCB_CCSIDR_RA_Msk                  (1UL << SCB_CCSIDR_RA_Pos)                     /*!< SCB CCSIDR: RA Mask */
+
+#define SCB_CCSIDR_WA_Pos                  28U                                            /*!< SCB CCSIDR: WA Position */
+#define SCB_CCSIDR_WA_Msk                  (1UL << SCB_CCSIDR_WA_Pos)                     /*!< SCB CCSIDR: WA Mask */
+
+#define SCB_CCSIDR_NUMSETS_Pos             13U                                            /*!< SCB CCSIDR: NumSets Position */
+#define SCB_CCSIDR_NUMSETS_Msk             (0x7FFFUL << SCB_CCSIDR_NUMSETS_Pos)           /*!< SCB CCSIDR: NumSets Mask */
+
+#define SCB_CCSIDR_ASSOCIATIVITY_Pos        3U                                            /*!< SCB CCSIDR: Associativity Position */
+#define SCB_CCSIDR_ASSOCIATIVITY_Msk       (0x3FFUL << SCB_CCSIDR_ASSOCIATIVITY_Pos)      /*!< SCB CCSIDR: Associativity Mask */
+
+#define SCB_CCSIDR_LINESIZE_Pos             0U                                            /*!< SCB CCSIDR: LineSize Position */
+#define SCB_CCSIDR_LINESIZE_Msk            (7UL /*<< SCB_CCSIDR_LINESIZE_Pos*/)           /*!< SCB CCSIDR: LineSize Mask */
+
+/** \brief SCB Cache Size Selection Register Definitions */
+#define SCB_CSSELR_LEVEL_Pos                1U                                            /*!< SCB CSSELR: Level Position */
+#define SCB_CSSELR_LEVEL_Msk               (7UL << SCB_CSSELR_LEVEL_Pos)                  /*!< SCB CSSELR: Level Mask */
+
+#define SCB_CSSELR_IND_Pos                  0U                                            /*!< SCB CSSELR: InD Position */
+#define SCB_CSSELR_IND_Msk                 (1UL /*<< SCB_CSSELR_IND_Pos*/)                /*!< SCB CSSELR: InD Mask */
+
+/** \brief SCB Software Triggered Interrupt Register Definitions */
+#define SCB_STIR_INTID_Pos                  0U                                            /*!< SCB STIR: INTID Position */
+#define SCB_STIR_INTID_Msk                 (0x1FFUL /*<< SCB_STIR_INTID_Pos*/)            /*!< SCB STIR: INTID Mask */
+
+/** \brief SCB RAS Fault Status Register Definitions */
+#define SCB_RFSR_V_Pos                     31U                                            /*!< SCB RFSR: V Position */
+#define SCB_RFSR_V_Msk                     (1UL << SCB_RFSR_V_Pos)                        /*!< SCB RFSR: V Mask */
+
+#define SCB_RFSR_IS_Pos                    16U                                            /*!< SCB RFSR: IS Position */
+#define SCB_RFSR_IS_Msk                    (0x7FFFUL << SCB_RFSR_IS_Pos)                  /*!< SCB RFSR: IS Mask */
+
+#define SCB_RFSR_UET_Pos                    0U                                            /*!< SCB RFSR: UET Position */
+#define SCB_RFSR_UET_Msk                   (3UL /*<< SCB_RFSR_UET_Pos*/)                  /*!< SCB RFSR: UET Mask */
+
+/** \brief SCB D-Cache Invalidate by Set-way Register Definitions */
+#define SCB_DCISW_WAY_Pos                  30U                                            /*!< SCB DCISW: Way Position */
+#define SCB_DCISW_WAY_Msk                  (3UL << SCB_DCISW_WAY_Pos)                     /*!< SCB DCISW: Way Mask */
+
+#define SCB_DCISW_SET_Pos                   5U                                            /*!< SCB DCISW: Set Position */
+#define SCB_DCISW_SET_Msk                  (0x1FFUL << SCB_DCISW_SET_Pos)                 /*!< SCB DCISW: Set Mask */
+
+/** \brief SCB D-Cache Clean by Set-way Register Definitions */
+#define SCB_DCCSW_WAY_Pos                  30U                                            /*!< SCB DCCSW: Way Position */
+#define SCB_DCCSW_WAY_Msk                  (3UL << SCB_DCCSW_WAY_Pos)                     /*!< SCB DCCSW: Way Mask */
+
+#define SCB_DCCSW_SET_Pos                   5U                                            /*!< SCB DCCSW: Set Position */
+#define SCB_DCCSW_SET_Msk                  (0x1FFUL << SCB_DCCSW_SET_Pos)                 /*!< SCB DCCSW: Set Mask */
+
+/** \brief SCB D-Cache Clean and Invalidate by Set-way Register Definitions */
+#define SCB_DCCISW_WAY_Pos                 30U                                            /*!< SCB DCCISW: Way Position */
+#define SCB_DCCISW_WAY_Msk                 (3UL << SCB_DCCISW_WAY_Pos)                    /*!< SCB DCCISW: Way Mask */
+
+#define SCB_DCCISW_SET_Pos                  5U                                            /*!< SCB DCCISW: Set Position */
+#define SCB_DCCISW_SET_Msk                 (0x1FFUL << SCB_DCCISW_SET_Pos)                /*!< SCB DCCISW: Set Mask */
+
+/*@} end of group CMSIS_SCB */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_ICB Implementation Control Block register (ICB)
+  \brief    Type definitions for the Implementation Control Block Register
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Implementation Control Block (ICB).
+ */
+typedef struct
+{
+        uint32_t RESERVED0[1U];
+  __IM  uint32_t ICTR;                   /*!< Offset: 0x004 (R/ )  Interrupt Controller Type Register */
+  __IOM uint32_t ACTLR;                  /*!< Offset: 0x008 (R/W)  Auxiliary Control Register */
+  __IOM uint32_t CPPWR;                  /*!< Offset: 0x00C (R/W)  Coprocessor Power Control  Register */
+} ICB_Type;
+
+/** \brief ICB Auxiliary Control Register Definitions */
+#define ICB_ACTLR_DISCRITAXIRUW_Pos     27U                                               /*!< ACTLR: DISCRITAXIRUW Position */
+#define ICB_ACTLR_DISCRITAXIRUW_Msk     (1UL << ICB_ACTLR_DISCRITAXIRUW_Pos)              /*!< ACTLR: DISCRITAXIRUW Mask */
+
+#define ICB_ACTLR_DISCRITAXIRUR_Pos     15U                                               /*!< ACTLR: DISCRITAXIRUR Position */
+#define ICB_ACTLR_DISCRITAXIRUR_Msk     (1UL << ICB_ACTLR_DISCRITAXIRUR_Pos)              /*!< ACTLR: DISCRITAXIRUR Mask */
+
+#define ICB_ACTLR_EVENTBUSEN_Pos        14U                                               /*!< ACTLR: EVENTBUSEN Position */
+#define ICB_ACTLR_EVENTBUSEN_Msk        (1UL << ICB_ACTLR_EVENTBUSEN_Pos)                 /*!< ACTLR: EVENTBUSEN Mask */
+
+#define ICB_ACTLR_EVENTBUSEN_S_Pos      13U                                               /*!< ACTLR: EVENTBUSEN_S Position */
+#define ICB_ACTLR_EVENTBUSEN_S_Msk      (1UL << ICB_ACTLR_EVENTBUSEN_S_Pos)               /*!< ACTLR: EVENTBUSEN_S Mask */
+
+#define ICB_ACTLR_DISITMATBFLUSH_Pos    12U                                               /*!< ACTLR: DISITMATBFLUSH Position */
+#define ICB_ACTLR_DISITMATBFLUSH_Msk    (1UL << ICB_ACTLR_DISITMATBFLUSH_Pos)             /*!< ACTLR: DISITMATBFLUSH Mask */
+
+#define ICB_ACTLR_DISNWAMODE_Pos        11U                                               /*!< ACTLR: DISNWAMODE Position */
+#define ICB_ACTLR_DISNWAMODE_Msk        (1UL << ICB_ACTLR_DISNWAMODE_Pos)                 /*!< ACTLR: DISNWAMODE Mask */
+
+#define ICB_ACTLR_FPEXCODIS_Pos         10U                                               /*!< ACTLR: FPEXCODIS Position */
+#define ICB_ACTLR_FPEXCODIS_Msk         (1UL << ICB_ACTLR_FPEXCODIS_Pos)                  /*!< ACTLR: FPEXCODIS Mask */
+
+/** \brief ICB Interrupt Controller Type Register Definitions */
+#define ICB_ICTR_INTLINESNUM_Pos         0U                                               /*!< ICTR: INTLINESNUM Position */
+#define ICB_ICTR_INTLINESNUM_Msk        (0xFUL /*<< ICB_ICTR_INTLINESNUM_Pos*/)           /*!< ICTR: INTLINESNUM Mask */
+
+/*@} end of group CMSIS_ICB */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SysTick     System Tick Timer (SysTick)
+  \brief    Type definitions for the System Timer Registers.
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Timer (SysTick).
+ */
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  SysTick Control and Status Register */
+  __IOM uint32_t LOAD;                   /*!< Offset: 0x004 (R/W)  SysTick Reload Value Register */
+  __IOM uint32_t VAL;                    /*!< Offset: 0x008 (R/W)  SysTick Current Value Register */
+  __IM  uint32_t CALIB;                  /*!< Offset: 0x00C (R/ )  SysTick Calibration Register */
+} SysTick_Type;
+
+/** \brief SysTick Control / Status Register Definitions */
+#define SysTick_CTRL_COUNTFLAG_Pos         16U                                            /*!< SysTick CTRL: COUNTFLAG Position */
+#define SysTick_CTRL_COUNTFLAG_Msk         (1UL << SysTick_CTRL_COUNTFLAG_Pos)            /*!< SysTick CTRL: COUNTFLAG Mask */
+
+#define SysTick_CTRL_CLKSOURCE_Pos          2U                                            /*!< SysTick CTRL: CLKSOURCE Position */
+#define SysTick_CTRL_CLKSOURCE_Msk         (1UL << SysTick_CTRL_CLKSOURCE_Pos)            /*!< SysTick CTRL: CLKSOURCE Mask */
+
+#define SysTick_CTRL_TICKINT_Pos            1U                                            /*!< SysTick CTRL: TICKINT Position */
+#define SysTick_CTRL_TICKINT_Msk           (1UL << SysTick_CTRL_TICKINT_Pos)              /*!< SysTick CTRL: TICKINT Mask */
+
+#define SysTick_CTRL_ENABLE_Pos             0U                                            /*!< SysTick CTRL: ENABLE Position */
+#define SysTick_CTRL_ENABLE_Msk            (1UL /*<< SysTick_CTRL_ENABLE_Pos*/)           /*!< SysTick CTRL: ENABLE Mask */
+
+/** \brief SysTick Reload Register Definitions */
+#define SysTick_LOAD_RELOAD_Pos             0U                                            /*!< SysTick LOAD: RELOAD Position */
+#define SysTick_LOAD_RELOAD_Msk            (0xFFFFFFUL /*<< SysTick_LOAD_RELOAD_Pos*/)    /*!< SysTick LOAD: RELOAD Mask */
+
+/** \brief SysTick Current Register Definitions */
+#define SysTick_VAL_CURRENT_Pos             0U                                            /*!< SysTick VAL: CURRENT Position */
+#define SysTick_VAL_CURRENT_Msk            (0xFFFFFFUL /*<< SysTick_VAL_CURRENT_Pos*/)    /*!< SysTick VAL: CURRENT Mask */
+
+/** \brief SysTick Calibration Register Definitions */
+#define SysTick_CALIB_NOREF_Pos            31U                                            /*!< SysTick CALIB: NOREF Position */
+#define SysTick_CALIB_NOREF_Msk            (1UL << SysTick_CALIB_NOREF_Pos)               /*!< SysTick CALIB: NOREF Mask */
+
+#define SysTick_CALIB_SKEW_Pos             30U                                            /*!< SysTick CALIB: SKEW Position */
+#define SysTick_CALIB_SKEW_Msk             (1UL << SysTick_CALIB_SKEW_Pos)                /*!< SysTick CALIB: SKEW Mask */
+
+#define SysTick_CALIB_TENMS_Pos             0U                                            /*!< SysTick CALIB: TENMS Position */
+#define SysTick_CALIB_TENMS_Msk            (0xFFFFFFUL /*<< SysTick_CALIB_TENMS_Pos*/)    /*!< SysTick CALIB: TENMS Mask */
+
+/*@} end of group CMSIS_SysTick */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_ITM     Instrumentation Trace Macrocell (ITM)
+  \brief    Type definitions for the Instrumentation Trace Macrocell (ITM)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Instrumentation Trace Macrocell Register (ITM).
+ */
+typedef struct
+{
+  __OM  union
+  {
+    __OM  uint8_t    u8;                 /*!< Offset: 0x000 ( /W)  Stimulus Port 8-bit */
+    __OM  uint16_t   u16;                /*!< Offset: 0x000 ( /W)  Stimulus Port 16-bit */
+    __OM  uint32_t   u32;                /*!< Offset: 0x000 ( /W)  Stimulus Port 32-bit */
+  }  PORT [32U];                         /*!< Offset: 0x000 ( /W)  Stimulus Port Registers */
+        uint32_t RESERVED0[864U];
+  __IOM uint32_t TER;                    /*!< Offset: 0xE00 (R/W)  Trace Enable Register */
+        uint32_t RESERVED1[15U];
+  __IOM uint32_t TPR;                    /*!< Offset: 0xE40 (R/W)  Trace Privilege Register */
+        uint32_t RESERVED2[15U];
+  __IOM uint32_t TCR;                    /*!< Offset: 0xE80 (R/W)  Trace Control Register */
+        uint32_t RESERVED3[27U];
+  __IM  uint32_t ITREAD;                 /*!< Offset: 0xEF0 (R/ )  Integration Read Register */
+        uint32_t RESERVED4[1U];
+  __OM  uint32_t ITWRITE;                /*!< Offset: 0xEF8 ( /W)  Integration Write Register */
+        uint32_t RESERVED5[1U];
+  __IOM uint32_t ITCTRL;                 /*!< Offset: 0xF00 (R/W)  Integration Mode Control Register */
+        uint32_t RESERVED6[46U];
+  __IM  uint32_t DEVARCH;                /*!< Offset: 0xFBC (R/ )  Device Architecture Register */
+        uint32_t RESERVED7[3U];
+  __IM  uint32_t DEVTYPE;                /*!< Offset: 0xFCC (R/ )  Device Type Register */
+} ITM_Type;
+
+/** \brief ITM Stimulus Port Register Definitions */
+#define ITM_STIM_DISABLED_Pos               1U                                            /*!< ITM STIM: DISABLED Position */
+#define ITM_STIM_DISABLED_Msk              (1UL << ITM_STIM_DISABLED_Pos)                 /*!< ITM STIM: DISABLED Mask */
+
+#define ITM_STIM_FIFOREADY_Pos              0U                                            /*!< ITM STIM: FIFOREADY Position */
+#define ITM_STIM_FIFOREADY_Msk             (1UL /*<< ITM_STIM_FIFOREADY_Pos*/)            /*!< ITM STIM: FIFOREADY Mask */
+
+/** \brief ITM Trace Privilege Register Definitions */
+#define ITM_TPR_PRIVMASK_Pos                0U                                            /*!< ITM TPR: PRIVMASK Position */
+#define ITM_TPR_PRIVMASK_Msk               (0xFUL /*<< ITM_TPR_PRIVMASK_Pos*/)            /*!< ITM TPR: PRIVMASK Mask */
+
+/** \brief ITM Trace Control Register Definitions */
+#define ITM_TCR_BUSY_Pos                   23U                                            /*!< ITM TCR: BUSY Position */
+#define ITM_TCR_BUSY_Msk                   (1UL << ITM_TCR_BUSY_Pos)                      /*!< ITM TCR: BUSY Mask */
+
+#define ITM_TCR_TRACEBUSID_Pos             16U                                            /*!< ITM TCR: ATBID Position */
+#define ITM_TCR_TRACEBUSID_Msk             (0x7FUL << ITM_TCR_TRACEBUSID_Pos)             /*!< ITM TCR: ATBID Mask */
+
+#define ITM_TCR_GTSFREQ_Pos                10U                                            /*!< ITM TCR: Global timestamp frequency Position */
+#define ITM_TCR_GTSFREQ_Msk                (3UL << ITM_TCR_GTSFREQ_Pos)                   /*!< ITM TCR: Global timestamp frequency Mask */
+
+#define ITM_TCR_TSPRESCALE_Pos              8U                                            /*!< ITM TCR: TSPRESCALE Position */
+#define ITM_TCR_TSPRESCALE_Msk             (3UL << ITM_TCR_TSPRESCALE_Pos)                /*!< ITM TCR: TSPRESCALE Mask */
+
+#define ITM_TCR_STALLENA_Pos                5U                                            /*!< ITM TCR: STALLENA Position */
+#define ITM_TCR_STALLENA_Msk               (1UL << ITM_TCR_STALLENA_Pos)                  /*!< ITM TCR: STALLENA Mask */
+
+#define ITM_TCR_SWOENA_Pos                  4U                                            /*!< ITM TCR: SWOENA Position */
+#define ITM_TCR_SWOENA_Msk                 (1UL << ITM_TCR_SWOENA_Pos)                    /*!< ITM TCR: SWOENA Mask */
+
+#define ITM_TCR_DWTENA_Pos                  3U                                            /*!< ITM TCR: DWTENA Position */
+#define ITM_TCR_DWTENA_Msk                 (1UL << ITM_TCR_DWTENA_Pos)                    /*!< ITM TCR: DWTENA Mask */
+
+#define ITM_TCR_SYNCENA_Pos                 2U                                            /*!< ITM TCR: SYNCENA Position */
+#define ITM_TCR_SYNCENA_Msk                (1UL << ITM_TCR_SYNCENA_Pos)                   /*!< ITM TCR: SYNCENA Mask */
+
+#define ITM_TCR_TSENA_Pos                   1U                                            /*!< ITM TCR: TSENA Position */
+#define ITM_TCR_TSENA_Msk                  (1UL << ITM_TCR_TSENA_Pos)                     /*!< ITM TCR: TSENA Mask */
+
+#define ITM_TCR_ITMENA_Pos                  0U                                            /*!< ITM TCR: ITM Enable bit Position */
+#define ITM_TCR_ITMENA_Msk                 (1UL /*<< ITM_TCR_ITMENA_Pos*/)                /*!< ITM TCR: ITM Enable bit Mask */
+
+/** \brief ITM Integration Read Register Definitions */
+#define ITM_ITREAD_AFVALID_Pos              1U                                            /*!< ITM ITREAD: AFVALID Position */
+#define ITM_ITREAD_AFVALID_Msk             (1UL << ITM_ITREAD_AFVALID_Pos)                /*!< ITM ITREAD: AFVALID Mask */
+
+#define ITM_ITREAD_ATREADY_Pos              0U                                            /*!< ITM ITREAD: ATREADY Position */
+#define ITM_ITREAD_ATREADY_Msk             (1UL /*<< ITM_ITREAD_ATREADY_Pos*/)            /*!< ITM ITREAD: ATREADY Mask */
+
+/** \brief ITM Integration Write Register Definitions */
+#define ITM_ITWRITE_AFVALID_Pos             1U                                            /*!< ITM ITWRITE: AFVALID Position */
+#define ITM_ITWRITE_AFVALID_Msk            (1UL << ITM_ITWRITE_AFVALID_Pos)               /*!< ITM ITWRITE: AFVALID Mask */
+
+#define ITM_ITWRITE_ATREADY_Pos             0U                                            /*!< ITM ITWRITE: ATREADY Position */
+#define ITM_ITWRITE_ATREADY_Msk            (1UL /*<< ITM_ITWRITE_ATREADY_Pos*/)           /*!< ITM ITWRITE: ATREADY Mask */
+
+/** \brief ITM Integration Mode Control Register Definitions */
+#define ITM_ITCTRL_IME_Pos                  0U                                            /*!< ITM ITCTRL: IME Position */
+#define ITM_ITCTRL_IME_Msk                 (1UL /*<< ITM_ITCTRL_IME_Pos*/)                /*!< ITM ITCTRL: IME Mask */
+
+/*@}*/ /* end of group CMSIS_ITM */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_DWT     Data Watchpoint and Trace (DWT)
+  \brief    Type definitions for the Data Watchpoint and Trace (DWT)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Data Watchpoint and Trace Register (DWT).
+ */
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  Control Register */
+  __IOM uint32_t CYCCNT;                 /*!< Offset: 0x004 (R/W)  Cycle Count Register */
+  __IOM uint32_t CPICNT;                 /*!< Offset: 0x008 (R/W)  CPI Count Register */
+  __IOM uint32_t EXCCNT;                 /*!< Offset: 0x00C (R/W)  Exception Overhead Count Register */
+  __IOM uint32_t SLEEPCNT;               /*!< Offset: 0x010 (R/W)  Sleep Count Register */
+  __IOM uint32_t LSUCNT;                 /*!< Offset: 0x014 (R/W)  LSU Count Register */
+  __IOM uint32_t FOLDCNT;                /*!< Offset: 0x018 (R/W)  Folded-instruction Count Register */
+  __IM  uint32_t PCSR;                   /*!< Offset: 0x01C (R/ )  Program Counter Sample Register */
+  __IOM uint32_t COMP0;                  /*!< Offset: 0x020 (R/W)  Comparator Register 0 */
+        uint32_t RESERVED1[1U];
+  __IOM uint32_t FUNCTION0;              /*!< Offset: 0x028 (R/W)  Function Register 0 */
+        uint32_t RESERVED2[1U];
+  __IOM uint32_t COMP1;                  /*!< Offset: 0x030 (R/W)  Comparator Register 1 */
+        uint32_t RESERVED3[1U];
+  __IOM uint32_t FUNCTION1;              /*!< Offset: 0x038 (R/W)  Function Register 1 */
+  __IOM uint32_t VMASK1;                 /*!< Offset: 0x03C (R/W)  Comparator Value Mask 1 */
+  __IOM uint32_t COMP2;                  /*!< Offset: 0x040 (R/W)  Comparator Register 2 */
+        uint32_t RESERVED4[1U];
+  __IOM uint32_t FUNCTION2;              /*!< Offset: 0x048 (R/W)  Function Register 2 */
+        uint32_t RESERVED5[1U];
+  __IOM uint32_t COMP3;                  /*!< Offset: 0x050 (R/W)  Comparator Register 3 */
+        uint32_t RESERVED6[1U];
+  __IOM uint32_t FUNCTION3;              /*!< Offset: 0x058 (R/W)  Function Register 3 */
+  __IOM uint32_t VMASK3;                 /*!< Offset: 0x05C (R/W)  Comparator Value Mask 3 */
+  __IOM uint32_t COMP4;                  /*!< Offset: 0x060 (R/W)  Comparator Register 4 */
+        uint32_t RESERVED7[1U];
+  __IOM uint32_t FUNCTION4;              /*!< Offset: 0x068 (R/W)  Function Register 4 */
+        uint32_t RESERVED8[1U];
+  __IOM uint32_t COMP5;                  /*!< Offset: 0x070 (R/W)  Comparator Register 5 */
+        uint32_t RESERVED9[1U];
+  __IOM uint32_t FUNCTION5;              /*!< Offset: 0x078 (R/W)  Function Register 5 */
+        uint32_t RESERVED10[1U];
+  __IOM uint32_t COMP6;                  /*!< Offset: 0x080 (R/W)  Comparator Register 6 */
+        uint32_t RESERVED11[1U];
+  __IOM uint32_t FUNCTION6;              /*!< Offset: 0x088 (R/W)  Function Register 6 */
+        uint32_t RESERVED12[1U];
+  __IOM uint32_t COMP7;                  /*!< Offset: 0x090 (R/W)  Comparator Register 7 */
+        uint32_t RESERVED13[1U];
+  __IOM uint32_t FUNCTION7;              /*!< Offset: 0x098 (R/W)  Function Register 7 */
+        uint32_t RESERVED14[968U];
+  __IM  uint32_t DEVARCH;                /*!< Offset: 0xFBC (R/ )  Device Type Architecture Register */
+        uint32_t RESERVED15[3U];
+  __IM  uint32_t DEVTYPE;                /*!< Offset: 0xFCC (R/ )  Device Type Identifier Register */
+} DWT_Type;
+
+/** \brief DWT Control Register Definitions */
+#define DWT_CTRL_NUMCOMP_Pos               28U                                         /*!< DWT CTRL: NUMCOMP Position */
+#define DWT_CTRL_NUMCOMP_Msk               (0xFUL << DWT_CTRL_NUMCOMP_Pos)             /*!< DWT CTRL: NUMCOMP Mask */
+
+#define DWT_CTRL_NOTRCPKT_Pos              27U                                         /*!< DWT CTRL: NOTRCPKT Position */
+#define DWT_CTRL_NOTRCPKT_Msk              (1UL << DWT_CTRL_NOTRCPKT_Pos)              /*!< DWT CTRL: NOTRCPKT Mask */
+
+#define DWT_CTRL_NOEXTTRIG_Pos             26U                                         /*!< DWT CTRL: NOEXTTRIG Position */
+#define DWT_CTRL_NOEXTTRIG_Msk             (1UL << DWT_CTRL_NOEXTTRIG_Pos)             /*!< DWT CTRL: NOEXTTRIG Mask */
+
+#define DWT_CTRL_NOCYCCNT_Pos              25U                                         /*!< DWT CTRL: NOCYCCNT Position */
+#define DWT_CTRL_NOCYCCNT_Msk              (1UL << DWT_CTRL_NOCYCCNT_Pos)              /*!< DWT CTRL: NOCYCCNT Mask */
+
+#define DWT_CTRL_NOPRFCNT_Pos              24U                                         /*!< DWT CTRL: NOPRFCNT Position */
+#define DWT_CTRL_NOPRFCNT_Msk              (1UL << DWT_CTRL_NOPRFCNT_Pos)              /*!< DWT CTRL: NOPRFCNT Mask */
+
+#define DWT_CTRL_CYCDISS_Pos               23U                                         /*!< DWT CTRL: CYCDISS Position */
+#define DWT_CTRL_CYCDISS_Msk               (1UL << DWT_CTRL_CYCDISS_Pos)               /*!< DWT CTRL: CYCDISS Mask */
+
+#define DWT_CTRL_CYCEVTENA_Pos             22U                                         /*!< DWT CTRL: CYCEVTENA Position */
+#define DWT_CTRL_CYCEVTENA_Msk             (1UL << DWT_CTRL_CYCEVTENA_Pos)             /*!< DWT CTRL: CYCEVTENA Mask */
+
+#define DWT_CTRL_FOLDEVTENA_Pos            21U                                         /*!< DWT CTRL: FOLDEVTENA Position */
+#define DWT_CTRL_FOLDEVTENA_Msk            (1UL << DWT_CTRL_FOLDEVTENA_Pos)            /*!< DWT CTRL: FOLDEVTENA Mask */
+
+#define DWT_CTRL_LSUEVTENA_Pos             20U                                         /*!< DWT CTRL: LSUEVTENA Position */
+#define DWT_CTRL_LSUEVTENA_Msk             (1UL << DWT_CTRL_LSUEVTENA_Pos)             /*!< DWT CTRL: LSUEVTENA Mask */
+
+#define DWT_CTRL_SLEEPEVTENA_Pos           19U                                         /*!< DWT CTRL: SLEEPEVTENA Position */
+#define DWT_CTRL_SLEEPEVTENA_Msk           (1UL << DWT_CTRL_SLEEPEVTENA_Pos)           /*!< DWT CTRL: SLEEPEVTENA Mask */
+
+#define DWT_CTRL_EXCEVTENA_Pos             18U                                         /*!< DWT CTRL: EXCEVTENA Position */
+#define DWT_CTRL_EXCEVTENA_Msk             (1UL << DWT_CTRL_EXCEVTENA_Pos)             /*!< DWT CTRL: EXCEVTENA Mask */
+
+#define DWT_CTRL_CPIEVTENA_Pos             17U                                         /*!< DWT CTRL: CPIEVTENA Position */
+#define DWT_CTRL_CPIEVTENA_Msk             (1UL << DWT_CTRL_CPIEVTENA_Pos)             /*!< DWT CTRL: CPIEVTENA Mask */
+
+#define DWT_CTRL_EXCTRCENA_Pos             16U                                         /*!< DWT CTRL: EXCTRCENA Position */
+#define DWT_CTRL_EXCTRCENA_Msk             (1UL << DWT_CTRL_EXCTRCENA_Pos)             /*!< DWT CTRL: EXCTRCENA Mask */
+
+#define DWT_CTRL_PCSAMPLENA_Pos            12U                                         /*!< DWT CTRL: PCSAMPLENA Position */
+#define DWT_CTRL_PCSAMPLENA_Msk            (1UL << DWT_CTRL_PCSAMPLENA_Pos)            /*!< DWT CTRL: PCSAMPLENA Mask */
+
+#define DWT_CTRL_SYNCTAP_Pos               10U                                         /*!< DWT CTRL: SYNCTAP Position */
+#define DWT_CTRL_SYNCTAP_Msk               (0x3UL << DWT_CTRL_SYNCTAP_Pos)             /*!< DWT CTRL: SYNCTAP Mask */
+
+#define DWT_CTRL_CYCTAP_Pos                 9U                                         /*!< DWT CTRL: CYCTAP Position */
+#define DWT_CTRL_CYCTAP_Msk                (1UL << DWT_CTRL_CYCTAP_Pos)                /*!< DWT CTRL: CYCTAP Mask */
+
+#define DWT_CTRL_POSTINIT_Pos               5U                                         /*!< DWT CTRL: POSTINIT Position */
+#define DWT_CTRL_POSTINIT_Msk              (0xFUL << DWT_CTRL_POSTINIT_Pos)            /*!< DWT CTRL: POSTINIT Mask */
+
+#define DWT_CTRL_POSTPRESET_Pos             1U                                         /*!< DWT CTRL: POSTPRESET Position */
+#define DWT_CTRL_POSTPRESET_Msk            (0xFUL << DWT_CTRL_POSTPRESET_Pos)          /*!< DWT CTRL: POSTPRESET Mask */
+
+#define DWT_CTRL_CYCCNTENA_Pos              0U                                         /*!< DWT CTRL: CYCCNTENA Position */
+#define DWT_CTRL_CYCCNTENA_Msk             (1UL /*<< DWT_CTRL_CYCCNTENA_Pos*/)         /*!< DWT CTRL: CYCCNTENA Mask */
+
+/** \brief DWT CPI Count Register Definitions */
+#define DWT_CPICNT_CPICNT_Pos               0U                                         /*!< DWT CPICNT: CPICNT Position */
+#define DWT_CPICNT_CPICNT_Msk              (0xFFUL /*<< DWT_CPICNT_CPICNT_Pos*/)       /*!< DWT CPICNT: CPICNT Mask */
+
+/** \brief DWT Exception Overhead Count Register Definitions */
+#define DWT_EXCCNT_EXCCNT_Pos               0U                                         /*!< DWT EXCCNT: EXCCNT Position */
+#define DWT_EXCCNT_EXCCNT_Msk              (0xFFUL /*<< DWT_EXCCNT_EXCCNT_Pos*/)       /*!< DWT EXCCNT: EXCCNT Mask */
+
+/** \brief DWT Sleep Count Register Definitions */
+#define DWT_SLEEPCNT_SLEEPCNT_Pos           0U                                         /*!< DWT SLEEPCNT: SLEEPCNT Position */
+#define DWT_SLEEPCNT_SLEEPCNT_Msk          (0xFFUL /*<< DWT_SLEEPCNT_SLEEPCNT_Pos*/)   /*!< DWT SLEEPCNT: SLEEPCNT Mask */
+
+/** \brief DWT LSU Count Register Definitions */
+#define DWT_LSUCNT_LSUCNT_Pos               0U                                         /*!< DWT LSUCNT: LSUCNT Position */
+#define DWT_LSUCNT_LSUCNT_Msk              (0xFFUL /*<< DWT_LSUCNT_LSUCNT_Pos*/)       /*!< DWT LSUCNT: LSUCNT Mask */
+
+/** \brief DWT Folded-instruction Count Register Definitions */
+#define DWT_FOLDCNT_FOLDCNT_Pos             0U                                         /*!< DWT FOLDCNT: FOLDCNT Position */
+#define DWT_FOLDCNT_FOLDCNT_Msk            (0xFFUL /*<< DWT_FOLDCNT_FOLDCNT_Pos*/)     /*!< DWT FOLDCNT: FOLDCNT Mask */
+
+/** \brief DWT Comparator Function Register Definitions */
+#define DWT_FUNCTION_ID_Pos                27U                                         /*!< DWT FUNCTION: ID Position */
+#define DWT_FUNCTION_ID_Msk                (0x1FUL << DWT_FUNCTION_ID_Pos)             /*!< DWT FUNCTION: ID Mask */
+
+#define DWT_FUNCTION_MATCHED_Pos           24U                                         /*!< DWT FUNCTION: MATCHED Position */
+#define DWT_FUNCTION_MATCHED_Msk           (1UL << DWT_FUNCTION_MATCHED_Pos)           /*!< DWT FUNCTION: MATCHED Mask */
+
+#define DWT_FUNCTION_DATAVSIZE_Pos         10U                                         /*!< DWT FUNCTION: DATAVSIZE Position */
+#define DWT_FUNCTION_DATAVSIZE_Msk         (0x3UL << DWT_FUNCTION_DATAVSIZE_Pos)       /*!< DWT FUNCTION: DATAVSIZE Mask */
+
+#define DWT_FUNCTION_ACTION_Pos             4U                                         /*!< DWT FUNCTION: ACTION Position */
+#define DWT_FUNCTION_ACTION_Msk            (0x3UL << DWT_FUNCTION_ACTION_Pos)          /*!< DWT FUNCTION: ACTION Mask */
+
+#define DWT_FUNCTION_MATCH_Pos              0U                                         /*!< DWT FUNCTION: MATCH Position */
+#define DWT_FUNCTION_MATCH_Msk             (0xFUL /*<< DWT_FUNCTION_MATCH_Pos*/)       /*!< DWT FUNCTION: MATCH Mask */
+
+/*@}*/ /* end of group CMSIS_DWT */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup MemSysCtl_Type     Memory System Control Registers (IMPLEMENTATION DEFINED)
+  \brief    Type definitions for the Memory System Control Registers (MEMSYSCTL)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Memory System Control Registers (MEMSYSCTL).
+ */
+typedef struct
+{
+  __IOM uint32_t MSCR;                   /*!< Offset: 0x000 (R/W)  Memory System Control Register */
+  __IOM uint32_t PFCR;                   /*!< Offset: 0x004 (R/W)  Prefetcher Control Register */
+        uint32_t RESERVED1[2U];
+  __IOM uint32_t ITCMCR;                 /*!< Offset: 0x010 (R/W)  ITCM Control Register */
+  __IOM uint32_t DTCMCR;                 /*!< Offset: 0x014 (R/W)  DTCM Control Register */
+  __IOM uint32_t PAHBCR;                 /*!< Offset: 0x018 (R/W)  P-AHB Control Register */
+        uint32_t RESERVED2[313U];
+  __IOM uint32_t ITGU_CTRL;              /*!< Offset: 0x500 (R/W)  ITGU Control Register */
+  __IOM uint32_t ITGU_CFG;               /*!< Offset: 0x504 (R/W)  ITGU Configuration Register */
+        uint32_t RESERVED3[2U];
+  __IOM uint32_t ITGU_LUT[16U];          /*!< Offset: 0x510 (R/W)  ITGU Look Up Table Register */
+        uint32_t RESERVED4[44U];
+  __IOM uint32_t DTGU_CTRL;              /*!< Offset: 0x600 (R/W)  DTGU Control Registers */
+  __IOM uint32_t DTGU_CFG;               /*!< Offset: 0x604 (R/W)  DTGU Configuration Register */
+        uint32_t RESERVED5[2U];
+  __IOM uint32_t DTGU_LUT[16U];          /*!< Offset: 0x610 (R/W)  DTGU Look Up Table Register */
+} MemSysCtl_Type;
+
+/** \brief MemSysCtl Memory System Control Register Definitions */
+#define MEMSYSCTL_MSCR_CPWRDN_Pos          17U                                         /*!< MEMSYSCTL MSCR: CPWRDN Position */
+#define MEMSYSCTL_MSCR_CPWRDN_Msk          (1UL << MEMSYSCTL_MSCR_CPWRDN_Pos)          /*!< MEMSYSCTL MSCR: CPWRDN Mask */
+
+#define MEMSYSCTL_MSCR_DCCLEAN_Pos         16U                                         /*!< MEMSYSCTL MSCR: DCCLEAN Position */
+#define MEMSYSCTL_MSCR_DCCLEAN_Msk         (1UL << MEMSYSCTL_MSCR_DCCLEAN_Pos)         /*!< MEMSYSCTL MSCR: DCCLEAN Mask */
+
+#define MEMSYSCTL_MSCR_ICACTIVE_Pos        13U                                         /*!< MEMSYSCTL MSCR: ICACTIVE Position */
+#define MEMSYSCTL_MSCR_ICACTIVE_Msk        (1UL << MEMSYSCTL_MSCR_ICACTIVE_Pos)        /*!< MEMSYSCTL MSCR: ICACTIVE Mask */
+
+#define MEMSYSCTL_MSCR_DCACTIVE_Pos        12U                                         /*!< MEMSYSCTL MSCR: DCACTIVE Position */
+#define MEMSYSCTL_MSCR_DCACTIVE_Msk        (1UL << MEMSYSCTL_MSCR_DCACTIVE_Pos)        /*!< MEMSYSCTL MSCR: DCACTIVE Mask */
+
+#define MEMSYSCTL_MSCR_TECCCHKDIS_Pos       4U                                         /*!< MEMSYSCTL MSCR: TECCCHKDIS Position */
+#define MEMSYSCTL_MSCR_TECCCHKDIS_Msk      (1UL << MEMSYSCTL_MSCR_TECCCHKDIS_Pos)      /*!< MEMSYSCTL MSCR: TECCCHKDIS Mask */
+
+#define MEMSYSCTL_MSCR_EVECCFAULT_Pos       3U                                         /*!< MEMSYSCTL MSCR: EVECCFAULT Position */
+#define MEMSYSCTL_MSCR_EVECCFAULT_Msk      (1UL << MEMSYSCTL_MSCR_EVECCFAULT_Pos)      /*!< MEMSYSCTL MSCR: EVECCFAULT Mask */
+
+#define MEMSYSCTL_MSCR_FORCEWT_Pos          2U                                         /*!< MEMSYSCTL MSCR: FORCEWT Position */
+#define MEMSYSCTL_MSCR_FORCEWT_Msk         (1UL << MEMSYSCTL_MSCR_FORCEWT_Pos)         /*!< MEMSYSCTL MSCR: FORCEWT Mask */
+
+#define MEMSYSCTL_MSCR_ECCEN_Pos            1U                                         /*!< MEMSYSCTL MSCR: ECCEN Position */
+#define MEMSYSCTL_MSCR_ECCEN_Msk           (1UL << MEMSYSCTL_MSCR_ECCEN_Pos)           /*!< MEMSYSCTL MSCR: ECCEN Mask */
+
+/** \brief MemSysCtl Prefetcher Control Register Definitions */
+#define MEMSYSCTL_PFCR_DIS_NLP_Pos          7U                                         /*!< MEMSYSCTL PFCR: DIS_NLP Position */
+#define MEMSYSCTL_PFCR_DIS_NLP_Msk         (1UL << MEMSYSCTL_PFCR_DIS_NLP_Pos)         /*!< MEMSYSCTL PFCR: DIS_NLP Mask */
+
+#define MEMSYSCTL_PFCR_ENABLE_Pos           0U                                         /*!< MEMSYSCTL PFCR: ENABLE Position */
+#define MEMSYSCTL_PFCR_ENABLE_Msk          (1UL /*<< MEMSYSCTL_PFCR_ENABLE_Pos*/)      /*!< MEMSYSCTL PFCR: ENABLE Mask */
+
+/** \brief MemSysCtl ITCM Control Register Definitions */
+#define MEMSYSCTL_ITCMCR_SZ_Pos             3U                                         /*!< MEMSYSCTL ITCMCR: SZ Position */
+#define MEMSYSCTL_ITCMCR_SZ_Msk            (0xFUL << MEMSYSCTL_ITCMCR_SZ_Pos)          /*!< MEMSYSCTL ITCMCR: SZ Mask */
+
+#define MEMSYSCTL_ITCMCR_EN_Pos             0U                                         /*!< MEMSYSCTL ITCMCR: EN Position */
+#define MEMSYSCTL_ITCMCR_EN_Msk            (1UL /*<< MEMSYSCTL_ITCMCR_EN_Pos*/)        /*!< MEMSYSCTL ITCMCR: EN Mask */
+
+/** \brief MemSysCtl DTCM Control Register Definitions */
+#define MEMSYSCTL_DTCMCR_SZ_Pos             3U                                         /*!< MEMSYSCTL DTCMCR: SZ Position */
+#define MEMSYSCTL_DTCMCR_SZ_Msk            (0xFUL << MEMSYSCTL_DTCMCR_SZ_Pos)          /*!< MEMSYSCTL DTCMCR: SZ Mask */
+
+#define MEMSYSCTL_DTCMCR_EN_Pos             0U                                         /*!< MEMSYSCTL DTCMCR: EN Position */
+#define MEMSYSCTL_DTCMCR_EN_Msk            (1UL /*<< MEMSYSCTL_DTCMCR_EN_Pos*/)        /*!< MEMSYSCTL DTCMCR: EN Mask */
+
+/** \brief MemSysCtl P-AHB Control Register Definitions */
+#define MEMSYSCTL_PAHBCR_SZ_Pos             1U                                         /*!< MEMSYSCTL PAHBCR: SZ Position */
+#define MEMSYSCTL_PAHBCR_SZ_Msk            (0x7UL << MEMSYSCTL_PAHBCR_SZ_Pos)          /*!< MEMSYSCTL PAHBCR: SZ Mask */
+
+#define MEMSYSCTL_PAHBCR_EN_Pos             0U                                         /*!< MEMSYSCTL PAHBCR: EN Position */
+#define MEMSYSCTL_PAHBCR_EN_Msk            (1UL /*<< MEMSYSCTL_PAHBCR_EN_Pos*/)        /*!< MEMSYSCTL PAHBCR: EN Mask */
+
+/** \brief MemSysCtl ITGU Control Register Definitions */
+#define MEMSYSCTL_ITGU_CTRL_DEREN_Pos       1U                                         /*!< MEMSYSCTL ITGU_CTRL: DEREN Position */
+#define MEMSYSCTL_ITGU_CTRL_DEREN_Msk      (1UL << MEMSYSCTL_ITGU_CTRL_DEREN_Pos)      /*!< MEMSYSCTL ITGU_CTRL: DEREN Mask */
+
+#define MEMSYSCTL_ITGU_CTRL_DBFEN_Pos       0U                                         /*!< MEMSYSCTL ITGU_CTRL: DBFEN Position */
+#define MEMSYSCTL_ITGU_CTRL_DBFEN_Msk      (1UL /*<< MEMSYSCTL_ITGU_CTRL_DBFEN_Pos*/)  /*!< MEMSYSCTL ITGU_CTRL: DBFEN Mask */
+
+/** \brief MemSysCtl ITGU Configuration Register Definitions */
+#define MEMSYSCTL_ITGU_CFG_PRESENT_Pos     31U                                         /*!< MEMSYSCTL ITGU_CFG: PRESENT Position */
+#define MEMSYSCTL_ITGU_CFG_PRESENT_Msk     (1UL << MEMSYSCTL_ITGU_CFG_PRESENT_Pos)     /*!< MEMSYSCTL ITGU_CFG: PRESENT Mask */
+
+#define MEMSYSCTL_ITGU_CFG_NUMBLKS_Pos      8U                                         /*!< MEMSYSCTL ITGU_CFG: NUMBLKS Position */
+#define MEMSYSCTL_ITGU_CFG_NUMBLKS_Msk     (0xFUL << MEMSYSCTL_ITGU_CFG_NUMBLKS_Pos)   /*!< MEMSYSCTL ITGU_CFG: NUMBLKS Mask */
+
+#define MEMSYSCTL_ITGU_CFG_BLKSZ_Pos        0U                                         /*!< MEMSYSCTL ITGU_CFG: BLKSZ Position */
+#define MEMSYSCTL_ITGU_CFG_BLKSZ_Msk       (0xFUL /*<< MEMSYSCTL_ITGU_CFG_BLKSZ_Pos*/) /*!< MEMSYSCTL ITGU_CFG: BLKSZ Mask */
+
+/** \brief MemSysCtl DTGU Control Registers Definitions */
+#define MEMSYSCTL_DTGU_CTRL_DEREN_Pos       1U                                         /*!< MEMSYSCTL DTGU_CTRL: DEREN Position */
+#define MEMSYSCTL_DTGU_CTRL_DEREN_Msk      (1UL << MEMSYSCTL_DTGU_CTRL_DEREN_Pos)      /*!< MEMSYSCTL DTGU_CTRL: DEREN Mask */
+
+#define MEMSYSCTL_DTGU_CTRL_DBFEN_Pos       0U                                         /*!< MEMSYSCTL DTGU_CTRL: DBFEN Position */
+#define MEMSYSCTL_DTGU_CTRL_DBFEN_Msk      (1UL /*<< MEMSYSCTL_DTGU_CTRL_DBFEN_Pos*/)  /*!< MEMSYSCTL DTGU_CTRL: DBFEN Mask */
+
+/** \brief MemSysCtl DTGU Configuration Register Definitions */
+#define MEMSYSCTL_DTGU_CFG_PRESENT_Pos     31U                                         /*!< MEMSYSCTL DTGU_CFG: PRESENT Position */
+#define MEMSYSCTL_DTGU_CFG_PRESENT_Msk     (1UL << MEMSYSCTL_DTGU_CFG_PRESENT_Pos)     /*!< MEMSYSCTL DTGU_CFG: PRESENT Mask */
+
+#define MEMSYSCTL_DTGU_CFG_NUMBLKS_Pos      8U                                         /*!< MEMSYSCTL DTGU_CFG: NUMBLKS Position */
+#define MEMSYSCTL_DTGU_CFG_NUMBLKS_Msk     (0xFUL << MEMSYSCTL_DTGU_CFG_NUMBLKS_Pos)   /*!< MEMSYSCTL DTGU_CFG: NUMBLKS Mask */
+
+#define MEMSYSCTL_DTGU_CFG_BLKSZ_Pos        0U                                         /*!< MEMSYSCTL DTGU_CFG: BLKSZ Position */
+#define MEMSYSCTL_DTGU_CFG_BLKSZ_Msk       (0xFUL /*<< MEMSYSCTL_DTGU_CFG_BLKSZ_Pos*/) /*!< MEMSYSCTL DTGU_CFG: BLKSZ Mask */
+
+/*@}*/ /* end of group MemSysCtl_Type */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup PwrModCtl_Type     Power Mode Control Registers
+  \brief    Type definitions for the Power Mode Control Registers (PWRMODCTL)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Power Mode Control Registers (PWRMODCTL).
+ */
+typedef struct
+{
+  __IOM uint32_t CPDLPSTATE;             /*!< Offset: 0x000 (R/W)  Core Power Domain Low Power State Register */
+  __IOM uint32_t DPDLPSTATE;             /*!< Offset: 0x004 (R/W)  Debug Power Domain Low Power State Register */
+} PwrModCtl_Type;
+
+/** \brief PwrModCtl Core Power Domain Low Power State Register Definitions */
+#define PWRMODCTL_CPDLPSTATE_RLPSTATE_Pos   8U                                              /*!< PWRMODCTL CPDLPSTATE: RLPSTATE Position */
+#define PWRMODCTL_CPDLPSTATE_RLPSTATE_Msk  (0x3UL << PWRMODCTL_CPDLPSTATE_RLPSTATE_Pos)     /*!< PWRMODCTL CPDLPSTATE: RLPSTATE Mask */
+
+#define PWRMODCTL_CPDLPSTATE_ELPSTATE_Pos   4U                                              /*!< PWRMODCTL CPDLPSTATE: ELPSTATE Position */
+#define PWRMODCTL_CPDLPSTATE_ELPSTATE_Msk  (0x3UL << PWRMODCTL_CPDLPSTATE_ELPSTATE_Pos)     /*!< PWRMODCTL CPDLPSTATE: ELPSTATE Mask */
+
+#define PWRMODCTL_CPDLPSTATE_CLPSTATE_Pos   0U                                              /*!< PWRMODCTL CPDLPSTATE: CLPSTATE Position */
+#define PWRMODCTL_CPDLPSTATE_CLPSTATE_Msk  (0x3UL /*<< PWRMODCTL_CPDLPSTATE_CLPSTATE_Pos*/) /*!< PWRMODCTL CPDLPSTATE: CLPSTATE Mask */
+
+/** \brief PwrModCtl Debug Power Domain Low Power State Register Definitions */
+#define PWRMODCTL_DPDLPSTATE_DLPSTATE_Pos   0U                                              /*!< PWRMODCTL DPDLPSTATE: DLPSTATE Position */
+#define PWRMODCTL_DPDLPSTATE_DLPSTATE_Msk  (0x3UL /*<< PWRMODCTL_DPDLPSTATE_DLPSTATE_Pos*/) /*!< PWRMODCTL DPDLPSTATE: DLPSTATE Mask */
+
+/*@}*/ /* end of group PwrModCtl_Type */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup EWIC_Type     External Wakeup Interrupt Controller Registers
+  \brief    Type definitions for the External Wakeup Interrupt Controller Registers (EWIC)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the External Wakeup Interrupt Controller Registers (EWIC).
+ */
+typedef struct
+{
+  __IOM uint32_t EWIC_CR;                /*!< Offset: 0x000 (R/W)  EWIC Control Register */
+  __IOM uint32_t EWIC_ASCR;              /*!< Offset: 0x004 (R/W)  EWIC Automatic Sequence Control Register */
+  __OM  uint32_t EWIC_CLRMASK;           /*!< Offset: 0x008 ( /W)  EWIC Clear Mask Register */
+  __IM  uint32_t EWIC_NUMID;             /*!< Offset: 0x00C (R/ )  EWIC Event Number ID Register */
+        uint32_t RESERVED0[124U];
+  __IOM uint32_t EWIC_MASKA;             /*!< Offset: 0x200 (R/W)  EWIC MaskA Register */
+  __IOM uint32_t EWIC_MASKn[15];         /*!< Offset: 0x204 (R/W)  EWIC Maskn Registers */
+        uint32_t RESERVED1[112U];
+  __IM  uint32_t EWIC_PENDA;             /*!< Offset: 0x400 (R/ )  EWIC PendA Event Register */
+  __IOM uint32_t EWIC_PENDn[15];         /*!< Offset: 0x404 (R/W)  EWIC Pendn Event Registers */
+        uint32_t RESERVED2[112U];
+  __IM  uint32_t EWIC_PSR;               /*!< Offset: 0x600 (R/ )  EWIC Pend Summary Register */
+} EWIC_Type;
+
+/** \brief EWIC Control Register Definitions */
+#define EWIC_EWIC_CR_EN_Pos                 0U                                         /*!< EWIC EWIC_CR: EN Position */
+#define EWIC_EWIC_CR_EN_Msk                (1UL /*<< EWIC_EWIC_CR_EN_Pos*/)            /*!< EWIC EWIC_CR: EN Mask */
+
+/** \brief EWIC Automatic Sequence Control Register Definitions */
+#define EWIC_EWIC_ASCR_ASPU_Pos             1U                                         /*!< EWIC EWIC_ASCR: ASPU Position */
+#define EWIC_EWIC_ASCR_ASPU_Msk            (1UL << EWIC_EWIC_ASCR_ASPU_Pos)            /*!< EWIC EWIC_ASCR: ASPU Mask */
+
+#define EWIC_EWIC_ASCR_ASPD_Pos             0U                                         /*!< EWIC EWIC_ASCR: ASPD Position */
+#define EWIC_EWIC_ASCR_ASPD_Msk            (1UL /*<< EWIC_EWIC_ASCR_ASPD_Pos*/)        /*!< EWIC EWIC_ASCR: ASPD Mask */
+
+/** \brief EWIC Event Number ID Register Definitions */
+#define EWIC_EWIC_NUMID_NUMEVENT_Pos        0U                                         /*!< EWIC_NUMID: NUMEVENT Position */
+#define EWIC_EWIC_NUMID_NUMEVENT_Msk       (0xFFFFUL /*<< EWIC_EWIC_NUMID_NUMEVENT_Pos*/) /*!< EWIC_NUMID: NUMEVENT Mask */
+
+/** \brief EWIC Mask A Register Definitions */
+#define EWIC_EWIC_MASKA_EDBGREQ_Pos         2U                                         /*!< EWIC EWIC_MASKA: EDBGREQ Position */
+#define EWIC_EWIC_MASKA_EDBGREQ_Msk        (1UL << EWIC_EWIC_MASKA_EDBGREQ_Pos)        /*!< EWIC EWIC_MASKA: EDBGREQ Mask */
+
+#define EWIC_EWIC_MASKA_NMI_Pos             1U                                         /*!< EWIC EWIC_MASKA: NMI Position */
+#define EWIC_EWIC_MASKA_NMI_Msk            (1UL << EWIC_EWIC_MASKA_NMI_Pos)            /*!< EWIC EWIC_MASKA: NMI Mask */
+
+#define EWIC_EWIC_MASKA_EVENT_Pos           0U                                         /*!< EWIC EWIC_MASKA: EVENT Position */
+#define EWIC_EWIC_MASKA_EVENT_Msk          (1UL /*<< EWIC_EWIC_MASKA_EVENT_Pos*/)      /*!< EWIC EWIC_MASKA: EVENT Mask */
+
+/** \brief EWIC Mask n Register Definitions */
+#define EWIC_EWIC_MASKn_IRQ_Pos             0U                                         /*!< EWIC EWIC_MASKn: IRQ Position */
+#define EWIC_EWIC_MASKn_IRQ_Msk            (0xFFFFFFFFUL /*<< EWIC_EWIC_MASKn_IRQ_Pos*/) /*!< EWIC EWIC_MASKn: IRQ Mask */
+
+/** \brief EWIC Pend A Register Definitions */
+#define EWIC_EWIC_PENDA_EDBGREQ_Pos         2U                                         /*!< EWIC EWIC_PENDA: EDBGREQ Position */
+#define EWIC_EWIC_PENDA_EDBGREQ_Msk        (1UL << EWIC_EWIC_PENDA_EDBGREQ_Pos)        /*!< EWIC EWIC_PENDA: EDBGREQ Mask */
+
+#define EWIC_EWIC_PENDA_NMI_Pos             1U                                         /*!< EWIC EWIC_PENDA: NMI Position */
+#define EWIC_EWIC_PENDA_NMI_Msk            (1UL << EWIC_EWIC_PENDA_NMI_Pos)            /*!< EWIC EWIC_PENDA: NMI Mask */
+
+#define EWIC_EWIC_PENDA_EVENT_Pos           0U                                         /*!< EWIC EWIC_PENDA: EVENT Position */
+#define EWIC_EWIC_PENDA_EVENT_Msk          (1UL /*<< EWIC_EWIC_PENDA_EVENT_Pos*/)      /*!< EWIC EWIC_PENDA: EVENT Mask */
+
+/** \brief EWIC Pend n Register Definitions */
+#define EWIC_EWIC_PENDn_IRQ_Pos             0U                                         /*!< EWIC EWIC_PENDn: IRQ Position */
+#define EWIC_EWIC_PENDn_IRQ_Msk            (0xFFFFFFFFUL /*<< EWIC_EWIC_PENDn_IRQ_Pos*/) /*!< EWIC EWIC_PENDn: IRQ Mask */
+
+/** \brief EWIC Pend Summary Register Definitions */
+#define EWIC_EWIC_PSR_NZ_Pos                1U                                         /*!< EWIC EWIC_PSR: NZ Position */
+#define EWIC_EWIC_PSR_NZ_Msk               (0x7FFFUL << EWIC_EWIC_PSR_NZ_Pos)          /*!< EWIC EWIC_PSR: NZ Mask */
+
+#define EWIC_EWIC_PSR_NZA_Pos               0U                                         /*!< EWIC EWIC_PSR: NZA Position */
+#define EWIC_EWIC_PSR_NZA_Msk              (1UL /*<< EWIC_EWIC_PSR_NZA_Pos*/)          /*!< EWIC EWIC_PSR: NZA Mask */
+
+/*@}*/ /* end of group EWIC_Type */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup EWIC_ISA_Type     External Wakeup Interrupt Controller (EWIC) interrupt status access registers
+  \brief    Type definitions for the External Wakeup Interrupt Controller interrupt status access registers (EWIC_ISA)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the External Wakeup Interrupt Controller interrupt status access registers (EWIC_ISA).
+ */
+typedef struct
+{
+  __OM  uint32_t EVENTSPR;               /*!< Offset: 0x000 ( /W)  Event Set Pending Register */
+        uint32_t RESERVED0[31U];
+  __IM  uint32_t EVENTMASKA;             /*!< Offset: 0x080 (R/ )  Event Mask A Register */
+  __IM  uint32_t EVENTMASKn[15];         /*!< Offset: 0x084 (R/ )  Event Mask Register */
+} EWIC_ISA_Type;
+
+/** \brief EWIC_ISA Event Set Pending Register Definitions */
+#define EWIC_ISA_EVENTSPR_EDBGREQ_Pos       2U                                         /*!< EWIC_ISA EVENTSPR: EDBGREQ Position */
+#define EWIC_ISA_EVENTSPR_EDBGREQ_Msk      (1UL << EWIC_ISA_EVENTSPR_EDBGREQ_Pos)      /*!< EWIC_ISA EVENTSPR: EDBGREQ Mask */
+
+#define EWIC_ISA_EVENTSPR_NMI_Pos           1U                                         /*!< EWIC_ISA EVENTSPR: NMI Position */
+#define EWIC_ISA_EVENTSPR_NMI_Msk          (1UL << EWIC_ISA_EVENTSPR_NMI_Pos)          /*!< EWIC_ISA EVENTSPR: NMI Mask */
+
+#define EWIC_ISA_EVENTSPR_EVENT_Pos         0U                                         /*!< EWIC_ISA EVENTSPR: EVENT Position */
+#define EWIC_ISA_EVENTSPR_EVENT_Msk        (1UL /*<< EWIC_ISA_EVENTSPR_EVENT_Pos*/)    /*!< EWIC_ISA EVENTSPR: EVENT Mask */
+
+/** \brief EWIC_ISA Event Mask A Register Definitions */
+#define EWIC_ISA_EVENTMASKA_EDBGREQ_Pos     2U                                         /*!< EWIC_ISA EVENTMASKA: EDBGREQ Position */
+#define EWIC_ISA_EVENTMASKA_EDBGREQ_Msk    (1UL << EWIC_ISA_EVENTMASKA_EDBGREQ_Pos)    /*!< EWIC_ISA EVENTMASKA: EDBGREQ Mask */
+
+#define EWIC_ISA_EVENTMASKA_NMI_Pos         1U                                         /*!< EWIC_ISA EVENTMASKA: NMI Position */
+#define EWIC_ISA_EVENTMASKA_NMI_Msk        (1UL << EWIC_ISA_EVENTMASKA_NMI_Pos)        /*!< EWIC_ISA EVENTMASKA: NMI Mask */
+
+#define EWIC_ISA_EVENTMASKA_EVENT_Pos       0U                                         /*!< EWIC_ISA EVENTMASKA: EVENT Position */
+#define EWIC_ISA_EVENTMASKA_EVENT_Msk      (1UL /*<< EWIC_ISA_EVENTMASKA_EVENT_Pos*/)  /*!< EWIC_ISA EVENTMASKA: EVENT Mask */
+
+/** \brief EWIC_ISA Event Mask n Register Definitions */
+#define EWIC_ISA_EVENTMASKn_IRQ_Pos         0U                                         /*!< EWIC_ISA EVENTMASKn: IRQ Position */
+#define EWIC_ISA_EVENTMASKn_IRQ_Msk        (0xFFFFFFFFUL /*<< EWIC_ISA_EVENTMASKn_IRQ_Pos*/) /*!< EWIC_ISA EVENTMASKn: IRQ Mask */
+
+/*@}*/ /* end of group EWIC_ISA_Type */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup ErrBnk_Type     Error Banking Registers (IMPLEMENTATION DEFINED)
+  \brief    Type definitions for the Error Banking Registers (ERRBNK)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Error Banking Registers (ERRBNK).
+ */
+typedef struct
+{
+  __IOM uint32_t IEBR0;                  /*!< Offset: 0x000 (R/W)  Instruction Cache Error Bank Register 0 */
+  __IOM uint32_t IEBR1;                  /*!< Offset: 0x004 (R/W)  Instruction Cache Error Bank Register 1 */
+        uint32_t RESERVED0[2U];
+  __IOM uint32_t DEBR0;                  /*!< Offset: 0x010 (R/W)  Data Cache Error Bank Register 0 */
+  __IOM uint32_t DEBR1;                  /*!< Offset: 0x014 (R/W)  Data Cache Error Bank Register 1 */
+        uint32_t RESERVED1[2U];
+  __IOM uint32_t TEBR0;                  /*!< Offset: 0x020 (R/W)  TCM Error Bank Register 0 */
+        uint32_t RESERVED2[1U];
+  __IOM uint32_t TEBR1;                  /*!< Offset: 0x028 (R/W)  TCM Error Bank Register 1 */
+} ErrBnk_Type;
+
+/** \brief ErrBnk Instruction Cache Error Bank Register 0 Definitions */
+#define ERRBNK_IEBR0_SWDEF_Pos             30U                                         /*!< ERRBNK IEBR0: SWDEF Position */
+#define ERRBNK_IEBR0_SWDEF_Msk             (0x3UL << ERRBNK_IEBR0_SWDEF_Pos)           /*!< ERRBNK IEBR0: SWDEF Mask */
+
+#define ERRBNK_IEBR0_BANK_Pos              16U                                         /*!< ERRBNK IEBR0: BANK Position */
+#define ERRBNK_IEBR0_BANK_Msk              (1UL << ERRBNK_IEBR0_BANK_Pos)              /*!< ERRBNK IEBR0: BANK Mask */
+
+#define ERRBNK_IEBR0_LOCATION_Pos           2U                                         /*!< ERRBNK IEBR0: LOCATION Position */
+#define ERRBNK_IEBR0_LOCATION_Msk          (0x3FFFUL << ERRBNK_IEBR0_LOCATION_Pos)     /*!< ERRBNK IEBR0: LOCATION Mask */
+
+#define ERRBNK_IEBR0_LOCKED_Pos             1U                                         /*!< ERRBNK IEBR0: LOCKED Position */
+#define ERRBNK_IEBR0_LOCKED_Msk            (1UL << ERRBNK_IEBR0_LOCKED_Pos)            /*!< ERRBNK IEBR0: LOCKED Mask */
+
+#define ERRBNK_IEBR0_VALID_Pos              0U                                         /*!< ERRBNK IEBR0: VALID Position */
+#define ERRBNK_IEBR0_VALID_Msk             (1UL << /*ERRBNK_IEBR0_VALID_Pos*/)         /*!< ERRBNK IEBR0: VALID Mask */
+
+/** \brief ErrBnk Instruction Cache Error Bank Register 1 Definitions */
+#define ERRBNK_IEBR1_SWDEF_Pos             30U                                         /*!< ERRBNK IEBR1: SWDEF Position */
+#define ERRBNK_IEBR1_SWDEF_Msk             (0x3UL << ERRBNK_IEBR1_SWDEF_Pos)           /*!< ERRBNK IEBR1: SWDEF Mask */
+
+#define ERRBNK_IEBR1_BANK_Pos              16U                                         /*!< ERRBNK IEBR1: BANK Position */
+#define ERRBNK_IEBR1_BANK_Msk              (1UL << ERRBNK_IEBR1_BANK_Pos)              /*!< ERRBNK IEBR1: BANK Mask */
+
+#define ERRBNK_IEBR1_LOCATION_Pos           2U                                         /*!< ERRBNK IEBR1: LOCATION Position */
+#define ERRBNK_IEBR1_LOCATION_Msk          (0x3FFFUL << ERRBNK_IEBR1_LOCATION_Pos)     /*!< ERRBNK IEBR1: LOCATION Mask */
+
+#define ERRBNK_IEBR1_LOCKED_Pos             1U                                         /*!< ERRBNK IEBR1: LOCKED Position */
+#define ERRBNK_IEBR1_LOCKED_Msk            (1UL << ERRBNK_IEBR1_LOCKED_Pos)            /*!< ERRBNK IEBR1: LOCKED Mask */
+
+#define ERRBNK_IEBR1_VALID_Pos              0U                                         /*!< ERRBNK IEBR1: VALID Position */
+#define ERRBNK_IEBR1_VALID_Msk             (1UL << /*ERRBNK_IEBR1_VALID_Pos*/)         /*!< ERRBNK IEBR1: VALID Mask */
+
+/** \brief ErrBnk Data Cache Error Bank Register 0 Definitions */
+#define ERRBNK_DEBR0_SWDEF_Pos             30U                                         /*!< ERRBNK DEBR0: SWDEF Position */
+#define ERRBNK_DEBR0_SWDEF_Msk             (0x3UL << ERRBNK_DEBR0_SWDEF_Pos)           /*!< ERRBNK DEBR0: SWDEF Mask */
+
+#define ERRBNK_DEBR0_TYPE_Pos              17U                                         /*!< ERRBNK DEBR0: TYPE Position */
+#define ERRBNK_DEBR0_TYPE_Msk              (1UL << ERRBNK_DEBR0_TYPE_Pos)              /*!< ERRBNK DEBR0: TYPE Mask */
+
+#define ERRBNK_DEBR0_BANK_Pos              16U                                         /*!< ERRBNK DEBR0: BANK Position */
+#define ERRBNK_DEBR0_BANK_Msk              (1UL << ERRBNK_DEBR0_BANK_Pos)              /*!< ERRBNK DEBR0: BANK Mask */
+
+#define ERRBNK_DEBR0_LOCATION_Pos           2U                                         /*!< ERRBNK DEBR0: LOCATION Position */
+#define ERRBNK_DEBR0_LOCATION_Msk          (0x3FFFUL << ERRBNK_DEBR0_LOCATION_Pos)     /*!< ERRBNK DEBR0: LOCATION Mask */
+
+#define ERRBNK_DEBR0_LOCKED_Pos             1U                                         /*!< ERRBNK DEBR0: LOCKED Position */
+#define ERRBNK_DEBR0_LOCKED_Msk            (1UL << ERRBNK_DEBR0_LOCKED_Pos)            /*!< ERRBNK DEBR0: LOCKED Mask */
+
+#define ERRBNK_DEBR0_VALID_Pos              0U                                         /*!< ERRBNK DEBR0: VALID Position */
+#define ERRBNK_DEBR0_VALID_Msk             (1UL << /*ERRBNK_DEBR0_VALID_Pos*/)         /*!< ERRBNK DEBR0: VALID Mask */
+
+/** \brief ErrBnk Data Cache Error Bank Register 1 Definitions */
+#define ERRBNK_DEBR1_SWDEF_Pos             30U                                         /*!< ERRBNK DEBR1: SWDEF Position */
+#define ERRBNK_DEBR1_SWDEF_Msk             (0x3UL << ERRBNK_DEBR1_SWDEF_Pos)           /*!< ERRBNK DEBR1: SWDEF Mask */
+
+#define ERRBNK_DEBR1_TYPE_Pos              17U                                         /*!< ERRBNK DEBR1: TYPE Position */
+#define ERRBNK_DEBR1_TYPE_Msk              (1UL << ERRBNK_DEBR1_TYPE_Pos)              /*!< ERRBNK DEBR1: TYPE Mask */
+
+#define ERRBNK_DEBR1_BANK_Pos              16U                                         /*!< ERRBNK DEBR1: BANK Position */
+#define ERRBNK_DEBR1_BANK_Msk              (1UL << ERRBNK_DEBR1_BANK_Pos)              /*!< ERRBNK DEBR1: BANK Mask */
+
+#define ERRBNK_DEBR1_LOCATION_Pos           2U                                         /*!< ERRBNK DEBR1: LOCATION Position */
+#define ERRBNK_DEBR1_LOCATION_Msk          (0x3FFFUL << ERRBNK_DEBR1_LOCATION_Pos)     /*!< ERRBNK DEBR1: LOCATION Mask */
+
+#define ERRBNK_DEBR1_LOCKED_Pos             1U                                         /*!< ERRBNK DEBR1: LOCKED Position */
+#define ERRBNK_DEBR1_LOCKED_Msk            (1UL << ERRBNK_DEBR1_LOCKED_Pos)            /*!< ERRBNK DEBR1: LOCKED Mask */
+
+#define ERRBNK_DEBR1_VALID_Pos              0U                                         /*!< ERRBNK DEBR1: VALID Position */
+#define ERRBNK_DEBR1_VALID_Msk             (1UL << /*ERRBNK_DEBR1_VALID_Pos*/)         /*!< ERRBNK DEBR1: VALID Mask */
+
+/** \brief ErrBnk TCM Error Bank Register 0 Definitions */
+#define ERRBNK_TEBR0_SWDEF_Pos             30U                                         /*!< ERRBNK TEBR0: SWDEF Position */
+#define ERRBNK_TEBR0_SWDEF_Msk             (0x3UL << ERRBNK_TEBR0_SWDEF_Pos)           /*!< ERRBNK TEBR0: SWDEF Mask */
+
+#define ERRBNK_TEBR0_POISON_Pos            28U                                         /*!< ERRBNK TEBR0: POISON Position */
+#define ERRBNK_TEBR0_POISON_Msk            (1UL << ERRBNK_TEBR0_POISON_Pos)            /*!< ERRBNK TEBR0: POISON Mask */
+
+#define ERRBNK_TEBR0_TYPE_Pos              27U                                         /*!< ERRBNK TEBR0: TYPE Position */
+#define ERRBNK_TEBR0_TYPE_Msk              (1UL << ERRBNK_TEBR0_TYPE_Pos)              /*!< ERRBNK TEBR0: TYPE Mask */
+
+#define ERRBNK_TEBR0_BANK_Pos              24U                                         /*!< ERRBNK TEBR0: BANK Position */
+#define ERRBNK_TEBR0_BANK_Msk              (0x7UL << ERRBNK_TEBR0_BANK_Pos)            /*!< ERRBNK TEBR0: BANK Mask */
+
+#define ERRBNK_TEBR0_LOCATION_Pos           2U                                         /*!< ERRBNK TEBR0: LOCATION Position */
+#define ERRBNK_TEBR0_LOCATION_Msk          (0x3FFFFFUL << ERRBNK_TEBR0_LOCATION_Pos)   /*!< ERRBNK TEBR0: LOCATION Mask */
+
+#define ERRBNK_TEBR0_LOCKED_Pos             1U                                         /*!< ERRBNK TEBR0: LOCKED Position */
+#define ERRBNK_TEBR0_LOCKED_Msk            (1UL << ERRBNK_TEBR0_LOCKED_Pos)            /*!< ERRBNK TEBR0: LOCKED Mask */
+
+#define ERRBNK_TEBR0_VALID_Pos              0U                                         /*!< ERRBNK TEBR0: VALID Position */
+#define ERRBNK_TEBR0_VALID_Msk             (1UL << /*ERRBNK_TEBR0_VALID_Pos*/)         /*!< ERRBNK TEBR0: VALID Mask */
+
+/** \brief ErrBnk TCM Error Bank Register 1 Definitions */
+#define ERRBNK_TEBR1_SWDEF_Pos             30U                                         /*!< ERRBNK TEBR1: SWDEF Position */
+#define ERRBNK_TEBR1_SWDEF_Msk             (0x3UL << ERRBNK_TEBR1_SWDEF_Pos)           /*!< ERRBNK TEBR1: SWDEF Mask */
+
+#define ERRBNK_TEBR1_POISON_Pos            28U                                         /*!< ERRBNK TEBR1: POISON Position */
+#define ERRBNK_TEBR1_POISON_Msk            (1UL << ERRBNK_TEBR1_POISON_Pos)            /*!< ERRBNK TEBR1: POISON Mask */
+
+#define ERRBNK_TEBR1_TYPE_Pos              27U                                         /*!< ERRBNK TEBR1: TYPE Position */
+#define ERRBNK_TEBR1_TYPE_Msk              (1UL << ERRBNK_TEBR1_TYPE_Pos)              /*!< ERRBNK TEBR1: TYPE Mask */
+
+#define ERRBNK_TEBR1_BANK_Pos              24U                                         /*!< ERRBNK TEBR1: BANK Position */
+#define ERRBNK_TEBR1_BANK_Msk              (0x7UL << ERRBNK_TEBR1_BANK_Pos)            /*!< ERRBNK TEBR1: BANK Mask */
+
+#define ERRBNK_TEBR1_LOCATION_Pos           2U                                         /*!< ERRBNK TEBR1: LOCATION Position */
+#define ERRBNK_TEBR1_LOCATION_Msk          (0x3FFFFFUL << ERRBNK_TEBR1_LOCATION_Pos)   /*!< ERRBNK TEBR1: LOCATION Mask */
+
+#define ERRBNK_TEBR1_LOCKED_Pos             1U                                         /*!< ERRBNK TEBR1: LOCKED Position */
+#define ERRBNK_TEBR1_LOCKED_Msk            (1UL << ERRBNK_TEBR1_LOCKED_Pos)            /*!< ERRBNK TEBR1: LOCKED Mask */
+
+#define ERRBNK_TEBR1_VALID_Pos              0U                                         /*!< ERRBNK TEBR1: VALID Position */
+#define ERRBNK_TEBR1_VALID_Msk             (1UL << /*ERRBNK_TEBR1_VALID_Pos*/)         /*!< ERRBNK TEBR1: VALID Mask */
+
+/*@}*/ /* end of group ErrBnk_Type */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup PrcCfgInf_Type     Processor Configuration Information Registers (IMPLEMENTATION DEFINED)
+  \brief    Type definitions for the Processor Configuration Information Registerss (PRCCFGINF)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Processor Configuration Information Registerss (PRCCFGINF).
+ */
+typedef struct
+{
+  __OM  uint32_t CFGINFOSEL;             /*!< Offset: 0x000 ( /W)  Processor Configuration Information Selection Register */
+  __IM  uint32_t CFGINFORD;              /*!< Offset: 0x004 (R/ )  Processor Configuration Information Read Data Register */
+} PrcCfgInf_Type;
+
+/** \brief PrcCfgInf Processor Configuration Information Selection Register Definitions */
+
+/** \brief PrcCfgInf Processor Configuration Information Read Data Register Definitions */
+
+/*@}*/ /* end of group PrcCfgInf_Type */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup STL_Type     Software Test Library Observation Registers
+  \brief    Type definitions for the Software Test Library Observation Registerss (STL)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Software Test Library Observation Registerss (STL).
+ */
+typedef struct
+{
+  __IM  uint32_t STLNVICPENDOR;          /*!< Offset: 0x000 (R/ )  NVIC Pending Priority Tree Register */
+  __IM  uint32_t STLNVICACTVOR;          /*!< Offset: 0x004 (R/ )  NVIC Active Priority Tree Register */
+        uint32_t RESERVED0[2U];
+  __IOM uint32_t STLIDMPUSR;             /*!< Offset: 0x010 ( /W)  MPU Sample Register */
+  __IM  uint32_t STLIMPUOR;              /*!< Offset: 0x014 (R/ )  MPU Region Hit Register */
+  __IM  uint32_t STLD0MPUOR;             /*!< Offset: 0x018 (R/ )  MPU Memory Attributes Register 0 */
+  __IM  uint32_t STLD1MPUOR;             /*!< Offset: 0x01C (R/ )  MPU Memory Attributes Register 1 */
+  __IM  uint32_t STLD2MPUOR;             /*!< Offset: 0x020 (R/ )  MPU Memory Attributes Register 2 */
+  __IM  uint32_t STLD3MPUOR;             /*!< Offset: 0x024 (R/ )  MPU Memory Attributes Register 3 */
+  __IOM uint32_t STLSTBSLOTSR;           /*!< Offset: 0x028 (R/W)  STB Control Register */
+  __IOM uint32_t STLLFDENTRYSR;          /*!< Offset: 0x02C (R/W)  LFD Control Register */
+} STL_Type;
+
+/** \brief STL NVIC Pending Priority Tree Register Definitions */
+#define STL_STLNVICPENDOR_VALID_Pos        18U                                         /*!< STL STLNVICPENDOR: VALID Position */
+#define STL_STLNVICPENDOR_VALID_Msk        (1UL << STL_STLNVICPENDOR_VALID_Pos)        /*!< STL STLNVICPENDOR: VALID Mask */
+
+#define STL_STLNVICPENDOR_TARGET_Pos       17U                                         /*!< STL STLNVICPENDOR: TARGET Position */
+#define STL_STLNVICPENDOR_TARGET_Msk       (1UL << STL_STLNVICPENDOR_TARGET_Pos)       /*!< STL STLNVICPENDOR: TARGET Mask */
+
+#define STL_STLNVICPENDOR_PRIORITY_Pos      9U                                         /*!< STL STLNVICPENDOR: PRIORITY Position */
+#define STL_STLNVICPENDOR_PRIORITY_Msk     (0xFFUL << STL_STLNVICPENDOR_PRIORITY_Pos)  /*!< STL STLNVICPENDOR: PRIORITY Mask */
+
+#define STL_STLNVICPENDOR_INTNUM_Pos        0U                                         /*!< STL STLNVICPENDOR: INTNUM Position */
+#define STL_STLNVICPENDOR_INTNUM_Msk       (0x1FFUL /*<< STL_STLNVICPENDOR_INTNUM_Pos*/) /*!< STL STLNVICPENDOR: INTNUM Mask */
+
+/** \brief STL NVIC Active Priority Tree Register Definitions */
+#define STL_STLNVICACTVOR_VALID_Pos        18U                                         /*!< STL STLNVICACTVOR: VALID Position */
+#define STL_STLNVICACTVOR_VALID_Msk        (1UL << STL_STLNVICACTVOR_VALID_Pos)        /*!< STL STLNVICACTVOR: VALID Mask */
+
+#define STL_STLNVICACTVOR_TARGET_Pos       17U                                         /*!< STL STLNVICACTVOR: TARGET Position */
+#define STL_STLNVICACTVOR_TARGET_Msk       (1UL << STL_STLNVICACTVOR_TARGET_Pos)       /*!< STL STLNVICACTVOR: TARGET Mask */
+
+#define STL_STLNVICACTVOR_PRIORITY_Pos      9U                                         /*!< STL STLNVICACTVOR: PRIORITY Position */
+#define STL_STLNVICACTVOR_PRIORITY_Msk     (0xFFUL << STL_STLNVICACTVOR_PRIORITY_Pos)  /*!< STL STLNVICACTVOR: PRIORITY Mask */
+
+#define STL_STLNVICACTVOR_INTNUM_Pos        0U                                         /*!< STL STLNVICACTVOR: INTNUM Position */
+#define STL_STLNVICACTVOR_INTNUM_Msk       (0x1FFUL /*<< STL_STLNVICACTVOR_INTNUM_Pos*/) /*!< STL STLNVICACTVOR: INTNUM Mask */
+
+/** \brief STL MPU Sample Register Definitions */
+#define STL_STLIDMPUSR_ADDR_Pos             5U                                         /*!< STL STLIDMPUSR: ADDR Position */
+#define STL_STLIDMPUSR_ADDR_Msk            (0x7FFFFFFUL << STL_STLIDMPUSR_ADDR_Pos)    /*!< STL STLIDMPUSR: ADDR Mask */
+
+#define STL_STLIDMPUSR_INSTR_Pos            2U                                         /*!< STL STLIDMPUSR: INSTR Position */
+#define STL_STLIDMPUSR_INSTR_Msk           (1UL << STL_STLIDMPUSR_INSTR_Pos)           /*!< STL STLIDMPUSR: INSTR Mask */
+
+#define STL_STLIDMPUSR_DATA_Pos             1U                                         /*!< STL STLIDMPUSR: DATA Position */
+#define STL_STLIDMPUSR_DATA_Msk            (1UL << STL_STLIDMPUSR_DATA_Pos)            /*!< STL STLIDMPUSR: DATA Mask */
+
+/** \brief STL MPU Region Hit Register Definitions */
+#define STL_STLIMPUOR_HITREGION_Pos         9U                                         /*!< STL STLIMPUOR: HITREGION Position */
+#define STL_STLIMPUOR_HITREGION_Msk        (0xFFUL << STL_STLIMPUOR_HITREGION_Pos)     /*!< STL STLIMPUOR: HITREGION Mask */
+
+#define STL_STLIMPUOR_ATTR_Pos              0U                                         /*!< STL STLIMPUOR: ATTR Position */
+#define STL_STLIMPUOR_ATTR_Msk             (0x1FFUL /*<< STL_STLIMPUOR_ATTR_Pos*/)     /*!< STL STLIMPUOR: ATTR Mask */
+
+/** \brief STL MPU Memory Attributes Register 0 Definitions */
+#define STL_STLD0MPUOR_HITREGION_Pos        9U                                         /*!< STL STLD0MPUOR: HITREGION Position */
+#define STL_STLD0MPUOR_HITREGION_Msk       (0xFFUL << STL_STLD0MPUOR_HITREGION_Pos)    /*!< STL STLD0MPUOR: HITREGION Mask */
+
+#define STL_STLD0MPUOR_ATTR_Pos             0U                                         /*!< STL STLD0MPUOR: ATTR Position */
+#define STL_STLD0MPUOR_ATTR_Msk            (0x1FFUL /*<< STL_STLD0MPUOR_ATTR_Pos*/)    /*!< STL STLD0MPUOR: ATTR Mask */
+
+/** \brief STL MPU Memory Attributes Register 1 Definitions */
+#define STL_STLD1MPUOR_HITREGION_Pos        9U                                         /*!< STL STLD1MPUOR: HITREGION Position */
+#define STL_STLD1MPUOR_HITREGION_Msk       (0xFFUL << STL_STLD1MPUOR_HITREGION_Pos)    /*!< STL STLD1MPUOR: HITREGION Mask */
+
+#define STL_STLD1MPUOR_ATTR_Pos             0U                                         /*!< STL STLD1MPUOR: ATTR Position */
+#define STL_STLD1MPUOR_ATTR_Msk            (0x1FFUL /*<< STL_STLD1MPUOR_ATTR_Pos*/)    /*!< STL STLD1MPUOR: ATTR Mask */
+
+/** \brief STL MPU Memory Attributes Register 2 Definitions */
+#define STL_STLD2MPUOR_HITREGION_Pos        9U                                         /*!< STL STLD2MPUOR: HITREGION Position */
+#define STL_STLD2MPUOR_HITREGION_Msk       (0xFFUL << STL_STLD2MPUOR_HITREGION_Pos)    /*!< STL STLD2MPUOR: HITREGION Mask */
+
+#define STL_STLD2MPUOR_ATTR_Pos             0U                                         /*!< STL STLD2MPUOR: ATTR Position */
+#define STL_STLD2MPUOR_ATTR_Msk            (0x1FFUL /*<< STL_STLD2MPUOR_ATTR_Pos*/)    /*!< STL STLD2MPUOR: ATTR Mask */
+
+/** \brief STL MPU Memory Attributes Register 3 Definitions */
+#define STL_STLD3MPUOR_HITREGION_Pos        9U                                         /*!< STL STLD3MPUOR: HITREGION Position */
+#define STL_STLD3MPUOR_HITREGION_Msk       (0xFFUL << STL_STLD3MPUOR_HITREGION_Pos)    /*!< STL STLD3MPUOR: HITREGION Mask */
+
+#define STL_STLD3MPUOR_ATTR_Pos             0U                                         /*!< STL STLD3MPUOR: ATTR Position */
+#define STL_STLD3MPUOR_ATTR_Msk            (0x1FFUL /*<< STL_STLD3MPUOR_ATTR_Pos*/)    /*!< STL STLD3MPUOR: ATTR Mask */
+
+/** \brief STL STB Control Register Definitions */
+#define STL_STLSTBSLOTSR_VALID_Pos          4U                                         /*!< STL STLSTBSLOTSR: VALID Position */
+#define STL_STLSTBSLOTSR_VALID_Msk         (1UL << STL_STLSTBSLOTSR_VALID_Pos)         /*!< STL STLSTBSLOTSR: VALID Mask */
+
+#define STL_STLSTBSLOTSR_STBSLOTNUM_Pos     0U                                         /*!< STL STLSTBSLOTSR: STBSLOTNUM Position */
+#define STL_STLSTBSLOTSR_STBSLOTNUM_Msk    (0xFUL /*<< STL_STLSTBSLOTSR_STBSLOTNUM_Pos*/) /*!< STL STLSTBSLOTSR: STBSLOTNUM Mask */
+
+/** \brief STL LFD Control Register Definitions */
+#define STL_STLLFDENTRYSR_VALID_Pos         4U                                         /*!< STL STLLFDENTRYSR: VALID Position */
+#define STL_STLLFDENTRYSR_VALID_Msk        (1UL << STL_STLLFDENTRYSR_VALID_Pos)        /*!< STL STLLFDENTRYSR: VALID Mask */
+
+#define STL_STLLFDENTRYSR_LFDENTRYNUM_Pos   0U                                         /*!< STL STLLFDENTRYSR: LFDENTRYNUM Position */
+#define STL_STLLFDENTRYSR_LFDENTRYNUM_Msk  (0xFUL /*<< STL_STLLFDENTRYSR_LFDENTRYNUM_Pos*/) /*!< STL STLLFDENTRYSR: LFDENTRYNUM Mask */
+/*@}*/ /* end of group STL_Type */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_TPIU    Trace Port Interface Unit (TPIU)
+  \brief    Type definitions for the Trace Port Interface Unit (TPIU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Trace Port Interface Unit Register (TPIU).
+ */
+typedef struct
+{
+  __IM  uint32_t SSPSR;                  /*!< Offset: 0x000 (R/ )  Supported Parallel Port Size Register */
+  __IOM uint32_t CSPSR;                  /*!< Offset: 0x004 (R/W)  Current Parallel Port Size Register */
+        uint32_t RESERVED0[2U];
+  __IOM uint32_t ACPR;                   /*!< Offset: 0x010 (R/W)  Asynchronous Clock Prescaler Register */
+        uint32_t RESERVED1[55U];
+  __IOM uint32_t SPPR;                   /*!< Offset: 0x0F0 (R/W)  Selected Pin Protocol Register */
+        uint32_t RESERVED2[131U];
+  __IM  uint32_t FFSR;                   /*!< Offset: 0x300 (R/ )  Formatter and Flush Status Register */
+  __IOM uint32_t FFCR;                   /*!< Offset: 0x304 (R/W)  Formatter and Flush Control Register */
+  __IOM uint32_t PSCR;                   /*!< Offset: 0x308 (R/W)  Periodic Synchronization Control Register */
+        uint32_t RESERVED3[759U];
+  __IM  uint32_t TRIGGER;                /*!< Offset: 0xEE8 (R/ )  TRIGGER Register */
+  __IM  uint32_t ITFTTD0;                /*!< Offset: 0xEEC (R/ )  Integration Test FIFO Test Data 0 Register */
+  __IOM uint32_t ITATBCTR2;              /*!< Offset: 0xEF0 (R/W)  Integration Test ATB Control Register 2 */
+        uint32_t RESERVED4[1U];
+  __IM  uint32_t ITATBCTR0;              /*!< Offset: 0xEF8 (R/ )  Integration Test ATB Control Register 0 */
+  __IM  uint32_t ITFTTD1;                /*!< Offset: 0xEFC (R/ )  Integration Test FIFO Test Data 1 Register */
+  __IOM uint32_t ITCTRL;                 /*!< Offset: 0xF00 (R/W)  Integration Mode Control */
+        uint32_t RESERVED5[39U];
+  __IOM uint32_t CLAIMSET;               /*!< Offset: 0xFA0 (R/W)  Claim tag set */
+  __IOM uint32_t CLAIMCLR;               /*!< Offset: 0xFA4 (R/W)  Claim tag clear */
+        uint32_t RESERVED7[8U];
+  __IM  uint32_t DEVID;                  /*!< Offset: 0xFC8 (R/ )  Device Configuration Register */
+  __IM  uint32_t DEVTYPE;                /*!< Offset: 0xFCC (R/ )  Device Type Identifier Register */
+} TPIU_Type;
+
+/** \brief TPIU Asynchronous Clock Prescaler Register Definitions */
+#define TPIU_ACPR_PRESCALER_Pos             0U                                         /*!< TPIU ACPR: PRESCALER Position */
+#define TPIU_ACPR_PRESCALER_Msk            (0x1FFFUL /*<< TPIU_ACPR_PRESCALER_Pos*/)   /*!< TPIU ACPR: PRESCALER Mask */
+
+/** \brief TPIU Selected Pin Protocol Register Definitions */
+#define TPIU_SPPR_TXMODE_Pos                0U                                         /*!< TPIU SPPR: TXMODE Position */
+#define TPIU_SPPR_TXMODE_Msk               (0x3UL /*<< TPIU_SPPR_TXMODE_Pos*/)         /*!< TPIU SPPR: TXMODE Mask */
+
+/** \brief TPIU Formatter and Flush Status Register Definitions */
+#define TPIU_FFSR_FtNonStop_Pos             3U                                         /*!< TPIU FFSR: FtNonStop Position */
+#define TPIU_FFSR_FtNonStop_Msk            (1UL << TPIU_FFSR_FtNonStop_Pos)            /*!< TPIU FFSR: FtNonStop Mask */
+
+#define TPIU_FFSR_TCPresent_Pos             2U                                         /*!< TPIU FFSR: TCPresent Position */
+#define TPIU_FFSR_TCPresent_Msk            (1UL << TPIU_FFSR_TCPresent_Pos)            /*!< TPIU FFSR: TCPresent Mask */
+
+#define TPIU_FFSR_FtStopped_Pos             1U                                         /*!< TPIU FFSR: FtStopped Position */
+#define TPIU_FFSR_FtStopped_Msk            (1UL << TPIU_FFSR_FtStopped_Pos)            /*!< TPIU FFSR: FtStopped Mask */
+
+#define TPIU_FFSR_FlInProg_Pos              0U                                         /*!< TPIU FFSR: FlInProg Position */
+#define TPIU_FFSR_FlInProg_Msk             (1UL /*<< TPIU_FFSR_FlInProg_Pos*/)         /*!< TPIU FFSR: FlInProg Mask */
+
+/** \brief TPIU Formatter and Flush Control Register Definitions */
+#define TPIU_FFCR_TrigIn_Pos                8U                                         /*!< TPIU FFCR: TrigIn Position */
+#define TPIU_FFCR_TrigIn_Msk               (1UL << TPIU_FFCR_TrigIn_Pos)               /*!< TPIU FFCR: TrigIn Mask */
+
+#define TPIU_FFCR_FOnMan_Pos                6U                                         /*!< TPIU FFCR: FOnMan Position */
+#define TPIU_FFCR_FOnMan_Msk               (1UL << TPIU_FFCR_FOnMan_Pos)               /*!< TPIU FFCR: FOnMan Mask */
+
+#define TPIU_FFCR_EnFCont_Pos               1U                                         /*!< TPIU FFCR: EnFCont Position */
+#define TPIU_FFCR_EnFCont_Msk              (1UL << TPIU_FFCR_EnFCont_Pos)              /*!< TPIU FFCR: EnFCont Mask */
+
+/** \brief TPIU Periodic Synchronization Control Register Definitions */
+#define TPIU_PSCR_PSCount_Pos               0U                                         /*!< TPIU PSCR: PSCount Position */
+#define TPIU_PSCR_PSCount_Msk              (0x1FUL /*<< TPIU_PSCR_PSCount_Pos*/)       /*!< TPIU PSCR: TPSCount Mask */
+
+/** \brief TPIU TRIGGER Register Definitions */
+#define TPIU_TRIGGER_TRIGGER_Pos            0U                                         /*!< TPIU TRIGGER: TRIGGER Position */
+#define TPIU_TRIGGER_TRIGGER_Msk           (1UL /*<< TPIU_TRIGGER_TRIGGER_Pos*/)       /*!< TPIU TRIGGER: TRIGGER Mask */
+
+/** \brief TPIU Integration Test FIFO Test Data 0 Register Definitions */
+#define TPIU_ITFTTD0_ATB_IF2_ATVALID_Pos   29U                                         /*!< TPIU ITFTTD0: ATB Interface 2 ATVALIDPosition */
+#define TPIU_ITFTTD0_ATB_IF2_ATVALID_Msk   (0x3UL << TPIU_ITFTTD0_ATB_IF2_ATVALID_Pos) /*!< TPIU ITFTTD0: ATB Interface 2 ATVALID Mask */
+
+#define TPIU_ITFTTD0_ATB_IF2_bytecount_Pos 27U                                         /*!< TPIU ITFTTD0: ATB Interface 2 byte count Position */
+#define TPIU_ITFTTD0_ATB_IF2_bytecount_Msk (0x3UL << TPIU_ITFTTD0_ATB_IF2_bytecount_Pos) /*!< TPIU ITFTTD0: ATB Interface 2 byte count Mask */
+
+#define TPIU_ITFTTD0_ATB_IF1_ATVALID_Pos   26U                                         /*!< TPIU ITFTTD0: ATB Interface 1 ATVALID Position */
+#define TPIU_ITFTTD0_ATB_IF1_ATVALID_Msk   (0x3UL << TPIU_ITFTTD0_ATB_IF1_ATVALID_Pos) /*!< TPIU ITFTTD0: ATB Interface 1 ATVALID Mask */
+
+#define TPIU_ITFTTD0_ATB_IF1_bytecount_Pos 24U                                         /*!< TPIU ITFTTD0: ATB Interface 1 byte count Position */
+#define TPIU_ITFTTD0_ATB_IF1_bytecount_Msk (0x3UL << TPIU_ITFTTD0_ATB_IF1_bytecount_Pos) /*!< TPIU ITFTTD0: ATB Interface 1 byte countt Mask */
+
+#define TPIU_ITFTTD0_ATB_IF1_data2_Pos     16U                                         /*!< TPIU ITFTTD0: ATB Interface 1 data2 Position */
+#define TPIU_ITFTTD0_ATB_IF1_data2_Msk     (0xFFUL << TPIU_ITFTTD0_ATB_IF1_data1_Pos)  /*!< TPIU ITFTTD0: ATB Interface 1 data2 Mask */
+
+#define TPIU_ITFTTD0_ATB_IF1_data1_Pos      8U                                         /*!< TPIU ITFTTD0: ATB Interface 1 data1 Position */
+#define TPIU_ITFTTD0_ATB_IF1_data1_Msk     (0xFFUL << TPIU_ITFTTD0_ATB_IF1_data1_Pos)  /*!< TPIU ITFTTD0: ATB Interface 1 data1 Mask */
+
+#define TPIU_ITFTTD0_ATB_IF1_data0_Pos      0U                                          /*!< TPIU ITFTTD0: ATB Interface 1 data0 Position */
+#define TPIU_ITFTTD0_ATB_IF1_data0_Msk     (0xFFUL /*<< TPIU_ITFTTD0_ATB_IF1_data0_Pos*/) /*!< TPIU ITFTTD0: ATB Interface 1 data0 Mask */
+
+/** \brief TPIU Integration Test ATB Control Register 2 Register Definitions */
+#define TPIU_ITATBCTR2_AFVALID2S_Pos        1U                                         /*!< TPIU ITATBCTR2: AFVALID2S Position */
+#define TPIU_ITATBCTR2_AFVALID2S_Msk       (1UL << TPIU_ITATBCTR2_AFVALID2S_Pos)       /*!< TPIU ITATBCTR2: AFVALID2SS Mask */
+
+#define TPIU_ITATBCTR2_AFVALID1S_Pos        1U                                         /*!< TPIU ITATBCTR2: AFVALID1S Position */
+#define TPIU_ITATBCTR2_AFVALID1S_Msk       (1UL << TPIU_ITATBCTR2_AFVALID1S_Pos)       /*!< TPIU ITATBCTR2: AFVALID1SS Mask */
+
+#define TPIU_ITATBCTR2_ATREADY2S_Pos        0U                                         /*!< TPIU ITATBCTR2: ATREADY2S Position */
+#define TPIU_ITATBCTR2_ATREADY2S_Msk       (1UL /*<< TPIU_ITATBCTR2_ATREADY2S_Pos*/)   /*!< TPIU ITATBCTR2: ATREADY2S Mask */
+
+#define TPIU_ITATBCTR2_ATREADY1S_Pos        0U                                         /*!< TPIU ITATBCTR2: ATREADY1S Position */
+#define TPIU_ITATBCTR2_ATREADY1S_Msk       (1UL /*<< TPIU_ITATBCTR2_ATREADY1S_Pos*/)   /*!< TPIU ITATBCTR2: ATREADY1S Mask */
+
+/** \brief TPIU Integration Test FIFO Test Data 1 Register Definitions */
+#define TPIU_ITFTTD1_ATB_IF2_ATVALID_Pos   29U                                         /*!< TPIU ITFTTD1: ATB Interface 2 ATVALID Position */
+#define TPIU_ITFTTD1_ATB_IF2_ATVALID_Msk   (0x3UL << TPIU_ITFTTD1_ATB_IF2_ATVALID_Pos) /*!< TPIU ITFTTD1: ATB Interface 2 ATVALID Mask */
+
+#define TPIU_ITFTTD1_ATB_IF2_bytecount_Pos 27U                                         /*!< TPIU ITFTTD1: ATB Interface 2 byte count Position */
+#define TPIU_ITFTTD1_ATB_IF2_bytecount_Msk (0x3UL << TPIU_ITFTTD1_ATB_IF2_bytecount_Pos) /*!< TPIU ITFTTD1: ATB Interface 2 byte count Mask */
+
+#define TPIU_ITFTTD1_ATB_IF1_ATVALID_Pos   26U                                         /*!< TPIU ITFTTD1: ATB Interface 1 ATVALID Position */
+#define TPIU_ITFTTD1_ATB_IF1_ATVALID_Msk   (0x3UL << TPIU_ITFTTD1_ATB_IF1_ATVALID_Pos) /*!< TPIU ITFTTD1: ATB Interface 1 ATVALID Mask */
+
+#define TPIU_ITFTTD1_ATB_IF1_bytecount_Pos 24U                                         /*!< TPIU ITFTTD1: ATB Interface 1 byte count Position */
+#define TPIU_ITFTTD1_ATB_IF1_bytecount_Msk (0x3UL << TPIU_ITFTTD1_ATB_IF1_bytecount_Pos) /*!< TPIU ITFTTD1: ATB Interface 1 byte countt Mask */
+
+#define TPIU_ITFTTD1_ATB_IF2_data2_Pos     16U                                         /*!< TPIU ITFTTD1: ATB Interface 2 data2 Position */
+#define TPIU_ITFTTD1_ATB_IF2_data2_Msk     (0xFFUL << TPIU_ITFTTD1_ATB_IF2_data1_Pos)  /*!< TPIU ITFTTD1: ATB Interface 2 data2 Mask */
+
+#define TPIU_ITFTTD1_ATB_IF2_data1_Pos      8U                                         /*!< TPIU ITFTTD1: ATB Interface 2 data1 Position */
+#define TPIU_ITFTTD1_ATB_IF2_data1_Msk     (0xFFUL << TPIU_ITFTTD1_ATB_IF2_data1_Pos)  /*!< TPIU ITFTTD1: ATB Interface 2 data1 Mask */
+
+#define TPIU_ITFTTD1_ATB_IF2_data0_Pos      0U                                         /*!< TPIU ITFTTD1: ATB Interface 2 data0 Position */
+#define TPIU_ITFTTD1_ATB_IF2_data0_Msk     (0xFFUL /*<< TPIU_ITFTTD1_ATB_IF2_data0_Pos*/) /*!< TPIU ITFTTD1: ATB Interface 2 data0 Mask */
+
+/** \brief TPIU Integration Test ATB Control Register 0 Definitions */
+#define TPIU_ITATBCTR0_AFVALID2S_Pos        1U                                         /*!< TPIU ITATBCTR0: AFVALID2S Position */
+#define TPIU_ITATBCTR0_AFVALID2S_Msk       (1UL << TPIU_ITATBCTR0_AFVALID2S_Pos)       /*!< TPIU ITATBCTR0: AFVALID2SS Mask */
+
+#define TPIU_ITATBCTR0_AFVALID1S_Pos        1U                                         /*!< TPIU ITATBCTR0: AFVALID1S Position */
+#define TPIU_ITATBCTR0_AFVALID1S_Msk       (1UL << TPIU_ITATBCTR0_AFVALID1S_Pos)       /*!< TPIU ITATBCTR0: AFVALID1SS Mask */
+
+#define TPIU_ITATBCTR0_ATREADY2S_Pos        0U                                         /*!< TPIU ITATBCTR0: ATREADY2S Position */
+#define TPIU_ITATBCTR0_ATREADY2S_Msk       (1UL /*<< TPIU_ITATBCTR0_ATREADY2S_Pos*/)   /*!< TPIU ITATBCTR0: ATREADY2S Mask */
+
+#define TPIU_ITATBCTR0_ATREADY1S_Pos        0U                                         /*!< TPIU ITATBCTR0: ATREADY1S Position */
+#define TPIU_ITATBCTR0_ATREADY1S_Msk       (1UL /*<< TPIU_ITATBCTR0_ATREADY1S_Pos*/)   /*!< TPIU ITATBCTR0: ATREADY1S Mask */
+
+/** \brief TPIU Integration Mode Control Register Definitions */
+#define TPIU_ITCTRL_Mode_Pos                0U                                         /*!< TPIU ITCTRL: Mode Position */
+#define TPIU_ITCTRL_Mode_Msk               (0x3UL /*<< TPIU_ITCTRL_Mode_Pos*/)         /*!< TPIU ITCTRL: Mode Mask */
+
+/** \brief TPIU Claim Tag Set Register Definitions */
+#define TPIU_CLAIMSET_SET_Pos               0U                                         /*!< TPIU CLAIMSET: SET Position */
+#define TPIU_CLAIMSET_SET_Msk              (0xFUL /*<< TPIU_CLAIMSET_SET_Pos*/)        /*!< TPIU CLAIMSET: SET Mask */
+
+/** \brief TPIU Claim Tag Clear Register Definitions */
+#define TPIU_CLAIMCLR_CLR_Pos               0U                                         /*!< TPIU CLAIMCLR: CLR Position */
+#define TPIU_CLAIMCLR_CLR_Msk              (0xFUL /*<< TPIU_CLAIMCLR_CLR_Pos*/)        /*!< TPIU CLAIMCLR: CLR Mask */
+
+/** \brief TPIU DEVID Register Definitions */
+#define TPIU_DEVID_NRZVALID_Pos            11U                                         /*!< TPIU DEVID: NRZVALID Position */
+#define TPIU_DEVID_NRZVALID_Msk            (1UL << TPIU_DEVID_NRZVALID_Pos)            /*!< TPIU DEVID: NRZVALID Mask */
+
+#define TPIU_DEVID_MANCVALID_Pos           10U                                         /*!< TPIU DEVID: MANCVALID Position */
+#define TPIU_DEVID_MANCVALID_Msk           (1UL << TPIU_DEVID_MANCVALID_Pos)           /*!< TPIU DEVID: MANCVALID Mask */
+
+#define TPIU_DEVID_PTINVALID_Pos            9U                                         /*!< TPIU DEVID: PTINVALID Position */
+#define TPIU_DEVID_PTINVALID_Msk           (1UL << TPIU_DEVID_PTINVALID_Pos)           /*!< TPIU DEVID: PTINVALID Mask */
+
+#define TPIU_DEVID_FIFOSZ_Pos               6U                                         /*!< TPIU DEVID: FIFOSZ Position */
+#define TPIU_DEVID_FIFOSZ_Msk              (0x7UL << TPIU_DEVID_FIFOSZ_Pos)            /*!< TPIU DEVID: FIFOSZ Mask */
+
+#define TPIU_DEVID_NrTraceInput_Pos         0U                                         /*!< TPIU DEVID: NrTraceInput Position */
+#define TPIU_DEVID_NrTraceInput_Msk        (0x3FUL /*<< TPIU_DEVID_NrTraceInput_Pos*/) /*!< TPIU DEVID: NrTraceInput Mask */
+
+/** \brief TPIU DEVTYPE Register Definitions */
+#define TPIU_DEVTYPE_SubType_Pos            4U                                         /*!< TPIU DEVTYPE: SubType Position */
+#define TPIU_DEVTYPE_SubType_Msk           (0xFUL /*<< TPIU_DEVTYPE_SubType_Pos*/)     /*!< TPIU DEVTYPE: SubType Mask */
+
+#define TPIU_DEVTYPE_MajorType_Pos          0U                                         /*!< TPIU DEVTYPE: MajorType Position */
+#define TPIU_DEVTYPE_MajorType_Msk         (0xFUL << TPIU_DEVTYPE_MajorType_Pos)       /*!< TPIU DEVTYPE: MajorType Mask */
+
+/*@}*/ /* end of group CMSIS_TPIU */
+
+
+#if defined (__PMU_PRESENT) && (__PMU_PRESENT == 1U)
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_PMU     Performance Monitoring Unit (PMU)
+  \brief    Type definitions for the Performance Monitoring Unit (PMU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Performance Monitoring Unit (PMU).
+ */
+typedef struct
+{
+  __IOM uint32_t EVCNTR[__PMU_NUM_EVENTCNT];        /*!< Offset: 0x0 (R/W)    Event Counter Registers */
+#if __PMU_NUM_EVENTCNT<31
+        uint32_t RESERVED0[31U-__PMU_NUM_EVENTCNT];
+#endif
+  __IOM uint32_t CCNTR;                             /*!< Offset: 0x7C (R/W)   Cycle Counter Register */
+        uint32_t RESERVED1[224];
+  __IOM uint32_t EVTYPER[__PMU_NUM_EVENTCNT];       /*!< Offset: 0x400 (R/W)  Event Type and Filter Registers */
+#if __PMU_NUM_EVENTCNT<31
+        uint32_t RESERVED2[31U-__PMU_NUM_EVENTCNT];
+#endif
+  __IOM uint32_t CCFILTR;                           /*!< Offset: 0x47C (R/W)  Cycle Counter Filter Register */
+        uint32_t RESERVED3[480];
+  __IOM uint32_t CNTENSET;                          /*!< Offset: 0xC00 (R/W)  Count Enable Set Register */
+        uint32_t RESERVED4[7];
+  __IOM uint32_t CNTENCLR;                          /*!< Offset: 0xC20 (R/W)  Count Enable Clear Register */
+        uint32_t RESERVED5[7];
+  __IOM uint32_t INTENSET;                          /*!< Offset: 0xC40 (R/W)  Interrupt Enable Set Register */
+        uint32_t RESERVED6[7];
+  __IOM uint32_t INTENCLR;                          /*!< Offset: 0xC60 (R/W)  Interrupt Enable Clear Register */
+        uint32_t RESERVED7[7];
+  __IOM uint32_t OVSCLR;                            /*!< Offset: 0xC80 (R/W)  Overflow Flag Status Clear Register */
+        uint32_t RESERVED8[7];
+  __IOM uint32_t SWINC;                             /*!< Offset: 0xCA0 (R/W)  Software Increment Register */
+        uint32_t RESERVED9[7];
+  __IOM uint32_t OVSSET;                            /*!< Offset: 0xCC0 (R/W)  Overflow Flag Status Set Register */
+        uint32_t RESERVED10[79];
+  __IOM uint32_t TYPE;                              /*!< Offset: 0xE00 (R/W)  Type Register */
+  __IOM uint32_t CTRL;                              /*!< Offset: 0xE04 (R/W)  Control Register */
+        uint32_t RESERVED11[108];
+  __IOM uint32_t AUTHSTATUS;                        /*!< Offset: 0xFB8 (R/W)  Authentication Status Register */
+  __IOM uint32_t DEVARCH;                           /*!< Offset: 0xFBC (R/W)  Device Architecture Register */
+        uint32_t RESERVED12[3];
+  __IOM uint32_t DEVTYPE;                           /*!< Offset: 0xFCC (R/W)  Device Type Register */
+} PMU_Type;
+
+/** \brief PMU Event Counter Registers (0-30) Definitions  */
+#define PMU_EVCNTR_CNT_Pos                    0U                                           /*!< PMU EVCNTR: Counter Position */
+#define PMU_EVCNTR_CNT_Msk                   (0xFFFFUL /*<< PMU_EVCNTRx_CNT_Pos*/)         /*!< PMU EVCNTR: Counter Mask */
+
+/** \brief PMU Event Type and Filter Registers (0-30) Definitions  */
+#define PMU_EVTYPER_EVENTTOCNT_Pos            0U                                           /*!< PMU EVTYPER: Event to Count Position */
+#define PMU_EVTYPER_EVENTTOCNT_Msk           (0xFFFFUL /*<< EVTYPERx_EVENTTOCNT_Pos*/)     /*!< PMU EVTYPER: Event to Count Mask */
+
+/** \brief PMU Count Enable Set Register Definitions */
+#define PMU_CNTENSET_CNT0_ENABLE_Pos          0U                                           /*!< PMU CNTENSET: Event Counter 0 Enable Set Position */
+#define PMU_CNTENSET_CNT0_ENABLE_Msk         (1UL /*<< PMU_CNTENSET_CNT0_ENABLE_Pos*/)     /*!< PMU CNTENSET: Event Counter 0 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT1_ENABLE_Pos          1U                                           /*!< PMU CNTENSET: Event Counter 1 Enable Set Position */
+#define PMU_CNTENSET_CNT1_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT1_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 1 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT2_ENABLE_Pos          2U                                           /*!< PMU CNTENSET: Event Counter 2 Enable Set Position */
+#define PMU_CNTENSET_CNT2_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT2_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 2 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT3_ENABLE_Pos          3U                                           /*!< PMU CNTENSET: Event Counter 3 Enable Set Position */
+#define PMU_CNTENSET_CNT3_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT3_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 3 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT4_ENABLE_Pos          4U                                           /*!< PMU CNTENSET: Event Counter 4 Enable Set Position */
+#define PMU_CNTENSET_CNT4_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT4_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 4 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT5_ENABLE_Pos          5U                                           /*!< PMU CNTENSET: Event Counter 5 Enable Set Position */
+#define PMU_CNTENSET_CNT5_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT5_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 5 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT6_ENABLE_Pos          6U                                           /*!< PMU CNTENSET: Event Counter 6 Enable Set Position */
+#define PMU_CNTENSET_CNT6_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT6_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 6 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT7_ENABLE_Pos          7U                                           /*!< PMU CNTENSET: Event Counter 7 Enable Set Position */
+#define PMU_CNTENSET_CNT7_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT7_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 7 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT8_ENABLE_Pos          8U                                           /*!< PMU CNTENSET: Event Counter 8 Enable Set Position */
+#define PMU_CNTENSET_CNT8_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT8_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 8 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT9_ENABLE_Pos          9U                                           /*!< PMU CNTENSET: Event Counter 9 Enable Set Position */
+#define PMU_CNTENSET_CNT9_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT9_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 9 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT10_ENABLE_Pos         10U                                          /*!< PMU CNTENSET: Event Counter 10 Enable Set Position */
+#define PMU_CNTENSET_CNT10_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT10_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 10 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT11_ENABLE_Pos         11U                                          /*!< PMU CNTENSET: Event Counter 11 Enable Set Position */
+#define PMU_CNTENSET_CNT11_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT11_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 11 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT12_ENABLE_Pos         12U                                          /*!< PMU CNTENSET: Event Counter 12 Enable Set Position */
+#define PMU_CNTENSET_CNT12_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT12_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 12 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT13_ENABLE_Pos         13U                                          /*!< PMU CNTENSET: Event Counter 13 Enable Set Position */
+#define PMU_CNTENSET_CNT13_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT13_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 13 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT14_ENABLE_Pos         14U                                          /*!< PMU CNTENSET: Event Counter 14 Enable Set Position */
+#define PMU_CNTENSET_CNT14_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT14_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 14 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT15_ENABLE_Pos         15U                                          /*!< PMU CNTENSET: Event Counter 15 Enable Set Position */
+#define PMU_CNTENSET_CNT15_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT15_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 15 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT16_ENABLE_Pos         16U                                          /*!< PMU CNTENSET: Event Counter 16 Enable Set Position */
+#define PMU_CNTENSET_CNT16_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT16_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 16 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT17_ENABLE_Pos         17U                                          /*!< PMU CNTENSET: Event Counter 17 Enable Set Position */
+#define PMU_CNTENSET_CNT17_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT17_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 17 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT18_ENABLE_Pos         18U                                          /*!< PMU CNTENSET: Event Counter 18 Enable Set Position */
+#define PMU_CNTENSET_CNT18_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT18_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 18 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT19_ENABLE_Pos         19U                                          /*!< PMU CNTENSET: Event Counter 19 Enable Set Position */
+#define PMU_CNTENSET_CNT19_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT19_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 19 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT20_ENABLE_Pos         20U                                          /*!< PMU CNTENSET: Event Counter 20 Enable Set Position */
+#define PMU_CNTENSET_CNT20_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT20_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 20 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT21_ENABLE_Pos         21U                                          /*!< PMU CNTENSET: Event Counter 21 Enable Set Position */
+#define PMU_CNTENSET_CNT21_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT21_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 21 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT22_ENABLE_Pos         22U                                          /*!< PMU CNTENSET: Event Counter 22 Enable Set Position */
+#define PMU_CNTENSET_CNT22_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT22_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 22 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT23_ENABLE_Pos         23U                                          /*!< PMU CNTENSET: Event Counter 23 Enable Set Position */
+#define PMU_CNTENSET_CNT23_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT23_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 23 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT24_ENABLE_Pos         24U                                          /*!< PMU CNTENSET: Event Counter 24 Enable Set Position */
+#define PMU_CNTENSET_CNT24_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT24_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 24 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT25_ENABLE_Pos         25U                                          /*!< PMU CNTENSET: Event Counter 25 Enable Set Position */
+#define PMU_CNTENSET_CNT25_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT25_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 25 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT26_ENABLE_Pos         26U                                          /*!< PMU CNTENSET: Event Counter 26 Enable Set Position */
+#define PMU_CNTENSET_CNT26_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT26_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 26 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT27_ENABLE_Pos         27U                                          /*!< PMU CNTENSET: Event Counter 27 Enable Set Position */
+#define PMU_CNTENSET_CNT27_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT27_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 27 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT28_ENABLE_Pos         28U                                          /*!< PMU CNTENSET: Event Counter 28 Enable Set Position */
+#define PMU_CNTENSET_CNT28_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT28_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 28 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT29_ENABLE_Pos         29U                                          /*!< PMU CNTENSET: Event Counter 29 Enable Set Position */
+#define PMU_CNTENSET_CNT29_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT29_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 29 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT30_ENABLE_Pos         30U                                          /*!< PMU CNTENSET: Event Counter 30 Enable Set Position */
+#define PMU_CNTENSET_CNT30_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT30_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 30 Enable Set Mask */
+
+#define PMU_CNTENSET_CCNTR_ENABLE_Pos         31U                                          /*!< PMU CNTENSET: Cycle Counter Enable Set Position */
+#define PMU_CNTENSET_CCNTR_ENABLE_Msk        (1UL << PMU_CNTENSET_CCNTR_ENABLE_Pos)        /*!< PMU CNTENSET: Cycle Counter Enable Set Mask */
+
+/** \brief PMU Count Enable Clear Register Definitions */
+#define PMU_CNTENSET_CNT0_ENABLE_Pos          0U                                           /*!< PMU CNTENCLR: Event Counter 0 Enable Clear Position */
+#define PMU_CNTENCLR_CNT0_ENABLE_Msk         (1UL /*<< PMU_CNTENCLR_CNT0_ENABLE_Pos*/)     /*!< PMU CNTENCLR: Event Counter 0 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT1_ENABLE_Pos          1U                                           /*!< PMU CNTENCLR: Event Counter 1 Enable Clear Position */
+#define PMU_CNTENCLR_CNT1_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT1_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 1 Enable Clear */
+
+#define PMU_CNTENCLR_CNT2_ENABLE_Pos          2U                                           /*!< PMU CNTENCLR: Event Counter 2 Enable Clear Position */
+#define PMU_CNTENCLR_CNT2_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT2_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 2 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT3_ENABLE_Pos          3U                                           /*!< PMU CNTENCLR: Event Counter 3 Enable Clear Position */
+#define PMU_CNTENCLR_CNT3_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT3_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 3 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT4_ENABLE_Pos          4U                                           /*!< PMU CNTENCLR: Event Counter 4 Enable Clear Position */
+#define PMU_CNTENCLR_CNT4_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT4_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 4 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT5_ENABLE_Pos          5U                                           /*!< PMU CNTENCLR: Event Counter 5 Enable Clear Position */
+#define PMU_CNTENCLR_CNT5_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT5_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 5 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT6_ENABLE_Pos          6U                                           /*!< PMU CNTENCLR: Event Counter 6 Enable Clear Position */
+#define PMU_CNTENCLR_CNT6_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT6_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 6 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT7_ENABLE_Pos          7U                                           /*!< PMU CNTENCLR: Event Counter 7 Enable Clear Position */
+#define PMU_CNTENCLR_CNT7_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT7_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 7 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT8_ENABLE_Pos          8U                                           /*!< PMU CNTENCLR: Event Counter 8 Enable Clear Position */
+#define PMU_CNTENCLR_CNT8_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT8_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 8 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT9_ENABLE_Pos          9U                                           /*!< PMU CNTENCLR: Event Counter 9 Enable Clear Position */
+#define PMU_CNTENCLR_CNT9_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT9_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 9 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT10_ENABLE_Pos         10U                                          /*!< PMU CNTENCLR: Event Counter 10 Enable Clear Position */
+#define PMU_CNTENCLR_CNT10_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT10_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 10 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT11_ENABLE_Pos         11U                                          /*!< PMU CNTENCLR: Event Counter 11 Enable Clear Position */
+#define PMU_CNTENCLR_CNT11_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT11_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 11 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT12_ENABLE_Pos         12U                                          /*!< PMU CNTENCLR: Event Counter 12 Enable Clear Position */
+#define PMU_CNTENCLR_CNT12_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT12_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 12 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT13_ENABLE_Pos         13U                                          /*!< PMU CNTENCLR: Event Counter 13 Enable Clear Position */
+#define PMU_CNTENCLR_CNT13_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT13_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 13 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT14_ENABLE_Pos         14U                                          /*!< PMU CNTENCLR: Event Counter 14 Enable Clear Position */
+#define PMU_CNTENCLR_CNT14_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT14_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 14 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT15_ENABLE_Pos         15U                                          /*!< PMU CNTENCLR: Event Counter 15 Enable Clear Position */
+#define PMU_CNTENCLR_CNT15_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT15_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 15 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT16_ENABLE_Pos         16U                                          /*!< PMU CNTENCLR: Event Counter 16 Enable Clear Position */
+#define PMU_CNTENCLR_CNT16_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT16_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 16 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT17_ENABLE_Pos         17U                                          /*!< PMU CNTENCLR: Event Counter 17 Enable Clear Position */
+#define PMU_CNTENCLR_CNT17_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT17_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 17 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT18_ENABLE_Pos         18U                                          /*!< PMU CNTENCLR: Event Counter 18 Enable Clear Position */
+#define PMU_CNTENCLR_CNT18_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT18_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 18 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT19_ENABLE_Pos         19U                                          /*!< PMU CNTENCLR: Event Counter 19 Enable Clear Position */
+#define PMU_CNTENCLR_CNT19_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT19_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 19 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT20_ENABLE_Pos         20U                                          /*!< PMU CNTENCLR: Event Counter 20 Enable Clear Position */
+#define PMU_CNTENCLR_CNT20_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT20_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 20 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT21_ENABLE_Pos         21U                                          /*!< PMU CNTENCLR: Event Counter 21 Enable Clear Position */
+#define PMU_CNTENCLR_CNT21_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT21_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 21 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT22_ENABLE_Pos         22U                                          /*!< PMU CNTENCLR: Event Counter 22 Enable Clear Position */
+#define PMU_CNTENCLR_CNT22_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT22_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 22 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT23_ENABLE_Pos         23U                                          /*!< PMU CNTENCLR: Event Counter 23 Enable Clear Position */
+#define PMU_CNTENCLR_CNT23_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT23_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 23 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT24_ENABLE_Pos         24U                                          /*!< PMU CNTENCLR: Event Counter 24 Enable Clear Position */
+#define PMU_CNTENCLR_CNT24_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT24_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 24 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT25_ENABLE_Pos         25U                                          /*!< PMU CNTENCLR: Event Counter 25 Enable Clear Position */
+#define PMU_CNTENCLR_CNT25_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT25_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 25 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT26_ENABLE_Pos         26U                                          /*!< PMU CNTENCLR: Event Counter 26 Enable Clear Position */
+#define PMU_CNTENCLR_CNT26_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT26_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 26 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT27_ENABLE_Pos         27U                                          /*!< PMU CNTENCLR: Event Counter 27 Enable Clear Position */
+#define PMU_CNTENCLR_CNT27_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT27_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 27 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT28_ENABLE_Pos         28U                                          /*!< PMU CNTENCLR: Event Counter 28 Enable Clear Position */
+#define PMU_CNTENCLR_CNT28_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT28_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 28 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT29_ENABLE_Pos         29U                                          /*!< PMU CNTENCLR: Event Counter 29 Enable Clear Position */
+#define PMU_CNTENCLR_CNT29_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT29_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 29 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT30_ENABLE_Pos         30U                                          /*!< PMU CNTENCLR: Event Counter 30 Enable Clear Position */
+#define PMU_CNTENCLR_CNT30_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT30_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 30 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CCNTR_ENABLE_Pos         31U                                          /*!< PMU CNTENCLR: Cycle Counter Enable Clear Position */
+#define PMU_CNTENCLR_CCNTR_ENABLE_Msk        (1UL << PMU_CNTENCLR_CCNTR_ENABLE_Pos)        /*!< PMU CNTENCLR: Cycle Counter Enable Clear Mask */
+
+/** \brief PMU Interrupt Enable Set Register Definitions */
+#define PMU_INTENSET_CNT0_ENABLE_Pos          0U                                           /*!< PMU INTENSET: Event Counter 0 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT0_ENABLE_Msk         (1UL /*<< PMU_INTENSET_CNT0_ENABLE_Pos*/)     /*!< PMU INTENSET: Event Counter 0 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT1_ENABLE_Pos          1U                                           /*!< PMU INTENSET: Event Counter 1 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT1_ENABLE_Msk         (1UL << PMU_INTENSET_CNT1_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 1 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT2_ENABLE_Pos          2U                                           /*!< PMU INTENSET: Event Counter 2 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT2_ENABLE_Msk         (1UL << PMU_INTENSET_CNT2_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 2 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT3_ENABLE_Pos          3U                                           /*!< PMU INTENSET: Event Counter 3 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT3_ENABLE_Msk         (1UL << PMU_INTENSET_CNT3_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 3 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT4_ENABLE_Pos          4U                                           /*!< PMU INTENSET: Event Counter 4 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT4_ENABLE_Msk         (1UL << PMU_INTENSET_CNT4_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 4 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT5_ENABLE_Pos          5U                                           /*!< PMU INTENSET: Event Counter 5 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT5_ENABLE_Msk         (1UL << PMU_INTENSET_CNT5_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 5 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT6_ENABLE_Pos          6U                                           /*!< PMU INTENSET: Event Counter 6 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT6_ENABLE_Msk         (1UL << PMU_INTENSET_CNT6_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 6 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT7_ENABLE_Pos          7U                                           /*!< PMU INTENSET: Event Counter 7 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT7_ENABLE_Msk         (1UL << PMU_INTENSET_CNT7_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 7 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT8_ENABLE_Pos          8U                                           /*!< PMU INTENSET: Event Counter 8 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT8_ENABLE_Msk         (1UL << PMU_INTENSET_CNT8_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 8 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT9_ENABLE_Pos          9U                                           /*!< PMU INTENSET: Event Counter 9 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT9_ENABLE_Msk         (1UL << PMU_INTENSET_CNT9_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 9 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT10_ENABLE_Pos         10U                                          /*!< PMU INTENSET: Event Counter 10 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT10_ENABLE_Msk        (1UL << PMU_INTENSET_CNT10_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 10 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT11_ENABLE_Pos         11U                                          /*!< PMU INTENSET: Event Counter 11 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT11_ENABLE_Msk        (1UL << PMU_INTENSET_CNT11_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 11 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT12_ENABLE_Pos         12U                                          /*!< PMU INTENSET: Event Counter 12 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT12_ENABLE_Msk        (1UL << PMU_INTENSET_CNT12_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 12 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT13_ENABLE_Pos         13U                                          /*!< PMU INTENSET: Event Counter 13 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT13_ENABLE_Msk        (1UL << PMU_INTENSET_CNT13_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 13 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT14_ENABLE_Pos         14U                                          /*!< PMU INTENSET: Event Counter 14 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT14_ENABLE_Msk        (1UL << PMU_INTENSET_CNT14_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 14 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT15_ENABLE_Pos         15U                                          /*!< PMU INTENSET: Event Counter 15 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT15_ENABLE_Msk        (1UL << PMU_INTENSET_CNT15_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 15 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT16_ENABLE_Pos         16U                                          /*!< PMU INTENSET: Event Counter 16 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT16_ENABLE_Msk        (1UL << PMU_INTENSET_CNT16_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 16 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT17_ENABLE_Pos         17U                                          /*!< PMU INTENSET: Event Counter 17 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT17_ENABLE_Msk        (1UL << PMU_INTENSET_CNT17_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 17 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT18_ENABLE_Pos         18U                                          /*!< PMU INTENSET: Event Counter 18 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT18_ENABLE_Msk        (1UL << PMU_INTENSET_CNT18_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 18 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT19_ENABLE_Pos         19U                                          /*!< PMU INTENSET: Event Counter 19 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT19_ENABLE_Msk        (1UL << PMU_INTENSET_CNT19_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 19 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT20_ENABLE_Pos         20U                                          /*!< PMU INTENSET: Event Counter 20 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT20_ENABLE_Msk        (1UL << PMU_INTENSET_CNT20_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 20 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT21_ENABLE_Pos         21U                                          /*!< PMU INTENSET: Event Counter 21 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT21_ENABLE_Msk        (1UL << PMU_INTENSET_CNT21_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 21 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT22_ENABLE_Pos         22U                                          /*!< PMU INTENSET: Event Counter 22 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT22_ENABLE_Msk        (1UL << PMU_INTENSET_CNT22_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 22 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT23_ENABLE_Pos         23U                                          /*!< PMU INTENSET: Event Counter 23 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT23_ENABLE_Msk        (1UL << PMU_INTENSET_CNT23_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 23 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT24_ENABLE_Pos         24U                                          /*!< PMU INTENSET: Event Counter 24 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT24_ENABLE_Msk        (1UL << PMU_INTENSET_CNT24_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 24 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT25_ENABLE_Pos         25U                                          /*!< PMU INTENSET: Event Counter 25 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT25_ENABLE_Msk        (1UL << PMU_INTENSET_CNT25_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 25 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT26_ENABLE_Pos         26U                                          /*!< PMU INTENSET: Event Counter 26 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT26_ENABLE_Msk        (1UL << PMU_INTENSET_CNT26_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 26 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT27_ENABLE_Pos         27U                                          /*!< PMU INTENSET: Event Counter 27 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT27_ENABLE_Msk        (1UL << PMU_INTENSET_CNT27_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 27 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT28_ENABLE_Pos         28U                                          /*!< PMU INTENSET: Event Counter 28 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT28_ENABLE_Msk        (1UL << PMU_INTENSET_CNT28_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 28 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT29_ENABLE_Pos         29U                                          /*!< PMU INTENSET: Event Counter 29 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT29_ENABLE_Msk        (1UL << PMU_INTENSET_CNT29_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 29 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT30_ENABLE_Pos         30U                                          /*!< PMU INTENSET: Event Counter 30 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT30_ENABLE_Msk        (1UL << PMU_INTENSET_CNT30_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 30 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CYCCNT_ENABLE_Pos        31U                                          /*!< PMU INTENSET: Cycle Counter Interrupt Enable Set Position */
+#define PMU_INTENSET_CCYCNT_ENABLE_Msk       (1UL << PMU_INTENSET_CYCCNT_ENABLE_Pos)       /*!< PMU INTENSET: Cycle Counter Interrupt Enable Set Mask */
+
+/** \brief PMU Interrupt Enable Clear Register Definitions */
+#define PMU_INTENSET_CNT0_ENABLE_Pos          0U                                           /*!< PMU INTENCLR: Event Counter 0 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT0_ENABLE_Msk         (1UL /*<< PMU_INTENCLR_CNT0_ENABLE_Pos*/)     /*!< PMU INTENCLR: Event Counter 0 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT1_ENABLE_Pos          1U                                           /*!< PMU INTENCLR: Event Counter 1 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT1_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT1_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 1 Interrupt Enable Clear */
+
+#define PMU_INTENCLR_CNT2_ENABLE_Pos          2U                                           /*!< PMU INTENCLR: Event Counter 2 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT2_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT2_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 2 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT3_ENABLE_Pos          3U                                           /*!< PMU INTENCLR: Event Counter 3 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT3_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT3_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 3 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT4_ENABLE_Pos          4U                                           /*!< PMU INTENCLR: Event Counter 4 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT4_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT4_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 4 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT5_ENABLE_Pos          5U                                           /*!< PMU INTENCLR: Event Counter 5 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT5_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT5_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 5 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT6_ENABLE_Pos          6U                                           /*!< PMU INTENCLR: Event Counter 6 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT6_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT6_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 6 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT7_ENABLE_Pos          7U                                           /*!< PMU INTENCLR: Event Counter 7 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT7_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT7_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 7 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT8_ENABLE_Pos          8U                                           /*!< PMU INTENCLR: Event Counter 8 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT8_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT8_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 8 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT9_ENABLE_Pos          9U                                           /*!< PMU INTENCLR: Event Counter 9 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT9_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT9_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 9 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT10_ENABLE_Pos         10U                                          /*!< PMU INTENCLR: Event Counter 10 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT10_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT10_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 10 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT11_ENABLE_Pos         11U                                          /*!< PMU INTENCLR: Event Counter 11 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT11_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT11_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 11 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT12_ENABLE_Pos         12U                                          /*!< PMU INTENCLR: Event Counter 12 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT12_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT12_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 12 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT13_ENABLE_Pos         13U                                          /*!< PMU INTENCLR: Event Counter 13 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT13_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT13_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 13 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT14_ENABLE_Pos         14U                                          /*!< PMU INTENCLR: Event Counter 14 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT14_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT14_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 14 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT15_ENABLE_Pos         15U                                          /*!< PMU INTENCLR: Event Counter 15 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT15_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT15_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 15 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT16_ENABLE_Pos         16U                                          /*!< PMU INTENCLR: Event Counter 16 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT16_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT16_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 16 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT17_ENABLE_Pos         17U                                          /*!< PMU INTENCLR: Event Counter 17 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT17_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT17_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 17 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT18_ENABLE_Pos         18U                                          /*!< PMU INTENCLR: Event Counter 18 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT18_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT18_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 18 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT19_ENABLE_Pos         19U                                          /*!< PMU INTENCLR: Event Counter 19 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT19_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT19_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 19 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT20_ENABLE_Pos         20U                                          /*!< PMU INTENCLR: Event Counter 20 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT20_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT20_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 20 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT21_ENABLE_Pos         21U                                          /*!< PMU INTENCLR: Event Counter 21 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT21_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT21_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 21 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT22_ENABLE_Pos         22U                                          /*!< PMU INTENCLR: Event Counter 22 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT22_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT22_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 22 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT23_ENABLE_Pos         23U                                          /*!< PMU INTENCLR: Event Counter 23 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT23_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT23_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 23 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT24_ENABLE_Pos         24U                                          /*!< PMU INTENCLR: Event Counter 24 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT24_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT24_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 24 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT25_ENABLE_Pos         25U                                          /*!< PMU INTENCLR: Event Counter 25 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT25_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT25_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 25 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT26_ENABLE_Pos         26U                                          /*!< PMU INTENCLR: Event Counter 26 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT26_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT26_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 26 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT27_ENABLE_Pos         27U                                          /*!< PMU INTENCLR: Event Counter 27 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT27_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT27_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 27 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT28_ENABLE_Pos         28U                                          /*!< PMU INTENCLR: Event Counter 28 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT28_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT28_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 28 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT29_ENABLE_Pos         29U                                          /*!< PMU INTENCLR: Event Counter 29 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT29_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT29_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 29 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT30_ENABLE_Pos         30U                                          /*!< PMU INTENCLR: Event Counter 30 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT30_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT30_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 30 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CYCCNT_ENABLE_Pos        31U                                          /*!< PMU INTENCLR: Cycle Counter Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CYCCNT_ENABLE_Msk       (1UL << PMU_INTENCLR_CYCCNT_ENABLE_Pos)       /*!< PMU INTENCLR: Cycle Counter Interrupt Enable Clear Mask */
+
+/** \brief PMU Overflow Flag Status Set Register Definitions */
+#define PMU_OVSSET_CNT0_STATUS_Pos            0U                                           /*!< PMU OVSSET: Event Counter 0 Overflow Set Position */
+#define PMU_OVSSET_CNT0_STATUS_Msk           (1UL /*<< PMU_OVSSET_CNT0_STATUS_Pos*/)       /*!< PMU OVSSET: Event Counter 0 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT1_STATUS_Pos            1U                                           /*!< PMU OVSSET: Event Counter 1 Overflow Set Position */
+#define PMU_OVSSET_CNT1_STATUS_Msk           (1UL << PMU_OVSSET_CNT1_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 1 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT2_STATUS_Pos            2U                                           /*!< PMU OVSSET: Event Counter 2 Overflow Set Position */
+#define PMU_OVSSET_CNT2_STATUS_Msk           (1UL << PMU_OVSSET_CNT2_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 2 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT3_STATUS_Pos            3U                                           /*!< PMU OVSSET: Event Counter 3 Overflow Set Position */
+#define PMU_OVSSET_CNT3_STATUS_Msk           (1UL << PMU_OVSSET_CNT3_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 3 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT4_STATUS_Pos            4U                                           /*!< PMU OVSSET: Event Counter 4 Overflow Set Position */
+#define PMU_OVSSET_CNT4_STATUS_Msk           (1UL << PMU_OVSSET_CNT4_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 4 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT5_STATUS_Pos            5U                                           /*!< PMU OVSSET: Event Counter 5 Overflow Set Position */
+#define PMU_OVSSET_CNT5_STATUS_Msk           (1UL << PMU_OVSSET_CNT5_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 5 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT6_STATUS_Pos            6U                                           /*!< PMU OVSSET: Event Counter 6 Overflow Set Position */
+#define PMU_OVSSET_CNT6_STATUS_Msk           (1UL << PMU_OVSSET_CNT6_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 6 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT7_STATUS_Pos            7U                                           /*!< PMU OVSSET: Event Counter 7 Overflow Set Position */
+#define PMU_OVSSET_CNT7_STATUS_Msk           (1UL << PMU_OVSSET_CNT7_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 7 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT8_STATUS_Pos            8U                                           /*!< PMU OVSSET: Event Counter 8 Overflow Set Position */
+#define PMU_OVSSET_CNT8_STATUS_Msk           (1UL << PMU_OVSSET_CNT8_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 8 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT9_STATUS_Pos            9U                                           /*!< PMU OVSSET: Event Counter 9 Overflow Set Position */
+#define PMU_OVSSET_CNT9_STATUS_Msk           (1UL << PMU_OVSSET_CNT9_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 9 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT10_STATUS_Pos           10U                                          /*!< PMU OVSSET: Event Counter 10 Overflow Set Position */
+#define PMU_OVSSET_CNT10_STATUS_Msk          (1UL << PMU_OVSSET_CNT10_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 10 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT11_STATUS_Pos           11U                                          /*!< PMU OVSSET: Event Counter 11 Overflow Set Position */
+#define PMU_OVSSET_CNT11_STATUS_Msk          (1UL << PMU_OVSSET_CNT11_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 11 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT12_STATUS_Pos           12U                                          /*!< PMU OVSSET: Event Counter 12 Overflow Set Position */
+#define PMU_OVSSET_CNT12_STATUS_Msk          (1UL << PMU_OVSSET_CNT12_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 12 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT13_STATUS_Pos           13U                                          /*!< PMU OVSSET: Event Counter 13 Overflow Set Position */
+#define PMU_OVSSET_CNT13_STATUS_Msk          (1UL << PMU_OVSSET_CNT13_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 13 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT14_STATUS_Pos           14U                                          /*!< PMU OVSSET: Event Counter 14 Overflow Set Position */
+#define PMU_OVSSET_CNT14_STATUS_Msk          (1UL << PMU_OVSSET_CNT14_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 14 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT15_STATUS_Pos           15U                                          /*!< PMU OVSSET: Event Counter 15 Overflow Set Position */
+#define PMU_OVSSET_CNT15_STATUS_Msk          (1UL << PMU_OVSSET_CNT15_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 15 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT16_STATUS_Pos           16U                                          /*!< PMU OVSSET: Event Counter 16 Overflow Set Position */
+#define PMU_OVSSET_CNT16_STATUS_Msk          (1UL << PMU_OVSSET_CNT16_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 16 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT17_STATUS_Pos           17U                                          /*!< PMU OVSSET: Event Counter 17 Overflow Set Position */
+#define PMU_OVSSET_CNT17_STATUS_Msk          (1UL << PMU_OVSSET_CNT17_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 17 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT18_STATUS_Pos           18U                                          /*!< PMU OVSSET: Event Counter 18 Overflow Set Position */
+#define PMU_OVSSET_CNT18_STATUS_Msk          (1UL << PMU_OVSSET_CNT18_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 18 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT19_STATUS_Pos           19U                                          /*!< PMU OVSSET: Event Counter 19 Overflow Set Position */
+#define PMU_OVSSET_CNT19_STATUS_Msk          (1UL << PMU_OVSSET_CNT19_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 19 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT20_STATUS_Pos           20U                                          /*!< PMU OVSSET: Event Counter 20 Overflow Set Position */
+#define PMU_OVSSET_CNT20_STATUS_Msk          (1UL << PMU_OVSSET_CNT20_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 20 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT21_STATUS_Pos           21U                                          /*!< PMU OVSSET: Event Counter 21 Overflow Set Position */
+#define PMU_OVSSET_CNT21_STATUS_Msk          (1UL << PMU_OVSSET_CNT21_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 21 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT22_STATUS_Pos           22U                                          /*!< PMU OVSSET: Event Counter 22 Overflow Set Position */
+#define PMU_OVSSET_CNT22_STATUS_Msk          (1UL << PMU_OVSSET_CNT22_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 22 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT23_STATUS_Pos           23U                                          /*!< PMU OVSSET: Event Counter 23 Overflow Set Position */
+#define PMU_OVSSET_CNT23_STATUS_Msk          (1UL << PMU_OVSSET_CNT23_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 23 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT24_STATUS_Pos           24U                                          /*!< PMU OVSSET: Event Counter 24 Overflow Set Position */
+#define PMU_OVSSET_CNT24_STATUS_Msk          (1UL << PMU_OVSSET_CNT24_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 24 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT25_STATUS_Pos           25U                                          /*!< PMU OVSSET: Event Counter 25 Overflow Set Position */
+#define PMU_OVSSET_CNT25_STATUS_Msk          (1UL << PMU_OVSSET_CNT25_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 25 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT26_STATUS_Pos           26U                                          /*!< PMU OVSSET: Event Counter 26 Overflow Set Position */
+#define PMU_OVSSET_CNT26_STATUS_Msk          (1UL << PMU_OVSSET_CNT26_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 26 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT27_STATUS_Pos           27U                                          /*!< PMU OVSSET: Event Counter 27 Overflow Set Position */
+#define PMU_OVSSET_CNT27_STATUS_Msk          (1UL << PMU_OVSSET_CNT27_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 27 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT28_STATUS_Pos           28U                                          /*!< PMU OVSSET: Event Counter 28 Overflow Set Position */
+#define PMU_OVSSET_CNT28_STATUS_Msk          (1UL << PMU_OVSSET_CNT28_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 28 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT29_STATUS_Pos           29U                                          /*!< PMU OVSSET: Event Counter 29 Overflow Set Position */
+#define PMU_OVSSET_CNT29_STATUS_Msk          (1UL << PMU_OVSSET_CNT29_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 29 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT30_STATUS_Pos           30U                                          /*!< PMU OVSSET: Event Counter 30 Overflow Set Position */
+#define PMU_OVSSET_CNT30_STATUS_Msk          (1UL << PMU_OVSSET_CNT30_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 30 Overflow Set Mask */
+
+#define PMU_OVSSET_CYCCNT_STATUS_Pos          31U                                          /*!< PMU OVSSET: Cycle Counter Overflow Set Position */
+#define PMU_OVSSET_CYCCNT_STATUS_Msk         (1UL << PMU_OVSSET_CYCCNT_STATUS_Pos)         /*!< PMU OVSSET: Cycle Counter Overflow Set Mask */
+
+/** \brief PMU Overflow Flag Status Clear Register Definitions */
+#define PMU_OVSCLR_CNT0_STATUS_Pos            0U                                           /*!< PMU OVSCLR: Event Counter 0 Overflow Clear Position */
+#define PMU_OVSCLR_CNT0_STATUS_Msk           (1UL /*<< PMU_OVSCLR_CNT0_STATUS_Pos*/)       /*!< PMU OVSCLR: Event Counter 0 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT1_STATUS_Pos            1U                                           /*!< PMU OVSCLR: Event Counter 1 Overflow Clear Position */
+#define PMU_OVSCLR_CNT1_STATUS_Msk           (1UL << PMU_OVSCLR_CNT1_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 1 Overflow Clear */
+
+#define PMU_OVSCLR_CNT2_STATUS_Pos            2U                                           /*!< PMU OVSCLR: Event Counter 2 Overflow Clear Position */
+#define PMU_OVSCLR_CNT2_STATUS_Msk           (1UL << PMU_OVSCLR_CNT2_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 2 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT3_STATUS_Pos            3U                                           /*!< PMU OVSCLR: Event Counter 3 Overflow Clear Position */
+#define PMU_OVSCLR_CNT3_STATUS_Msk           (1UL << PMU_OVSCLR_CNT3_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 3 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT4_STATUS_Pos            4U                                           /*!< PMU OVSCLR: Event Counter 4 Overflow Clear Position */
+#define PMU_OVSCLR_CNT4_STATUS_Msk           (1UL << PMU_OVSCLR_CNT4_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 4 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT5_STATUS_Pos            5U                                           /*!< PMU OVSCLR: Event Counter 5 Overflow Clear Position */
+#define PMU_OVSCLR_CNT5_STATUS_Msk           (1UL << PMU_OVSCLR_CNT5_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 5 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT6_STATUS_Pos            6U                                           /*!< PMU OVSCLR: Event Counter 6 Overflow Clear Position */
+#define PMU_OVSCLR_CNT6_STATUS_Msk           (1UL << PMU_OVSCLR_CNT6_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 6 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT7_STATUS_Pos            7U                                           /*!< PMU OVSCLR: Event Counter 7 Overflow Clear Position */
+#define PMU_OVSCLR_CNT7_STATUS_Msk           (1UL << PMU_OVSCLR_CNT7_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 7 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT8_STATUS_Pos            8U                                           /*!< PMU OVSCLR: Event Counter 8 Overflow Clear Position */
+#define PMU_OVSCLR_CNT8_STATUS_Msk           (1UL << PMU_OVSCLR_CNT8_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 8 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT9_STATUS_Pos            9U                                           /*!< PMU OVSCLR: Event Counter 9 Overflow Clear Position */
+#define PMU_OVSCLR_CNT9_STATUS_Msk           (1UL << PMU_OVSCLR_CNT9_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 9 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT10_STATUS_Pos           10U                                          /*!< PMU OVSCLR: Event Counter 10 Overflow Clear Position */
+#define PMU_OVSCLR_CNT10_STATUS_Msk          (1UL << PMU_OVSCLR_CNT10_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 10 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT11_STATUS_Pos           11U                                          /*!< PMU OVSCLR: Event Counter 11 Overflow Clear Position */
+#define PMU_OVSCLR_CNT11_STATUS_Msk          (1UL << PMU_OVSCLR_CNT11_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 11 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT12_STATUS_Pos           12U                                          /*!< PMU OVSCLR: Event Counter 12 Overflow Clear Position */
+#define PMU_OVSCLR_CNT12_STATUS_Msk          (1UL << PMU_OVSCLR_CNT12_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 12 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT13_STATUS_Pos           13U                                          /*!< PMU OVSCLR: Event Counter 13 Overflow Clear Position */
+#define PMU_OVSCLR_CNT13_STATUS_Msk          (1UL << PMU_OVSCLR_CNT13_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 13 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT14_STATUS_Pos           14U                                          /*!< PMU OVSCLR: Event Counter 14 Overflow Clear Position */
+#define PMU_OVSCLR_CNT14_STATUS_Msk          (1UL << PMU_OVSCLR_CNT14_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 14 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT15_STATUS_Pos           15U                                          /*!< PMU OVSCLR: Event Counter 15 Overflow Clear Position */
+#define PMU_OVSCLR_CNT15_STATUS_Msk          (1UL << PMU_OVSCLR_CNT15_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 15 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT16_STATUS_Pos           16U                                          /*!< PMU OVSCLR: Event Counter 16 Overflow Clear Position */
+#define PMU_OVSCLR_CNT16_STATUS_Msk          (1UL << PMU_OVSCLR_CNT16_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 16 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT17_STATUS_Pos           17U                                          /*!< PMU OVSCLR: Event Counter 17 Overflow Clear Position */
+#define PMU_OVSCLR_CNT17_STATUS_Msk          (1UL << PMU_OVSCLR_CNT17_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 17 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT18_STATUS_Pos           18U                                          /*!< PMU OVSCLR: Event Counter 18 Overflow Clear Position */
+#define PMU_OVSCLR_CNT18_STATUS_Msk          (1UL << PMU_OVSCLR_CNT18_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 18 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT19_STATUS_Pos           19U                                          /*!< PMU OVSCLR: Event Counter 19 Overflow Clear Position */
+#define PMU_OVSCLR_CNT19_STATUS_Msk          (1UL << PMU_OVSCLR_CNT19_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 19 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT20_STATUS_Pos           20U                                          /*!< PMU OVSCLR: Event Counter 20 Overflow Clear Position */
+#define PMU_OVSCLR_CNT20_STATUS_Msk          (1UL << PMU_OVSCLR_CNT20_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 20 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT21_STATUS_Pos           21U                                          /*!< PMU OVSCLR: Event Counter 21 Overflow Clear Position */
+#define PMU_OVSCLR_CNT21_STATUS_Msk          (1UL << PMU_OVSCLR_CNT21_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 21 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT22_STATUS_Pos           22U                                          /*!< PMU OVSCLR: Event Counter 22 Overflow Clear Position */
+#define PMU_OVSCLR_CNT22_STATUS_Msk          (1UL << PMU_OVSCLR_CNT22_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 22 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT23_STATUS_Pos           23U                                          /*!< PMU OVSCLR: Event Counter 23 Overflow Clear Position */
+#define PMU_OVSCLR_CNT23_STATUS_Msk          (1UL << PMU_OVSCLR_CNT23_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 23 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT24_STATUS_Pos           24U                                          /*!< PMU OVSCLR: Event Counter 24 Overflow Clear Position */
+#define PMU_OVSCLR_CNT24_STATUS_Msk          (1UL << PMU_OVSCLR_CNT24_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 24 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT25_STATUS_Pos           25U                                          /*!< PMU OVSCLR: Event Counter 25 Overflow Clear Position */
+#define PMU_OVSCLR_CNT25_STATUS_Msk          (1UL << PMU_OVSCLR_CNT25_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 25 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT26_STATUS_Pos           26U                                          /*!< PMU OVSCLR: Event Counter 26 Overflow Clear Position */
+#define PMU_OVSCLR_CNT26_STATUS_Msk          (1UL << PMU_OVSCLR_CNT26_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 26 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT27_STATUS_Pos           27U                                          /*!< PMU OVSCLR: Event Counter 27 Overflow Clear Position */
+#define PMU_OVSCLR_CNT27_STATUS_Msk          (1UL << PMU_OVSCLR_CNT27_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 27 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT28_STATUS_Pos           28U                                          /*!< PMU OVSCLR: Event Counter 28 Overflow Clear Position */
+#define PMU_OVSCLR_CNT28_STATUS_Msk          (1UL << PMU_OVSCLR_CNT28_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 28 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT29_STATUS_Pos           29U                                          /*!< PMU OVSCLR: Event Counter 29 Overflow Clear Position */
+#define PMU_OVSCLR_CNT29_STATUS_Msk          (1UL << PMU_OVSCLR_CNT29_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 29 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT30_STATUS_Pos           30U                                          /*!< PMU OVSCLR: Event Counter 30 Overflow Clear Position */
+#define PMU_OVSCLR_CNT30_STATUS_Msk          (1UL << PMU_OVSCLR_CNT30_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 30 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CYCCNT_STATUS_Pos          31U                                          /*!< PMU OVSCLR: Cycle Counter Overflow Clear Position */
+#define PMU_OVSCLR_CYCCNT_STATUS_Msk         (1UL << PMU_OVSCLR_CYCCNT_STATUS_Pos)         /*!< PMU OVSCLR: Cycle Counter Overflow Clear Mask */
+
+/** \brief PMU Software Increment Counter */
+#define PMU_SWINC_CNT0_Pos                    0U                                           /*!< PMU SWINC: Event Counter 0 Software Increment Position */
+#define PMU_SWINC_CNT0_Msk                   (1UL /*<< PMU_SWINC_CNT0_Pos */)              /*!< PMU SWINC: Event Counter 0 Software Increment Mask */
+
+#define PMU_SWINC_CNT1_Pos                    1U                                           /*!< PMU SWINC: Event Counter 1 Software Increment Position */
+#define PMU_SWINC_CNT1_Msk                   (1UL << PMU_SWINC_CNT1_Pos)                   /*!< PMU SWINC: Event Counter 1 Software Increment Mask */
+
+#define PMU_SWINC_CNT2_Pos                    2U                                           /*!< PMU SWINC: Event Counter 2 Software Increment Position */
+#define PMU_SWINC_CNT2_Msk                   (1UL << PMU_SWINC_CNT2_Pos)                   /*!< PMU SWINC: Event Counter 2 Software Increment Mask */
+
+#define PMU_SWINC_CNT3_Pos                    3U                                           /*!< PMU SWINC: Event Counter 3 Software Increment Position */
+#define PMU_SWINC_CNT3_Msk                   (1UL << PMU_SWINC_CNT3_Pos)                   /*!< PMU SWINC: Event Counter 3 Software Increment Mask */
+
+#define PMU_SWINC_CNT4_Pos                    4U                                           /*!< PMU SWINC: Event Counter 4 Software Increment Position */
+#define PMU_SWINC_CNT4_Msk                   (1UL << PMU_SWINC_CNT4_Pos)                   /*!< PMU SWINC: Event Counter 4 Software Increment Mask */
+
+#define PMU_SWINC_CNT5_Pos                    5U                                           /*!< PMU SWINC: Event Counter 5 Software Increment Position */
+#define PMU_SWINC_CNT5_Msk                   (1UL << PMU_SWINC_CNT5_Pos)                   /*!< PMU SWINC: Event Counter 5 Software Increment Mask */
+
+#define PMU_SWINC_CNT6_Pos                    6U                                           /*!< PMU SWINC: Event Counter 6 Software Increment Position */
+#define PMU_SWINC_CNT6_Msk                   (1UL << PMU_SWINC_CNT6_Pos)                   /*!< PMU SWINC: Event Counter 6 Software Increment Mask */
+
+#define PMU_SWINC_CNT7_Pos                    7U                                           /*!< PMU SWINC: Event Counter 7 Software Increment Position */
+#define PMU_SWINC_CNT7_Msk                   (1UL << PMU_SWINC_CNT7_Pos)                   /*!< PMU SWINC: Event Counter 7 Software Increment Mask */
+
+#define PMU_SWINC_CNT8_Pos                    8U                                           /*!< PMU SWINC: Event Counter 8 Software Increment Position */
+#define PMU_SWINC_CNT8_Msk                   (1UL << PMU_SWINC_CNT8_Pos)                   /*!< PMU SWINC: Event Counter 8 Software Increment Mask */
+
+#define PMU_SWINC_CNT9_Pos                    9U                                           /*!< PMU SWINC: Event Counter 9 Software Increment Position */
+#define PMU_SWINC_CNT9_Msk                   (1UL << PMU_SWINC_CNT9_Pos)                   /*!< PMU SWINC: Event Counter 9 Software Increment Mask */
+
+#define PMU_SWINC_CNT10_Pos                   10U                                          /*!< PMU SWINC: Event Counter 10 Software Increment Position */
+#define PMU_SWINC_CNT10_Msk                  (1UL << PMU_SWINC_CNT10_Pos)                  /*!< PMU SWINC: Event Counter 10 Software Increment Mask */
+
+#define PMU_SWINC_CNT11_Pos                   11U                                          /*!< PMU SWINC: Event Counter 11 Software Increment Position */
+#define PMU_SWINC_CNT11_Msk                  (1UL << PMU_SWINC_CNT11_Pos)                  /*!< PMU SWINC: Event Counter 11 Software Increment Mask */
+
+#define PMU_SWINC_CNT12_Pos                   12U                                          /*!< PMU SWINC: Event Counter 12 Software Increment Position */
+#define PMU_SWINC_CNT12_Msk                  (1UL << PMU_SWINC_CNT12_Pos)                  /*!< PMU SWINC: Event Counter 12 Software Increment Mask */
+
+#define PMU_SWINC_CNT13_Pos                   13U                                          /*!< PMU SWINC: Event Counter 13 Software Increment Position */
+#define PMU_SWINC_CNT13_Msk                  (1UL << PMU_SWINC_CNT13_Pos)                  /*!< PMU SWINC: Event Counter 13 Software Increment Mask */
+
+#define PMU_SWINC_CNT14_Pos                   14U                                          /*!< PMU SWINC: Event Counter 14 Software Increment Position */
+#define PMU_SWINC_CNT14_Msk                  (1UL << PMU_SWINC_CNT14_Pos)                  /*!< PMU SWINC: Event Counter 14 Software Increment Mask */
+
+#define PMU_SWINC_CNT15_Pos                   15U                                          /*!< PMU SWINC: Event Counter 15 Software Increment Position */
+#define PMU_SWINC_CNT15_Msk                  (1UL << PMU_SWINC_CNT15_Pos)                  /*!< PMU SWINC: Event Counter 15 Software Increment Mask */
+
+#define PMU_SWINC_CNT16_Pos                   16U                                          /*!< PMU SWINC: Event Counter 16 Software Increment Position */
+#define PMU_SWINC_CNT16_Msk                  (1UL << PMU_SWINC_CNT16_Pos)                  /*!< PMU SWINC: Event Counter 16 Software Increment Mask */
+
+#define PMU_SWINC_CNT17_Pos                   17U                                          /*!< PMU SWINC: Event Counter 17 Software Increment Position */
+#define PMU_SWINC_CNT17_Msk                  (1UL << PMU_SWINC_CNT17_Pos)                  /*!< PMU SWINC: Event Counter 17 Software Increment Mask */
+
+#define PMU_SWINC_CNT18_Pos                   18U                                          /*!< PMU SWINC: Event Counter 18 Software Increment Position */
+#define PMU_SWINC_CNT18_Msk                  (1UL << PMU_SWINC_CNT18_Pos)                  /*!< PMU SWINC: Event Counter 18 Software Increment Mask */
+
+#define PMU_SWINC_CNT19_Pos                   19U                                          /*!< PMU SWINC: Event Counter 19 Software Increment Position */
+#define PMU_SWINC_CNT19_Msk                  (1UL << PMU_SWINC_CNT19_Pos)                  /*!< PMU SWINC: Event Counter 19 Software Increment Mask */
+
+#define PMU_SWINC_CNT20_Pos                   20U                                          /*!< PMU SWINC: Event Counter 20 Software Increment Position */
+#define PMU_SWINC_CNT20_Msk                  (1UL << PMU_SWINC_CNT20_Pos)                  /*!< PMU SWINC: Event Counter 20 Software Increment Mask */
+
+#define PMU_SWINC_CNT21_Pos                   21U                                          /*!< PMU SWINC: Event Counter 21 Software Increment Position */
+#define PMU_SWINC_CNT21_Msk                  (1UL << PMU_SWINC_CNT21_Pos)                  /*!< PMU SWINC: Event Counter 21 Software Increment Mask */
+
+#define PMU_SWINC_CNT22_Pos                   22U                                          /*!< PMU SWINC: Event Counter 22 Software Increment Position */
+#define PMU_SWINC_CNT22_Msk                  (1UL << PMU_SWINC_CNT22_Pos)                  /*!< PMU SWINC: Event Counter 22 Software Increment Mask */
+
+#define PMU_SWINC_CNT23_Pos                   23U                                          /*!< PMU SWINC: Event Counter 23 Software Increment Position */
+#define PMU_SWINC_CNT23_Msk                  (1UL << PMU_SWINC_CNT23_Pos)                  /*!< PMU SWINC: Event Counter 23 Software Increment Mask */
+
+#define PMU_SWINC_CNT24_Pos                   24U                                          /*!< PMU SWINC: Event Counter 24 Software Increment Position */
+#define PMU_SWINC_CNT24_Msk                  (1UL << PMU_SWINC_CNT24_Pos)                  /*!< PMU SWINC: Event Counter 24 Software Increment Mask */
+
+#define PMU_SWINC_CNT25_Pos                   25U                                          /*!< PMU SWINC: Event Counter 25 Software Increment Position */
+#define PMU_SWINC_CNT25_Msk                  (1UL << PMU_SWINC_CNT25_Pos)                  /*!< PMU SWINC: Event Counter 25 Software Increment Mask */
+
+#define PMU_SWINC_CNT26_Pos                   26U                                          /*!< PMU SWINC: Event Counter 26 Software Increment Position */
+#define PMU_SWINC_CNT26_Msk                  (1UL << PMU_SWINC_CNT26_Pos)                  /*!< PMU SWINC: Event Counter 26 Software Increment Mask */
+
+#define PMU_SWINC_CNT27_Pos                   27U                                          /*!< PMU SWINC: Event Counter 27 Software Increment Position */
+#define PMU_SWINC_CNT27_Msk                  (1UL << PMU_SWINC_CNT27_Pos)                  /*!< PMU SWINC: Event Counter 27 Software Increment Mask */
+
+#define PMU_SWINC_CNT28_Pos                   28U                                          /*!< PMU SWINC: Event Counter 28 Software Increment Position */
+#define PMU_SWINC_CNT28_Msk                  (1UL << PMU_SWINC_CNT28_Pos)                  /*!< PMU SWINC: Event Counter 28 Software Increment Mask */
+
+#define PMU_SWINC_CNT29_Pos                   29U                                          /*!< PMU SWINC: Event Counter 29 Software Increment Position */
+#define PMU_SWINC_CNT29_Msk                  (1UL << PMU_SWINC_CNT29_Pos)                  /*!< PMU SWINC: Event Counter 29 Software Increment Mask */
+
+#define PMU_SWINC_CNT30_Pos                   30U                                          /*!< PMU SWINC: Event Counter 30 Software Increment Position */
+#define PMU_SWINC_CNT30_Msk                  (1UL << PMU_SWINC_CNT30_Pos)                  /*!< PMU SWINC: Event Counter 30 Software Increment Mask */
+
+/** \brief PMU Control Register Definitions */
+#define PMU_CTRL_ENABLE_Pos                   0U                                           /*!< PMU CTRL: ENABLE Position */
+#define PMU_CTRL_ENABLE_Msk                  (1UL /*<< PMU_CTRL_ENABLE_Pos*/)              /*!< PMU CTRL: ENABLE Mask */
+
+#define PMU_CTRL_EVENTCNT_RESET_Pos           1U                                           /*!< PMU CTRL: Event Counter Reset Position */
+#define PMU_CTRL_EVENTCNT_RESET_Msk          (1UL << PMU_CTRL_EVENTCNT_RESET_Pos)          /*!< PMU CTRL: Event Counter Reset Mask */
+
+#define PMU_CTRL_CYCCNT_RESET_Pos             2U                                           /*!< PMU CTRL: Cycle Counter Reset Position */
+#define PMU_CTRL_CYCCNT_RESET_Msk            (1UL << PMU_CTRL_CYCCNT_RESET_Pos)            /*!< PMU CTRL: Cycle Counter Reset Mask */
+
+#define PMU_CTRL_CYCCNT_DISABLE_Pos           5U                                           /*!< PMU CTRL: Disable Cycle Counter Position */
+#define PMU_CTRL_CYCCNT_DISABLE_Msk          (1UL << PMU_CTRL_CYCCNT_DISABLE_Pos)          /*!< PMU CTRL: Disable Cycle Counter Mask */
+
+#define PMU_CTRL_FRZ_ON_OV_Pos                9U                                           /*!< PMU CTRL: Freeze-on-overflow Position */
+#define PMU_CTRL_FRZ_ON_OV_Msk               (1UL << PMU_CTRL_FRZ_ON_OVERFLOW_Pos)         /*!< PMU CTRL: Freeze-on-overflow Mask */
+
+#define PMU_CTRL_TRACE_ON_OV_Pos              11U                                          /*!< PMU CTRL: Trace-on-overflow Position */
+#define PMU_CTRL_TRACE_ON_OV_Msk             (1UL << PMU_CTRL_TRACE_ON_OVERFLOW_Pos)       /*!< PMU CTRL: Trace-on-overflow Mask */
+
+/** \brief PMU Type Register Definitions */
+#define PMU_TYPE_NUM_CNTS_Pos                 0U                                           /*!< PMU TYPE: Number of Counters Position */
+#define PMU_TYPE_NUM_CNTS_Msk                (0xFFUL /*<< PMU_TYPE_NUM_CNTS_Pos*/)         /*!< PMU TYPE: Number of Counters Mask */
+
+#define PMU_TYPE_SIZE_CNTS_Pos                8U                                           /*!< PMU TYPE: Size of Counters Position */
+#define PMU_TYPE_SIZE_CNTS_Msk               (0x3FUL << PMU_TYPE_SIZE_CNTS_Pos)            /*!< PMU TYPE: Size of Counters Mask */
+
+#define PMU_TYPE_CYCCNT_PRESENT_Pos           14U                                          /*!< PMU TYPE: Cycle Counter Present Position */
+#define PMU_TYPE_CYCCNT_PRESENT_Msk          (1UL << PMU_TYPE_CYCCNT_PRESENT_Pos)          /*!< PMU TYPE: Cycle Counter Present Mask */
+
+#define PMU_TYPE_FRZ_OV_SUPPORT_Pos           21U                                          /*!< PMU TYPE: Freeze-on-overflow Support Position */
+#define PMU_TYPE_FRZ_OV_SUPPORT_Msk          (1UL << PMU_TYPE_FRZ_OV_SUPPORT_Pos)          /*!< PMU TYPE: Freeze-on-overflow Support Mask */
+
+#define PMU_TYPE_TRACE_ON_OV_SUPPORT_Pos      23U                                          /*!< PMU TYPE: Trace-on-overflow Support Position */
+#define PMU_TYPE_TRACE_ON_OV_SUPPORT_Msk     (1UL << PMU_TYPE_FRZ_OV_SUPPORT_Pos)          /*!< PMU TYPE: Trace-on-overflow Support Mask */
+
+/** \brief PMU Authentication Status Register Definitions */
+#define PMU_AUTHSTATUS_NSID_Pos               0U                                           /*!< PMU AUTHSTATUS: Non-secure Invasive Debug Position */
+#define PMU_AUTHSTATUS_NSID_Msk              (0x3UL /*<< PMU_AUTHSTATUS_NSID_Pos*/)        /*!< PMU AUTHSTATUS: Non-secure Invasive Debug Mask */
+
+#define PMU_AUTHSTATUS_NSNID_Pos              2U                                           /*!< PMU AUTHSTATUS: Non-secure Non-invasive Debug Position */
+#define PMU_AUTHSTATUS_NSNID_Msk             (0x3UL << PMU_AUTHSTATUS_NSNID_Pos)           /*!< PMU AUTHSTATUS: Non-secure Non-invasive Debug Mask */
+
+#define PMU_AUTHSTATUS_SID_Pos                4U                                           /*!< PMU AUTHSTATUS: Secure Invasive Debug Position */
+#define PMU_AUTHSTATUS_SID_Msk               (0x3UL << PMU_AUTHSTATUS_SID_Pos)             /*!< PMU AUTHSTATUS: Secure Invasive Debug Mask */
+
+#define PMU_AUTHSTATUS_SNID_Pos               6U                                           /*!< PMU AUTHSTATUS: Secure Non-invasive Debug Position */
+#define PMU_AUTHSTATUS_SNID_Msk              (0x3UL << PMU_AUTHSTATUS_SNID_Pos)            /*!< PMU AUTHSTATUS: Secure Non-invasive Debug Mask */
+
+#define PMU_AUTHSTATUS_NSUID_Pos              16U                                          /*!< PMU AUTHSTATUS: Non-secure Unprivileged Invasive Debug Position */
+#define PMU_AUTHSTATUS_NSUID_Msk             (0x3UL << PMU_AUTHSTATUS_NSUID_Pos)           /*!< PMU AUTHSTATUS: Non-secure Unprivileged Invasive Debug Mask */
+
+#define PMU_AUTHSTATUS_NSUNID_Pos             18U                                          /*!< PMU AUTHSTATUS: Non-secure Unprivileged Non-invasive Debug Position */
+#define PMU_AUTHSTATUS_NSUNID_Msk            (0x3UL << PMU_AUTHSTATUS_NSUNID_Pos)          /*!< PMU AUTHSTATUS: Non-secure Unprivileged Non-invasive Debug Mask */
+
+#define PMU_AUTHSTATUS_SUID_Pos               20U                                          /*!< PMU AUTHSTATUS: Secure Unprivileged Invasive Debug Position */
+#define PMU_AUTHSTATUS_SUID_Msk              (0x3UL << PMU_AUTHSTATUS_SUID_Pos)            /*!< PMU AUTHSTATUS: Secure Unprivileged Invasive Debug Mask */
+
+#define PMU_AUTHSTATUS_SUNID_Pos              22U                                          /*!< PMU AUTHSTATUS: Secure Unprivileged Non-invasive Debug Position */
+#define PMU_AUTHSTATUS_SUNID_Msk             (0x3UL << PMU_AUTHSTATUS_SUNID_Pos)           /*!< PMU AUTHSTATUS: Secure Unprivileged Non-invasive Debug Mask */
+
+/*@} end of group CMSIS_PMU */
+#endif
+
+
+#if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_MPU     Memory Protection Unit (MPU)
+  \brief    Type definitions for the Memory Protection Unit (MPU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Memory Protection Unit (MPU).
+ */
+typedef struct
+{
+  __IM  uint32_t TYPE;                   /*!< Offset: 0x000 (R/ )  MPU Type Register */
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x004 (R/W)  MPU Control Register */
+  __IOM uint32_t RNR;                    /*!< Offset: 0x008 (R/W)  MPU Region Number Register */
+  __IOM uint32_t RBAR;                   /*!< Offset: 0x00C (R/W)  MPU Region Base Address Register */
+  __IOM uint32_t RLAR;                   /*!< Offset: 0x010 (R/W)  MPU Region Limit Address Register */
+  __IOM uint32_t RBAR_A1;                /*!< Offset: 0x014 (R/W)  MPU Region Base Address Register Alias 1 */
+  __IOM uint32_t RLAR_A1;                /*!< Offset: 0x018 (R/W)  MPU Region Limit Address Register Alias 1 */
+  __IOM uint32_t RBAR_A2;                /*!< Offset: 0x01C (R/W)  MPU Region Base Address Register Alias 2 */
+  __IOM uint32_t RLAR_A2;                /*!< Offset: 0x020 (R/W)  MPU Region Limit Address Register Alias 2 */
+  __IOM uint32_t RBAR_A3;                /*!< Offset: 0x024 (R/W)  MPU Region Base Address Register Alias 3 */
+  __IOM uint32_t RLAR_A3;                /*!< Offset: 0x028 (R/W)  MPU Region Limit Address Register Alias 3 */
+        uint32_t RESERVED0[1];
+  union {
+  __IOM uint32_t MAIR[2];
+  struct {
+  __IOM uint32_t MAIR0;                  /*!< Offset: 0x030 (R/W)  MPU Memory Attribute Indirection Register 0 */
+  __IOM uint32_t MAIR1;                  /*!< Offset: 0x034 (R/W)  MPU Memory Attribute Indirection Register 1 */
+  };
+  };
+} MPU_Type;
+
+#define MPU_TYPE_RALIASES                  4U
+
+/** \brief MPU Type Register Definitions */
+#define MPU_TYPE_IREGION_Pos               16U                                            /*!< MPU TYPE: IREGION Position */
+#define MPU_TYPE_IREGION_Msk               (0xFFUL << MPU_TYPE_IREGION_Pos)               /*!< MPU TYPE: IREGION Mask */
+
+#define MPU_TYPE_DREGION_Pos                8U                                            /*!< MPU TYPE: DREGION Position */
+#define MPU_TYPE_DREGION_Msk               (0xFFUL << MPU_TYPE_DREGION_Pos)               /*!< MPU TYPE: DREGION Mask */
+
+#define MPU_TYPE_SEPARATE_Pos               0U                                            /*!< MPU TYPE: SEPARATE Position */
+#define MPU_TYPE_SEPARATE_Msk              (1UL /*<< MPU_TYPE_SEPARATE_Pos*/)             /*!< MPU TYPE: SEPARATE Mask */
+
+/** \brief MPU Control Register Definitions */
+#define MPU_CTRL_PRIVDEFENA_Pos             2U                                            /*!< MPU CTRL: PRIVDEFENA Position */
+#define MPU_CTRL_PRIVDEFENA_Msk            (1UL << MPU_CTRL_PRIVDEFENA_Pos)               /*!< MPU CTRL: PRIVDEFENA Mask */
+
+#define MPU_CTRL_HFNMIENA_Pos               1U                                            /*!< MPU CTRL: HFNMIENA Position */
+#define MPU_CTRL_HFNMIENA_Msk              (1UL << MPU_CTRL_HFNMIENA_Pos)                 /*!< MPU CTRL: HFNMIENA Mask */
+
+#define MPU_CTRL_ENABLE_Pos                 0U                                            /*!< MPU CTRL: ENABLE Position */
+#define MPU_CTRL_ENABLE_Msk                (1UL /*<< MPU_CTRL_ENABLE_Pos*/)               /*!< MPU CTRL: ENABLE Mask */
+
+/** \brief MPU Region Number Register Definitions */
+#define MPU_RNR_REGION_Pos                  0U                                            /*!< MPU RNR: REGION Position */
+#define MPU_RNR_REGION_Msk                 (0xFFUL /*<< MPU_RNR_REGION_Pos*/)             /*!< MPU RNR: REGION Mask */
+
+/** \brief MPU Region Base Address Register Definitions */
+#define MPU_RBAR_BASE_Pos                   5U                                            /*!< MPU RBAR: BASE Position */
+#define MPU_RBAR_BASE_Msk                  (0x7FFFFFFUL << MPU_RBAR_BASE_Pos)             /*!< MPU RBAR: BASE Mask */
+
+#define MPU_RBAR_SH_Pos                     3U                                            /*!< MPU RBAR: SH Position */
+#define MPU_RBAR_SH_Msk                    (0x3UL << MPU_RBAR_SH_Pos)                     /*!< MPU RBAR: SH Mask */
+
+#define MPU_RBAR_AP_Pos                     1U                                            /*!< MPU RBAR: AP Position */
+#define MPU_RBAR_AP_Msk                    (0x3UL << MPU_RBAR_AP_Pos)                     /*!< MPU RBAR: AP Mask */
+
+#define MPU_RBAR_XN_Pos                     0U                                            /*!< MPU RBAR: XN Position */
+#define MPU_RBAR_XN_Msk                    (01UL /*<< MPU_RBAR_XN_Pos*/)                  /*!< MPU RBAR: XN Mask */
+
+/** \brief MPU Region Limit Address Register Definitions */
+#define MPU_RLAR_LIMIT_Pos                  5U                                            /*!< MPU RLAR: LIMIT Position */
+#define MPU_RLAR_LIMIT_Msk                 (0x7FFFFFFUL << MPU_RLAR_LIMIT_Pos)            /*!< MPU RLAR: LIMIT Mask */
+
+#define MPU_RLAR_PXN_Pos                    4U                                            /*!< MPU RLAR: PXN Position */
+#define MPU_RLAR_PXN_Msk                   (1UL << MPU_RLAR_PXN_Pos)                      /*!< MPU RLAR: PXN Mask */
+
+#define MPU_RLAR_AttrIndx_Pos               1U                                            /*!< MPU RLAR: AttrIndx Position */
+#define MPU_RLAR_AttrIndx_Msk              (0x7UL << MPU_RLAR_AttrIndx_Pos)               /*!< MPU RLAR: AttrIndx Mask */
+
+#define MPU_RLAR_EN_Pos                     0U                                            /*!< MPU RLAR: Region enable bit Position */
+#define MPU_RLAR_EN_Msk                    (1UL /*<< MPU_RLAR_EN_Pos*/)                   /*!< MPU RLAR: Region enable bit Mask */
+
+/** \brief MPU Memory Attribute Indirection Register 0 Definitions */
+#define MPU_MAIR0_Attr3_Pos                24U                                            /*!< MPU MAIR0: Attr3 Position */
+#define MPU_MAIR0_Attr3_Msk                (0xFFUL << MPU_MAIR0_Attr3_Pos)                /*!< MPU MAIR0: Attr3 Mask */
+
+#define MPU_MAIR0_Attr2_Pos                16U                                            /*!< MPU MAIR0: Attr2 Position */
+#define MPU_MAIR0_Attr2_Msk                (0xFFUL << MPU_MAIR0_Attr2_Pos)                /*!< MPU MAIR0: Attr2 Mask */
+
+#define MPU_MAIR0_Attr1_Pos                 8U                                            /*!< MPU MAIR0: Attr1 Position */
+#define MPU_MAIR0_Attr1_Msk                (0xFFUL << MPU_MAIR0_Attr1_Pos)                /*!< MPU MAIR0: Attr1 Mask */
+
+#define MPU_MAIR0_Attr0_Pos                 0U                                            /*!< MPU MAIR0: Attr0 Position */
+#define MPU_MAIR0_Attr0_Msk                (0xFFUL /*<< MPU_MAIR0_Attr0_Pos*/)            /*!< MPU MAIR0: Attr0 Mask */
+
+/** \brief MPU Memory Attribute Indirection Register 1 Definitions */
+#define MPU_MAIR1_Attr7_Pos                24U                                            /*!< MPU MAIR1: Attr7 Position */
+#define MPU_MAIR1_Attr7_Msk                (0xFFUL << MPU_MAIR1_Attr7_Pos)                /*!< MPU MAIR1: Attr7 Mask */
+
+#define MPU_MAIR1_Attr6_Pos                16U                                            /*!< MPU MAIR1: Attr6 Position */
+#define MPU_MAIR1_Attr6_Msk                (0xFFUL << MPU_MAIR1_Attr6_Pos)                /*!< MPU MAIR1: Attr6 Mask */
+
+#define MPU_MAIR1_Attr5_Pos                 8U                                            /*!< MPU MAIR1: Attr5 Position */
+#define MPU_MAIR1_Attr5_Msk                (0xFFUL << MPU_MAIR1_Attr5_Pos)                /*!< MPU MAIR1: Attr5 Mask */
+
+#define MPU_MAIR1_Attr4_Pos                 0U                                            /*!< MPU MAIR1: Attr4 Position */
+#define MPU_MAIR1_Attr4_Msk                (0xFFUL /*<< MPU_MAIR1_Attr4_Pos*/)            /*!< MPU MAIR1: Attr4 Mask */
+
+/*@} end of group CMSIS_MPU */
+#endif
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SAU     Security Attribution Unit (SAU)
+  \brief    Type definitions for the Security Attribution Unit (SAU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Security Attribution Unit (SAU).
+ */
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  SAU Control Register */
+  __IM  uint32_t TYPE;                   /*!< Offset: 0x004 (R/ )  SAU Type Register */
+#if defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U)
+  __IOM uint32_t RNR;                    /*!< Offset: 0x008 (R/W)  SAU Region Number Register */
+  __IOM uint32_t RBAR;                   /*!< Offset: 0x00C (R/W)  SAU Region Base Address Register */
+  __IOM uint32_t RLAR;                   /*!< Offset: 0x010 (R/W)  SAU Region Limit Address Register */
+#else
+        uint32_t RESERVED0[3];
+#endif
+  __IOM uint32_t SFSR;                   /*!< Offset: 0x014 (R/W)  Secure Fault Status Register */
+  __IOM uint32_t SFAR;                   /*!< Offset: 0x018 (R/W)  Secure Fault Address Register */
+} SAU_Type;
+
+/** \brief SAU Control Register Definitions */
+#define SAU_CTRL_ALLNS_Pos                  1U                                            /*!< SAU CTRL: ALLNS Position */
+#define SAU_CTRL_ALLNS_Msk                 (1UL << SAU_CTRL_ALLNS_Pos)                    /*!< SAU CTRL: ALLNS Mask */
+
+#define SAU_CTRL_ENABLE_Pos                 0U                                            /*!< SAU CTRL: ENABLE Position */
+#define SAU_CTRL_ENABLE_Msk                (1UL /*<< SAU_CTRL_ENABLE_Pos*/)               /*!< SAU CTRL: ENABLE Mask */
+
+/** \brief SAU Type Register Definitions */
+#define SAU_TYPE_SREGION_Pos                0U                                            /*!< SAU TYPE: SREGION Position */
+#define SAU_TYPE_SREGION_Msk               (0xFFUL /*<< SAU_TYPE_SREGION_Pos*/)           /*!< SAU TYPE: SREGION Mask */
+
+#if defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U)
+/** \brief SAU Region Number Register Definitions */
+#define SAU_RNR_REGION_Pos                  0U                                            /*!< SAU RNR: REGION Position */
+#define SAU_RNR_REGION_Msk                 (0xFFUL /*<< SAU_RNR_REGION_Pos*/)             /*!< SAU RNR: REGION Mask */
+
+/** \brief SAU Region Base Address Register Definitions */
+#define SAU_RBAR_BADDR_Pos                  5U                                            /*!< SAU RBAR: BADDR Position */
+#define SAU_RBAR_BADDR_Msk                 (0x7FFFFFFUL << SAU_RBAR_BADDR_Pos)            /*!< SAU RBAR: BADDR Mask */
+
+/** \brief SAU Region Limit Address Register Definitions */
+#define SAU_RLAR_LADDR_Pos                  5U                                            /*!< SAU RLAR: LADDR Position */
+#define SAU_RLAR_LADDR_Msk                 (0x7FFFFFFUL << SAU_RLAR_LADDR_Pos)            /*!< SAU RLAR: LADDR Mask */
+
+#define SAU_RLAR_NSC_Pos                    1U                                            /*!< SAU RLAR: NSC Position */
+#define SAU_RLAR_NSC_Msk                   (1UL << SAU_RLAR_NSC_Pos)                      /*!< SAU RLAR: NSC Mask */
+
+#define SAU_RLAR_ENABLE_Pos                 0U                                            /*!< SAU RLAR: ENABLE Position */
+#define SAU_RLAR_ENABLE_Msk                (1UL /*<< SAU_RLAR_ENABLE_Pos*/)               /*!< SAU RLAR: ENABLE Mask */
+
+#endif /* defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U) */
+
+/** \brief SAU Secure Fault Status Register Definitions */
+#define SAU_SFSR_LSERR_Pos                  7U                                            /*!< SAU SFSR: LSERR Position */
+#define SAU_SFSR_LSERR_Msk                 (1UL << SAU_SFSR_LSERR_Pos)                    /*!< SAU SFSR: LSERR Mask */
+
+#define SAU_SFSR_SFARVALID_Pos              6U                                            /*!< SAU SFSR: SFARVALID Position */
+#define SAU_SFSR_SFARVALID_Msk             (1UL << SAU_SFSR_SFARVALID_Pos)                /*!< SAU SFSR: SFARVALID Mask */
+
+#define SAU_SFSR_LSPERR_Pos                 5U                                            /*!< SAU SFSR: LSPERR Position */
+#define SAU_SFSR_LSPERR_Msk                (1UL << SAU_SFSR_LSPERR_Pos)                   /*!< SAU SFSR: LSPERR Mask */
+
+#define SAU_SFSR_INVTRAN_Pos                4U                                            /*!< SAU SFSR: INVTRAN Position */
+#define SAU_SFSR_INVTRAN_Msk               (1UL << SAU_SFSR_INVTRAN_Pos)                  /*!< SAU SFSR: INVTRAN Mask */
+
+#define SAU_SFSR_AUVIOL_Pos                 3U                                            /*!< SAU SFSR: AUVIOL Position */
+#define SAU_SFSR_AUVIOL_Msk                (1UL << SAU_SFSR_AUVIOL_Pos)                   /*!< SAU SFSR: AUVIOL Mask */
+
+#define SAU_SFSR_INVER_Pos                  2U                                            /*!< SAU SFSR: INVER Position */
+#define SAU_SFSR_INVER_Msk                 (1UL << SAU_SFSR_INVER_Pos)                    /*!< SAU SFSR: INVER Mask */
+
+#define SAU_SFSR_INVIS_Pos                  1U                                            /*!< SAU SFSR: INVIS Position */
+#define SAU_SFSR_INVIS_Msk                 (1UL << SAU_SFSR_INVIS_Pos)                    /*!< SAU SFSR: INVIS Mask */
+
+#define SAU_SFSR_INVEP_Pos                  0U                                            /*!< SAU SFSR: INVEP Position */
+#define SAU_SFSR_INVEP_Msk                 (1UL /*<< SAU_SFSR_INVEP_Pos*/)                /*!< SAU SFSR: INVEP Mask */
+
+/*@} end of group CMSIS_SAU */
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_FPU     Floating Point Unit (FPU)
+  \brief    Type definitions for the Floating Point Unit (FPU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Floating Point Unit (FPU).
+ */
+typedef struct
+{
+        uint32_t RESERVED0[1U];
+  __IOM uint32_t FPCCR;                  /*!< Offset: 0x004 (R/W)  Floating-Point Context Control Register */
+  __IOM uint32_t FPCAR;                  /*!< Offset: 0x008 (R/W)  Floating-Point Context Address Register */
+  __IOM uint32_t FPDSCR;                 /*!< Offset: 0x00C (R/W)  Floating-Point Default Status Control Register */
+  __IM  uint32_t MVFR0;                  /*!< Offset: 0x010 (R/ )  Media and VFP Feature Register 0 */
+  __IM  uint32_t MVFR1;                  /*!< Offset: 0x014 (R/ )  Media and VFP Feature Register 1 */
+  __IM  uint32_t MVFR2;                  /*!< Offset: 0x018 (R/ )  Media and VFP Feature Register 2 */
+} FPU_Type;
+
+/** \brief FPU Floating-Point Context Control Register Definitions */
+#define FPU_FPCCR_ASPEN_Pos                31U                                            /*!< FPCCR: ASPEN bit Position */
+#define FPU_FPCCR_ASPEN_Msk                (1UL << FPU_FPCCR_ASPEN_Pos)                   /*!< FPCCR: ASPEN bit Mask */
+
+#define FPU_FPCCR_LSPEN_Pos                30U                                            /*!< FPCCR: LSPEN Position */
+#define FPU_FPCCR_LSPEN_Msk                (1UL << FPU_FPCCR_LSPEN_Pos)                   /*!< FPCCR: LSPEN bit Mask */
+
+#define FPU_FPCCR_LSPENS_Pos               29U                                            /*!< FPCCR: LSPENS Position */
+#define FPU_FPCCR_LSPENS_Msk               (1UL << FPU_FPCCR_LSPENS_Pos)                  /*!< FPCCR: LSPENS bit Mask */
+
+#define FPU_FPCCR_CLRONRET_Pos             28U                                            /*!< FPCCR: CLRONRET Position */
+#define FPU_FPCCR_CLRONRET_Msk             (1UL << FPU_FPCCR_CLRONRET_Pos)                /*!< FPCCR: CLRONRET bit Mask */
+
+#define FPU_FPCCR_CLRONRETS_Pos            27U                                            /*!< FPCCR: CLRONRETS Position */
+#define FPU_FPCCR_CLRONRETS_Msk            (1UL << FPU_FPCCR_CLRONRETS_Pos)               /*!< FPCCR: CLRONRETS bit Mask */
+
+#define FPU_FPCCR_TS_Pos                   26U                                            /*!< FPCCR: TS Position */
+#define FPU_FPCCR_TS_Msk                   (1UL << FPU_FPCCR_TS_Pos)                      /*!< FPCCR: TS bit Mask */
+
+#define FPU_FPCCR_UFRDY_Pos                10U                                            /*!< FPCCR: UFRDY Position */
+#define FPU_FPCCR_UFRDY_Msk                (1UL << FPU_FPCCR_UFRDY_Pos)                   /*!< FPCCR: UFRDY bit Mask */
+
+#define FPU_FPCCR_SPLIMVIOL_Pos             9U                                            /*!< FPCCR: SPLIMVIOL Position */
+#define FPU_FPCCR_SPLIMVIOL_Msk            (1UL << FPU_FPCCR_SPLIMVIOL_Pos)               /*!< FPCCR: SPLIMVIOL bit Mask */
+
+#define FPU_FPCCR_MONRDY_Pos                8U                                            /*!< FPCCR: MONRDY Position */
+#define FPU_FPCCR_MONRDY_Msk               (1UL << FPU_FPCCR_MONRDY_Pos)                  /*!< FPCCR: MONRDY bit Mask */
+
+#define FPU_FPCCR_SFRDY_Pos                 7U                                            /*!< FPCCR: SFRDY Position */
+#define FPU_FPCCR_SFRDY_Msk                (1UL << FPU_FPCCR_SFRDY_Pos)                   /*!< FPCCR: SFRDY bit Mask */
+
+#define FPU_FPCCR_BFRDY_Pos                 6U                                            /*!< FPCCR: BFRDY Position */
+#define FPU_FPCCR_BFRDY_Msk                (1UL << FPU_FPCCR_BFRDY_Pos)                   /*!< FPCCR: BFRDY bit Mask */
+
+#define FPU_FPCCR_MMRDY_Pos                 5U                                            /*!< FPCCR: MMRDY Position */
+#define FPU_FPCCR_MMRDY_Msk                (1UL << FPU_FPCCR_MMRDY_Pos)                   /*!< FPCCR: MMRDY bit Mask */
+
+#define FPU_FPCCR_HFRDY_Pos                 4U                                            /*!< FPCCR: HFRDY Position */
+#define FPU_FPCCR_HFRDY_Msk                (1UL << FPU_FPCCR_HFRDY_Pos)                   /*!< FPCCR: HFRDY bit Mask */
+
+#define FPU_FPCCR_THREAD_Pos                3U                                            /*!< FPCCR: processor mode bit Position */
+#define FPU_FPCCR_THREAD_Msk               (1UL << FPU_FPCCR_THREAD_Pos)                  /*!< FPCCR: processor mode active bit Mask */
+
+#define FPU_FPCCR_S_Pos                     2U                                            /*!< FPCCR: Security status of the FP context bit Position */
+#define FPU_FPCCR_S_Msk                    (1UL << FPU_FPCCR_S_Pos)                       /*!< FPCCR: Security status of the FP context bit Mask */
+
+#define FPU_FPCCR_USER_Pos                  1U                                            /*!< FPCCR: privilege level bit Position */
+#define FPU_FPCCR_USER_Msk                 (1UL << FPU_FPCCR_USER_Pos)                    /*!< FPCCR: privilege level bit Mask */
+
+#define FPU_FPCCR_LSPACT_Pos                0U                                            /*!< FPCCR: Lazy state preservation active bit Position */
+#define FPU_FPCCR_LSPACT_Msk               (1UL /*<< FPU_FPCCR_LSPACT_Pos*/)              /*!< FPCCR: Lazy state preservation active bit Mask */
+
+/** \brief FPU Floating-Point Context Address Register Definitions */
+#define FPU_FPCAR_ADDRESS_Pos               3U                                            /*!< FPCAR: ADDRESS bit Position */
+#define FPU_FPCAR_ADDRESS_Msk              (0x1FFFFFFFUL << FPU_FPCAR_ADDRESS_Pos)        /*!< FPCAR: ADDRESS bit Mask */
+
+/** \brief FPU Floating-Point Default Status Control Register Definitions */
+#define FPU_FPDSCR_AHP_Pos                 26U                                            /*!< FPDSCR: AHP bit Position */
+#define FPU_FPDSCR_AHP_Msk                 (1UL << FPU_FPDSCR_AHP_Pos)                    /*!< FPDSCR: AHP bit Mask */
+
+#define FPU_FPDSCR_DN_Pos                  25U                                            /*!< FPDSCR: DN bit Position */
+#define FPU_FPDSCR_DN_Msk                  (1UL << FPU_FPDSCR_DN_Pos)                     /*!< FPDSCR: DN bit Mask */
+
+#define FPU_FPDSCR_FZ_Pos                  24U                                            /*!< FPDSCR: FZ bit Position */
+#define FPU_FPDSCR_FZ_Msk                  (1UL << FPU_FPDSCR_FZ_Pos)                     /*!< FPDSCR: FZ bit Mask */
+
+#define FPU_FPDSCR_RMode_Pos               22U                                            /*!< FPDSCR: RMode bit Position */
+#define FPU_FPDSCR_RMode_Msk               (3UL << FPU_FPDSCR_RMode_Pos)                  /*!< FPDSCR: RMode bit Mask */
+
+#define FPU_FPDSCR_FZ16_Pos                19U                                            /*!< FPDSCR: FZ16 bit Position */
+#define FPU_FPDSCR_FZ16_Msk                (1UL << FPU_FPDSCR_FZ16_Pos)                   /*!< FPDSCR: FZ16 bit Mask */
+
+#define FPU_FPDSCR_LTPSIZE_Pos             16U                                            /*!< FPDSCR: LTPSIZE bit Position */
+#define FPU_FPDSCR_LTPSIZE_Msk             (7UL << FPU_FPDSCR_LTPSIZE_Pos)                /*!< FPDSCR: LTPSIZE bit Mask */
+
+/** \brief FPU Media and VFP Feature Register 0 Definitions */
+#define FPU_MVFR0_FPRound_Pos              28U                                            /*!< MVFR0: Rounding modes bits Position */
+#define FPU_MVFR0_FPRound_Msk              (0xFUL << FPU_MVFR0_FPRound_Pos)               /*!< MVFR0: Rounding modes bits Mask */
+
+#define FPU_MVFR0_FPSqrt_Pos               20U                                            /*!< MVFR0: Square root bits Position */
+#define FPU_MVFR0_FPSqrt_Msk               (0xFUL << FPU_MVFR0_FPSqrt_Pos)                /*!< MVFR0: Square root bits Mask */
+
+#define FPU_MVFR0_FPDivide_Pos             16U                                            /*!< MVFR0: Divide bits Position */
+#define FPU_MVFR0_FPDivide_Msk             (0xFUL << FPU_MVFR0_FPDivide_Pos)              /*!< MVFR0: Divide bits Mask */
+
+#define FPU_MVFR0_FPDP_Pos                  8U                                            /*!< MVFR0: Double-precision bits Position */
+#define FPU_MVFR0_FPDP_Msk                 (0xFUL << FPU_MVFR0_FPDP_Pos)                  /*!< MVFR0: Double-precision bits Mask */
+
+#define FPU_MVFR0_FPSP_Pos                  4U                                            /*!< MVFR0: Single-precision bits Position */
+#define FPU_MVFR0_FPSP_Msk                 (0xFUL << FPU_MVFR0_FPSP_Pos)                  /*!< MVFR0: Single-precision bits Mask */
+
+#define FPU_MVFR0_SIMDReg_Pos               0U                                            /*!< MVFR0: SIMD registers bits Position */
+#define FPU_MVFR0_SIMDReg_Msk              (0xFUL /*<< FPU_MVFR0_SIMDReg_Pos*/)           /*!< MVFR0: SIMD registers bits Mask */
+
+/** \brief FPU Media and VFP Feature Register 1 Definitions */
+#define FPU_MVFR1_FMAC_Pos                 28U                                            /*!< MVFR1: Fused MAC bits Position */
+#define FPU_MVFR1_FMAC_Msk                 (0xFUL << FPU_MVFR1_FMAC_Pos)                  /*!< MVFR1: Fused MAC bits Mask */
+
+#define FPU_MVFR1_FPHP_Pos                 24U                                            /*!< MVFR1: FP HPFP bits Position */
+#define FPU_MVFR1_FPHP_Msk                 (0xFUL << FPU_MVFR1_FPHP_Pos)                  /*!< MVFR1: FP HPFP bits Mask */
+
+#define FPU_MVFR1_FP16_Pos                 20U                                            /*!< MVFR1: FP16 bits Position */
+#define FPU_MVFR1_FP16_Msk                 (0xFUL << FPU_MVFR1_FP16_Pos)                  /*!< MVFR1: FP16 bits Mask */
+
+#define FPU_MVFR1_MVE_Pos                   8U                                            /*!< MVFR1: MVE bits Position */
+#define FPU_MVFR1_MVE_Msk                  (0xFUL << FPU_MVFR1_MVE_Pos)                   /*!< MVFR1: MVE bits Mask */
+
+#define FPU_MVFR1_FPDNaN_Pos                4U                                            /*!< MVFR1: D_NaN mode bits Position */
+#define FPU_MVFR1_FPDNaN_Msk               (0xFUL << FPU_MVFR1_FPDNaN_Pos)                /*!< MVFR1: D_NaN mode bits Mask */
+
+#define FPU_MVFR1_FPFtZ_Pos                 0U                                            /*!< MVFR1: FtZ mode bits Position */
+#define FPU_MVFR1_FPFtZ_Msk                (0xFUL /*<< FPU_MVFR1_FPFtZ_Pos*/)             /*!< MVFR1: FtZ mode bits Mask */
+
+/** \brief FPU Media and VFP Feature Register 2 Definitions */
+#define FPU_MVFR2_FPMisc_Pos                4U                                            /*!< MVFR2: VFP Misc bits Position */
+#define FPU_MVFR2_FPMisc_Msk               (0xFUL << FPU_MVFR2_FPMisc_Pos)                /*!< MVFR2: VFP Misc bits Mask */
+
+/*@} end of group CMSIS_FPU */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_DCB       Debug Control Block
+  \brief    Type definitions for the Debug Control Block Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Debug Control Block Registers (DCB).
+ */
+typedef struct
+{
+  __IOM uint32_t DHCSR;                  /*!< Offset: 0x000 (R/W)  Debug Halting Control and Status Register */
+  __OM  uint32_t DCRSR;                  /*!< Offset: 0x004 ( /W)  Debug Core Register Selector Register */
+  __IOM uint32_t DCRDR;                  /*!< Offset: 0x008 (R/W)  Debug Core Register Data Register */
+  __IOM uint32_t DEMCR;                  /*!< Offset: 0x00C (R/W)  Debug Exception and Monitor Control Register */
+  __OM  uint32_t DSCEMCR;                /*!< Offset: 0x010 ( /W)  Debug Set Clear Exception and Monitor Control Register */
+  __IOM uint32_t DAUTHCTRL;              /*!< Offset: 0x014 (R/W)  Debug Authentication Control Register */
+  __IOM uint32_t DSCSR;                  /*!< Offset: 0x018 (R/W)  Debug Security Control and Status Register */
+} DCB_Type;
+
+/** \brief DCB Debug Halting Control and Status Register Definitions */
+#define DCB_DHCSR_DBGKEY_Pos               16U                                            /*!< DCB DHCSR: Debug key Position */
+#define DCB_DHCSR_DBGKEY_Msk               (0xFFFFUL << DCB_DHCSR_DBGKEY_Pos)             /*!< DCB DHCSR: Debug key Mask */
+
+#define DCB_DHCSR_S_RESTART_ST_Pos         26U                                            /*!< DCB DHCSR: Restart sticky status Position */
+#define DCB_DHCSR_S_RESTART_ST_Msk         (1UL << DCB_DHCSR_S_RESTART_ST_Pos)            /*!< DCB DHCSR: Restart sticky status Mask */
+
+#define DCB_DHCSR_S_RESET_ST_Pos           25U                                            /*!< DCB DHCSR: Reset sticky status Position */
+#define DCB_DHCSR_S_RESET_ST_Msk           (1UL << DCB_DHCSR_S_RESET_ST_Pos)              /*!< DCB DHCSR: Reset sticky status Mask */
+
+#define DCB_DHCSR_S_RETIRE_ST_Pos          24U                                            /*!< DCB DHCSR: Retire sticky status Position */
+#define DCB_DHCSR_S_RETIRE_ST_Msk          (1UL << DCB_DHCSR_S_RETIRE_ST_Pos)             /*!< DCB DHCSR: Retire sticky status Mask */
+
+#define DCB_DHCSR_S_FPD_Pos                23U                                            /*!< DCB DHCSR: Floating-point registers Debuggable Position */
+#define DCB_DHCSR_S_FPD_Msk                (1UL << DCB_DHCSR_S_FPD_Pos)                   /*!< DCB DHCSR: Floating-point registers Debuggable Mask */
+
+#define DCB_DHCSR_S_SUIDE_Pos              22U                                            /*!< DCB DHCSR: Secure unprivileged halting debug enabled Position */
+#define DCB_DHCSR_S_SUIDE_Msk              (1UL << DCB_DHCSR_S_SUIDE_Pos)                 /*!< DCB DHCSR: Secure unprivileged halting debug enabled Mask */
+
+#define DCB_DHCSR_S_NSUIDE_Pos             21U                                            /*!< DCB DHCSR: Non-secure unprivileged halting debug enabled Position */
+#define DCB_DHCSR_S_NSUIDE_Msk             (1UL << DCB_DHCSR_S_NSUIDE_Pos)                /*!< DCB DHCSR: Non-secure unprivileged halting debug enabled Mask */
+
+#define DCB_DHCSR_S_SDE_Pos                20U                                            /*!< DCB DHCSR: Secure debug enabled Position */
+#define DCB_DHCSR_S_SDE_Msk                (1UL << DCB_DHCSR_S_SDE_Pos)                   /*!< DCB DHCSR: Secure debug enabled Mask */
+
+#define DCB_DHCSR_S_LOCKUP_Pos             19U                                            /*!< DCB DHCSR: Lockup status Position */
+#define DCB_DHCSR_S_LOCKUP_Msk             (1UL << DCB_DHCSR_S_LOCKUP_Pos)                /*!< DCB DHCSR: Lockup status Mask */
+
+#define DCB_DHCSR_S_SLEEP_Pos              18U                                            /*!< DCB DHCSR: Sleeping status Position */
+#define DCB_DHCSR_S_SLEEP_Msk              (1UL << DCB_DHCSR_S_SLEEP_Pos)                 /*!< DCB DHCSR: Sleeping status Mask */
+
+#define DCB_DHCSR_S_HALT_Pos               17U                                            /*!< DCB DHCSR: Halted status Position */
+#define DCB_DHCSR_S_HALT_Msk               (1UL << DCB_DHCSR_S_HALT_Pos)                  /*!< DCB DHCSR: Halted status Mask */
+
+#define DCB_DHCSR_S_REGRDY_Pos             16U                                            /*!< DCB DHCSR: Register ready status Position */
+#define DCB_DHCSR_S_REGRDY_Msk             (1UL << DCB_DHCSR_S_REGRDY_Pos)                /*!< DCB DHCSR: Register ready status Mask */
+
+#define DCB_DHCSR_C_PMOV_Pos                6U                                            /*!< DCB DHCSR: Halt on PMU overflow control Position */
+#define DCB_DHCSR_C_PMOV_Msk               (1UL << DCB_DHCSR_C_PMOV_Pos)                  /*!< DCB DHCSR: Halt on PMU overflow control Mask */
+
+#define DCB_DHCSR_C_SNAPSTALL_Pos           5U                                            /*!< DCB DHCSR: Snap stall control Position */
+#define DCB_DHCSR_C_SNAPSTALL_Msk          (1UL << DCB_DHCSR_C_SNAPSTALL_Pos)             /*!< DCB DHCSR: Snap stall control Mask */
+
+#define DCB_DHCSR_C_MASKINTS_Pos            3U                                            /*!< DCB DHCSR: Mask interrupts control Position */
+#define DCB_DHCSR_C_MASKINTS_Msk           (1UL << DCB_DHCSR_C_MASKINTS_Pos)              /*!< DCB DHCSR: Mask interrupts control Mask */
+
+#define DCB_DHCSR_C_STEP_Pos                2U                                            /*!< DCB DHCSR: Step control Position */
+#define DCB_DHCSR_C_STEP_Msk               (1UL << DCB_DHCSR_C_STEP_Pos)                  /*!< DCB DHCSR: Step control Mask */
+
+#define DCB_DHCSR_C_HALT_Pos                1U                                            /*!< DCB DHCSR: Halt control Position */
+#define DCB_DHCSR_C_HALT_Msk               (1UL << DCB_DHCSR_C_HALT_Pos)                  /*!< DCB DHCSR: Halt control Mask */
+
+#define DCB_DHCSR_C_DEBUGEN_Pos             0U                                            /*!< DCB DHCSR: Debug enable control Position */
+#define DCB_DHCSR_C_DEBUGEN_Msk            (1UL /*<< DCB_DHCSR_C_DEBUGEN_Pos*/)           /*!< DCB DHCSR: Debug enable control Mask */
+
+/** \brief DCB Debug Core Register Selector Register Definitions */
+#define DCB_DCRSR_REGWnR_Pos               16U                                            /*!< DCB DCRSR: Register write/not-read Position */
+#define DCB_DCRSR_REGWnR_Msk               (1UL << DCB_DCRSR_REGWnR_Pos)                  /*!< DCB DCRSR: Register write/not-read Mask */
+
+#define DCB_DCRSR_REGSEL_Pos                0U                                            /*!< DCB DCRSR: Register selector Position */
+#define DCB_DCRSR_REGSEL_Msk               (0x7FUL /*<< DCB_DCRSR_REGSEL_Pos*/)           /*!< DCB DCRSR: Register selector Mask */
+
+/** \brief DCB Debug Core Register Data Register Definitions */
+#define DCB_DCRDR_DBGTMP_Pos                0U                                            /*!< DCB DCRDR: Data temporary buffer Position */
+#define DCB_DCRDR_DBGTMP_Msk               (0xFFFFFFFFUL /*<< DCB_DCRDR_DBGTMP_Pos*/)     /*!< DCB DCRDR: Data temporary buffer Mask */
+
+/** \brief DCB Debug Exception and Monitor Control Register Definitions */
+#define DCB_DEMCR_TRCENA_Pos               24U                                            /*!< DCB DEMCR: Trace enable Position */
+#define DCB_DEMCR_TRCENA_Msk               (1UL << DCB_DEMCR_TRCENA_Pos)                  /*!< DCB DEMCR: Trace enable Mask */
+
+#define DCB_DEMCR_MONPRKEY_Pos             23U                                            /*!< DCB DEMCR: Monitor pend req key Position */
+#define DCB_DEMCR_MONPRKEY_Msk             (1UL << DCB_DEMCR_MONPRKEY_Pos)                /*!< DCB DEMCR: Monitor pend req key Mask */
+
+#define DCB_DEMCR_UMON_EN_Pos              21U                                            /*!< DCB DEMCR: Unprivileged monitor enable Position */
+#define DCB_DEMCR_UMON_EN_Msk              (1UL << DCB_DEMCR_UMON_EN_Pos)                 /*!< DCB DEMCR: Unprivileged monitor enable Mask */
+
+#define DCB_DEMCR_SDME_Pos                 20U                                            /*!< DCB DEMCR: Secure DebugMonitor enable Position */
+#define DCB_DEMCR_SDME_Msk                 (1UL << DCB_DEMCR_SDME_Pos)                    /*!< DCB DEMCR: Secure DebugMonitor enable Mask */
+
+#define DCB_DEMCR_MON_REQ_Pos              19U                                            /*!< DCB DEMCR: Monitor request Position */
+#define DCB_DEMCR_MON_REQ_Msk              (1UL << DCB_DEMCR_MON_REQ_Pos)                 /*!< DCB DEMCR: Monitor request Mask */
+
+#define DCB_DEMCR_MON_STEP_Pos             18U                                            /*!< DCB DEMCR: Monitor step Position */
+#define DCB_DEMCR_MON_STEP_Msk             (1UL << DCB_DEMCR_MON_STEP_Pos)                /*!< DCB DEMCR: Monitor step Mask */
+
+#define DCB_DEMCR_MON_PEND_Pos             17U                                            /*!< DCB DEMCR: Monitor pend Position */
+#define DCB_DEMCR_MON_PEND_Msk             (1UL << DCB_DEMCR_MON_PEND_Pos)                /*!< DCB DEMCR: Monitor pend Mask */
+
+#define DCB_DEMCR_MON_EN_Pos               16U                                            /*!< DCB DEMCR: Monitor enable Position */
+#define DCB_DEMCR_MON_EN_Msk               (1UL << DCB_DEMCR_MON_EN_Pos)                  /*!< DCB DEMCR: Monitor enable Mask */
+
+#define DCB_DEMCR_VC_SFERR_Pos             11U                                            /*!< DCB DEMCR: Vector Catch SecureFault Position */
+#define DCB_DEMCR_VC_SFERR_Msk             (1UL << DCB_DEMCR_VC_SFERR_Pos)                /*!< DCB DEMCR: Vector Catch SecureFault Mask */
+
+#define DCB_DEMCR_VC_HARDERR_Pos           10U                                            /*!< DCB DEMCR: Vector Catch HardFault errors Position */
+#define DCB_DEMCR_VC_HARDERR_Msk           (1UL << DCB_DEMCR_VC_HARDERR_Pos)              /*!< DCB DEMCR: Vector Catch HardFault errors Mask */
+
+#define DCB_DEMCR_VC_INTERR_Pos             9U                                            /*!< DCB DEMCR: Vector Catch interrupt errors Position */
+#define DCB_DEMCR_VC_INTERR_Msk            (1UL << DCB_DEMCR_VC_INTERR_Pos)               /*!< DCB DEMCR: Vector Catch interrupt errors Mask */
+
+#define DCB_DEMCR_VC_BUSERR_Pos             8U                                            /*!< DCB DEMCR: Vector Catch BusFault errors Position */
+#define DCB_DEMCR_VC_BUSERR_Msk            (1UL << DCB_DEMCR_VC_BUSERR_Pos)               /*!< DCB DEMCR: Vector Catch BusFault errors Mask */
+
+#define DCB_DEMCR_VC_STATERR_Pos            7U                                            /*!< DCB DEMCR: Vector Catch state errors Position */
+#define DCB_DEMCR_VC_STATERR_Msk           (1UL << DCB_DEMCR_VC_STATERR_Pos)              /*!< DCB DEMCR: Vector Catch state errors Mask */
+
+#define DCB_DEMCR_VC_CHKERR_Pos             6U                                            /*!< DCB DEMCR: Vector Catch check errors Position */
+#define DCB_DEMCR_VC_CHKERR_Msk            (1UL << DCB_DEMCR_VC_CHKERR_Pos)               /*!< DCB DEMCR: Vector Catch check errors Mask */
+
+#define DCB_DEMCR_VC_NOCPERR_Pos            5U                                            /*!< DCB DEMCR: Vector Catch NOCP errors Position */
+#define DCB_DEMCR_VC_NOCPERR_Msk           (1UL << DCB_DEMCR_VC_NOCPERR_Pos)              /*!< DCB DEMCR: Vector Catch NOCP errors Mask */
+
+#define DCB_DEMCR_VC_MMERR_Pos              4U                                            /*!< DCB DEMCR: Vector Catch MemManage errors Position */
+#define DCB_DEMCR_VC_MMERR_Msk             (1UL << DCB_DEMCR_VC_MMERR_Pos)                /*!< DCB DEMCR: Vector Catch MemManage errors Mask */
+
+#define DCB_DEMCR_VC_CORERESET_Pos          0U                                            /*!< DCB DEMCR: Vector Catch Core reset Position */
+#define DCB_DEMCR_VC_CORERESET_Msk         (1UL /*<< DCB_DEMCR_VC_CORERESET_Pos*/)        /*!< DCB DEMCR: Vector Catch Core reset Mask */
+
+/** \brief DCB Debug Set Clear Exception and Monitor Control Register Definitions */
+#define DCB_DSCEMCR_CLR_MON_REQ_Pos        19U                                            /*!< DCB DSCEMCR: Clear monitor request Position */
+#define DCB_DSCEMCR_CLR_MON_REQ_Msk        (1UL << DCB_DSCEMCR_CLR_MON_REQ_Pos)           /*!< DCB DSCEMCR: Clear monitor request Mask */
+
+#define DCB_DSCEMCR_CLR_MON_PEND_Pos       17U                                            /*!< DCB DSCEMCR: Clear monitor pend Position */
+#define DCB_DSCEMCR_CLR_MON_PEND_Msk       (1UL << DCB_DSCEMCR_CLR_MON_PEND_Pos)          /*!< DCB DSCEMCR: Clear monitor pend Mask */
+
+#define DCB_DSCEMCR_SET_MON_REQ_Pos         3U                                            /*!< DCB DSCEMCR: Set monitor request Position */
+#define DCB_DSCEMCR_SET_MON_REQ_Msk        (1UL << DCB_DSCEMCR_SET_MON_REQ_Pos)           /*!< DCB DSCEMCR: Set monitor request Mask */
+
+#define DCB_DSCEMCR_SET_MON_PEND_Pos        1U                                            /*!< DCB DSCEMCR: Set monitor pend Position */
+#define DCB_DSCEMCR_SET_MON_PEND_Msk       (1UL << DCB_DSCEMCR_SET_MON_PEND_Pos)          /*!< DCB DSCEMCR: Set monitor pend Mask */
+
+/** \brief DCB Debug Authentication Control Register Definitions */
+#define DCB_DAUTHCTRL_UIDEN_Pos            10U                                            /*!< DCB DAUTHCTRL: Unprivileged Invasive Debug Enable Position */
+#define DCB_DAUTHCTRL_UIDEN_Msk            (1UL << DCB_DAUTHCTRL_UIDEN_Pos)               /*!< DCB DAUTHCTRL: Unprivileged Invasive Debug Enable Mask */
+
+#define DCB_DAUTHCTRL_UIDAPEN_Pos           9U                                            /*!< DCB DAUTHCTRL: Unprivileged Invasive DAP Access Enable Position */
+#define DCB_DAUTHCTRL_UIDAPEN_Msk          (1UL << DCB_DAUTHCTRL_UIDAPEN_Pos)             /*!< DCB DAUTHCTRL: Unprivileged Invasive DAP Access Enable Mask */
+
+#define DCB_DAUTHCTRL_FSDMA_Pos             8U                                            /*!< DCB DAUTHCTRL: Force Secure DebugMonitor Allowed Position */
+#define DCB_DAUTHCTRL_FSDMA_Msk            (1UL << DCB_DAUTHCTRL_FSDMA_Pos)               /*!< DCB DAUTHCTRL: Force Secure DebugMonitor Allowed Mask */
+
+#define DCB_DAUTHCTRL_INTSPNIDEN_Pos        3U                                            /*!< DCB DAUTHCTRL: Internal Secure non-invasive debug enable Position */
+#define DCB_DAUTHCTRL_INTSPNIDEN_Msk       (1UL << DCB_DAUTHCTRL_INTSPNIDEN_Pos)          /*!< DCB DAUTHCTRL: Internal Secure non-invasive debug enable Mask */
+
+#define DCB_DAUTHCTRL_SPNIDENSEL_Pos        2U                                            /*!< DCB DAUTHCTRL: Secure non-invasive debug enable select Position */
+#define DCB_DAUTHCTRL_SPNIDENSEL_Msk       (1UL << DCB_DAUTHCTRL_SPNIDENSEL_Pos)          /*!< DCB DAUTHCTRL: Secure non-invasive debug enable select Mask */
+
+#define DCB_DAUTHCTRL_INTSPIDEN_Pos         1U                                            /*!< DCB DAUTHCTRL: Internal Secure invasive debug enable Position */
+#define DCB_DAUTHCTRL_INTSPIDEN_Msk        (1UL << DCB_DAUTHCTRL_INTSPIDEN_Pos)           /*!< DCB DAUTHCTRL: Internal Secure invasive debug enable Mask */
+
+#define DCB_DAUTHCTRL_SPIDENSEL_Pos         0U                                            /*!< DCB DAUTHCTRL: Secure invasive debug enable select Position */
+#define DCB_DAUTHCTRL_SPIDENSEL_Msk        (1UL /*<< DCB_DAUTHCTRL_SPIDENSEL_Pos*/)       /*!< DCB DAUTHCTRL: Secure invasive debug enable select Mask */
+
+/** \brief DCB Debug Security Control and Status Register Definitions */
+#define DCB_DSCSR_CDSKEY_Pos               17U                                            /*!< DCB DSCSR: CDS write-enable key Position */
+#define DCB_DSCSR_CDSKEY_Msk               (1UL << DCB_DSCSR_CDSKEY_Pos)                  /*!< DCB DSCSR: CDS write-enable key Mask */
+
+#define DCB_DSCSR_CDS_Pos                  16U                                            /*!< DCB DSCSR: Current domain Secure Position */
+#define DCB_DSCSR_CDS_Msk                  (1UL << DCB_DSCSR_CDS_Pos)                     /*!< DCB DSCSR: Current domain Secure Mask */
+
+#define DCB_DSCSR_SBRSEL_Pos                1U                                            /*!< DCB DSCSR: Secure banked register select Position */
+#define DCB_DSCSR_SBRSEL_Msk               (1UL << DCB_DSCSR_SBRSEL_Pos)                  /*!< DCB DSCSR: Secure banked register select Mask */
+
+#define DCB_DSCSR_SBRSELEN_Pos              0U                                            /*!< DCB DSCSR: Secure banked register select enable Position */
+#define DCB_DSCSR_SBRSELEN_Msk             (1UL /*<< DCB_DSCSR_SBRSELEN_Pos*/)            /*!< DCB DSCSR: Secure banked register select enable Mask */
+
+/*@} end of group CMSIS_DCB */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_DIB       Debug Identification Block
+  \brief    Type definitions for the Debug Identification Block Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Debug Identification Block Registers (DIB).
+ */
+typedef struct
+{
+        uint32_t RESERVED0[2U];
+  __IM  uint32_t DAUTHSTATUS;            /*!< Offset: 0x008 (R/ )  Debug Authentication Status Register */
+  __IM  uint32_t DDEVARCH;               /*!< Offset: 0x00C (R/ )  SCS Device Architecture Register */
+        uint32_t RESERVED1[3U];
+  __IM  uint32_t DDEVTYPE;               /*!< Offset: 0x01C (R/ )  SCS Device Type Register */
+} DIB_Type;
+
+/** \brief DIB Debug Authentication Status Register Definitions */
+#define DIB_DAUTHSTATUS_SUNID_Pos          22U                                            /*!< DIB DAUTHSTATUS: Secure Unprivileged Non-invasive Debug Allowed Position */
+#define DIB_DAUTHSTATUS_SUNID_Msk          (0x3UL << DIB_DAUTHSTATUS_SUNID_Pos )          /*!< DIB DAUTHSTATUS: Secure Unprivileged Non-invasive Debug Allowed Mask */
+
+#define DIB_DAUTHSTATUS_SUID_Pos           20U                                            /*!< DIB DAUTHSTATUS: Secure Unprivileged Invasive Debug Allowed Position */
+#define DIB_DAUTHSTATUS_SUID_Msk           (0x3UL << DIB_DAUTHSTATUS_SUID_Pos )           /*!< DIB DAUTHSTATUS: Secure Unprivileged Invasive Debug Allowed Mask */
+
+#define DIB_DAUTHSTATUS_NSUNID_Pos         18U                                            /*!< DIB DAUTHSTATUS: Non-secure Unprivileged Non-invasive Debug Allo Position */
+#define DIB_DAUTHSTATUS_NSUNID_Msk         (0x3UL << DIB_DAUTHSTATUS_NSUNID_Pos )         /*!< DIB DAUTHSTATUS: Non-secure Unprivileged Non-invasive Debug Allo Mask */
+
+#define DIB_DAUTHSTATUS_NSUID_Pos          16U                                            /*!< DIB DAUTHSTATUS: Non-secure Unprivileged Invasive Debug Allowed Position */
+#define DIB_DAUTHSTATUS_NSUID_Msk          (0x3UL << DIB_DAUTHSTATUS_NSUID_Pos )          /*!< DIB DAUTHSTATUS: Non-secure Unprivileged Invasive Debug Allowed Mask */
+
+#define DIB_DAUTHSTATUS_SNID_Pos            6U                                            /*!< DIB DAUTHSTATUS: Secure Non-invasive Debug Position */
+#define DIB_DAUTHSTATUS_SNID_Msk           (0x3UL << DIB_DAUTHSTATUS_SNID_Pos )           /*!< DIB DAUTHSTATUS: Secure Non-invasive Debug Mask */
+
+#define DIB_DAUTHSTATUS_SID_Pos             4U                                            /*!< DIB DAUTHSTATUS: Secure Invasive Debug Position */
+#define DIB_DAUTHSTATUS_SID_Msk            (0x3UL << DIB_DAUTHSTATUS_SID_Pos )            /*!< DIB DAUTHSTATUS: Secure Invasive Debug Mask */
+
+#define DIB_DAUTHSTATUS_NSNID_Pos           2U                                            /*!< DIB DAUTHSTATUS: Non-secure Non-invasive Debug Position */
+#define DIB_DAUTHSTATUS_NSNID_Msk          (0x3UL << DIB_DAUTHSTATUS_NSNID_Pos )          /*!< DIB DAUTHSTATUS: Non-secure Non-invasive Debug Mask */
+
+#define DIB_DAUTHSTATUS_NSID_Pos            0U                                            /*!< DIB DAUTHSTATUS: Non-secure Invasive Debug Position */
+#define DIB_DAUTHSTATUS_NSID_Msk           (0x3UL /*<< DIB_DAUTHSTATUS_NSID_Pos*/)        /*!< DIB DAUTHSTATUS: Non-secure Invasive Debug Mask */
+
+/** \brief DIB SCS Device Architecture Register Definitions */
+#define DIB_DDEVARCH_ARCHITECT_Pos         21U                                            /*!< DIB DDEVARCH: Architect Position */
+#define DIB_DDEVARCH_ARCHITECT_Msk         (0x7FFUL << DIB_DDEVARCH_ARCHITECT_Pos )       /*!< DIB DDEVARCH: Architect Mask */
+
+#define DIB_DDEVARCH_PRESENT_Pos           20U                                            /*!< DIB DDEVARCH: DEVARCH Present Position */
+#define DIB_DDEVARCH_PRESENT_Msk           (0x1FUL << DIB_DDEVARCH_PRESENT_Pos )          /*!< DIB DDEVARCH: DEVARCH Present Mask */
+
+#define DIB_DDEVARCH_REVISION_Pos          16U                                            /*!< DIB DDEVARCH: Revision Position */
+#define DIB_DDEVARCH_REVISION_Msk          (0xFUL << DIB_DDEVARCH_REVISION_Pos )          /*!< DIB DDEVARCH: Revision Mask */
+
+#define DIB_DDEVARCH_ARCHVER_Pos           12U                                            /*!< DIB DDEVARCH: Architecture Version Position */
+#define DIB_DDEVARCH_ARCHVER_Msk           (0xFUL << DIB_DDEVARCH_ARCHVER_Pos )           /*!< DIB DDEVARCH: Architecture Version Mask */
+
+#define DIB_DDEVARCH_ARCHPART_Pos           0U                                            /*!< DIB DDEVARCH: Architecture Part Position */
+#define DIB_DDEVARCH_ARCHPART_Msk          (0xFFFUL /*<< DIB_DDEVARCH_ARCHPART_Pos*/)     /*!< DIB DDEVARCH: Architecture Part Mask */
+
+/** \brief DIB SCS Device Type Register Definitions */
+#define DIB_DDEVTYPE_SUB_Pos                4U                                            /*!< DIB DDEVTYPE: Sub-type Position */
+#define DIB_DDEVTYPE_SUB_Msk               (0xFUL << DIB_DDEVTYPE_SUB_Pos )               /*!< DIB DDEVTYPE: Sub-type Mask */
+
+#define DIB_DDEVTYPE_MAJOR_Pos              0U                                            /*!< DIB DDEVTYPE: Major type Position */
+#define DIB_DDEVTYPE_MAJOR_Msk             (0xFUL /*<< DIB_DDEVTYPE_MAJOR_Pos*/)          /*!< DIB DDEVTYPE: Major type Mask */
+
+/*@} end of group CMSIS_DIB */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_core_bitfield     Core register bit field macros
+  \brief      Macros for use with bit field definitions (xxx_Pos, xxx_Msk).
+  @{
+ */
+
+/**
+  \brief   Mask and shift a bit field value for use in a register bit range.
+  \param[in] field  Name of the register bit field.
+  \param[in] value  Value of the bit field. This parameter is interpreted as an uint32_t type.
+  \return           Masked and shifted value.
+*/
+#define _VAL2FLD(field, value)    (((uint32_t)(value) << field ## _Pos) & field ## _Msk)
+
+/**
+  \brief     Mask and shift a register value to extract a bit filed value.
+  \param[in] field  Name of the register bit field.
+  \param[in] value  Value of register. This parameter is interpreted as an uint32_t type.
+  \return           Masked and shifted bit field value.
+*/
+#define _FLD2VAL(field, value)    (((uint32_t)(value) & field ## _Msk) >> field ## _Pos)
+
+/*@} end of group CMSIS_core_bitfield */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_core_base     Core Definitions
+  \brief      Definitions for base addresses, unions, and structures.
+  @{
+ */
+
+/* Memory mapping of Core Hardware */
+  #define SCS_BASE            (0xE000E000UL)                             /*!< System Control Space Base Address */
+  #define ITM_BASE            (0xE0000000UL)                             /*!< ITM Base Address */
+  #define DWT_BASE            (0xE0001000UL)                             /*!< DWT Base Address */
+  #define MEMSYSCTL_BASE      (0xE001E000UL)                             /*!< Memory System Control Base Address */
+  #define ERRBNK_BASE         (0xE001E100UL)                             /*!< Error Banking Base Address */
+  #define PWRMODCTL_BASE      (0xE001E300UL)                             /*!< Power Mode Control Base Address */
+  #define EWIC_ISA_BASE       (0xE001E400UL)                             /*!< External Wakeup Interrupt Controller interrupt status access Base Address */
+  #define PRCCFGINF_BASE      (0xE001E700UL)                             /*!< Processor Configuration Information Base Address */
+  #define STL_BASE            (0xE001E800UL)                             /*!< Software Test Library Base Address */
+  #define TPIU_BASE           (0xE0040000UL)                             /*!< TPIU Base Address */
+  #define EWIC_BASE           (0xE0047000UL)                             /*!< External Wakeup Interrupt Controller Base Address */
+  #define DCB_BASE            (0xE000EDF0UL)                             /*!< DCB Base Address */
+  #define DIB_BASE            (0xE000EFB0UL)                             /*!< DIB Base Address */
+  #define SysTick_BASE        (SCS_BASE +  0x0010UL)                     /*!< SysTick Base Address */
+  #define NVIC_BASE           (SCS_BASE +  0x0100UL)                     /*!< NVIC Base Address */
+  #define SCB_BASE            (SCS_BASE +  0x0D00UL)                     /*!< System Control Block Base Address */
+
+  #define ICB                 ((ICB_Type       *)     SCS_BASE         ) /*!< System control Register not in SCB */
+  #define SCB                 ((SCB_Type       *)     SCB_BASE         ) /*!< SCB configuration struct */
+  #define SysTick             ((SysTick_Type   *)     SysTick_BASE     ) /*!< SysTick configuration struct */
+  #define NVIC                ((NVIC_Type      *)     NVIC_BASE        ) /*!< NVIC configuration struct */
+  #define ITM                 ((ITM_Type       *)     ITM_BASE         ) /*!< ITM configuration struct */
+  #define DWT                 ((DWT_Type       *)     DWT_BASE         ) /*!< DWT configuration struct */
+  #define TPIU                ((TPIU_Type      *)     TPIU_BASE        ) /*!< TPIU configuration struct */
+  #define MEMSYSCTL           ((MemSysCtl_Type *)     MEMSYSCTL_BASE   ) /*!< Memory System Control configuration struct */
+  #define ERRBNK              ((ErrBnk_Type    *)     ERRBNK_BASE      ) /*!< Error Banking configuration struct */
+  #define PWRMODCTL           ((PwrModCtl_Type *)     PWRMODCTL_BASE   ) /*!< Power Mode Control configuration struct */
+  #define EWIC_ISA            ((EWIC_ISA_Type  *)     EWIC_ISA_BASE    ) /*!< EWIC interrupt status access struct */
+  #define EWIC                ((EWIC_Type      *)     EWIC_BASE        ) /*!< EWIC configuration struct */
+  #define PRCCFGINF           ((PrcCfgInf_Type *)     PRCCFGINF_BASE   ) /*!< Processor Configuration Information configuration struct */
+  #define STL                 ((STL_Type       *)     STL_BASE         ) /*!< Software Test Library configuration struct */
+  #define DCB                 ((DCB_Type       *)     DCB_BASE         ) /*!< DCB configuration struct */
+  #define DIB                 ((DIB_Type       *)     DIB_BASE         ) /*!< DIB configuration struct */
+
+  #if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+    #define MPU_BASE          (SCS_BASE +  0x0D90UL)                     /*!< Memory Protection Unit */
+    #define MPU               ((MPU_Type       *)     MPU_BASE         ) /*!< Memory Protection Unit */
+  #endif
+
+  #if defined (__PMU_PRESENT) && (__PMU_PRESENT == 1U)
+    #define PMU_BASE          (0xE0003000UL)                             /*!< PMU Base Address */
+    #define PMU               ((PMU_Type       *)     PMU_BASE         ) /*!< PMU configuration struct */
+  #endif
+
+  #if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+    #define SAU_BASE          (SCS_BASE +  0x0DD0UL)                     /*!< Security Attribution Unit */
+    #define SAU               ((SAU_Type       *)     SAU_BASE         ) /*!< Security Attribution Unit */
+  #endif
+
+  #define FPU_BASE            (SCS_BASE +  0x0F30UL)                     /*!< Floating Point Unit */
+  #define FPU                 ((FPU_Type       *)     FPU_BASE         ) /*!< Floating Point Unit */
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  #define SCS_BASE_NS         (0xE002E000UL)                             /*!< System Control Space Base Address (non-secure address space) */
+  #define DCB_BASE_NS         (0xE002EDF0UL)                             /*!< DCB Base Address                  (non-secure address space) */
+  #define DIB_BASE_NS         (0xE002EFB0UL)                             /*!< DIB Base Address                  (non-secure address space) */
+  #define SysTick_BASE_NS     (SCS_BASE_NS +  0x0010UL)                  /*!< SysTick Base Address              (non-secure address space) */
+  #define NVIC_BASE_NS        (SCS_BASE_NS +  0x0100UL)                  /*!< NVIC Base Address                 (non-secure address space) */
+  #define SCB_BASE_NS         (SCS_BASE_NS +  0x0D00UL)                  /*!< System Control Block Base Address (non-secure address space) */
+
+  #define ICB_NS              ((ICB_Type       *)     SCS_BASE_NS      ) /*!< System control Register not in SCB(non-secure address space) */
+  #define SCB_NS              ((SCB_Type       *)     SCB_BASE_NS      ) /*!< SCB configuration struct          (non-secure address space) */
+  #define SysTick_NS          ((SysTick_Type   *)     SysTick_BASE_NS  ) /*!< SysTick configuration struct      (non-secure address space) */
+  #define NVIC_NS             ((NVIC_Type      *)     NVIC_BASE_NS     ) /*!< NVIC configuration struct         (non-secure address space) */
+  #define DCB_NS              ((DCB_Type       *)     DCB_BASE_NS      ) /*!< DCB configuration struct          (non-secure address space) */
+  #define DIB_NS              ((DIB_Type       *)     DIB_BASE_NS      ) /*!< DIB configuration struct          (non-secure address space) */
+
+  #if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+    #define MPU_BASE_NS       (SCS_BASE_NS +  0x0D90UL)                  /*!< Memory Protection Unit            (non-secure address space) */
+    #define MPU_NS            ((MPU_Type       *)     MPU_BASE_NS      ) /*!< Memory Protection Unit            (non-secure address space) */
+  #endif
+
+  #define FPU_BASE_NS         (SCS_BASE_NS +  0x0F30UL)                  /*!< Floating Point Unit               (non-secure address space) */
+  #define FPU_NS              ((FPU_Type       *)     FPU_BASE_NS      ) /*!< Floating Point Unit               (non-secure address space) */
+
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+/*@} */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_register_aliases     Backwards Compatibility Aliases
+  \brief      Register alias definitions for backwards compatibility.
+  @{
+ */
+
+/*@} */
+
+
+/*******************************************************************************
+ *                Hardware Abstraction Layer
+  Core Function Interface contains:
+  - Core NVIC Functions
+  - Core SysTick Functions
+  - Core Debug Functions
+  - Core Register Access Functions
+ ******************************************************************************/
+/**
+  \defgroup CMSIS_Core_FunctionInterface Functions and Instructions Reference
+*/
+
+
+
+/* ##########################   NVIC functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_NVICFunctions NVIC Functions
+  \brief    Functions that manage interrupts and exceptions via the NVIC.
+  @{
+ */
+
+#ifdef CMSIS_NVIC_VIRTUAL
+  #ifndef CMSIS_NVIC_VIRTUAL_HEADER_FILE
+    #define CMSIS_NVIC_VIRTUAL_HEADER_FILE "cmsis_nvic_virtual.h"
+  #endif
+  #include CMSIS_NVIC_VIRTUAL_HEADER_FILE
+#else
+  #define NVIC_SetPriorityGrouping    __NVIC_SetPriorityGrouping
+  #define NVIC_GetPriorityGrouping    __NVIC_GetPriorityGrouping
+  #define NVIC_EnableIRQ              __NVIC_EnableIRQ
+  #define NVIC_GetEnableIRQ           __NVIC_GetEnableIRQ
+  #define NVIC_DisableIRQ             __NVIC_DisableIRQ
+  #define NVIC_GetPendingIRQ          __NVIC_GetPendingIRQ
+  #define NVIC_SetPendingIRQ          __NVIC_SetPendingIRQ
+  #define NVIC_ClearPendingIRQ        __NVIC_ClearPendingIRQ
+  #define NVIC_GetActive              __NVIC_GetActive
+  #define NVIC_SetPriority            __NVIC_SetPriority
+  #define NVIC_GetPriority            __NVIC_GetPriority
+  #define NVIC_SystemReset            __NVIC_SystemReset
+#endif /* CMSIS_NVIC_VIRTUAL */
+
+#ifdef CMSIS_VECTAB_VIRTUAL
+  #ifndef CMSIS_VECTAB_VIRTUAL_HEADER_FILE
+    #define CMSIS_VECTAB_VIRTUAL_HEADER_FILE "cmsis_vectab_virtual.h"
+  #endif
+  #include CMSIS_VECTAB_VIRTUAL_HEADER_FILE
+#else
+  #define NVIC_SetVector              __NVIC_SetVector
+  #define NVIC_GetVector              __NVIC_GetVector
+#endif  /* (CMSIS_VECTAB_VIRTUAL) */
+
+#define NVIC_USER_IRQ_OFFSET          16
+
+
+/* Special LR values for Secure/Non-Secure call handling and exception handling                                               */
+
+/* Function Return Payload (from ARMv8-M Architecture Reference Manual) LR value on entry from Secure BLXNS                   */
+#define FNC_RETURN                 (0xFEFFFFFFUL)     /* bit [0] ignored when processing a branch                             */
+
+/* The following EXC_RETURN mask values are used to evaluate the LR on exception entry */
+#define EXC_RETURN_PREFIX          (0xFF000000UL)     /* bits [31:24] set to indicate an EXC_RETURN value                     */
+#define EXC_RETURN_S               (0x00000040UL)     /* bit [6] stack used to push registers: 0=Non-secure 1=Secure          */
+#define EXC_RETURN_DCRS            (0x00000020UL)     /* bit [5] stacking rules for called registers: 0=skipped 1=saved       */
+#define EXC_RETURN_FTYPE           (0x00000010UL)     /* bit [4] allocate stack for floating-point context: 0=done 1=skipped  */
+#define EXC_RETURN_MODE            (0x00000008UL)     /* bit [3] processor mode for return: 0=Handler mode 1=Thread mode      */
+#define EXC_RETURN_SPSEL           (0x00000004UL)     /* bit [2] stack pointer used to restore context: 0=MSP 1=PSP           */
+#define EXC_RETURN_ES              (0x00000001UL)     /* bit [0] security state exception was taken to: 0=Non-secure 1=Secure */
+
+/* Integrity Signature (from ARMv8-M Architecture Reference Manual) for exception context stacking                            */
+#if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)  /* Value for processors with floating-point extension:                  */
+#define EXC_INTEGRITY_SIGNATURE     (0xFEFA125AUL)     /* bit [0] SFTC must match LR bit[4] EXC_RETURN_FTYPE                   */
+#else
+#define EXC_INTEGRITY_SIGNATURE     (0xFEFA125BUL)     /* Value for processors without floating-point extension                */
+#endif
+
+
+/**
+  \brief   Set Priority Grouping
+  \details Sets the priority grouping field using the required unlock sequence.
+           The parameter PriorityGroup is assigned to the field SCB->AIRCR [10:8] PRIGROUP field.
+           Only values from 0..7 are used.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+  \param [in]      PriorityGroup  Priority grouping field.
+ */
+__STATIC_INLINE void __NVIC_SetPriorityGrouping(uint32_t PriorityGroup)
+{
+  uint32_t reg_value;
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);             /* only values 0..7 are used          */
+
+  reg_value  =  SCB->AIRCR;                                                   /* read old register configuration    */
+  reg_value &= ~((uint32_t)(SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk)); /* clear bits to change               */
+  reg_value  =  (reg_value                                   |
+                ((uint32_t)0x5FAUL << SCB_AIRCR_VECTKEY_Pos) |
+                (PriorityGroupTmp << SCB_AIRCR_PRIGROUP_Pos)  );              /* Insert write key and priority group */
+  SCB->AIRCR =  reg_value;
+}
+
+
+/**
+  \brief   Get Priority Grouping
+  \details Reads the priority grouping field from the NVIC Interrupt Controller.
+  \return                Priority grouping field (SCB->AIRCR [10:8] PRIGROUP field).
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPriorityGrouping(void)
+{
+  return ((uint32_t)((SCB->AIRCR & SCB_AIRCR_PRIGROUP_Msk) >> SCB_AIRCR_PRIGROUP_Pos));
+}
+
+
+/**
+  \brief   Enable Interrupt
+  \details Enables a device specific interrupt in the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_EnableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    __COMPILER_BARRIER();
+    NVIC->ISER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+    __COMPILER_BARRIER();
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Enable status
+  \details Returns a device specific interrupt enable status from the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt is not enabled.
+  \return             1  Interrupt is enabled.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetEnableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ISER[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Disable Interrupt
+  \details Disables a device specific interrupt in the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_DisableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ICER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+    __DSB();
+    __ISB();
+  }
+}
+
+
+/**
+  \brief   Get Pending Interrupt
+  \details Reads the NVIC pending register and returns the pending bit for the specified device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not pending.
+  \return             1  Interrupt status is pending.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ISPR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Pending Interrupt
+  \details Sets the pending bit of a device specific interrupt in the NVIC pending register.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_SetPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ISPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Clear Pending Interrupt
+  \details Clears the pending bit of a device specific interrupt in the NVIC pending register.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_ClearPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ICPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Active Interrupt
+  \details Reads the active register in the NVIC and returns the active bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not active.
+  \return             1  Interrupt status is active.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetActive(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->IABR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   Get Interrupt Target State
+  \details Reads the interrupt target field in the NVIC and returns the interrupt target bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  if interrupt is assigned to Secure
+  \return             1  if interrupt is assigned to Non Secure
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t NVIC_GetTargetState(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Interrupt Target State
+  \details Sets the interrupt target field in the NVIC and returns the interrupt target bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  if interrupt is assigned to Secure
+                      1  if interrupt is assigned to Non Secure
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t NVIC_SetTargetState(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] |=  ((uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL)));
+    return((uint32_t)(((NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Clear Interrupt Target State
+  \details Clears the interrupt target field in the NVIC and returns the interrupt target bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  if interrupt is assigned to Secure
+                      1  if interrupt is assigned to Non Secure
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t NVIC_ClearTargetState(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] &= ~((uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL)));
+    return((uint32_t)(((NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+
+/**
+  \brief   Set Interrupt Priority
+  \details Sets the priority of a device specific interrupt or a processor exception.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]      IRQn  Interrupt number.
+  \param [in]  priority  Priority to set.
+  \note    The priority cannot be set for every processor exception.
+ */
+__STATIC_INLINE void __NVIC_SetPriority(IRQn_Type IRQn, uint32_t priority)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->IPR[((uint32_t)IRQn)]               = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+  else
+  {
+    SCB->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Priority
+  \details Reads the priority of a device specific interrupt or a processor exception.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn  Interrupt number.
+  \return             Interrupt Priority.
+                      Value is aligned automatically to the implemented priority bits of the microcontroller.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPriority(IRQn_Type IRQn)
+{
+
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return(((uint32_t)NVIC->IPR[((uint32_t)IRQn)]               >> (8U - __NVIC_PRIO_BITS)));
+  }
+  else
+  {
+    return(((uint32_t)SCB->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] >> (8U - __NVIC_PRIO_BITS)));
+  }
+}
+
+
+/**
+  \brief   Encode Priority
+  \details Encodes the priority for an interrupt with the given priority group,
+           preemptive priority value, and subpriority value.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+  \param [in]     PriorityGroup  Used priority group.
+  \param [in]   PreemptPriority  Preemptive priority value (starting from 0).
+  \param [in]       SubPriority  Subpriority value (starting from 0).
+  \return                        Encoded priority. Value can be used in the function \ref NVIC_SetPriority().
+ */
+__STATIC_INLINE uint32_t NVIC_EncodePriority (uint32_t PriorityGroup, uint32_t PreemptPriority, uint32_t SubPriority)
+{
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);   /* only values 0..7 are used          */
+  uint32_t PreemptPriorityBits;
+  uint32_t SubPriorityBits;
+
+  PreemptPriorityBits = ((7UL - PriorityGroupTmp) > (uint32_t)(__NVIC_PRIO_BITS)) ? (uint32_t)(__NVIC_PRIO_BITS) : (uint32_t)(7UL - PriorityGroupTmp);
+  SubPriorityBits     = ((PriorityGroupTmp + (uint32_t)(__NVIC_PRIO_BITS)) < (uint32_t)7UL) ? (uint32_t)0UL : (uint32_t)((PriorityGroupTmp - 7UL) + (uint32_t)(__NVIC_PRIO_BITS));
+
+  return (
+           ((PreemptPriority & (uint32_t)((1UL << (PreemptPriorityBits)) - 1UL)) << SubPriorityBits) |
+           ((SubPriority     & (uint32_t)((1UL << (SubPriorityBits    )) - 1UL)))
+         );
+}
+
+
+/**
+  \brief   Decode Priority
+  \details Decodes an interrupt priority value with a given priority group to
+           preemptive priority value and subpriority value.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS) the smallest possible priority group is set.
+  \param [in]         Priority   Priority value, which can be retrieved with the function \ref NVIC_GetPriority().
+  \param [in]     PriorityGroup  Used priority group.
+  \param [out] pPreemptPriority  Preemptive priority value (starting from 0).
+  \param [out]     pSubPriority  Subpriority value (starting from 0).
+ */
+__STATIC_INLINE void NVIC_DecodePriority (uint32_t Priority, uint32_t PriorityGroup, uint32_t* const pPreemptPriority, uint32_t* const pSubPriority)
+{
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);   /* only values 0..7 are used          */
+  uint32_t PreemptPriorityBits;
+  uint32_t SubPriorityBits;
+
+  PreemptPriorityBits = ((7UL - PriorityGroupTmp) > (uint32_t)(__NVIC_PRIO_BITS)) ? (uint32_t)(__NVIC_PRIO_BITS) : (uint32_t)(7UL - PriorityGroupTmp);
+  SubPriorityBits     = ((PriorityGroupTmp + (uint32_t)(__NVIC_PRIO_BITS)) < (uint32_t)7UL) ? (uint32_t)0UL : (uint32_t)((PriorityGroupTmp - 7UL) + (uint32_t)(__NVIC_PRIO_BITS));
+
+  *pPreemptPriority = (Priority >> SubPriorityBits) & (uint32_t)((1UL << (PreemptPriorityBits)) - 1UL);
+  *pSubPriority     = (Priority                   ) & (uint32_t)((1UL << (SubPriorityBits    )) - 1UL);
+}
+
+
+/**
+  \brief   Set Interrupt Vector
+  \details Sets an interrupt vector in SRAM based interrupt vector table.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+           VTOR must been relocated to SRAM before.
+  \param [in]   IRQn      Interrupt number
+  \param [in]   vector    Address of interrupt handler function
+ */
+__STATIC_INLINE void __NVIC_SetVector(IRQn_Type IRQn, uint32_t vector)
+{
+  uint32_t *vectors = (uint32_t *) ((uintptr_t) SCB->VTOR);
+  vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET] = vector;
+  __DSB();
+}
+
+
+/**
+  \brief   Get Interrupt Vector
+  \details Reads an interrupt vector from interrupt vector table.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn      Interrupt number.
+  \return                 Address of interrupt handler function
+ */
+__STATIC_INLINE uint32_t __NVIC_GetVector(IRQn_Type IRQn)
+{
+  uint32_t *vectors = (uint32_t *) ((uintptr_t) SCB->VTOR);
+  return vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET];
+}
+
+
+/**
+  \brief   System Reset
+  \details Initiates a system reset request to reset the MCU.
+ */
+__NO_RETURN __STATIC_INLINE void __NVIC_SystemReset(void)
+{
+  __DSB();                                                          /* Ensure all outstanding memory accesses included
+                                                                       buffered write are completed before reset */
+  SCB->AIRCR  = (uint32_t)((0x5FAUL << SCB_AIRCR_VECTKEY_Pos)    |
+                           (SCB->AIRCR & SCB_AIRCR_PRIGROUP_Msk) |
+                            SCB_AIRCR_SYSRESETREQ_Msk    );         /* Keep priority group unchanged */
+  __DSB();                                                          /* Ensure completion of memory access */
+
+  for(;;)                                                           /* wait until reset */
+  {
+    __NOP();
+  }
+}
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   Set Priority Grouping (non-secure)
+  \details Sets the non-secure priority grouping field when in secure state using the required unlock sequence.
+           The parameter PriorityGroup is assigned to the field SCB->AIRCR [10:8] PRIGROUP field.
+           Only values from 0..7 are used.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+  \param [in]      PriorityGroup  Priority grouping field.
+ */
+__STATIC_INLINE void TZ_NVIC_SetPriorityGrouping_NS(uint32_t PriorityGroup)
+{
+  uint32_t reg_value;
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);             /* only values 0..7 are used          */
+
+  reg_value  =  SCB_NS->AIRCR;                                                /* read old register configuration    */
+  reg_value &= ~((uint32_t)(SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk)); /* clear bits to change               */
+  reg_value  =  (reg_value                                   |
+                ((uint32_t)0x5FAUL << SCB_AIRCR_VECTKEY_Pos) |
+                (PriorityGroupTmp << SCB_AIRCR_PRIGROUP_Pos)  );              /* Insert write key and priority group */
+  SCB_NS->AIRCR =  reg_value;
+}
+
+
+/**
+  \brief   Get Priority Grouping (non-secure)
+  \details Reads the priority grouping field from the non-secure NVIC when in secure state.
+  \return                Priority grouping field (SCB->AIRCR [10:8] PRIGROUP field).
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetPriorityGrouping_NS(void)
+{
+  return ((uint32_t)((SCB_NS->AIRCR & SCB_AIRCR_PRIGROUP_Msk) >> SCB_AIRCR_PRIGROUP_Pos));
+}
+
+
+/**
+  \brief   Enable Interrupt (non-secure)
+  \details Enables a device specific interrupt in the non-secure NVIC interrupt controller when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void TZ_NVIC_EnableIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->ISER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Enable status (non-secure)
+  \details Returns a device specific interrupt enable status from the non-secure NVIC interrupt controller when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt is not enabled.
+  \return             1  Interrupt is enabled.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetEnableIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC_NS->ISER[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Disable Interrupt (non-secure)
+  \details Disables a device specific interrupt in the non-secure NVIC interrupt controller when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void TZ_NVIC_DisableIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->ICER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Pending Interrupt (non-secure)
+  \details Reads the NVIC pending register in the non-secure NVIC when in secure state and returns the pending bit for the specified device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not pending.
+  \return             1  Interrupt status is pending.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetPendingIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC_NS->ISPR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Pending Interrupt (non-secure)
+  \details Sets the pending bit of a device specific interrupt in the non-secure NVIC pending register when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void TZ_NVIC_SetPendingIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->ISPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Clear Pending Interrupt (non-secure)
+  \details Clears the pending bit of a device specific interrupt in the non-secure NVIC pending register when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void TZ_NVIC_ClearPendingIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->ICPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Active Interrupt (non-secure)
+  \details Reads the active register in non-secure NVIC when in secure state and returns the active bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not active.
+  \return             1  Interrupt status is active.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetActive_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC_NS->IABR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Interrupt Priority (non-secure)
+  \details Sets the priority of a non-secure device specific interrupt or a non-secure processor exception when in secure state.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]      IRQn  Interrupt number.
+  \param [in]  priority  Priority to set.
+  \note    The priority cannot be set for every non-secure processor exception.
+ */
+__STATIC_INLINE void TZ_NVIC_SetPriority_NS(IRQn_Type IRQn, uint32_t priority)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->IPR[((uint32_t)IRQn)]               = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+  else
+  {
+    SCB_NS->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Priority (non-secure)
+  \details Reads the priority of a non-secure device specific interrupt or a non-secure processor exception when in secure state.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn  Interrupt number.
+  \return             Interrupt Priority. Value is aligned automatically to the implemented priority bits of the microcontroller.
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetPriority_NS(IRQn_Type IRQn)
+{
+
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return(((uint32_t)NVIC_NS->IPR[((uint32_t)IRQn)]               >> (8U - __NVIC_PRIO_BITS)));
+  }
+  else
+  {
+    return(((uint32_t)SCB_NS->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] >> (8U - __NVIC_PRIO_BITS)));
+  }
+}
+#endif /*  defined (__ARM_FEATURE_CMSE) &&(__ARM_FEATURE_CMSE == 3U) */
+
+/*@} end of CMSIS_Core_NVICFunctions */
+
+/* ##########################  MPU functions  #################################### */
+
+#if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+
+  #include "m-profile/armv8m_mpu.h"
+
+#endif
+
+/* ##########################  PMU functions and events  #################################### */
+
+#if defined (__PMU_PRESENT) && (__PMU_PRESENT == 1U)
+
+#include "m-profile/armv8m_pmu.h"
+
+/**
+  \brief   Cortex-M85 PMU events
+  \note    Architectural PMU events can be found in armv8m_pmu.h
+*/
+
+#define ARMCM85_PMU_ECC_ERR                          0xC000             /*!< One or more Error Correcting Code (ECC) errors detected */
+#define ARMCM85_PMU_ECC_ERR_MBIT                     0xC001             /*!< One or more multi-bit ECC errors detected */
+#define ARMCM85_PMU_ECC_ERR_DCACHE                   0xC010             /*!< One or more ECC errors in the data cache */
+#define ARMCM85_PMU_ECC_ERR_ICACHE                   0xC011             /*!< One or more ECC errors in the instruction cache */
+#define ARMCM85_PMU_ECC_ERR_MBIT_DCACHE              0xC012             /*!< One or more multi-bit ECC errors in the data cache */
+#define ARMCM85_PMU_ECC_ERR_MBIT_ICACHE              0xC013             /*!< One or more multi-bit ECC errors in the instruction cache */
+#define ARMCM85_PMU_ECC_ERR_DTCM                     0xC020             /*!< One or more ECC errors in the Data Tightly Coupled Memory (DTCM) */
+#define ARMCM85_PMU_ECC_ERR_ITCM                     0xC021             /*!< One or more ECC errors in the Instruction Tightly Coupled Memory (ITCM) */
+#define ARMCM85_PMU_ECC_ERR_MBIT_DTCM                0xC022             /*!< One or more multi-bit ECC errors in the DTCM */
+#define ARMCM85_PMU_ECC_ERR_MBIT_ITCM                0xC023             /*!< One or more multi-bit ECC errors in the ITCM */
+#define ARMCM85_PMU_PF_LINEFILL                      0xC100             /*!< The prefetcher starts a line-fill */
+#define ARMCM85_PMU_PF_CANCEL                        0xC101             /*!< The prefetcher stops prefetching */
+#define ARMCM85_PMU_PF_DROP_LINEFILL                 0xC102             /*!< A linefill triggered by a prefetcher has been dropped because of lack of buffering */
+#define ARMCM85_PMU_NWAMODE_ENTER                    0xC200             /*!< No write-allocate mode entry */
+#define ARMCM85_PMU_NWAMODE                          0xC201             /*!< Write-allocate store is not allocated into the data cache due to no-write-allocate mode */
+#define ARMCM85_PMU_SAHB_ACCESS                      0xC300             /*!< Read or write access on the S-AHB interface to the TCM */
+#define ARMCM85_PMU_PAHB_ACCESS                      0xC301             /*!< Read or write access on the P-AHB write interface */
+#define ARMCM85_PMU_AXI_WRITE_ACCESS                 0xC302             /*!< Any beat access to M-AXI write interface */
+#define ARMCM85_PMU_AXI_READ_ACCESS                  0xC303             /*!< Any beat access to M-AXI read interface */
+#define ARMCM85_PMU_DOSTIMEOUT_DOUBLE                0xC400             /*!< Denial of Service timeout has fired twice and caused buffers to drain to allow forward progress */
+#define ARMCM85_PMU_DOSTIMEOUT_TRIPLE                0xC401             /*!< Denial of Service timeout has fired three times and blocked the LSU to force forward progress */
+#define ARMCM85_PMU_FUSED_INST_RETIRED               0xC500             /*!< Fused instructions architecturally executed */
+#define ARMCM85_PMU_BR_INDIRECT                      0xC501             /*!< Indirect branch instruction architecturally executed */
+#define ARMCM85_PMU_BTAC_HIT                         0xC502             /*!< BTAC branch predictor hit */
+#define ARMCM85_PMU_BTAC_HIT_RETURNS                 0xC503             /*!< Return branch hits BTAC */
+#define ARMCM85_PMU_BTAC_HIT_CALLS                   0xC504             /*!< Call branch hits BTAC */
+#define ARMCM85_PMU_BTAC_HIT_INDIRECT                0xC505             /*!< Indirect branch hits BTACT */
+#define ARMCM85_PMU_BTAC_NEW_ALLOC                   0xC506             /*!< New allocation to BTAC */
+#define ARMCM85_PMU_BR_IND_MIS_PRED                  0xC507             /*!< Indirect branch mis-predicted */
+#define ARMCM85_PMU_BR_RETURN_MIS_PRED               0xC508             /*!< Return branch mis-predicted */
+#define ARMCM85_PMU_BR_BTAC_OFFSET_OVERFLOW          0xC509             /*!< Branch does not allocate in BTAC due to offset overflow */
+#define ARMCM85_PMU_STB_FULL_STALL_AXI               0xC50A             /*!< STore Buffer (STB) full with AXI requests causing CPU to stall */
+#define ARMCM85_PMU_STB_FULL_STALL_TCM               0xC50B             /*!< STB full with TCM requests causing CPU to stall */
+#define ARMCM85_PMU_CPU_STALLED_AHBS                 0xC50C             /*!< CPU is stalled because TCM access through AHBS */
+#define ARMCM85_PMU_AHBS_STALLED_CPU                 0xC50D             /*!< AHBS is stalled due to TCM access by CPU */
+#define ARMCM85_PMU_BR_INTERSTATING_MIS_PRED         0xC50E             /*!< Inter-stating branch is mis-predicted. */
+#define ARMCM85_PMU_DWT_STALL                        0xC50F             /*!< Data Watchpoint and Trace (DWT) stall */
+#define ARMCM85_PMU_DWT_FLUSH                        0xC510             /*!< DWT flush */
+#define ARMCM85_PMU_ETM_STALL                        0xC511             /*!< Embedded Trace Macrocell (ETM) stall */
+#define ARMCM85_PMU_ETM_FLUSH                        0xC512             /*!< ETM flush */
+#define ARMCM85_PMU_ADDRESS_BANK_CONFLICT            0xC513             /*!< Bank conflict prevents memory instruction dual issue */
+#define ARMCM85_PMU_BLOCKED_DUAL_ISSUE               0xC514             /*!< Dual instruction issuing is prevented */
+#define ARMCM85_PMU_FP_CONTEXT_TRIGGER               0xC515             /*!< Floating Point Context is created */
+#define ARMCM85_PMU_TAIL_CHAIN                       0xC516             /*!< New exception is handled without first unstacking */
+#define ARMCM85_PMU_LATE_ARRIVAL                     0xC517             /*!< Late-arriving exception taken during exception entry */
+#define ARMCM85_PMU_INT_STALL_FAULT                  0xC518             /*!< Delayed exception entry due to ongoing fault processing */
+#define ARMCM85_PMU_INT_STALL_DEV                    0xC519             /*!< Delayed exception entry due to outstanding device access */
+#define ARMCM85_PMU_PAC_STALL                        0xC51A             /*!< Stall caused by authentication code computation */
+#define ARMCM85_PMU_PAC_RETIRED                      0xC51B             /*!< PAC instruction architecturally executed */
+#define ARMCM85_PMU_AUT_RETIRED                      0xC51C             /*!< AUT instruction architecturally executed */
+#define ARMCM85_PMU_BTI_RETIRED                      0xC51D             /*!< BTI instruction architecturally executed */
+#define ARMCM85_PMU_PF_NL_MODE                       0xC51E             /*!< Prefetch in next line mode */
+#define ARMCM85_PMU_PF_STREAM_MODE                   0xC51F             /*!< Prefetch in stream mode */
+#define ARMCM85_PMU_PF_BUFF_CACHE_HIT                0xC520             /*!< Prefetch request that hit in the cache */
+#define ARMCM85_PMU_PF_REQ_LFB_HIT                   0xC521             /*!< Prefetch request that hit in line fill buffers */
+#define ARMCM85_PMU_PF_BUFF_FULL                     0xC522             /*!< Number of times prefetch buffer is full */
+#define ARMCM85_PMU_PF_REQ_DCACHE_HIT                0xC523             /*!< Generated prefetch request address that hit in D-Cache */
+
+#endif
+
+/* ##########################  FPU functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_FpuFunctions FPU Functions
+  \brief    Function that provides FPU type.
+  @{
+ */
+
+/**
+  \brief   get FPU type
+  \details returns the FPU type
+  \returns
+   - \b  0: No FPU
+   - \b  1: Single precision FPU
+   - \b  2: Double + Single precision FPU
+ */
+__STATIC_INLINE uint32_t SCB_GetFPUType(void)
+{
+  uint32_t mvfr0;
+
+  mvfr0 = FPU->MVFR0;
+  if      ((mvfr0 & (FPU_MVFR0_FPSP_Msk | FPU_MVFR0_FPDP_Msk)) == 0x220U)
+  {
+    return 2U;           /* Double + Single precision FPU */
+  }
+  else if ((mvfr0 & (FPU_MVFR0_FPSP_Msk | FPU_MVFR0_FPDP_Msk)) == 0x020U)
+  {
+    return 1U;           /* Single precision FPU */
+  }
+  else
+  {
+    return 0U;           /* No FPU */
+  }
+}
+
+
+/*@} end of CMSIS_Core_FpuFunctions */
+
+/* ##########################  MVE functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_MveFunctions MVE Functions
+  \brief    Function that provides MVE type.
+  @{
+ */
+
+/**
+  \brief   get MVE type
+  \details returns the MVE type
+  \returns
+   - \b  0: No Vector Extension (MVE)
+   - \b  1: Integer Vector Extension (MVE-I)
+   - \b  2: Floating-point Vector Extension (MVE-F)
+ */
+__STATIC_INLINE uint32_t SCB_GetMVEType(void)
+{
+  const uint32_t mvfr1 = FPU->MVFR1;
+  if      ((mvfr1 & FPU_MVFR1_MVE_Msk) == (0x2U << FPU_MVFR1_MVE_Pos))
+  {
+    return 2U;
+  }
+  else if ((mvfr1 & FPU_MVFR1_MVE_Msk) == (0x1U << FPU_MVFR1_MVE_Pos))
+  {
+    return 1U;
+  }
+  else
+  {
+    return 0U;
+  }
+}
+
+
+/*@} end of CMSIS_Core_MveFunctions */
+
+
+/* ##########################  Cache functions  #################################### */
+
+#if ((defined (__ICACHE_PRESENT) && (__ICACHE_PRESENT == 1U)) || \
+     (defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)))
+  #include "m-profile/armv7m_cachel1.h"
+#endif
+
+
+/* ##########################   SAU functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_SAUFunctions SAU Functions
+  \brief    Functions that configure the SAU.
+  @{
+ */
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+
+/**
+  \brief   Enable SAU
+  \details Enables the Security Attribution Unit (SAU).
+ */
+__STATIC_INLINE void TZ_SAU_Enable(void)
+{
+    SAU->CTRL |=  (SAU_CTRL_ENABLE_Msk);
+}
+
+
+
+/**
+  \brief   Disable SAU
+  \details Disables the Security Attribution Unit (SAU).
+ */
+__STATIC_INLINE void TZ_SAU_Disable(void)
+{
+    SAU->CTRL &= ~(SAU_CTRL_ENABLE_Msk);
+}
+
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+/*@} end of CMSIS_Core_SAUFunctions */
+
+
+
+/* ###################  PAC Key functions  ########################### */
+
+#if (defined (__ARM_FEATURE_PAUTH) && (__ARM_FEATURE_PAUTH == 1))
+#include "m-profile/armv81m_pac.h"
+#endif
+
+
+/* ##################################    Debug Control function  ############################################ */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_DCBFunctions Debug Control Functions
+  \brief    Functions that access the Debug Control Block.
+  @{
+ */
+
+
+/**
+  \brief   Set Debug Authentication Control Register
+  \details writes to Debug Authentication Control register.
+  \param [in]  value  value to be writen.
+ */
+__STATIC_INLINE void DCB_SetAuthCtrl(uint32_t value)
+{
+    __DSB();
+    __ISB();
+    DCB->DAUTHCTRL = value;
+    __DSB();
+    __ISB();
+}
+
+
+/**
+  \brief   Get Debug Authentication Control Register
+  \details Reads Debug Authentication Control register.
+  \return             Debug Authentication Control Register.
+ */
+__STATIC_INLINE uint32_t DCB_GetAuthCtrl(void)
+{
+    return (DCB->DAUTHCTRL);
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   Set Debug Authentication Control Register (non-secure)
+  \details writes to non-secure Debug Authentication Control register when in secure state.
+  \param [in]  value  value to be writen
+ */
+__STATIC_INLINE void TZ_DCB_SetAuthCtrl_NS(uint32_t value)
+{
+    __DSB();
+    __ISB();
+    DCB_NS->DAUTHCTRL = value;
+    __DSB();
+    __ISB();
+}
+
+
+/**
+  \brief   Get Debug Authentication Control Register (non-secure)
+  \details Reads non-secure Debug Authentication Control register when in secure state.
+  \return             Debug Authentication Control Register.
+ */
+__STATIC_INLINE uint32_t TZ_DCB_GetAuthCtrl_NS(void)
+{
+    return (DCB_NS->DAUTHCTRL);
+}
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+/*@} end of CMSIS_Core_DCBFunctions */
+
+
+
+
+/* ##################################    Debug Identification function  ############################################ */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_DIBFunctions Debug Identification Functions
+  \brief    Functions that access the Debug Identification Block.
+  @{
+ */
+
+
+/**
+  \brief   Get Debug Authentication Status Register
+  \details Reads Debug Authentication Status register.
+  \return             Debug Authentication Status Register.
+ */
+__STATIC_INLINE uint32_t DIB_GetAuthStatus(void)
+{
+    return (DIB->DAUTHSTATUS);
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   Get Debug Authentication Status Register (non-secure)
+  \details Reads non-secure Debug Authentication Status register when in secure state.
+  \return             Debug Authentication Status Register.
+ */
+__STATIC_INLINE uint32_t TZ_DIB_GetAuthStatus_NS(void)
+{
+    return (DIB_NS->DAUTHSTATUS);
+}
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+/*@} end of CMSIS_Core_DCBFunctions */
+
+
+
+
+/* ##################################    SysTick function  ############################################ */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_SysTickFunctions SysTick Functions
+  \brief    Functions that configure the System.
+  @{
+ */
+
+#if defined (__Vendor_SysTickConfig) && (__Vendor_SysTickConfig == 0U)
+
+/**
+  \brief   System Tick Configuration
+  \details Initializes the System Timer and its interrupt, and starts the System Tick Timer.
+           Counter is in free running mode to generate periodic interrupts.
+  \param [in]  ticks  Number of ticks between two interrupts.
+  \return          0  Function succeeded.
+  \return          1  Function failed.
+  \note    When the variable <b>__Vendor_SysTickConfig</b> is set to 1, then the
+           function <b>SysTick_Config</b> is not included. In this case, the file <b><i>device</i>.h</b>
+           must contain a vendor-specific implementation of this function.
+ */
+__STATIC_INLINE uint32_t SysTick_Config(uint32_t ticks)
+{
+  if ((ticks - 1UL) > SysTick_LOAD_RELOAD_Msk)
+  {
+    return (1UL);                                                   /* Reload value impossible */
+  }
+
+  SysTick->LOAD  = (uint32_t)(ticks - 1UL);                         /* set reload register */
+  NVIC_SetPriority (SysTick_IRQn, (1UL << __NVIC_PRIO_BITS) - 1UL); /* set Priority for Systick Interrupt */
+  SysTick->VAL   = 0UL;                                             /* Load the SysTick Counter Value */
+  SysTick->CTRL  = SysTick_CTRL_CLKSOURCE_Msk |
+                   SysTick_CTRL_TICKINT_Msk   |
+                   SysTick_CTRL_ENABLE_Msk;                         /* Enable SysTick IRQ and SysTick Timer */
+  return (0UL);                                                     /* Function successful */
+}
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   System Tick Configuration (non-secure)
+  \details Initializes the non-secure System Timer and its interrupt when in secure state, and starts the System Tick Timer.
+           Counter is in free running mode to generate periodic interrupts.
+  \param [in]  ticks  Number of ticks between two interrupts.
+  \return          0  Function succeeded.
+  \return          1  Function failed.
+  \note    When the variable <b>__Vendor_SysTickConfig</b> is set to 1, then the
+           function <b>TZ_SysTick_Config_NS</b> is not included. In this case, the file <b><i>device</i>.h</b>
+           must contain a vendor-specific implementation of this function.
+
+ */
+__STATIC_INLINE uint32_t TZ_SysTick_Config_NS(uint32_t ticks)
+{
+  if ((ticks - 1UL) > SysTick_LOAD_RELOAD_Msk)
+  {
+    return (1UL);                                                         /* Reload value impossible */
+  }
+
+  SysTick_NS->LOAD  = (uint32_t)(ticks - 1UL);                            /* set reload register */
+  TZ_NVIC_SetPriority_NS (SysTick_IRQn, (1UL << __NVIC_PRIO_BITS) - 1UL); /* set Priority for Systick Interrupt */
+  SysTick_NS->VAL   = 0UL;                                                /* Load the SysTick Counter Value */
+  SysTick_NS->CTRL  = SysTick_CTRL_CLKSOURCE_Msk |
+                      SysTick_CTRL_TICKINT_Msk   |
+                      SysTick_CTRL_ENABLE_Msk;                            /* Enable SysTick IRQ and SysTick Timer */
+  return (0UL);                                                           /* Function successful */
+}
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+#endif
+
+/*@} end of CMSIS_Core_SysTickFunctions */
+
+
+
+/* ##################################### Debug In/Output function ########################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_core_DebugFunctions ITM Functions
+  \brief    Functions that access the ITM debug interface.
+  @{
+ */
+
+extern volatile int32_t ITM_RxBuffer;                              /*!< External variable to receive characters. */
+#define                 ITM_RXBUFFER_EMPTY  ((int32_t)0x5AA55AA5U) /*!< Value identifying \ref ITM_RxBuffer is ready for next character. */
+
+
+/**
+  \brief   ITM Send Character
+  \details Transmits a character via the ITM channel 0, and
+           \li Just returns when no debugger is connected that has booked the output.
+           \li Is blocking when a debugger is connected, but the previous character sent has not been transmitted.
+  \param [in]     ch  Character to transmit.
+  \returns            Character to transmit.
+ */
+__STATIC_INLINE uint32_t ITM_SendChar (uint32_t ch)
+{
+  if (((ITM->TCR & ITM_TCR_ITMENA_Msk) != 0UL) &&      /* ITM enabled */
+      ((ITM->TER & 1UL               ) != 0UL)   )     /* ITM Port #0 enabled */
+  {
+    while (ITM->PORT[0U].u32 == 0UL)
+    {
+      __NOP();
+    }
+    ITM->PORT[0U].u8 = (uint8_t)ch;
+  }
+  return (ch);
+}
+
+
+/**
+  \brief   ITM Receive Character
+  \details Inputs a character via the external variable \ref ITM_RxBuffer.
+  \return             Received character.
+  \return         -1  No character pending.
+ */
+__STATIC_INLINE int32_t ITM_ReceiveChar (void)
+{
+  int32_t ch = -1;                           /* no character available */
+
+  if (ITM_RxBuffer != ITM_RXBUFFER_EMPTY)
+  {
+    ch = ITM_RxBuffer;
+    ITM_RxBuffer = ITM_RXBUFFER_EMPTY;       /* ready for next character */
+  }
+
+  return (ch);
+}
+
+
+/**
+  \brief   ITM Check Character
+  \details Checks whether a character is pending for reading in the variable \ref ITM_RxBuffer.
+  \return          0  No character available.
+  \return          1  Character available.
+ */
+__STATIC_INLINE int32_t ITM_CheckChar (void)
+{
+
+  if (ITM_RxBuffer == ITM_RXBUFFER_EMPTY)
+  {
+    return (0);                              /* no character available */
+  }
+  else
+  {
+    return (1);                              /*    character available */
+  }
+}
+
+/*@} end of CMSIS_core_DebugFunctions */
+
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_CM85_H_DEPENDANT */
+
+#endif /* __CMSIS_GENERIC */

--- a/platform/ext/cmsis/CMSIS/Core/Include/core_sc000.h
+++ b/platform/ext/cmsis/CMSIS/Core/Include/core_sc000.h
@@ -1,0 +1,1049 @@
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS SC000 Core Peripheral Access Layer Header File
+ */
+
+#if   defined ( __ICCARM__ )
+  #pragma system_include                        /* treat file as system include file for MISRA check */
+#elif defined (__clang__)
+  #pragma clang system_header                   /* treat file as system include file */
+#elif defined ( __GNUC__ )
+  #pragma GCC diagnostic ignored "-Wpedantic"   /* disable pedantic warning due to unnamed structs/unions */
+#endif
+
+#ifndef __CORE_SC000_H_GENERIC
+#define __CORE_SC000_H_GENERIC
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/**
+  \page CMSIS_MISRA_Exceptions  MISRA-C:2004 Compliance Exceptions
+  CMSIS violates the following MISRA-C:2004 rules:
+
+   \li Required Rule 8.5, object/function definition in header file.<br>
+     Function definitions in header files are used to allow 'inlining'.
+
+   \li Required Rule 18.4, declaration of union type or object of union type: '{...}'.<br>
+     Unions are used for effective representation of core registers.
+
+   \li Advisory Rule 19.7, Function-like macro defined.<br>
+     Function-like macros are used to allow more efficient code.
+ */
+
+
+/*******************************************************************************
+ *                 CMSIS definitions
+ ******************************************************************************/
+/**
+  \ingroup SC000
+  @{
+ */
+
+#include "cmsis_version.h"
+
+/* CMSIS SC000 definitions */
+
+#define __CORTEX_SC               (000U)                              /*!< Cortex Secure Core */
+
+/** __FPU_USED indicates whether an FPU is used or not.
+    This core does not support an FPU at all
+*/
+#define __FPU_USED       0U
+
+#if defined ( __CC_ARM )
+  #if defined (__TARGET_FPU_VFP)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #if defined (__ARM_FP)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined (__ti__)
+  #if defined (__ARM_FP)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __GNUC__ )
+  #if defined (__VFP_FP__) && !defined(__SOFTFP__)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __ICCARM__ )
+  #if defined (__ARMVFP__)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __TI_ARM__ )
+  #if defined (__TI_VFP_SUPPORT__)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __TASKING__ )
+  #if defined (__FPU_VFP__)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __CSMC__ )
+  #if ( __CSMC__ & 0x400U)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#endif
+
+#include "cmsis_compiler.h"               /* CMSIS compiler specific defines */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_SC000_H_GENERIC */
+
+#ifndef __CMSIS_GENERIC
+
+#ifndef __CORE_SC000_H_DEPENDANT
+#define __CORE_SC000_H_DEPENDANT
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* check device defines and use defaults */
+#if defined __CHECK_DEVICE_DEFINES
+  #ifndef __SC000_REV
+    #define __SC000_REV             0x0000U
+    #warning "__SC000_REV not defined in device header file; using default!"
+  #endif
+
+  #ifndef __MPU_PRESENT
+    #define __MPU_PRESENT             0U
+    #warning "__MPU_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __VTOR_PRESENT
+    #define __VTOR_PRESENT            0U
+    #warning "__VTOR_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __NVIC_PRIO_BITS
+    #define __NVIC_PRIO_BITS          2U
+    #warning "__NVIC_PRIO_BITS not defined in device header file; using default!"
+  #endif
+
+  #ifndef __Vendor_SysTickConfig
+    #define __Vendor_SysTickConfig    0U
+    #warning "__Vendor_SysTickConfig not defined in device header file; using default!"
+  #endif
+#endif
+
+/* IO definitions (access restrictions to peripheral registers) */
+/**
+    \defgroup CMSIS_glob_defs CMSIS Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+*/
+#ifdef __cplusplus
+  #define   __I     volatile             /*!< Defines 'read only' permissions */
+#else
+  #define   __I     volatile const       /*!< Defines 'read only' permissions */
+#endif
+#define     __O     volatile             /*!< Defines 'write only' permissions */
+#define     __IO    volatile             /*!< Defines 'read / write' permissions */
+
+/* following defines should be used for structure members */
+#define     __IM     volatile const      /*! Defines 'read only' structure member permissions */
+#define     __OM     volatile            /*! Defines 'write only' structure member permissions */
+#define     __IOM    volatile            /*! Defines 'read / write' structure member permissions */
+
+/*@} end of group SC000 */
+
+
+
+/*******************************************************************************
+ *                 Register Abstraction
+  Core Register contain:
+  - Core Register
+  - Core NVIC Register
+  - Core SCB Register
+  - Core SysTick Register
+  - Core MPU Register
+ ******************************************************************************/
+/**
+  \defgroup CMSIS_core_register Defines and Type Definitions
+  \brief Type definitions and defines for Cortex-M processor based devices.
+*/
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_CORE  Status and Control Registers
+  \brief      Core Register type definitions.
+  @{
+ */
+
+/**
+  \brief  Union type to access the Application Program Status Register (APSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t _reserved0:28;              /*!< bit:  0..27  Reserved */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} APSR_Type;
+
+/** \brief APSR Register Definitions */
+#define APSR_N_Pos                         31U                                            /*!< APSR: N Position */
+#define APSR_N_Msk                         (1UL << APSR_N_Pos)                            /*!< APSR: N Mask */
+
+#define APSR_Z_Pos                         30U                                            /*!< APSR: Z Position */
+#define APSR_Z_Msk                         (1UL << APSR_Z_Pos)                            /*!< APSR: Z Mask */
+
+#define APSR_C_Pos                         29U                                            /*!< APSR: C Position */
+#define APSR_C_Msk                         (1UL << APSR_C_Pos)                            /*!< APSR: C Mask */
+
+#define APSR_V_Pos                         28U                                            /*!< APSR: V Position */
+#define APSR_V_Msk                         (1UL << APSR_V_Pos)                            /*!< APSR: V Mask */
+
+
+/**
+  \brief  Union type to access the Interrupt Program Status Register (IPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number */
+    uint32_t _reserved0:23;              /*!< bit:  9..31  Reserved */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} IPSR_Type;
+
+/** \brief IPSR Register Definitions */
+#define IPSR_ISR_Pos                        0U                                            /*!< IPSR: ISR Position */
+#define IPSR_ISR_Msk                       (0x1FFUL /*<< IPSR_ISR_Pos*/)                  /*!< IPSR: ISR Mask */
+
+
+/**
+  \brief  Union type to access the Special-Purpose Program Status Registers (xPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number */
+    uint32_t _reserved0:15;              /*!< bit:  9..23  Reserved */
+    uint32_t T:1;                        /*!< bit:     24  Thumb bit        (read 0) */
+    uint32_t _reserved1:3;               /*!< bit: 25..27  Reserved */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} xPSR_Type;
+
+/** \brief xPSR Register Definitions */
+#define xPSR_N_Pos                         31U                                            /*!< xPSR: N Position */
+#define xPSR_N_Msk                         (1UL << xPSR_N_Pos)                            /*!< xPSR: N Mask */
+
+#define xPSR_Z_Pos                         30U                                            /*!< xPSR: Z Position */
+#define xPSR_Z_Msk                         (1UL << xPSR_Z_Pos)                            /*!< xPSR: Z Mask */
+
+#define xPSR_C_Pos                         29U                                            /*!< xPSR: C Position */
+#define xPSR_C_Msk                         (1UL << xPSR_C_Pos)                            /*!< xPSR: C Mask */
+
+#define xPSR_V_Pos                         28U                                            /*!< xPSR: V Position */
+#define xPSR_V_Msk                         (1UL << xPSR_V_Pos)                            /*!< xPSR: V Mask */
+
+#define xPSR_T_Pos                         24U                                            /*!< xPSR: T Position */
+#define xPSR_T_Msk                         (1UL << xPSR_T_Pos)                            /*!< xPSR: T Mask */
+
+#define xPSR_ISR_Pos                        0U                                            /*!< xPSR: ISR Position */
+#define xPSR_ISR_Msk                       (0x1FFUL /*<< xPSR_ISR_Pos*/)                  /*!< xPSR: ISR Mask */
+
+
+/**
+  \brief  Union type to access the Control Registers (CONTROL).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t _reserved0:1;               /*!< bit:      0  Reserved */
+    uint32_t SPSEL:1;                    /*!< bit:      1  Stack to be used */
+    uint32_t _reserved1:30;              /*!< bit:  2..31  Reserved */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} CONTROL_Type;
+
+/** \brief CONTROL Register Definitions */
+#define CONTROL_SPSEL_Pos                   1U                                            /*!< CONTROL: SPSEL Position */
+#define CONTROL_SPSEL_Msk                  (1UL << CONTROL_SPSEL_Pos)                     /*!< CONTROL: SPSEL Mask */
+
+/*@} end of group CMSIS_CORE */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_NVIC  Nested Vectored Interrupt Controller (NVIC)
+  \brief      Type definitions for the NVIC Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Nested Vectored Interrupt Controller (NVIC).
+ */
+typedef struct
+{
+  __IOM uint32_t ISER[1U];               /*!< Offset: 0x000 (R/W)  Interrupt Set Enable Register */
+        uint32_t RESERVED0[31U];
+  __IOM uint32_t ICER[1U];               /*!< Offset: 0x080 (R/W)  Interrupt Clear Enable Register */
+        uint32_t RESERVED1[31U];
+  __IOM uint32_t ISPR[1U];               /*!< Offset: 0x100 (R/W)  Interrupt Set Pending Register */
+        uint32_t RESERVED2[31U];
+  __IOM uint32_t ICPR[1U];               /*!< Offset: 0x180 (R/W)  Interrupt Clear Pending Register */
+        uint32_t RESERVED3[31U];
+        uint32_t RESERVED4[64U];
+  __IOM uint32_t IPR[8U];                /*!< Offset: 0x300 (R/W)  Interrupt Priority Register */
+}  NVIC_Type;
+
+/*@} end of group CMSIS_NVIC */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SCB     System Control Block (SCB)
+  \brief    Type definitions for the System Control Block Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Control Block (SCB).
+ */
+typedef struct
+{
+  __IM  uint32_t CPUID;                  /*!< Offset: 0x000 (R/ )  CPUID Base Register */
+  __IOM uint32_t ICSR;                   /*!< Offset: 0x004 (R/W)  Interrupt Control and State Register */
+  __IOM uint32_t VTOR;                   /*!< Offset: 0x008 (R/W)  Vector Table Offset Register */
+  __IOM uint32_t AIRCR;                  /*!< Offset: 0x00C (R/W)  Application Interrupt and Reset Control Register */
+  __IOM uint32_t SCR;                    /*!< Offset: 0x010 (R/W)  System Control Register */
+  __IOM uint32_t CCR;                    /*!< Offset: 0x014 (R/W)  Configuration Control Register */
+        uint32_t RESERVED0[1U];
+  __IOM uint32_t SHPR[2U];               /*!< Offset: 0x01C (R/W)  System Handlers Priority Registers. [0] is RESERVED */
+  __IOM uint32_t SHCSR;                  /*!< Offset: 0x024 (R/W)  System Handler Control and State Register */
+        uint32_t RESERVED1[154U];
+  __IOM uint32_t SFCR;                   /*!< Offset: 0x290 (R/W)  Security Features Control Register */
+} SCB_Type;
+
+/** \brief SCB CPUID Register Definitions */
+#define SCB_CPUID_IMPLEMENTER_Pos          24U                                            /*!< SCB CPUID: IMPLEMENTER Position */
+#define SCB_CPUID_IMPLEMENTER_Msk          (0xFFUL << SCB_CPUID_IMPLEMENTER_Pos)          /*!< SCB CPUID: IMPLEMENTER Mask */
+
+#define SCB_CPUID_VARIANT_Pos              20U                                            /*!< SCB CPUID: VARIANT Position */
+#define SCB_CPUID_VARIANT_Msk              (0xFUL << SCB_CPUID_VARIANT_Pos)               /*!< SCB CPUID: VARIANT Mask */
+
+#define SCB_CPUID_ARCHITECTURE_Pos         16U                                            /*!< SCB CPUID: ARCHITECTURE Position */
+#define SCB_CPUID_ARCHITECTURE_Msk         (0xFUL << SCB_CPUID_ARCHITECTURE_Pos)          /*!< SCB CPUID: ARCHITECTURE Mask */
+
+#define SCB_CPUID_PARTNO_Pos                4U                                            /*!< SCB CPUID: PARTNO Position */
+#define SCB_CPUID_PARTNO_Msk               (0xFFFUL << SCB_CPUID_PARTNO_Pos)              /*!< SCB CPUID: PARTNO Mask */
+
+#define SCB_CPUID_REVISION_Pos              0U                                            /*!< SCB CPUID: REVISION Position */
+#define SCB_CPUID_REVISION_Msk             (0xFUL /*<< SCB_CPUID_REVISION_Pos*/)          /*!< SCB CPUID: REVISION Mask */
+
+/** \brief SCB Interrupt Control State Register Definitions */
+#define SCB_ICSR_NMIPENDSET_Pos            31U                                            /*!< SCB ICSR: NMIPENDSET Position */
+#define SCB_ICSR_NMIPENDSET_Msk            (1UL << SCB_ICSR_NMIPENDSET_Pos)               /*!< SCB ICSR: NMIPENDSET Mask */
+
+#define SCB_ICSR_PENDSVSET_Pos             28U                                            /*!< SCB ICSR: PENDSVSET Position */
+#define SCB_ICSR_PENDSVSET_Msk             (1UL << SCB_ICSR_PENDSVSET_Pos)                /*!< SCB ICSR: PENDSVSET Mask */
+
+#define SCB_ICSR_PENDSVCLR_Pos             27U                                            /*!< SCB ICSR: PENDSVCLR Position */
+#define SCB_ICSR_PENDSVCLR_Msk             (1UL << SCB_ICSR_PENDSVCLR_Pos)                /*!< SCB ICSR: PENDSVCLR Mask */
+
+#define SCB_ICSR_PENDSTSET_Pos             26U                                            /*!< SCB ICSR: PENDSTSET Position */
+#define SCB_ICSR_PENDSTSET_Msk             (1UL << SCB_ICSR_PENDSTSET_Pos)                /*!< SCB ICSR: PENDSTSET Mask */
+
+#define SCB_ICSR_PENDSTCLR_Pos             25U                                            /*!< SCB ICSR: PENDSTCLR Position */
+#define SCB_ICSR_PENDSTCLR_Msk             (1UL << SCB_ICSR_PENDSTCLR_Pos)                /*!< SCB ICSR: PENDSTCLR Mask */
+
+#define SCB_ICSR_ISRPREEMPT_Pos            23U                                            /*!< SCB ICSR: ISRPREEMPT Position */
+#define SCB_ICSR_ISRPREEMPT_Msk            (1UL << SCB_ICSR_ISRPREEMPT_Pos)               /*!< SCB ICSR: ISRPREEMPT Mask */
+
+#define SCB_ICSR_ISRPENDING_Pos            22U                                            /*!< SCB ICSR: ISRPENDING Position */
+#define SCB_ICSR_ISRPENDING_Msk            (1UL << SCB_ICSR_ISRPENDING_Pos)               /*!< SCB ICSR: ISRPENDING Mask */
+
+#define SCB_ICSR_VECTPENDING_Pos           12U                                            /*!< SCB ICSR: VECTPENDING Position */
+#define SCB_ICSR_VECTPENDING_Msk           (0x1FFUL << SCB_ICSR_VECTPENDING_Pos)          /*!< SCB ICSR: VECTPENDING Mask */
+
+#define SCB_ICSR_VECTACTIVE_Pos             0U                                            /*!< SCB ICSR: VECTACTIVE Position */
+#define SCB_ICSR_VECTACTIVE_Msk            (0x1FFUL /*<< SCB_ICSR_VECTACTIVE_Pos*/)       /*!< SCB ICSR: VECTACTIVE Mask */
+
+/** \brief SCB Vector Table Offset Register Definitions */
+#define SCB_VTOR_TBLOFF_Pos                 7U                                            /*!< SCB VTOR: TBLOFF Position */
+#define SCB_VTOR_TBLOFF_Msk                (0x1FFFFFFUL << SCB_VTOR_TBLOFF_Pos)           /*!< SCB VTOR: TBLOFF Mask */
+
+/** \brief SCB Application Interrupt and Reset Control Register Definitions */
+#define SCB_AIRCR_VECTKEY_Pos              16U                                            /*!< SCB AIRCR: VECTKEY Position */
+#define SCB_AIRCR_VECTKEY_Msk              (0xFFFFUL << SCB_AIRCR_VECTKEY_Pos)            /*!< SCB AIRCR: VECTKEY Mask */
+
+#define SCB_AIRCR_VECTKEYSTAT_Pos          16U                                            /*!< SCB AIRCR: VECTKEYSTAT Position */
+#define SCB_AIRCR_VECTKEYSTAT_Msk          (0xFFFFUL << SCB_AIRCR_VECTKEYSTAT_Pos)        /*!< SCB AIRCR: VECTKEYSTAT Mask */
+
+#define SCB_AIRCR_ENDIANESS_Pos            15U                                            /*!< SCB AIRCR: ENDIANESS Position */
+#define SCB_AIRCR_ENDIANESS_Msk            (1UL << SCB_AIRCR_ENDIANESS_Pos)               /*!< SCB AIRCR: ENDIANESS Mask */
+
+#define SCB_AIRCR_SYSRESETREQ_Pos           2U                                            /*!< SCB AIRCR: SYSRESETREQ Position */
+#define SCB_AIRCR_SYSRESETREQ_Msk          (1UL << SCB_AIRCR_SYSRESETREQ_Pos)             /*!< SCB AIRCR: SYSRESETREQ Mask */
+
+#define SCB_AIRCR_VECTCLRACTIVE_Pos         1U                                            /*!< SCB AIRCR: VECTCLRACTIVE Position */
+#define SCB_AIRCR_VECTCLRACTIVE_Msk        (1UL << SCB_AIRCR_VECTCLRACTIVE_Pos)           /*!< SCB AIRCR: VECTCLRACTIVE Mask */
+
+/** \brief SCB System Control Register Definitions */
+#define SCB_SCR_SEVONPEND_Pos               4U                                            /*!< SCB SCR: SEVONPEND Position */
+#define SCB_SCR_SEVONPEND_Msk              (1UL << SCB_SCR_SEVONPEND_Pos)                 /*!< SCB SCR: SEVONPEND Mask */
+
+#define SCB_SCR_SLEEPDEEP_Pos               2U                                            /*!< SCB SCR: SLEEPDEEP Position */
+#define SCB_SCR_SLEEPDEEP_Msk              (1UL << SCB_SCR_SLEEPDEEP_Pos)                 /*!< SCB SCR: SLEEPDEEP Mask */
+
+#define SCB_SCR_SLEEPONEXIT_Pos             1U                                            /*!< SCB SCR: SLEEPONEXIT Position */
+#define SCB_SCR_SLEEPONEXIT_Msk            (1UL << SCB_SCR_SLEEPONEXIT_Pos)               /*!< SCB SCR: SLEEPONEXIT Mask */
+
+/** \brief SCB Configuration Control Register Definitions */
+#define SCB_CCR_STKALIGN_Pos                9U                                            /*!< SCB CCR: STKALIGN Position */
+#define SCB_CCR_STKALIGN_Msk               (1UL << SCB_CCR_STKALIGN_Pos)                  /*!< SCB CCR: STKALIGN Mask */
+
+#define SCB_CCR_UNALIGN_TRP_Pos             3U                                            /*!< SCB CCR: UNALIGN_TRP Position */
+#define SCB_CCR_UNALIGN_TRP_Msk            (1UL << SCB_CCR_UNALIGN_TRP_Pos)               /*!< SCB CCR: UNALIGN_TRP Mask */
+
+/** \brief SCB System Handler Control and State Register Definitions */
+#define SCB_SHCSR_SVCALLPENDED_Pos         15U                                            /*!< SCB SHCSR: SVCALLPENDED Position */
+#define SCB_SHCSR_SVCALLPENDED_Msk         (1UL << SCB_SHCSR_SVCALLPENDED_Pos)            /*!< SCB SHCSR: SVCALLPENDED Mask */
+
+/*@} end of group CMSIS_SCB */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SCnSCB System Controls not in SCB (SCnSCB)
+  \brief    Type definitions for the System Control and ID Register not in the SCB
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Control and ID Register not in the SCB.
+ */
+typedef struct
+{
+        uint32_t RESERVED0[2U];
+  __IOM uint32_t ACTLR;                  /*!< Offset: 0x008 (R/W)  Auxiliary Control Register */
+} SCnSCB_Type;
+
+/** \brief SCnSCB Auxiliary Control Register Definitions */
+#define SCnSCB_ACTLR_DISMCYCINT_Pos         0U                                         /*!< ACTLR: DISMCYCINT Position */
+#define SCnSCB_ACTLR_DISMCYCINT_Msk        (1UL /*<< SCnSCB_ACTLR_DISMCYCINT_Pos*/)    /*!< ACTLR: DISMCYCINT Mask */
+
+/*@} end of group CMSIS_SCnotSCB */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SysTick     System Tick Timer (SysTick)
+  \brief    Type definitions for the System Timer Registers.
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Timer (SysTick).
+ */
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  SysTick Control and Status Register */
+  __IOM uint32_t LOAD;                   /*!< Offset: 0x004 (R/W)  SysTick Reload Value Register */
+  __IOM uint32_t VAL;                    /*!< Offset: 0x008 (R/W)  SysTick Current Value Register */
+  __IM  uint32_t CALIB;                  /*!< Offset: 0x00C (R/ )  SysTick Calibration Register */
+} SysTick_Type;
+
+/** \brief SysTick Control / Status Register Definitions */
+#define SysTick_CTRL_COUNTFLAG_Pos         16U                                            /*!< SysTick CTRL: COUNTFLAG Position */
+#define SysTick_CTRL_COUNTFLAG_Msk         (1UL << SysTick_CTRL_COUNTFLAG_Pos)            /*!< SysTick CTRL: COUNTFLAG Mask */
+
+#define SysTick_CTRL_CLKSOURCE_Pos          2U                                            /*!< SysTick CTRL: CLKSOURCE Position */
+#define SysTick_CTRL_CLKSOURCE_Msk         (1UL << SysTick_CTRL_CLKSOURCE_Pos)            /*!< SysTick CTRL: CLKSOURCE Mask */
+
+#define SysTick_CTRL_TICKINT_Pos            1U                                            /*!< SysTick CTRL: TICKINT Position */
+#define SysTick_CTRL_TICKINT_Msk           (1UL << SysTick_CTRL_TICKINT_Pos)              /*!< SysTick CTRL: TICKINT Mask */
+
+#define SysTick_CTRL_ENABLE_Pos             0U                                            /*!< SysTick CTRL: ENABLE Position */
+#define SysTick_CTRL_ENABLE_Msk            (1UL /*<< SysTick_CTRL_ENABLE_Pos*/)           /*!< SysTick CTRL: ENABLE Mask */
+
+/** \brief SysTick Reload Register Definitions */
+#define SysTick_LOAD_RELOAD_Pos             0U                                            /*!< SysTick LOAD: RELOAD Position */
+#define SysTick_LOAD_RELOAD_Msk            (0xFFFFFFUL /*<< SysTick_LOAD_RELOAD_Pos*/)    /*!< SysTick LOAD: RELOAD Mask */
+
+/** \brief SysTick Current Register Definitions */
+#define SysTick_VAL_CURRENT_Pos             0U                                            /*!< SysTick VAL: CURRENT Position */
+#define SysTick_VAL_CURRENT_Msk            (0xFFFFFFUL /*<< SysTick_VAL_CURRENT_Pos*/)    /*!< SysTick VAL: CURRENT Mask */
+
+/** \brief SysTick Calibration Register Definitions */
+#define SysTick_CALIB_NOREF_Pos            31U                                            /*!< SysTick CALIB: NOREF Position */
+#define SysTick_CALIB_NOREF_Msk            (1UL << SysTick_CALIB_NOREF_Pos)               /*!< SysTick CALIB: NOREF Mask */
+
+#define SysTick_CALIB_SKEW_Pos             30U                                            /*!< SysTick CALIB: SKEW Position */
+#define SysTick_CALIB_SKEW_Msk             (1UL << SysTick_CALIB_SKEW_Pos)                /*!< SysTick CALIB: SKEW Mask */
+
+#define SysTick_CALIB_TENMS_Pos             0U                                            /*!< SysTick CALIB: TENMS Position */
+#define SysTick_CALIB_TENMS_Msk            (0xFFFFFFUL /*<< SysTick_CALIB_TENMS_Pos*/)    /*!< SysTick CALIB: TENMS Mask */
+
+/*@} end of group CMSIS_SysTick */
+
+#if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_MPU     Memory Protection Unit (MPU)
+  \brief    Type definitions for the Memory Protection Unit (MPU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Memory Protection Unit (MPU).
+ */
+typedef struct
+{
+  __IM  uint32_t TYPE;                   /*!< Offset: 0x000 (R/ )  MPU Type Register */
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x004 (R/W)  MPU Control Register */
+  __IOM uint32_t RNR;                    /*!< Offset: 0x008 (R/W)  MPU Region Number Register */
+  __IOM uint32_t RBAR;                   /*!< Offset: 0x00C (R/W)  MPU Region Base Address Register */
+  __IOM uint32_t RASR;                   /*!< Offset: 0x010 (R/W)  MPU Region Attribute and Size Register */
+} MPU_Type;
+
+#define MPU_TYPE_RALIASES                  1U
+
+/** \brief MPU Type Register Definitions */
+#define MPU_TYPE_IREGION_Pos               16U                                            /*!< MPU TYPE: IREGION Position */
+#define MPU_TYPE_IREGION_Msk               (0xFFUL << MPU_TYPE_IREGION_Pos)               /*!< MPU TYPE: IREGION Mask */
+
+#define MPU_TYPE_DREGION_Pos                8U                                            /*!< MPU TYPE: DREGION Position */
+#define MPU_TYPE_DREGION_Msk               (0xFFUL << MPU_TYPE_DREGION_Pos)               /*!< MPU TYPE: DREGION Mask */
+
+#define MPU_TYPE_SEPARATE_Pos               0U                                            /*!< MPU TYPE: SEPARATE Position */
+#define MPU_TYPE_SEPARATE_Msk              (1UL /*<< MPU_TYPE_SEPARATE_Pos*/)             /*!< MPU TYPE: SEPARATE Mask */
+
+/** \brief MPU Control Register Definitions */
+#define MPU_CTRL_PRIVDEFENA_Pos             2U                                            /*!< MPU CTRL: PRIVDEFENA Position */
+#define MPU_CTRL_PRIVDEFENA_Msk            (1UL << MPU_CTRL_PRIVDEFENA_Pos)               /*!< MPU CTRL: PRIVDEFENA Mask */
+
+#define MPU_CTRL_HFNMIENA_Pos               1U                                            /*!< MPU CTRL: HFNMIENA Position */
+#define MPU_CTRL_HFNMIENA_Msk              (1UL << MPU_CTRL_HFNMIENA_Pos)                 /*!< MPU CTRL: HFNMIENA Mask */
+
+#define MPU_CTRL_ENABLE_Pos                 0U                                            /*!< MPU CTRL: ENABLE Position */
+#define MPU_CTRL_ENABLE_Msk                (1UL /*<< MPU_CTRL_ENABLE_Pos*/)               /*!< MPU CTRL: ENABLE Mask */
+
+/** \brief MPU Region Number Register Definitions */
+#define MPU_RNR_REGION_Pos                  0U                                            /*!< MPU RNR: REGION Position */
+#define MPU_RNR_REGION_Msk                 (0xFFUL /*<< MPU_RNR_REGION_Pos*/)             /*!< MPU RNR: REGION Mask */
+
+/** \brief MPU Region Base Address Register Definitions */
+#define MPU_RBAR_ADDR_Pos                   8U                                            /*!< MPU RBAR: ADDR Position */
+#define MPU_RBAR_ADDR_Msk                  (0xFFFFFFUL << MPU_RBAR_ADDR_Pos)              /*!< MPU RBAR: ADDR Mask */
+
+#define MPU_RBAR_VALID_Pos                  4U                                            /*!< MPU RBAR: VALID Position */
+#define MPU_RBAR_VALID_Msk                 (1UL << MPU_RBAR_VALID_Pos)                    /*!< MPU RBAR: VALID Mask */
+
+#define MPU_RBAR_REGION_Pos                 0U                                            /*!< MPU RBAR: REGION Position */
+#define MPU_RBAR_REGION_Msk                (0xFUL /*<< MPU_RBAR_REGION_Pos*/)             /*!< MPU RBAR: REGION Mask */
+
+/** \brief MPU Region Attribute and Size Register Definitions */
+#define MPU_RASR_ATTRS_Pos                 16U                                            /*!< MPU RASR: MPU Region Attribute field Position */
+#define MPU_RASR_ATTRS_Msk                 (0xFFFFUL << MPU_RASR_ATTRS_Pos)               /*!< MPU RASR: MPU Region Attribute field Mask */
+
+#define MPU_RASR_XN_Pos                    28U                                            /*!< MPU RASR: ATTRS.XN Position */
+#define MPU_RASR_XN_Msk                    (1UL << MPU_RASR_XN_Pos)                       /*!< MPU RASR: ATTRS.XN Mask */
+
+#define MPU_RASR_AP_Pos                    24U                                            /*!< MPU RASR: ATTRS.AP Position */
+#define MPU_RASR_AP_Msk                    (0x7UL << MPU_RASR_AP_Pos)                     /*!< MPU RASR: ATTRS.AP Mask */
+
+#define MPU_RASR_TEX_Pos                   19U                                            /*!< MPU RASR: ATTRS.TEX Position */
+#define MPU_RASR_TEX_Msk                   (0x7UL << MPU_RASR_TEX_Pos)                    /*!< MPU RASR: ATTRS.TEX Mask */
+
+#define MPU_RASR_S_Pos                     18U                                            /*!< MPU RASR: ATTRS.S Position */
+#define MPU_RASR_S_Msk                     (1UL << MPU_RASR_S_Pos)                        /*!< MPU RASR: ATTRS.S Mask */
+
+#define MPU_RASR_C_Pos                     17U                                            /*!< MPU RASR: ATTRS.C Position */
+#define MPU_RASR_C_Msk                     (1UL << MPU_RASR_C_Pos)                        /*!< MPU RASR: ATTRS.C Mask */
+
+#define MPU_RASR_B_Pos                     16U                                            /*!< MPU RASR: ATTRS.B Position */
+#define MPU_RASR_B_Msk                     (1UL << MPU_RASR_B_Pos)                        /*!< MPU RASR: ATTRS.B Mask */
+
+#define MPU_RASR_SRD_Pos                    8U                                            /*!< MPU RASR: Sub-Region Disable Position */
+#define MPU_RASR_SRD_Msk                   (0xFFUL << MPU_RASR_SRD_Pos)                   /*!< MPU RASR: Sub-Region Disable Mask */
+
+#define MPU_RASR_SIZE_Pos                   1U                                            /*!< MPU RASR: Region Size Field Position */
+#define MPU_RASR_SIZE_Msk                  (0x1FUL << MPU_RASR_SIZE_Pos)                  /*!< MPU RASR: Region Size Field Mask */
+
+#define MPU_RASR_ENABLE_Pos                 0U                                            /*!< MPU RASR: Region enable bit Position */
+#define MPU_RASR_ENABLE_Msk                (1UL /*<< MPU_RASR_ENABLE_Pos*/)               /*!< MPU RASR: Region enable bit Disable Mask */
+
+/*@} end of group CMSIS_MPU */
+#endif
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_CoreDebug       Core Debug Registers (CoreDebug)
+  \brief    SC000 Core Debug Registers (DCB registers, SHCSR, and DFSR) are only accessible over DAP and not via processor.
+            Therefore they are not covered by the SC000 header file.
+  @{
+ */
+/*@} end of group CMSIS_CoreDebug */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_core_bitfield     Core register bit field macros
+  \brief      Macros for use with bit field definitions (xxx_Pos, xxx_Msk).
+  @{
+ */
+
+/**
+  \brief   Mask and shift a bit field value for use in a register bit range.
+  \param[in] field  Name of the register bit field.
+  \param[in] value  Value of the bit field. This parameter is interpreted as an uint32_t type.
+  \return           Masked and shifted value.
+*/
+#define _VAL2FLD(field, value)    (((uint32_t)(value) << field ## _Pos) & field ## _Msk)
+
+/**
+  \brief     Mask and shift a register value to extract a bit filed value.
+  \param[in] field  Name of the register bit field.
+  \param[in] value  Value of register. This parameter is interpreted as an uint32_t type.
+  \return           Masked and shifted bit field value.
+*/
+#define _FLD2VAL(field, value)    (((uint32_t)(value) & field ## _Msk) >> field ## _Pos)
+
+/*@} end of group CMSIS_core_bitfield */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_core_base     Core Definitions
+  \brief      Definitions for base addresses, unions, and structures.
+  @{
+ */
+
+/* Memory mapping of Core Hardware */
+#define SCS_BASE            (0xE000E000UL)                            /*!< System Control Space Base Address */
+#define SysTick_BASE        (SCS_BASE +  0x0010UL)                    /*!< SysTick Base Address */
+#define NVIC_BASE           (SCS_BASE +  0x0100UL)                    /*!< NVIC Base Address */
+#define SCB_BASE            (SCS_BASE +  0x0D00UL)                    /*!< System Control Block Base Address */
+
+#define SCnSCB              ((SCnSCB_Type    *)     SCS_BASE      )   /*!< System control Register not in SCB */
+#define SCB                 ((SCB_Type       *)     SCB_BASE      )   /*!< SCB configuration struct */
+#define SysTick             ((SysTick_Type   *)     SysTick_BASE  )   /*!< SysTick configuration struct */
+#define NVIC                ((NVIC_Type      *)     NVIC_BASE     )   /*!< NVIC configuration struct */
+
+#if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+  #define MPU_BASE          (SCS_BASE +  0x0D90UL)                    /*!< Memory Protection Unit */
+  #define MPU               ((MPU_Type       *)     MPU_BASE      )   /*!< Memory Protection Unit */
+#endif
+
+/*@} */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_register_aliases     Backwards Compatibility Aliases
+  \brief      Register alias definitions for backwards compatibility.
+  @{
+ */
+
+/*@} */
+
+
+/*******************************************************************************
+ *                Hardware Abstraction Layer
+  Core Function Interface contains:
+  - Core NVIC Functions
+  - Core SysTick Functions
+  - Core Register Access Functions
+ ******************************************************************************/
+/**
+  \defgroup CMSIS_Core_FunctionInterface Functions and Instructions Reference
+*/
+
+
+
+/* ##########################   NVIC functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_NVICFunctions NVIC Functions
+  \brief    Functions that manage interrupts and exceptions via the NVIC.
+  @{
+ */
+
+#ifdef CMSIS_NVIC_VIRTUAL
+  #ifndef CMSIS_NVIC_VIRTUAL_HEADER_FILE
+    #define CMSIS_NVIC_VIRTUAL_HEADER_FILE "cmsis_nvic_virtual.h"
+  #endif
+  #include CMSIS_NVIC_VIRTUAL_HEADER_FILE
+#else
+/*#define NVIC_SetPriorityGrouping    __NVIC_SetPriorityGrouping   not available for SC000 */
+/*#define NVIC_GetPriorityGrouping    __NVIC_GetPriorityGrouping   not available for SC000 */
+  #define NVIC_EnableIRQ              __NVIC_EnableIRQ
+  #define NVIC_GetEnableIRQ           __NVIC_GetEnableIRQ
+  #define NVIC_DisableIRQ             __NVIC_DisableIRQ
+  #define NVIC_GetPendingIRQ          __NVIC_GetPendingIRQ
+  #define NVIC_SetPendingIRQ          __NVIC_SetPendingIRQ
+  #define NVIC_ClearPendingIRQ        __NVIC_ClearPendingIRQ
+/*#define NVIC_GetActive              __NVIC_GetActive             not available for SC000 */
+  #define NVIC_SetPriority            __NVIC_SetPriority
+  #define NVIC_GetPriority            __NVIC_GetPriority
+  #define NVIC_SystemReset            __NVIC_SystemReset
+#endif /* CMSIS_NVIC_VIRTUAL */
+
+#ifdef CMSIS_VECTAB_VIRTUAL
+  #ifndef CMSIS_VECTAB_VIRTUAL_HEADER_FILE
+    #define CMSIS_VECTAB_VIRTUAL_HEADER_FILE "cmsis_vectab_virtual.h"
+  #endif
+  #include CMSIS_VECTAB_VIRTUAL_HEADER_FILE
+#else
+  #define NVIC_SetVector              __NVIC_SetVector
+  #define NVIC_GetVector              __NVIC_GetVector
+#endif  /* (CMSIS_VECTAB_VIRTUAL) */
+
+#define NVIC_USER_IRQ_OFFSET          16
+
+
+/* The following EXC_RETURN values are saved the LR on exception entry */
+#define EXC_RETURN_HANDLER         (0xFFFFFFF1UL)     /* return to Handler mode, uses MSP after return                               */
+#define EXC_RETURN_THREAD_MSP      (0xFFFFFFF9UL)     /* return to Thread mode, uses MSP after return                                */
+#define EXC_RETURN_THREAD_PSP      (0xFFFFFFFDUL)     /* return to Thread mode, uses PSP after return                                */
+
+
+/* Interrupt Priorities are WORD accessible only under Armv6-M                  */
+/* The following MACROS handle generation of the register offset and byte masks */
+#define _BIT_SHIFT(IRQn)         (  ((((uint32_t)(int32_t)(IRQn))         )      &  0x03UL) * 8UL)
+#define _SHP_IDX(IRQn)           ( (((((uint32_t)(int32_t)(IRQn)) & 0x0FUL)-8UL) >>    2UL)      )
+#define _IP_IDX(IRQn)            (   (((uint32_t)(int32_t)(IRQn))                >>    2UL)      )
+
+
+/**
+  \brief   Enable Interrupt
+  \details Enables a device specific interrupt in the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_EnableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    __COMPILER_BARRIER();
+    NVIC->ISER[0U] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+    __COMPILER_BARRIER();
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Enable status
+  \details Returns a device specific interrupt enable status from the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt is not enabled.
+  \return             1  Interrupt is enabled.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetEnableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ISER[0U] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Disable Interrupt
+  \details Disables a device specific interrupt in the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_DisableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ICER[0U] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+    __DSB();
+    __ISB();
+  }
+}
+
+
+/**
+  \brief   Get Pending Interrupt
+  \details Reads the NVIC pending register and returns the pending bit for the specified device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not pending.
+  \return             1  Interrupt status is pending.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ISPR[0U] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Pending Interrupt
+  \details Sets the pending bit of a device specific interrupt in the NVIC pending register.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_SetPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ISPR[0U] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Clear Pending Interrupt
+  \details Clears the pending bit of a device specific interrupt in the NVIC pending register.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_ClearPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ICPR[0U] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Set Interrupt Priority
+  \details Sets the priority of a device specific interrupt or a processor exception.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]      IRQn  Interrupt number.
+  \param [in]  priority  Priority to set.
+  \note    The priority cannot be set for every processor exception.
+ */
+__STATIC_INLINE void __NVIC_SetPriority(IRQn_Type IRQn, uint32_t priority)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->IPR[_IP_IDX(IRQn)]  = ((uint32_t)(NVIC->IPR[_IP_IDX(IRQn)]  & ~(0xFFUL << _BIT_SHIFT(IRQn))) |
+       (((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL) << _BIT_SHIFT(IRQn)));
+  }
+  else
+  {
+    SCB->SHPR[_SHP_IDX(IRQn)] = ((uint32_t)(SCB->SHPR[_SHP_IDX(IRQn)] & ~(0xFFUL << _BIT_SHIFT(IRQn))) |
+       (((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL) << _BIT_SHIFT(IRQn)));
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Priority
+  \details Reads the priority of a device specific interrupt or a processor exception.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn  Interrupt number.
+  \return             Interrupt Priority.
+                      Value is aligned automatically to the implemented priority bits of the microcontroller.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPriority(IRQn_Type IRQn)
+{
+
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->IPR[ _IP_IDX(IRQn)] >> _BIT_SHIFT(IRQn) ) & (uint32_t)0xFFUL) >> (8U - __NVIC_PRIO_BITS)));
+  }
+  else
+  {
+    return((uint32_t)(((SCB->SHPR[_SHP_IDX(IRQn)] >> _BIT_SHIFT(IRQn) ) & (uint32_t)0xFFUL) >> (8U - __NVIC_PRIO_BITS)));
+  }
+}
+
+
+/**
+  \brief   Set Interrupt Vector
+  \details Sets an interrupt vector in SRAM based interrupt vector table.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+           VTOR must been relocated to SRAM before.
+  \param [in]   IRQn      Interrupt number
+  \param [in]   vector    Address of interrupt handler function
+ */
+__STATIC_INLINE void __NVIC_SetVector(IRQn_Type IRQn, uint32_t vector)
+{
+  uint32_t *vectors = (uint32_t *) ((uintptr_t) SCB->VTOR);
+  vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET] = vector;
+  /* ARM Application Note 321 states that the M0 and M0+ do not require the architectural barrier - assume SC000 is the same */
+}
+
+
+/**
+  \brief   Get Interrupt Vector
+  \details Reads an interrupt vector from interrupt vector table.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn      Interrupt number.
+  \return                 Address of interrupt handler function
+ */
+__STATIC_INLINE uint32_t __NVIC_GetVector(IRQn_Type IRQn)
+{
+  uint32_t *vectors = (uint32_t *) ((uintptr_t) SCB->VTOR);
+  return vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET];
+}
+
+
+/**
+  \brief   System Reset
+  \details Initiates a system reset request to reset the MCU.
+ */
+__NO_RETURN __STATIC_INLINE void __NVIC_SystemReset(void)
+{
+  __DSB();                                                          /* Ensure all outstanding memory accesses included
+                                                                       buffered write are completed before reset */
+  SCB->AIRCR  = ((0x5FAUL << SCB_AIRCR_VECTKEY_Pos) |
+                 SCB_AIRCR_SYSRESETREQ_Msk);
+  __DSB();                                                          /* Ensure completion of memory access */
+
+  for(;;)                                                           /* wait until reset */
+  {
+    __NOP();
+  }
+}
+
+/*@} end of CMSIS_Core_NVICFunctions */
+
+/* ##########################  MPU functions  #################################### */
+
+#if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+
+#include "m-profile/armv7m_mpu.h"
+
+#endif
+
+/* ##########################  FPU functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_FpuFunctions FPU Functions
+  \brief    Function that provides FPU type.
+  @{
+ */
+
+/**
+  \brief   get FPU type
+  \details returns the FPU type
+  \returns
+   - \b  0: No FPU
+   - \b  1: Single precision FPU
+   - \b  2: Double + Single precision FPU
+ */
+__STATIC_INLINE uint32_t SCB_GetFPUType(void)
+{
+    return 0U;           /* No FPU */
+}
+
+
+/*@} end of CMSIS_Core_FpuFunctions */
+
+
+
+/* ##################################    SysTick function  ############################################ */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_SysTickFunctions SysTick Functions
+  \brief    Functions that configure the System.
+  @{
+ */
+
+#if defined (__Vendor_SysTickConfig) && (__Vendor_SysTickConfig == 0U)
+
+/**
+  \brief   System Tick Configuration
+  \details Initializes the System Timer and its interrupt, and starts the System Tick Timer.
+           Counter is in free running mode to generate periodic interrupts.
+  \param [in]  ticks  Number of ticks between two interrupts.
+  \return          0  Function succeeded.
+  \return          1  Function failed.
+  \note    When the variable <b>__Vendor_SysTickConfig</b> is set to 1, then the
+           function <b>SysTick_Config</b> is not included. In this case, the file <b><i>device</i>.h</b>
+           must contain a vendor-specific implementation of this function.
+ */
+__STATIC_INLINE uint32_t SysTick_Config(uint32_t ticks)
+{
+  if ((ticks - 1UL) > SysTick_LOAD_RELOAD_Msk)
+  {
+    return (1UL);                                                   /* Reload value impossible */
+  }
+
+  SysTick->LOAD  = (uint32_t)(ticks - 1UL);                         /* set reload register */
+  NVIC_SetPriority (SysTick_IRQn, (1UL << __NVIC_PRIO_BITS) - 1UL); /* set Priority for Systick Interrupt */
+  SysTick->VAL   = 0UL;                                             /* Load the SysTick Counter Value */
+  SysTick->CTRL  = SysTick_CTRL_CLKSOURCE_Msk |
+                   SysTick_CTRL_TICKINT_Msk   |
+                   SysTick_CTRL_ENABLE_Msk;                         /* Enable SysTick IRQ and SysTick Timer */
+  return (0UL);                                                     /* Function successful */
+}
+
+#endif
+
+/*@} end of CMSIS_Core_SysTickFunctions */
+
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_SC000_H_DEPENDANT */
+
+#endif /* __CMSIS_GENERIC */

--- a/platform/ext/cmsis/CMSIS/Core/Include/core_sc300.h
+++ b/platform/ext/cmsis/CMSIS/Core/Include/core_sc300.h
@@ -1,0 +1,1927 @@
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS SC300 Core Peripheral Access Layer Header File
+ */
+
+#if   defined ( __ICCARM__ )
+  #pragma system_include                        /* treat file as system include file for MISRA check */
+#elif defined (__clang__)
+  #pragma clang system_header                   /* treat file as system include file */
+#elif defined ( __GNUC__ )
+  #pragma GCC diagnostic ignored "-Wpedantic"   /* disable pedantic warning due to unnamed structs/unions */
+#endif
+
+#ifndef __CORE_SC300_H_GENERIC
+#define __CORE_SC300_H_GENERIC
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/**
+  \page CMSIS_MISRA_Exceptions  MISRA-C:2004 Compliance Exceptions
+  CMSIS violates the following MISRA-C:2004 rules:
+
+   \li Required Rule 8.5, object/function definition in header file.<br>
+     Function definitions in header files are used to allow 'inlining'.
+
+   \li Required Rule 18.4, declaration of union type or object of union type: '{...}'.<br>
+     Unions are used for effective representation of core registers.
+
+   \li Advisory Rule 19.7, Function-like macro defined.<br>
+     Function-like macros are used to allow more efficient code.
+ */
+
+
+/*******************************************************************************
+ *                 CMSIS definitions
+ ******************************************************************************/
+/**
+  \ingroup SC3000
+  @{
+ */
+
+#include "cmsis_version.h"
+
+/* CMSIS SC300 definitions */
+
+#define __CORTEX_SC               (300U)                              /*!< Cortex Secure Core */
+
+/** __FPU_USED indicates whether an FPU is used or not.
+    This core does not support an FPU at all
+*/
+#define __FPU_USED       0U
+
+#if defined ( __CC_ARM )
+  #if defined (__TARGET_FPU_VFP)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #if defined (__ARM_FP)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined (__ti__)
+  #if defined (__ARM_FP)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __GNUC__ )
+  #if defined (__VFP_FP__) && !defined(__SOFTFP__)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __ICCARM__ )
+  #if defined (__ARMVFP__)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __TI_ARM__ )
+  #if defined (__TI_VFP_SUPPORT__)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __TASKING__ )
+  #if defined (__FPU_VFP__)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __CSMC__ )
+  #if ( __CSMC__ & 0x400U)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#endif
+
+#include "cmsis_compiler.h"               /* CMSIS compiler specific defines */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_SC300_H_GENERIC */
+
+#ifndef __CMSIS_GENERIC
+
+#ifndef __CORE_SC300_H_DEPENDANT
+#define __CORE_SC300_H_DEPENDANT
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* check device defines and use defaults */
+#if defined __CHECK_DEVICE_DEFINES
+  #ifndef __SC300_REV
+    #define __SC300_REV               0x0000U
+    #warning "__SC300_REV not defined in device header file; using default!"
+  #endif
+
+  #ifndef __MPU_PRESENT
+    #define __MPU_PRESENT             0U
+    #warning "__MPU_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __VTOR_PRESENT
+    #define __VTOR_PRESENT            1U
+    #warning "__VTOR_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __NVIC_PRIO_BITS
+    #define __NVIC_PRIO_BITS          3U
+    #warning "__NVIC_PRIO_BITS not defined in device header file; using default!"
+  #endif
+
+  #ifndef __Vendor_SysTickConfig
+    #define __Vendor_SysTickConfig    0U
+    #warning "__Vendor_SysTickConfig not defined in device header file; using default!"
+  #endif
+#endif
+
+/* IO definitions (access restrictions to peripheral registers) */
+/**
+    \defgroup CMSIS_glob_defs CMSIS Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+*/
+#ifdef __cplusplus
+  #define   __I     volatile             /*!< Defines 'read only' permissions */
+#else
+  #define   __I     volatile const       /*!< Defines 'read only' permissions */
+#endif
+#define     __O     volatile             /*!< Defines 'write only' permissions */
+#define     __IO    volatile             /*!< Defines 'read / write' permissions */
+
+/* following defines should be used for structure members */
+#define     __IM     volatile const      /*! Defines 'read only' structure member permissions */
+#define     __OM     volatile            /*! Defines 'write only' structure member permissions */
+#define     __IOM    volatile            /*! Defines 'read / write' structure member permissions */
+
+/*@} end of group SC300 */
+
+
+
+/*******************************************************************************
+ *                 Register Abstraction
+  Core Register contain:
+  - Core Register
+  - Core NVIC Register
+  - Core SCB Register
+  - Core SysTick Register
+  - Core Debug Register
+  - Core MPU Register
+ ******************************************************************************/
+/**
+  \defgroup CMSIS_core_register Defines and Type Definitions
+  \brief Type definitions and defines for Cortex-M processor based devices.
+*/
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_CORE  Status and Control Registers
+  \brief      Core Register type definitions.
+  @{
+ */
+
+/**
+  \brief  Union type to access the Application Program Status Register (APSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t _reserved0:27;              /*!< bit:  0..26  Reserved */
+    uint32_t Q:1;                        /*!< bit:     27  Saturation condition flag */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} APSR_Type;
+
+/** \brief APSR Register Definitions */
+#define APSR_N_Pos                         31U                                            /*!< APSR: N Position */
+#define APSR_N_Msk                         (1UL << APSR_N_Pos)                            /*!< APSR: N Mask */
+
+#define APSR_Z_Pos                         30U                                            /*!< APSR: Z Position */
+#define APSR_Z_Msk                         (1UL << APSR_Z_Pos)                            /*!< APSR: Z Mask */
+
+#define APSR_C_Pos                         29U                                            /*!< APSR: C Position */
+#define APSR_C_Msk                         (1UL << APSR_C_Pos)                            /*!< APSR: C Mask */
+
+#define APSR_V_Pos                         28U                                            /*!< APSR: V Position */
+#define APSR_V_Msk                         (1UL << APSR_V_Pos)                            /*!< APSR: V Mask */
+
+#define APSR_Q_Pos                         27U                                            /*!< APSR: Q Position */
+#define APSR_Q_Msk                         (1UL << APSR_Q_Pos)                            /*!< APSR: Q Mask */
+
+
+/**
+  \brief  Union type to access the Interrupt Program Status Register (IPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number */
+    uint32_t _reserved0:23;              /*!< bit:  9..31  Reserved */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} IPSR_Type;
+
+/** \brief IPSR Register Definitions */
+#define IPSR_ISR_Pos                        0U                                            /*!< IPSR: ISR Position */
+#define IPSR_ISR_Msk                       (0x1FFUL /*<< IPSR_ISR_Pos*/)                  /*!< IPSR: ISR Mask */
+
+
+/**
+  \brief  Union type to access the Special-Purpose Program Status Registers (xPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number */
+    uint32_t _reserved0:1;               /*!< bit:      9  Reserved */
+    uint32_t ICI_IT_1:6;                 /*!< bit: 10..15  ICI/IT part 1 */
+    uint32_t _reserved1:8;               /*!< bit: 16..23  Reserved */
+    uint32_t T:1;                        /*!< bit:     24  Thumb bit */
+    uint32_t ICI_IT_2:2;                 /*!< bit: 25..26  ICI/IT part 2 */
+    uint32_t Q:1;                        /*!< bit:     27  Saturation condition flag */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} xPSR_Type;
+
+/** \brief xPSR Register Definitions */
+#define xPSR_N_Pos                         31U                                            /*!< xPSR: N Position */
+#define xPSR_N_Msk                         (1UL << xPSR_N_Pos)                            /*!< xPSR: N Mask */
+
+#define xPSR_Z_Pos                         30U                                            /*!< xPSR: Z Position */
+#define xPSR_Z_Msk                         (1UL << xPSR_Z_Pos)                            /*!< xPSR: Z Mask */
+
+#define xPSR_C_Pos                         29U                                            /*!< xPSR: C Position */
+#define xPSR_C_Msk                         (1UL << xPSR_C_Pos)                            /*!< xPSR: C Mask */
+
+#define xPSR_V_Pos                         28U                                            /*!< xPSR: V Position */
+#define xPSR_V_Msk                         (1UL << xPSR_V_Pos)                            /*!< xPSR: V Mask */
+
+#define xPSR_Q_Pos                         27U                                            /*!< xPSR: Q Position */
+#define xPSR_Q_Msk                         (1UL << xPSR_Q_Pos)                            /*!< xPSR: Q Mask */
+
+#define xPSR_ICI_IT_2_Pos                  25U                                            /*!< xPSR: ICI/IT part 2 Position */
+#define xPSR_ICI_IT_2_Msk                  (3UL << xPSR_ICI_IT_2_Pos)                     /*!< xPSR: ICI/IT part 2 Mask */
+
+#define xPSR_T_Pos                         24U                                            /*!< xPSR: T Position */
+#define xPSR_T_Msk                         (1UL << xPSR_T_Pos)                            /*!< xPSR: T Mask */
+
+#define xPSR_ICI_IT_1_Pos                  10U                                            /*!< xPSR: ICI/IT part 1 Position */
+#define xPSR_ICI_IT_1_Msk                  (0x3FUL << xPSR_ICI_IT_1_Pos)                  /*!< xPSR: ICI/IT part 1 Mask */
+
+#define xPSR_ISR_Pos                        0U                                            /*!< xPSR: ISR Position */
+#define xPSR_ISR_Msk                       (0x1FFUL /*<< xPSR_ISR_Pos*/)                  /*!< xPSR: ISR Mask */
+
+
+/**
+  \brief  Union type to access the Control Registers (CONTROL).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t nPRIV:1;                    /*!< bit:      0  Execution privilege in Thread mode */
+    uint32_t SPSEL:1;                    /*!< bit:      1  Stack to be used */
+    uint32_t _reserved1:30;              /*!< bit:  2..31  Reserved */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} CONTROL_Type;
+
+/** \brief CONTROL Register Definitions */
+#define CONTROL_SPSEL_Pos                   1U                                            /*!< CONTROL: SPSEL Position */
+#define CONTROL_SPSEL_Msk                  (1UL << CONTROL_SPSEL_Pos)                     /*!< CONTROL: SPSEL Mask */
+
+#define CONTROL_nPRIV_Pos                   0U                                            /*!< CONTROL: nPRIV Position */
+#define CONTROL_nPRIV_Msk                  (1UL /*<< CONTROL_nPRIV_Pos*/)                 /*!< CONTROL: nPRIV Mask */
+
+/*@} end of group CMSIS_CORE */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_NVIC  Nested Vectored Interrupt Controller (NVIC)
+  \brief      Type definitions for the NVIC Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Nested Vectored Interrupt Controller (NVIC).
+ */
+typedef struct
+{
+  __IOM uint32_t ISER[8U];               /*!< Offset: 0x000 (R/W)  Interrupt Set Enable Register */
+        uint32_t RESERVED0[24U];
+  __IOM uint32_t ICER[8U];               /*!< Offset: 0x080 (R/W)  Interrupt Clear Enable Register */
+        uint32_t RESERVED1[24U];
+  __IOM uint32_t ISPR[8U];               /*!< Offset: 0x100 (R/W)  Interrupt Set Pending Register */
+        uint32_t RESERVED2[24U];
+  __IOM uint32_t ICPR[8U];               /*!< Offset: 0x180 (R/W)  Interrupt Clear Pending Register */
+        uint32_t RESERVED3[24U];
+  __IOM uint32_t IABR[8U];               /*!< Offset: 0x200 (R/W)  Interrupt Active bit Register */
+        uint32_t RESERVED4[56U];
+  __IOM uint8_t  IPR[240U];              /*!< Offset: 0x300 (R/W)  Interrupt Priority Register (8Bit wide) */
+        uint32_t RESERVED5[644U];
+  __OM  uint32_t STIR;                   /*!< Offset: 0xE00 ( /W)  Software Trigger Interrupt Register */
+}  NVIC_Type;
+
+/** \brief NVIC Software Triggered Interrupt Register Definitions */
+#define NVIC_STIR_INTID_Pos                 0U                                         /*!< STIR: INTLINESNUM Position */
+#define NVIC_STIR_INTID_Msk                (0x1FFUL /*<< NVIC_STIR_INTID_Pos*/)        /*!< STIR: INTLINESNUM Mask */
+
+/*@} end of group CMSIS_NVIC */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SCB     System Control Block (SCB)
+  \brief    Type definitions for the System Control Block Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Control Block (SCB).
+ */
+typedef struct
+{
+  __IM  uint32_t CPUID;                  /*!< Offset: 0x000 (R/ )  CPUID Base Register */
+  __IOM uint32_t ICSR;                   /*!< Offset: 0x004 (R/W)  Interrupt Control and State Register */
+  __IOM uint32_t VTOR;                   /*!< Offset: 0x008 (R/W)  Vector Table Offset Register */
+  __IOM uint32_t AIRCR;                  /*!< Offset: 0x00C (R/W)  Application Interrupt and Reset Control Register */
+  __IOM uint32_t SCR;                    /*!< Offset: 0x010 (R/W)  System Control Register */
+  __IOM uint32_t CCR;                    /*!< Offset: 0x014 (R/W)  Configuration Control Register */
+  __IOM uint8_t  SHPR[12U];              /*!< Offset: 0x018 (R/W)  System Handlers Priority Registers (4-7, 8-11, 12-15) */
+  __IOM uint32_t SHCSR;                  /*!< Offset: 0x024 (R/W)  System Handler Control and State Register */
+  __IOM uint32_t CFSR;                   /*!< Offset: 0x028 (R/W)  Configurable Fault Status Register */
+  __IOM uint32_t HFSR;                   /*!< Offset: 0x02C (R/W)  HardFault Status Register */
+  __IOM uint32_t DFSR;                   /*!< Offset: 0x030 (R/W)  Debug Fault Status Register */
+  __IOM uint32_t MMFAR;                  /*!< Offset: 0x034 (R/W)  MemManage Fault Address Register */
+  __IOM uint32_t BFAR;                   /*!< Offset: 0x038 (R/W)  BusFault Address Register */
+  __IOM uint32_t AFSR;                   /*!< Offset: 0x03C (R/W)  Auxiliary Fault Status Register */
+  __IM  uint32_t ID_PFR[2U];             /*!< Offset: 0x040 (R/ )  Processor Feature Register */
+  __IM  uint32_t ID_DFR;                 /*!< Offset: 0x048 (R/ )  Debug Feature Register */
+  __IM  uint32_t ID_AFR;                 /*!< Offset: 0x04C (R/ )  Auxiliary Feature Register */
+  __IM  uint32_t ID_MMFR[4U];            /*!< Offset: 0x050 (R/ )  Memory Model Feature Register */
+  __IM  uint32_t ID_ISAR[5U];            /*!< Offset: 0x060 (R/ )  Instruction Set Attributes Register */
+        uint32_t RESERVED0[5U];
+  __IOM uint32_t CPACR;                  /*!< Offset: 0x088 (R/W)  Coprocessor Access Control Register */
+        uint32_t RESERVED1[129U];
+  __IOM uint32_t SFCR;                   /*!< Offset: 0x290 (R/W)  Security Features Control Register */
+} SCB_Type;
+
+/** \brief SCB CPUID Register Definitions */
+#define SCB_CPUID_IMPLEMENTER_Pos          24U                                            /*!< SCB CPUID: IMPLEMENTER Position */
+#define SCB_CPUID_IMPLEMENTER_Msk          (0xFFUL << SCB_CPUID_IMPLEMENTER_Pos)          /*!< SCB CPUID: IMPLEMENTER Mask */
+
+#define SCB_CPUID_VARIANT_Pos              20U                                            /*!< SCB CPUID: VARIANT Position */
+#define SCB_CPUID_VARIANT_Msk              (0xFUL << SCB_CPUID_VARIANT_Pos)               /*!< SCB CPUID: VARIANT Mask */
+
+#define SCB_CPUID_ARCHITECTURE_Pos         16U                                            /*!< SCB CPUID: ARCHITECTURE Position */
+#define SCB_CPUID_ARCHITECTURE_Msk         (0xFUL << SCB_CPUID_ARCHITECTURE_Pos)          /*!< SCB CPUID: ARCHITECTURE Mask */
+
+#define SCB_CPUID_PARTNO_Pos                4U                                            /*!< SCB CPUID: PARTNO Position */
+#define SCB_CPUID_PARTNO_Msk               (0xFFFUL << SCB_CPUID_PARTNO_Pos)              /*!< SCB CPUID: PARTNO Mask */
+
+#define SCB_CPUID_REVISION_Pos              0U                                            /*!< SCB CPUID: REVISION Position */
+#define SCB_CPUID_REVISION_Msk             (0xFUL /*<< SCB_CPUID_REVISION_Pos*/)          /*!< SCB CPUID: REVISION Mask */
+
+/** \brief SCB Interrupt Control State Register Definitions */
+#define SCB_ICSR_NMIPENDSET_Pos            31U                                            /*!< SCB ICSR: NMIPENDSET Position */
+#define SCB_ICSR_NMIPENDSET_Msk            (1UL << SCB_ICSR_NMIPENDSET_Pos)               /*!< SCB ICSR: NMIPENDSET Mask */
+
+#define SCB_ICSR_PENDSVSET_Pos             28U                                            /*!< SCB ICSR: PENDSVSET Position */
+#define SCB_ICSR_PENDSVSET_Msk             (1UL << SCB_ICSR_PENDSVSET_Pos)                /*!< SCB ICSR: PENDSVSET Mask */
+
+#define SCB_ICSR_PENDSVCLR_Pos             27U                                            /*!< SCB ICSR: PENDSVCLR Position */
+#define SCB_ICSR_PENDSVCLR_Msk             (1UL << SCB_ICSR_PENDSVCLR_Pos)                /*!< SCB ICSR: PENDSVCLR Mask */
+
+#define SCB_ICSR_PENDSTSET_Pos             26U                                            /*!< SCB ICSR: PENDSTSET Position */
+#define SCB_ICSR_PENDSTSET_Msk             (1UL << SCB_ICSR_PENDSTSET_Pos)                /*!< SCB ICSR: PENDSTSET Mask */
+
+#define SCB_ICSR_PENDSTCLR_Pos             25U                                            /*!< SCB ICSR: PENDSTCLR Position */
+#define SCB_ICSR_PENDSTCLR_Msk             (1UL << SCB_ICSR_PENDSTCLR_Pos)                /*!< SCB ICSR: PENDSTCLR Mask */
+
+#define SCB_ICSR_ISRPREEMPT_Pos            23U                                            /*!< SCB ICSR: ISRPREEMPT Position */
+#define SCB_ICSR_ISRPREEMPT_Msk            (1UL << SCB_ICSR_ISRPREEMPT_Pos)               /*!< SCB ICSR: ISRPREEMPT Mask */
+
+#define SCB_ICSR_ISRPENDING_Pos            22U                                            /*!< SCB ICSR: ISRPENDING Position */
+#define SCB_ICSR_ISRPENDING_Msk            (1UL << SCB_ICSR_ISRPENDING_Pos)               /*!< SCB ICSR: ISRPENDING Mask */
+
+#define SCB_ICSR_VECTPENDING_Pos           12U                                            /*!< SCB ICSR: VECTPENDING Position */
+#define SCB_ICSR_VECTPENDING_Msk           (0x1FFUL << SCB_ICSR_VECTPENDING_Pos)          /*!< SCB ICSR: VECTPENDING Mask */
+
+#define SCB_ICSR_RETTOBASE_Pos             11U                                            /*!< SCB ICSR: RETTOBASE Position */
+#define SCB_ICSR_RETTOBASE_Msk             (1UL << SCB_ICSR_RETTOBASE_Pos)                /*!< SCB ICSR: RETTOBASE Mask */
+
+#define SCB_ICSR_VECTACTIVE_Pos             0U                                            /*!< SCB ICSR: VECTACTIVE Position */
+#define SCB_ICSR_VECTACTIVE_Msk            (0x1FFUL /*<< SCB_ICSR_VECTACTIVE_Pos*/)       /*!< SCB ICSR: VECTACTIVE Mask */
+
+/** \brief SCB Vector Table Offset Register Definitions */
+#define SCB_VTOR_TBLBASE_Pos               29U                                            /*!< SCB VTOR: TBLBASE Position */
+#define SCB_VTOR_TBLBASE_Msk               (1UL << SCB_VTOR_TBLBASE_Pos)                  /*!< SCB VTOR: TBLBASE Mask */
+
+#define SCB_VTOR_TBLOFF_Pos                 7U                                            /*!< SCB VTOR: TBLOFF Position */
+#define SCB_VTOR_TBLOFF_Msk                (0x3FFFFFUL << SCB_VTOR_TBLOFF_Pos)            /*!< SCB VTOR: TBLOFF Mask */
+
+/** \brief SCB Application Interrupt and Reset Control Register Definitions */
+#define SCB_AIRCR_VECTKEY_Pos              16U                                            /*!< SCB AIRCR: VECTKEY Position */
+#define SCB_AIRCR_VECTKEY_Msk              (0xFFFFUL << SCB_AIRCR_VECTKEY_Pos)            /*!< SCB AIRCR: VECTKEY Mask */
+
+#define SCB_AIRCR_VECTKEYSTAT_Pos          16U                                            /*!< SCB AIRCR: VECTKEYSTAT Position */
+#define SCB_AIRCR_VECTKEYSTAT_Msk          (0xFFFFUL << SCB_AIRCR_VECTKEYSTAT_Pos)        /*!< SCB AIRCR: VECTKEYSTAT Mask */
+
+#define SCB_AIRCR_ENDIANESS_Pos            15U                                            /*!< SCB AIRCR: ENDIANESS Position */
+#define SCB_AIRCR_ENDIANESS_Msk            (1UL << SCB_AIRCR_ENDIANESS_Pos)               /*!< SCB AIRCR: ENDIANESS Mask */
+
+#define SCB_AIRCR_PRIGROUP_Pos              8U                                            /*!< SCB AIRCR: PRIGROUP Position */
+#define SCB_AIRCR_PRIGROUP_Msk             (7UL << SCB_AIRCR_PRIGROUP_Pos)                /*!< SCB AIRCR: PRIGROUP Mask */
+
+#define SCB_AIRCR_SYSRESETREQ_Pos           2U                                            /*!< SCB AIRCR: SYSRESETREQ Position */
+#define SCB_AIRCR_SYSRESETREQ_Msk          (1UL << SCB_AIRCR_SYSRESETREQ_Pos)             /*!< SCB AIRCR: SYSRESETREQ Mask */
+
+#define SCB_AIRCR_VECTCLRACTIVE_Pos         1U                                            /*!< SCB AIRCR: VECTCLRACTIVE Position */
+#define SCB_AIRCR_VECTCLRACTIVE_Msk        (1UL << SCB_AIRCR_VECTCLRACTIVE_Pos)           /*!< SCB AIRCR: VECTCLRACTIVE Mask */
+
+#define SCB_AIRCR_VECTRESET_Pos             0U                                            /*!< SCB AIRCR: VECTRESET Position */
+#define SCB_AIRCR_VECTRESET_Msk            (1UL /*<< SCB_AIRCR_VECTRESET_Pos*/)           /*!< SCB AIRCR: VECTRESET Mask */
+
+/** \brief SCB System Control Register Definitions */
+#define SCB_SCR_SEVONPEND_Pos               4U                                            /*!< SCB SCR: SEVONPEND Position */
+#define SCB_SCR_SEVONPEND_Msk              (1UL << SCB_SCR_SEVONPEND_Pos)                 /*!< SCB SCR: SEVONPEND Mask */
+
+#define SCB_SCR_SLEEPDEEP_Pos               2U                                            /*!< SCB SCR: SLEEPDEEP Position */
+#define SCB_SCR_SLEEPDEEP_Msk              (1UL << SCB_SCR_SLEEPDEEP_Pos)                 /*!< SCB SCR: SLEEPDEEP Mask */
+
+#define SCB_SCR_SLEEPONEXIT_Pos             1U                                            /*!< SCB SCR: SLEEPONEXIT Position */
+#define SCB_SCR_SLEEPONEXIT_Msk            (1UL << SCB_SCR_SLEEPONEXIT_Pos)               /*!< SCB SCR: SLEEPONEXIT Mask */
+
+/** \brief SCB Configuration Control Register Definitions */
+#define SCB_CCR_STKALIGN_Pos                9U                                            /*!< SCB CCR: STKALIGN Position */
+#define SCB_CCR_STKALIGN_Msk               (1UL << SCB_CCR_STKALIGN_Pos)                  /*!< SCB CCR: STKALIGN Mask */
+
+#define SCB_CCR_BFHFNMIGN_Pos               8U                                            /*!< SCB CCR: BFHFNMIGN Position */
+#define SCB_CCR_BFHFNMIGN_Msk              (1UL << SCB_CCR_BFHFNMIGN_Pos)                 /*!< SCB CCR: BFHFNMIGN Mask */
+
+#define SCB_CCR_DIV_0_TRP_Pos               4U                                            /*!< SCB CCR: DIV_0_TRP Position */
+#define SCB_CCR_DIV_0_TRP_Msk              (1UL << SCB_CCR_DIV_0_TRP_Pos)                 /*!< SCB CCR: DIV_0_TRP Mask */
+
+#define SCB_CCR_UNALIGN_TRP_Pos             3U                                            /*!< SCB CCR: UNALIGN_TRP Position */
+#define SCB_CCR_UNALIGN_TRP_Msk            (1UL << SCB_CCR_UNALIGN_TRP_Pos)               /*!< SCB CCR: UNALIGN_TRP Mask */
+
+#define SCB_CCR_USERSETMPEND_Pos            1U                                            /*!< SCB CCR: USERSETMPEND Position */
+#define SCB_CCR_USERSETMPEND_Msk           (1UL << SCB_CCR_USERSETMPEND_Pos)              /*!< SCB CCR: USERSETMPEND Mask */
+
+#define SCB_CCR_NONBASETHRDENA_Pos          0U                                            /*!< SCB CCR: NONBASETHRDENA Position */
+#define SCB_CCR_NONBASETHRDENA_Msk         (1UL /*<< SCB_CCR_NONBASETHRDENA_Pos*/)        /*!< SCB CCR: NONBASETHRDENA Mask */
+
+/** \brief SCB System Handler Control and State Register Definitions */
+#define SCB_SHCSR_USGFAULTENA_Pos          18U                                            /*!< SCB SHCSR: USGFAULTENA Position */
+#define SCB_SHCSR_USGFAULTENA_Msk          (1UL << SCB_SHCSR_USGFAULTENA_Pos)             /*!< SCB SHCSR: USGFAULTENA Mask */
+
+#define SCB_SHCSR_BUSFAULTENA_Pos          17U                                            /*!< SCB SHCSR: BUSFAULTENA Position */
+#define SCB_SHCSR_BUSFAULTENA_Msk          (1UL << SCB_SHCSR_BUSFAULTENA_Pos)             /*!< SCB SHCSR: BUSFAULTENA Mask */
+
+#define SCB_SHCSR_MEMFAULTENA_Pos          16U                                            /*!< SCB SHCSR: MEMFAULTENA Position */
+#define SCB_SHCSR_MEMFAULTENA_Msk          (1UL << SCB_SHCSR_MEMFAULTENA_Pos)             /*!< SCB SHCSR: MEMFAULTENA Mask */
+
+#define SCB_SHCSR_SVCALLPENDED_Pos         15U                                            /*!< SCB SHCSR: SVCALLPENDED Position */
+#define SCB_SHCSR_SVCALLPENDED_Msk         (1UL << SCB_SHCSR_SVCALLPENDED_Pos)            /*!< SCB SHCSR: SVCALLPENDED Mask */
+
+#define SCB_SHCSR_BUSFAULTPENDED_Pos       14U                                            /*!< SCB SHCSR: BUSFAULTPENDED Position */
+#define SCB_SHCSR_BUSFAULTPENDED_Msk       (1UL << SCB_SHCSR_BUSFAULTPENDED_Pos)          /*!< SCB SHCSR: BUSFAULTPENDED Mask */
+
+#define SCB_SHCSR_MEMFAULTPENDED_Pos       13U                                            /*!< SCB SHCSR: MEMFAULTPENDED Position */
+#define SCB_SHCSR_MEMFAULTPENDED_Msk       (1UL << SCB_SHCSR_MEMFAULTPENDED_Pos)          /*!< SCB SHCSR: MEMFAULTPENDED Mask */
+
+#define SCB_SHCSR_USGFAULTPENDED_Pos       12U                                            /*!< SCB SHCSR: USGFAULTPENDED Position */
+#define SCB_SHCSR_USGFAULTPENDED_Msk       (1UL << SCB_SHCSR_USGFAULTPENDED_Pos)          /*!< SCB SHCSR: USGFAULTPENDED Mask */
+
+#define SCB_SHCSR_SYSTICKACT_Pos           11U                                            /*!< SCB SHCSR: SYSTICKACT Position */
+#define SCB_SHCSR_SYSTICKACT_Msk           (1UL << SCB_SHCSR_SYSTICKACT_Pos)              /*!< SCB SHCSR: SYSTICKACT Mask */
+
+#define SCB_SHCSR_PENDSVACT_Pos            10U                                            /*!< SCB SHCSR: PENDSVACT Position */
+#define SCB_SHCSR_PENDSVACT_Msk            (1UL << SCB_SHCSR_PENDSVACT_Pos)               /*!< SCB SHCSR: PENDSVACT Mask */
+
+#define SCB_SHCSR_MONITORACT_Pos            8U                                            /*!< SCB SHCSR: MONITORACT Position */
+#define SCB_SHCSR_MONITORACT_Msk           (1UL << SCB_SHCSR_MONITORACT_Pos)              /*!< SCB SHCSR: MONITORACT Mask */
+
+#define SCB_SHCSR_SVCALLACT_Pos             7U                                            /*!< SCB SHCSR: SVCALLACT Position */
+#define SCB_SHCSR_SVCALLACT_Msk            (1UL << SCB_SHCSR_SVCALLACT_Pos)               /*!< SCB SHCSR: SVCALLACT Mask */
+
+#define SCB_SHCSR_USGFAULTACT_Pos           3U                                            /*!< SCB SHCSR: USGFAULTACT Position */
+#define SCB_SHCSR_USGFAULTACT_Msk          (1UL << SCB_SHCSR_USGFAULTACT_Pos)             /*!< SCB SHCSR: USGFAULTACT Mask */
+
+#define SCB_SHCSR_BUSFAULTACT_Pos           1U                                            /*!< SCB SHCSR: BUSFAULTACT Position */
+#define SCB_SHCSR_BUSFAULTACT_Msk          (1UL << SCB_SHCSR_BUSFAULTACT_Pos)             /*!< SCB SHCSR: BUSFAULTACT Mask */
+
+#define SCB_SHCSR_MEMFAULTACT_Pos           0U                                            /*!< SCB SHCSR: MEMFAULTACT Position */
+#define SCB_SHCSR_MEMFAULTACT_Msk          (1UL /*<< SCB_SHCSR_MEMFAULTACT_Pos*/)         /*!< SCB SHCSR: MEMFAULTACT Mask */
+
+/** \brief SCB Configurable Fault Status Register Definitions */
+#define SCB_CFSR_USGFAULTSR_Pos            16U                                            /*!< SCB CFSR: Usage Fault Status Register Position */
+#define SCB_CFSR_USGFAULTSR_Msk            (0xFFFFUL << SCB_CFSR_USGFAULTSR_Pos)          /*!< SCB CFSR: Usage Fault Status Register Mask */
+
+#define SCB_CFSR_BUSFAULTSR_Pos             8U                                            /*!< SCB CFSR: Bus Fault Status Register Position */
+#define SCB_CFSR_BUSFAULTSR_Msk            (0xFFUL << SCB_CFSR_BUSFAULTSR_Pos)            /*!< SCB CFSR: Bus Fault Status Register Mask */
+
+#define SCB_CFSR_MEMFAULTSR_Pos             0U                                            /*!< SCB CFSR: Memory Manage Fault Status Register Position */
+#define SCB_CFSR_MEMFAULTSR_Msk            (0xFFUL /*<< SCB_CFSR_MEMFAULTSR_Pos*/)        /*!< SCB CFSR: Memory Manage Fault Status Register Mask */
+
+/** \brief SCB MemManage Fault Status Register Definitions (part of SCB Configurable Fault Status Register) */
+#define SCB_CFSR_MMARVALID_Pos             (SCB_CFSR_MEMFAULTSR_Pos + 7U)                 /*!< SCB CFSR (MMFSR): MMARVALID Position */
+#define SCB_CFSR_MMARVALID_Msk             (1UL << SCB_CFSR_MMARVALID_Pos)                /*!< SCB CFSR (MMFSR): MMARVALID Mask */
+
+#define SCB_CFSR_MSTKERR_Pos               (SCB_CFSR_MEMFAULTSR_Pos + 4U)                 /*!< SCB CFSR (MMFSR): MSTKERR Position */
+#define SCB_CFSR_MSTKERR_Msk               (1UL << SCB_CFSR_MSTKERR_Pos)                  /*!< SCB CFSR (MMFSR): MSTKERR Mask */
+
+#define SCB_CFSR_MUNSTKERR_Pos             (SCB_CFSR_MEMFAULTSR_Pos + 3U)                 /*!< SCB CFSR (MMFSR): MUNSTKERR Position */
+#define SCB_CFSR_MUNSTKERR_Msk             (1UL << SCB_CFSR_MUNSTKERR_Pos)                /*!< SCB CFSR (MMFSR): MUNSTKERR Mask */
+
+#define SCB_CFSR_DACCVIOL_Pos              (SCB_CFSR_MEMFAULTSR_Pos + 1U)                 /*!< SCB CFSR (MMFSR): DACCVIOL Position */
+#define SCB_CFSR_DACCVIOL_Msk              (1UL << SCB_CFSR_DACCVIOL_Pos)                 /*!< SCB CFSR (MMFSR): DACCVIOL Mask */
+
+#define SCB_CFSR_IACCVIOL_Pos              (SCB_CFSR_MEMFAULTSR_Pos + 0U)                 /*!< SCB CFSR (MMFSR): IACCVIOL Position */
+#define SCB_CFSR_IACCVIOL_Msk              (1UL /*<< SCB_CFSR_IACCVIOL_Pos*/)             /*!< SCB CFSR (MMFSR): IACCVIOL Mask */
+
+/** \brief SCB BusFault Status Register Definitions (part of SCB Configurable Fault Status Register) */
+#define SCB_CFSR_BFARVALID_Pos            (SCB_CFSR_BUSFAULTSR_Pos + 7U)                  /*!< SCB CFSR (BFSR): BFARVALID Position */
+#define SCB_CFSR_BFARVALID_Msk            (1UL << SCB_CFSR_BFARVALID_Pos)                 /*!< SCB CFSR (BFSR): BFARVALID Mask */
+
+#define SCB_CFSR_STKERR_Pos               (SCB_CFSR_BUSFAULTSR_Pos + 4U)                  /*!< SCB CFSR (BFSR): STKERR Position */
+#define SCB_CFSR_STKERR_Msk               (1UL << SCB_CFSR_STKERR_Pos)                    /*!< SCB CFSR (BFSR): STKERR Mask */
+
+#define SCB_CFSR_UNSTKERR_Pos             (SCB_CFSR_BUSFAULTSR_Pos + 3U)                  /*!< SCB CFSR (BFSR): UNSTKERR Position */
+#define SCB_CFSR_UNSTKERR_Msk             (1UL << SCB_CFSR_UNSTKERR_Pos)                  /*!< SCB CFSR (BFSR): UNSTKERR Mask */
+
+#define SCB_CFSR_IMPRECISERR_Pos          (SCB_CFSR_BUSFAULTSR_Pos + 2U)                  /*!< SCB CFSR (BFSR): IMPRECISERR Position */
+#define SCB_CFSR_IMPRECISERR_Msk          (1UL << SCB_CFSR_IMPRECISERR_Pos)               /*!< SCB CFSR (BFSR): IMPRECISERR Mask */
+
+#define SCB_CFSR_PRECISERR_Pos            (SCB_CFSR_BUSFAULTSR_Pos + 1U)                  /*!< SCB CFSR (BFSR): PRECISERR Position */
+#define SCB_CFSR_PRECISERR_Msk            (1UL << SCB_CFSR_PRECISERR_Pos)                 /*!< SCB CFSR (BFSR): PRECISERR Mask */
+
+#define SCB_CFSR_IBUSERR_Pos              (SCB_CFSR_BUSFAULTSR_Pos + 0U)                  /*!< SCB CFSR (BFSR): IBUSERR Position */
+#define SCB_CFSR_IBUSERR_Msk              (1UL << SCB_CFSR_IBUSERR_Pos)                   /*!< SCB CFSR (BFSR): IBUSERR Mask */
+
+/** \brief SCB UsageFault Status Register Definitions (part of SCB Configurable Fault Status Register) */
+#define SCB_CFSR_DIVBYZERO_Pos            (SCB_CFSR_USGFAULTSR_Pos + 9U)                  /*!< SCB CFSR (UFSR): DIVBYZERO Position */
+#define SCB_CFSR_DIVBYZERO_Msk            (1UL << SCB_CFSR_DIVBYZERO_Pos)                 /*!< SCB CFSR (UFSR): DIVBYZERO Mask */
+
+#define SCB_CFSR_UNALIGNED_Pos            (SCB_CFSR_USGFAULTSR_Pos + 8U)                  /*!< SCB CFSR (UFSR): UNALIGNED Position */
+#define SCB_CFSR_UNALIGNED_Msk            (1UL << SCB_CFSR_UNALIGNED_Pos)                 /*!< SCB CFSR (UFSR): UNALIGNED Mask */
+
+#define SCB_CFSR_NOCP_Pos                 (SCB_CFSR_USGFAULTSR_Pos + 3U)                  /*!< SCB CFSR (UFSR): NOCP Position */
+#define SCB_CFSR_NOCP_Msk                 (1UL << SCB_CFSR_NOCP_Pos)                      /*!< SCB CFSR (UFSR): NOCP Mask */
+
+#define SCB_CFSR_INVPC_Pos                (SCB_CFSR_USGFAULTSR_Pos + 2U)                  /*!< SCB CFSR (UFSR): INVPC Position */
+#define SCB_CFSR_INVPC_Msk                (1UL << SCB_CFSR_INVPC_Pos)                     /*!< SCB CFSR (UFSR): INVPC Mask */
+
+#define SCB_CFSR_INVSTATE_Pos             (SCB_CFSR_USGFAULTSR_Pos + 1U)                  /*!< SCB CFSR (UFSR): INVSTATE Position */
+#define SCB_CFSR_INVSTATE_Msk             (1UL << SCB_CFSR_INVSTATE_Pos)                  /*!< SCB CFSR (UFSR): INVSTATE Mask */
+
+#define SCB_CFSR_UNDEFINSTR_Pos           (SCB_CFSR_USGFAULTSR_Pos + 0U)                  /*!< SCB CFSR (UFSR): UNDEFINSTR Position */
+#define SCB_CFSR_UNDEFINSTR_Msk           (1UL << SCB_CFSR_UNDEFINSTR_Pos)                /*!< SCB CFSR (UFSR): UNDEFINSTR Mask */
+
+/** \brief SCB Hard Fault Status Register Definitions */
+#define SCB_HFSR_DEBUGEVT_Pos              31U                                            /*!< SCB HFSR: DEBUGEVT Position */
+#define SCB_HFSR_DEBUGEVT_Msk              (1UL << SCB_HFSR_DEBUGEVT_Pos)                 /*!< SCB HFSR: DEBUGEVT Mask */
+
+#define SCB_HFSR_FORCED_Pos                30U                                            /*!< SCB HFSR: FORCED Position */
+#define SCB_HFSR_FORCED_Msk                (1UL << SCB_HFSR_FORCED_Pos)                   /*!< SCB HFSR: FORCED Mask */
+
+#define SCB_HFSR_VECTTBL_Pos                1U                                            /*!< SCB HFSR: VECTTBL Position */
+#define SCB_HFSR_VECTTBL_Msk               (1UL << SCB_HFSR_VECTTBL_Pos)                  /*!< SCB HFSR: VECTTBL Mask */
+
+/** \brief SCB Debug Fault Status Register Definitions */
+#define SCB_DFSR_EXTERNAL_Pos               4U                                            /*!< SCB DFSR: EXTERNAL Position */
+#define SCB_DFSR_EXTERNAL_Msk              (1UL << SCB_DFSR_EXTERNAL_Pos)                 /*!< SCB DFSR: EXTERNAL Mask */
+
+#define SCB_DFSR_VCATCH_Pos                 3U                                            /*!< SCB DFSR: VCATCH Position */
+#define SCB_DFSR_VCATCH_Msk                (1UL << SCB_DFSR_VCATCH_Pos)                   /*!< SCB DFSR: VCATCH Mask */
+
+#define SCB_DFSR_DWTTRAP_Pos                2U                                            /*!< SCB DFSR: DWTTRAP Position */
+#define SCB_DFSR_DWTTRAP_Msk               (1UL << SCB_DFSR_DWTTRAP_Pos)                  /*!< SCB DFSR: DWTTRAP Mask */
+
+#define SCB_DFSR_BKPT_Pos                   1U                                            /*!< SCB DFSR: BKPT Position */
+#define SCB_DFSR_BKPT_Msk                  (1UL << SCB_DFSR_BKPT_Pos)                     /*!< SCB DFSR: BKPT Mask */
+
+#define SCB_DFSR_HALTED_Pos                 0U                                            /*!< SCB DFSR: HALTED Position */
+#define SCB_DFSR_HALTED_Msk                (1UL /*<< SCB_DFSR_HALTED_Pos*/)               /*!< SCB DFSR: HALTED Mask */
+
+/*@} end of group CMSIS_SCB */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SCnSCB System Controls not in SCB (SCnSCB)
+  \brief    Type definitions for the System Control and ID Register not in the SCB
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Control and ID Register not in the SCB.
+ */
+typedef struct
+{
+        uint32_t RESERVED0[1U];
+  __IM  uint32_t ICTR;                   /*!< Offset: 0x004 (R/ )  Interrupt Controller Type Register */
+  __IOM uint32_t ACTLR;                  /*!< Offset: 0x008 (R/W)  Auxiliary Control Register */
+} SCnSCB_Type;
+
+/** \brief SCnSCB Interrupt Controller Type Register Definitions */
+#define SCnSCB_ICTR_INTLINESNUM_Pos         0U                                         /*!< ICTR: INTLINESNUM Position */
+#define SCnSCB_ICTR_INTLINESNUM_Msk        (0xFUL /*<< SCnSCB_ICTR_INTLINESNUM_Pos*/)  /*!< ICTR: INTLINESNUM Mask */
+
+/** \brief SCnSCB Auxiliary Control Register Definitions */
+#define SCnSCB_ACTLR_DISFOLD_Pos            2U                                         /*!< ACTLR: DISFOLD Position */
+#define SCnSCB_ACTLR_DISFOLD_Msk           (1UL << SCnSCB_ACTLR_DISFOLD_Pos)           /*!< ACTLR: DISFOLD Mask */
+
+#define SCnSCB_ACTLR_DISDEFWBUF_Pos         1U                                         /*!< ACTLR: DISDEFWBUF Position */
+#define SCnSCB_ACTLR_DISDEFWBUF_Msk        (1UL << SCnSCB_ACTLR_DISDEFWBUF_Pos)        /*!< ACTLR: DISDEFWBUF Mask */
+
+#define SCnSCB_ACTLR_DISMCYCINT_Pos         0U                                         /*!< ACTLR: DISMCYCINT Position */
+#define SCnSCB_ACTLR_DISMCYCINT_Msk        (1UL /*<< SCnSCB_ACTLR_DISMCYCINT_Pos*/)    /*!< ACTLR: DISMCYCINT Mask */
+
+/*@} end of group CMSIS_SCnotSCB */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SysTick     System Tick Timer (SysTick)
+  \brief    Type definitions for the System Timer Registers.
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Timer (SysTick).
+ */
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  SysTick Control and Status Register */
+  __IOM uint32_t LOAD;                   /*!< Offset: 0x004 (R/W)  SysTick Reload Value Register */
+  __IOM uint32_t VAL;                    /*!< Offset: 0x008 (R/W)  SysTick Current Value Register */
+  __IM  uint32_t CALIB;                  /*!< Offset: 0x00C (R/ )  SysTick Calibration Register */
+} SysTick_Type;
+
+/** \brief SysTick Control / Status Register Definitions */
+#define SysTick_CTRL_COUNTFLAG_Pos         16U                                            /*!< SysTick CTRL: COUNTFLAG Position */
+#define SysTick_CTRL_COUNTFLAG_Msk         (1UL << SysTick_CTRL_COUNTFLAG_Pos)            /*!< SysTick CTRL: COUNTFLAG Mask */
+
+#define SysTick_CTRL_CLKSOURCE_Pos          2U                                            /*!< SysTick CTRL: CLKSOURCE Position */
+#define SysTick_CTRL_CLKSOURCE_Msk         (1UL << SysTick_CTRL_CLKSOURCE_Pos)            /*!< SysTick CTRL: CLKSOURCE Mask */
+
+#define SysTick_CTRL_TICKINT_Pos            1U                                            /*!< SysTick CTRL: TICKINT Position */
+#define SysTick_CTRL_TICKINT_Msk           (1UL << SysTick_CTRL_TICKINT_Pos)              /*!< SysTick CTRL: TICKINT Mask */
+
+#define SysTick_CTRL_ENABLE_Pos             0U                                            /*!< SysTick CTRL: ENABLE Position */
+#define SysTick_CTRL_ENABLE_Msk            (1UL /*<< SysTick_CTRL_ENABLE_Pos*/)           /*!< SysTick CTRL: ENABLE Mask */
+
+/** \brief SysTick Reload Register Definitions */
+#define SysTick_LOAD_RELOAD_Pos             0U                                            /*!< SysTick LOAD: RELOAD Position */
+#define SysTick_LOAD_RELOAD_Msk            (0xFFFFFFUL /*<< SysTick_LOAD_RELOAD_Pos*/)    /*!< SysTick LOAD: RELOAD Mask */
+
+/** \brief SysTick Current Register Definitions */
+#define SysTick_VAL_CURRENT_Pos             0U                                            /*!< SysTick VAL: CURRENT Position */
+#define SysTick_VAL_CURRENT_Msk            (0xFFFFFFUL /*<< SysTick_VAL_CURRENT_Pos*/)    /*!< SysTick VAL: CURRENT Mask */
+
+/** \brief SysTick Calibration Register Definitions */
+#define SysTick_CALIB_NOREF_Pos            31U                                            /*!< SysTick CALIB: NOREF Position */
+#define SysTick_CALIB_NOREF_Msk            (1UL << SysTick_CALIB_NOREF_Pos)               /*!< SysTick CALIB: NOREF Mask */
+
+#define SysTick_CALIB_SKEW_Pos             30U                                            /*!< SysTick CALIB: SKEW Position */
+#define SysTick_CALIB_SKEW_Msk             (1UL << SysTick_CALIB_SKEW_Pos)                /*!< SysTick CALIB: SKEW Mask */
+
+#define SysTick_CALIB_TENMS_Pos             0U                                            /*!< SysTick CALIB: TENMS Position */
+#define SysTick_CALIB_TENMS_Msk            (0xFFFFFFUL /*<< SysTick_CALIB_TENMS_Pos*/)    /*!< SysTick CALIB: TENMS Mask */
+
+/*@} end of group CMSIS_SysTick */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_ITM     Instrumentation Trace Macrocell (ITM)
+  \brief    Type definitions for the Instrumentation Trace Macrocell (ITM)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Instrumentation Trace Macrocell Register (ITM).
+ */
+typedef struct
+{
+  __OM  union
+  {
+    __OM  uint8_t    u8;                 /*!< Offset: 0x000 ( /W)  Stimulus Port 8-bit */
+    __OM  uint16_t   u16;                /*!< Offset: 0x000 ( /W)  Stimulus Port 16-bit */
+    __OM  uint32_t   u32;                /*!< Offset: 0x000 ( /W)  Stimulus Port 32-bit */
+  }  PORT [32U];                         /*!< Offset: 0x000 ( /W)  Stimulus Port Registers */
+        uint32_t RESERVED0[864U];
+  __IOM uint32_t TER;                    /*!< Offset: 0xE00 (R/W)  Trace Enable Register */
+        uint32_t RESERVED1[15U];
+  __IOM uint32_t TPR;                    /*!< Offset: 0xE40 (R/W)  Trace Privilege Register */
+        uint32_t RESERVED2[15U];
+  __IOM uint32_t TCR;                    /*!< Offset: 0xE80 (R/W)  Trace Control Register */
+        uint32_t RESERVED3[32U];
+        uint32_t RESERVED4[43U];
+  __OM  uint32_t LAR;                    /*!< Offset: 0xFB0 ( /W)  Lock Access Register */
+  __IM  uint32_t LSR;                    /*!< Offset: 0xFB4 (R/ )  Lock Status Register */
+} ITM_Type;
+
+/** \brief ITM Trace Privilege Register Definitions */
+#define ITM_TPR_PRIVMASK_Pos                0U                                            /*!< ITM TPR: PRIVMASK Position */
+#define ITM_TPR_PRIVMASK_Msk               (0xFUL /*<< ITM_TPR_PRIVMASK_Pos*/)            /*!< ITM TPR: PRIVMASK Mask */
+
+/** \brief ITM Trace Control Register Definitions */
+#define ITM_TCR_BUSY_Pos                   23U                                            /*!< ITM TCR: BUSY Position */
+#define ITM_TCR_BUSY_Msk                   (1UL << ITM_TCR_BUSY_Pos)                      /*!< ITM TCR: BUSY Mask */
+
+#define ITM_TCR_TRACEBUSID_Pos             16U                                            /*!< ITM TCR: ATBID Position */
+#define ITM_TCR_TRACEBUSID_Msk             (0x7FUL << ITM_TCR_TRACEBUSID_Pos)             /*!< ITM TCR: ATBID Mask */
+
+#define ITM_TCR_GTSFREQ_Pos                10U                                            /*!< ITM TCR: Global timestamp frequency Position */
+#define ITM_TCR_GTSFREQ_Msk                (3UL << ITM_TCR_GTSFREQ_Pos)                   /*!< ITM TCR: Global timestamp frequency Mask */
+
+#define ITM_TCR_TSPRESCALE_Pos              8U                                            /*!< ITM TCR: TSPrescale Position */
+#define ITM_TCR_TSPRESCALE_Msk             (3UL << ITM_TCR_TSPRESCALE_Pos)                /*!< ITM TCR: TSPrescale Mask */
+
+#define ITM_TCR_SWOENA_Pos                  4U                                            /*!< ITM TCR: SWOENA Position */
+#define ITM_TCR_SWOENA_Msk                 (1UL << ITM_TCR_SWOENA_Pos)                    /*!< ITM TCR: SWOENA Mask */
+
+#define ITM_TCR_DWTENA_Pos                  3U                                            /*!< ITM TCR: DWTENA Position */
+#define ITM_TCR_DWTENA_Msk                 (1UL << ITM_TCR_DWTENA_Pos)                    /*!< ITM TCR: DWTENA Mask */
+
+#define ITM_TCR_SYNCENA_Pos                 2U                                            /*!< ITM TCR: SYNCENA Position */
+#define ITM_TCR_SYNCENA_Msk                (1UL << ITM_TCR_SYNCENA_Pos)                   /*!< ITM TCR: SYNCENA Mask */
+
+#define ITM_TCR_TSENA_Pos                   1U                                            /*!< ITM TCR: TSENA Position */
+#define ITM_TCR_TSENA_Msk                  (1UL << ITM_TCR_TSENA_Pos)                     /*!< ITM TCR: TSENA Mask */
+
+#define ITM_TCR_ITMENA_Pos                  0U                                            /*!< ITM TCR: ITM Enable bit Position */
+#define ITM_TCR_ITMENA_Msk                 (1UL /*<< ITM_TCR_ITMENA_Pos*/)                /*!< ITM TCR: ITM Enable bit Mask */
+
+/** \brief ITM Lock Status Register Definitions */
+#define ITM_LSR_BYTEACC_Pos                 2U                                            /*!< ITM LSR: ByteAcc Position */
+#define ITM_LSR_BYTEACC_Msk                (1UL << ITM_LSR_BYTEACC_Pos)                   /*!< ITM LSR: ByteAcc Mask */
+
+#define ITM_LSR_ACCESS_Pos                  1U                                            /*!< ITM LSR: Access Position */
+#define ITM_LSR_ACCESS_Msk                 (1UL << ITM_LSR_ACCESS_Pos)                    /*!< ITM LSR: Access Mask */
+
+#define ITM_LSR_PRESENT_Pos                 0U                                            /*!< ITM LSR: Present Position */
+#define ITM_LSR_PRESENT_Msk                (1UL /*<< ITM_LSR_PRESENT_Pos*/)               /*!< ITM LSR: Present Mask */
+
+/*@}*/ /* end of group CMSIS_ITM */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_DWT     Data Watchpoint and Trace (DWT)
+  \brief    Type definitions for the Data Watchpoint and Trace (DWT)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Data Watchpoint and Trace Register (DWT).
+ */
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  Control Register */
+  __IOM uint32_t CYCCNT;                 /*!< Offset: 0x004 (R/W)  Cycle Count Register */
+  __IOM uint32_t CPICNT;                 /*!< Offset: 0x008 (R/W)  CPI Count Register */
+  __IOM uint32_t EXCCNT;                 /*!< Offset: 0x00C (R/W)  Exception Overhead Count Register */
+  __IOM uint32_t SLEEPCNT;               /*!< Offset: 0x010 (R/W)  Sleep Count Register */
+  __IOM uint32_t LSUCNT;                 /*!< Offset: 0x014 (R/W)  LSU Count Register */
+  __IOM uint32_t FOLDCNT;                /*!< Offset: 0x018 (R/W)  Folded-instruction Count Register */
+  __IM  uint32_t PCSR;                   /*!< Offset: 0x01C (R/ )  Program Counter Sample Register */
+  __IOM uint32_t COMP0;                  /*!< Offset: 0x020 (R/W)  Comparator Register 0 */
+  __IOM uint32_t MASK0;                  /*!< Offset: 0x024 (R/W)  Mask Register 0 */
+  __IOM uint32_t FUNCTION0;              /*!< Offset: 0x028 (R/W)  Function Register 0 */
+        uint32_t RESERVED0[1U];
+  __IOM uint32_t COMP1;                  /*!< Offset: 0x030 (R/W)  Comparator Register 1 */
+  __IOM uint32_t MASK1;                  /*!< Offset: 0x034 (R/W)  Mask Register 1 */
+  __IOM uint32_t FUNCTION1;              /*!< Offset: 0x038 (R/W)  Function Register 1 */
+        uint32_t RESERVED1[1U];
+  __IOM uint32_t COMP2;                  /*!< Offset: 0x040 (R/W)  Comparator Register 2 */
+  __IOM uint32_t MASK2;                  /*!< Offset: 0x044 (R/W)  Mask Register 2 */
+  __IOM uint32_t FUNCTION2;              /*!< Offset: 0x048 (R/W)  Function Register 2 */
+        uint32_t RESERVED2[1U];
+  __IOM uint32_t COMP3;                  /*!< Offset: 0x050 (R/W)  Comparator Register 3 */
+  __IOM uint32_t MASK3;                  /*!< Offset: 0x054 (R/W)  Mask Register 3 */
+  __IOM uint32_t FUNCTION3;              /*!< Offset: 0x058 (R/W)  Function Register 3 */
+} DWT_Type;
+
+/** \brief DWT Control Register Definitions */
+#define DWT_CTRL_NUMCOMP_Pos               28U                                         /*!< DWT CTRL: NUMCOMP Position */
+#define DWT_CTRL_NUMCOMP_Msk               (0xFUL << DWT_CTRL_NUMCOMP_Pos)             /*!< DWT CTRL: NUMCOMP Mask */
+
+#define DWT_CTRL_NOTRCPKT_Pos              27U                                         /*!< DWT CTRL: NOTRCPKT Position */
+#define DWT_CTRL_NOTRCPKT_Msk              (1UL << DWT_CTRL_NOTRCPKT_Pos)              /*!< DWT CTRL: NOTRCPKT Mask */
+
+#define DWT_CTRL_NOEXTTRIG_Pos             26U                                         /*!< DWT CTRL: NOEXTTRIG Position */
+#define DWT_CTRL_NOEXTTRIG_Msk             (1UL << DWT_CTRL_NOEXTTRIG_Pos)             /*!< DWT CTRL: NOEXTTRIG Mask */
+
+#define DWT_CTRL_NOCYCCNT_Pos              25U                                         /*!< DWT CTRL: NOCYCCNT Position */
+#define DWT_CTRL_NOCYCCNT_Msk              (1UL << DWT_CTRL_NOCYCCNT_Pos)              /*!< DWT CTRL: NOCYCCNT Mask */
+
+#define DWT_CTRL_NOPRFCNT_Pos              24U                                         /*!< DWT CTRL: NOPRFCNT Position */
+#define DWT_CTRL_NOPRFCNT_Msk              (1UL << DWT_CTRL_NOPRFCNT_Pos)              /*!< DWT CTRL: NOPRFCNT Mask */
+
+#define DWT_CTRL_CYCEVTENA_Pos             22U                                         /*!< DWT CTRL: CYCEVTENA Position */
+#define DWT_CTRL_CYCEVTENA_Msk             (1UL << DWT_CTRL_CYCEVTENA_Pos)             /*!< DWT CTRL: CYCEVTENA Mask */
+
+#define DWT_CTRL_FOLDEVTENA_Pos            21U                                         /*!< DWT CTRL: FOLDEVTENA Position */
+#define DWT_CTRL_FOLDEVTENA_Msk            (1UL << DWT_CTRL_FOLDEVTENA_Pos)            /*!< DWT CTRL: FOLDEVTENA Mask */
+
+#define DWT_CTRL_LSUEVTENA_Pos             20U                                         /*!< DWT CTRL: LSUEVTENA Position */
+#define DWT_CTRL_LSUEVTENA_Msk             (1UL << DWT_CTRL_LSUEVTENA_Pos)             /*!< DWT CTRL: LSUEVTENA Mask */
+
+#define DWT_CTRL_SLEEPEVTENA_Pos           19U                                         /*!< DWT CTRL: SLEEPEVTENA Position */
+#define DWT_CTRL_SLEEPEVTENA_Msk           (1UL << DWT_CTRL_SLEEPEVTENA_Pos)           /*!< DWT CTRL: SLEEPEVTENA Mask */
+
+#define DWT_CTRL_EXCEVTENA_Pos             18U                                         /*!< DWT CTRL: EXCEVTENA Position */
+#define DWT_CTRL_EXCEVTENA_Msk             (1UL << DWT_CTRL_EXCEVTENA_Pos)             /*!< DWT CTRL: EXCEVTENA Mask */
+
+#define DWT_CTRL_CPIEVTENA_Pos             17U                                         /*!< DWT CTRL: CPIEVTENA Position */
+#define DWT_CTRL_CPIEVTENA_Msk             (1UL << DWT_CTRL_CPIEVTENA_Pos)             /*!< DWT CTRL: CPIEVTENA Mask */
+
+#define DWT_CTRL_EXCTRCENA_Pos             16U                                         /*!< DWT CTRL: EXCTRCENA Position */
+#define DWT_CTRL_EXCTRCENA_Msk             (1UL << DWT_CTRL_EXCTRCENA_Pos)             /*!< DWT CTRL: EXCTRCENA Mask */
+
+#define DWT_CTRL_PCSAMPLENA_Pos            12U                                         /*!< DWT CTRL: PCSAMPLENA Position */
+#define DWT_CTRL_PCSAMPLENA_Msk            (1UL << DWT_CTRL_PCSAMPLENA_Pos)            /*!< DWT CTRL: PCSAMPLENA Mask */
+
+#define DWT_CTRL_SYNCTAP_Pos               10U                                         /*!< DWT CTRL: SYNCTAP Position */
+#define DWT_CTRL_SYNCTAP_Msk               (0x3UL << DWT_CTRL_SYNCTAP_Pos)             /*!< DWT CTRL: SYNCTAP Mask */
+
+#define DWT_CTRL_CYCTAP_Pos                 9U                                         /*!< DWT CTRL: CYCTAP Position */
+#define DWT_CTRL_CYCTAP_Msk                (1UL << DWT_CTRL_CYCTAP_Pos)                /*!< DWT CTRL: CYCTAP Mask */
+
+#define DWT_CTRL_POSTINIT_Pos               5U                                         /*!< DWT CTRL: POSTINIT Position */
+#define DWT_CTRL_POSTINIT_Msk              (0xFUL << DWT_CTRL_POSTINIT_Pos)            /*!< DWT CTRL: POSTINIT Mask */
+
+#define DWT_CTRL_POSTPRESET_Pos             1U                                         /*!< DWT CTRL: POSTPRESET Position */
+#define DWT_CTRL_POSTPRESET_Msk            (0xFUL << DWT_CTRL_POSTPRESET_Pos)          /*!< DWT CTRL: POSTPRESET Mask */
+
+#define DWT_CTRL_CYCCNTENA_Pos              0U                                         /*!< DWT CTRL: CYCCNTENA Position */
+#define DWT_CTRL_CYCCNTENA_Msk             (1UL /*<< DWT_CTRL_CYCCNTENA_Pos*/)         /*!< DWT CTRL: CYCCNTENA Mask */
+
+/** \brief DWT CPI Count Register Definitions */
+#define DWT_CPICNT_CPICNT_Pos               0U                                         /*!< DWT CPICNT: CPICNT Position */
+#define DWT_CPICNT_CPICNT_Msk              (0xFFUL /*<< DWT_CPICNT_CPICNT_Pos*/)       /*!< DWT CPICNT: CPICNT Mask */
+
+/** \brief DWT Exception Overhead Count Register Definitions */
+#define DWT_EXCCNT_EXCCNT_Pos               0U                                         /*!< DWT EXCCNT: EXCCNT Position */
+#define DWT_EXCCNT_EXCCNT_Msk              (0xFFUL /*<< DWT_EXCCNT_EXCCNT_Pos*/)       /*!< DWT EXCCNT: EXCCNT Mask */
+
+/** \brief DWT Sleep Count Register Definitions */
+#define DWT_SLEEPCNT_SLEEPCNT_Pos           0U                                         /*!< DWT SLEEPCNT: SLEEPCNT Position */
+#define DWT_SLEEPCNT_SLEEPCNT_Msk          (0xFFUL /*<< DWT_SLEEPCNT_SLEEPCNT_Pos*/)   /*!< DWT SLEEPCNT: SLEEPCNT Mask */
+
+/** \brief DWT LSU Count Register Definitions */
+#define DWT_LSUCNT_LSUCNT_Pos               0U                                         /*!< DWT LSUCNT: LSUCNT Position */
+#define DWT_LSUCNT_LSUCNT_Msk              (0xFFUL /*<< DWT_LSUCNT_LSUCNT_Pos*/)       /*!< DWT LSUCNT: LSUCNT Mask */
+
+/** \brief DWT Folded-instruction Count Register Definitions */
+#define DWT_FOLDCNT_FOLDCNT_Pos             0U                                         /*!< DWT FOLDCNT: FOLDCNT Position */
+#define DWT_FOLDCNT_FOLDCNT_Msk            (0xFFUL /*<< DWT_FOLDCNT_FOLDCNT_Pos*/)     /*!< DWT FOLDCNT: FOLDCNT Mask */
+
+/** \brief DWT Comparator Mask Register Definitions */
+#define DWT_MASK_MASK_Pos                   0U                                         /*!< DWT MASK: MASK Position */
+#define DWT_MASK_MASK_Msk                  (0x1FUL /*<< DWT_MASK_MASK_Pos*/)           /*!< DWT MASK: MASK Mask */
+
+/** \brief DWT Comparator Function Register Definitions */
+#define DWT_FUNCTION_MATCHED_Pos           24U                                         /*!< DWT FUNCTION: MATCHED Position */
+#define DWT_FUNCTION_MATCHED_Msk           (1UL << DWT_FUNCTION_MATCHED_Pos)           /*!< DWT FUNCTION: MATCHED Mask */
+
+#define DWT_FUNCTION_DATAVADDR1_Pos        16U                                         /*!< DWT FUNCTION: DATAVADDR1 Position */
+#define DWT_FUNCTION_DATAVADDR1_Msk        (0xFUL << DWT_FUNCTION_DATAVADDR1_Pos)      /*!< DWT FUNCTION: DATAVADDR1 Mask */
+
+#define DWT_FUNCTION_DATAVADDR0_Pos        12U                                         /*!< DWT FUNCTION: DATAVADDR0 Position */
+#define DWT_FUNCTION_DATAVADDR0_Msk        (0xFUL << DWT_FUNCTION_DATAVADDR0_Pos)      /*!< DWT FUNCTION: DATAVADDR0 Mask */
+
+#define DWT_FUNCTION_DATAVSIZE_Pos         10U                                         /*!< DWT FUNCTION: DATAVSIZE Position */
+#define DWT_FUNCTION_DATAVSIZE_Msk         (0x3UL << DWT_FUNCTION_DATAVSIZE_Pos)       /*!< DWT FUNCTION: DATAVSIZE Mask */
+
+#define DWT_FUNCTION_LNK1ENA_Pos            9U                                         /*!< DWT FUNCTION: LNK1ENA Position */
+#define DWT_FUNCTION_LNK1ENA_Msk           (1UL << DWT_FUNCTION_LNK1ENA_Pos)           /*!< DWT FUNCTION: LNK1ENA Mask */
+
+#define DWT_FUNCTION_DATAVMATCH_Pos         8U                                         /*!< DWT FUNCTION: DATAVMATCH Position */
+#define DWT_FUNCTION_DATAVMATCH_Msk        (1UL << DWT_FUNCTION_DATAVMATCH_Pos)        /*!< DWT FUNCTION: DATAVMATCH Mask */
+
+#define DWT_FUNCTION_CYCMATCH_Pos           7U                                         /*!< DWT FUNCTION: CYCMATCH Position */
+#define DWT_FUNCTION_CYCMATCH_Msk          (1UL << DWT_FUNCTION_CYCMATCH_Pos)          /*!< DWT FUNCTION: CYCMATCH Mask */
+
+#define DWT_FUNCTION_EMITRANGE_Pos          5U                                         /*!< DWT FUNCTION: EMITRANGE Position */
+#define DWT_FUNCTION_EMITRANGE_Msk         (1UL << DWT_FUNCTION_EMITRANGE_Pos)         /*!< DWT FUNCTION: EMITRANGE Mask */
+
+#define DWT_FUNCTION_FUNCTION_Pos           0U                                         /*!< DWT FUNCTION: FUNCTION Position */
+#define DWT_FUNCTION_FUNCTION_Msk          (0xFUL /*<< DWT_FUNCTION_FUNCTION_Pos*/)    /*!< DWT FUNCTION: FUNCTION Mask */
+
+/*@}*/ /* end of group CMSIS_DWT */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_TPIU    Trace Port Interface Unit (TPIU)
+  \brief    Type definitions for the Trace Port Interface Unit (TPIU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Trace Port Interface Unit Register (TPIU).
+ */
+typedef struct
+{
+  __IM  uint32_t SSPSR;                  /*!< Offset: 0x000 (R/ )  Supported Parallel Port Size Register */
+  __IOM uint32_t CSPSR;                  /*!< Offset: 0x004 (R/W)  Current Parallel Port Size Register */
+        uint32_t RESERVED0[2U];
+  __IOM uint32_t ACPR;                   /*!< Offset: 0x010 (R/W)  Asynchronous Clock Prescaler Register */
+        uint32_t RESERVED1[55U];
+  __IOM uint32_t SPPR;                   /*!< Offset: 0x0F0 (R/W)  Selected Pin Protocol Register */
+        uint32_t RESERVED2[131U];
+  __IM  uint32_t FFSR;                   /*!< Offset: 0x300 (R/ )  Formatter and Flush Status Register */
+  __IOM uint32_t FFCR;                   /*!< Offset: 0x304 (R/W)  Formatter and Flush Control Register */
+  __IM  uint32_t FSCR;                   /*!< Offset: 0x308 (R/ )  Formatter Synchronization Counter Register */
+        uint32_t RESERVED3[759U];
+  __IM  uint32_t TRIGGER;                /*!< Offset: 0xEE8 (R/ )  TRIGGER Register */
+  __IM  uint32_t FIFO0;                  /*!< Offset: 0xEEC (R/ )  Integration ETM Data */
+  __IM  uint32_t ITATBCTR2;              /*!< Offset: 0xEF0 (R/ )  ITATBCTR2 */
+        uint32_t RESERVED4[1U];
+  __IM  uint32_t ITATBCTR0;              /*!< Offset: 0xEF8 (R/ )  ITATBCTR0 */
+  __IM  uint32_t FIFO1;                  /*!< Offset: 0xEFC (R/ )  Integration ITM Data */
+  __IOM uint32_t ITCTRL;                 /*!< Offset: 0xF00 (R/W)  Integration Mode Control */
+        uint32_t RESERVED5[39U];
+  __IOM uint32_t CLAIMSET;               /*!< Offset: 0xFA0 (R/W)  Claim tag set */
+  __IOM uint32_t CLAIMCLR;               /*!< Offset: 0xFA4 (R/W)  Claim tag clear */
+        uint32_t RESERVED7[8U];
+  __IM  uint32_t DEVID;                  /*!< Offset: 0xFC8 (R/ )  Device Configuration Register */
+  __IM  uint32_t DEVTYPE;                /*!< Offset: 0xFCC (R/ )  Device Type Identifier Register */
+} TPIU_Type;
+
+/** \brief TPIU Asynchronous Clock Prescaler Register Definitions */
+#define TPIU_ACPR_PRESCALER_Pos             0U                                         /*!< TPIU ACPR: PRESCALER Position */
+#define TPIU_ACPR_PRESCALER_Msk            (0x1FFFUL /*<< TPIU_ACPR_PRESCALER_Pos*/)   /*!< TPIU ACPR: PRESCALER Mask */
+
+/** \brief TPIU Selected Pin Protocol Register Definitions */
+#define TPIU_SPPR_TXMODE_Pos                0U                                         /*!< TPIU SPPR: TXMODE Position */
+#define TPIU_SPPR_TXMODE_Msk               (0x3UL /*<< TPIU_SPPR_TXMODE_Pos*/)         /*!< TPIU SPPR: TXMODE Mask */
+
+/** \brief TPIU Formatter and Flush Status Register Definitions */
+#define TPIU_FFSR_FtNonStop_Pos             3U                                         /*!< TPIU FFSR: FtNonStop Position */
+#define TPIU_FFSR_FtNonStop_Msk            (1UL << TPIU_FFSR_FtNonStop_Pos)            /*!< TPIU FFSR: FtNonStop Mask */
+
+#define TPIU_FFSR_TCPresent_Pos             2U                                         /*!< TPIU FFSR: TCPresent Position */
+#define TPIU_FFSR_TCPresent_Msk            (1UL << TPIU_FFSR_TCPresent_Pos)            /*!< TPIU FFSR: TCPresent Mask */
+
+#define TPIU_FFSR_FtStopped_Pos             1U                                         /*!< TPIU FFSR: FtStopped Position */
+#define TPIU_FFSR_FtStopped_Msk            (1UL << TPIU_FFSR_FtStopped_Pos)            /*!< TPIU FFSR: FtStopped Mask */
+
+#define TPIU_FFSR_FlInProg_Pos              0U                                         /*!< TPIU FFSR: FlInProg Position */
+#define TPIU_FFSR_FlInProg_Msk             (1UL /*<< TPIU_FFSR_FlInProg_Pos*/)         /*!< TPIU FFSR: FlInProg Mask */
+
+/** \brief TPIU Formatter and Flush Control Register Definitions */
+#define TPIU_FFCR_TrigIn_Pos                8U                                         /*!< TPIU FFCR: TrigIn Position */
+#define TPIU_FFCR_TrigIn_Msk               (1UL << TPIU_FFCR_TrigIn_Pos)               /*!< TPIU FFCR: TrigIn Mask */
+
+#define TPIU_FFCR_EnFCont_Pos               1U                                         /*!< TPIU FFCR: EnFCont Position */
+#define TPIU_FFCR_EnFCont_Msk              (1UL << TPIU_FFCR_EnFCont_Pos)              /*!< TPIU FFCR: EnFCont Mask */
+
+/** \brief TPIU TRIGGER Register Definitions */
+#define TPIU_TRIGGER_TRIGGER_Pos            0U                                         /*!< TPIU TRIGGER: TRIGGER Position */
+#define TPIU_TRIGGER_TRIGGER_Msk           (1UL /*<< TPIU_TRIGGER_TRIGGER_Pos*/)       /*!< TPIU TRIGGER: TRIGGER Mask */
+
+/** \brief TPIU Integration ETM Data Register Definitions (FIFO0) */
+#define TPIU_FIFO0_ITM_ATVALID_Pos         29U                                         /*!< TPIU FIFO0: ITM_ATVALID Position */
+#define TPIU_FIFO0_ITM_ATVALID_Msk         (1UL << TPIU_FIFO0_ITM_ATVALID_Pos)         /*!< TPIU FIFO0: ITM_ATVALID Mask */
+
+#define TPIU_FIFO0_ITM_bytecount_Pos       27U                                         /*!< TPIU FIFO0: ITM_bytecount Position */
+#define TPIU_FIFO0_ITM_bytecount_Msk       (0x3UL << TPIU_FIFO0_ITM_bytecount_Pos)     /*!< TPIU FIFO0: ITM_bytecount Mask */
+
+#define TPIU_FIFO0_ETM_ATVALID_Pos         26U                                         /*!< TPIU FIFO0: ETM_ATVALID Position */
+#define TPIU_FIFO0_ETM_ATVALID_Msk         (1UL << TPIU_FIFO0_ETM_ATVALID_Pos)         /*!< TPIU FIFO0: ETM_ATVALID Mask */
+
+#define TPIU_FIFO0_ETM_bytecount_Pos       24U                                         /*!< TPIU FIFO0: ETM_bytecount Position */
+#define TPIU_FIFO0_ETM_bytecount_Msk       (0x3UL << TPIU_FIFO0_ETM_bytecount_Pos)     /*!< TPIU FIFO0: ETM_bytecount Mask */
+
+#define TPIU_FIFO0_ETM2_Pos                16U                                         /*!< TPIU FIFO0: ETM2 Position */
+#define TPIU_FIFO0_ETM2_Msk                (0xFFUL << TPIU_FIFO0_ETM2_Pos)             /*!< TPIU FIFO0: ETM2 Mask */
+
+#define TPIU_FIFO0_ETM1_Pos                 8U                                         /*!< TPIU FIFO0: ETM1 Position */
+#define TPIU_FIFO0_ETM1_Msk                (0xFFUL << TPIU_FIFO0_ETM1_Pos)             /*!< TPIU FIFO0: ETM1 Mask */
+
+#define TPIU_FIFO0_ETM0_Pos                 0U                                         /*!< TPIU FIFO0: ETM0 Position */
+#define TPIU_FIFO0_ETM0_Msk                (0xFFUL /*<< TPIU_FIFO0_ETM0_Pos*/)         /*!< TPIU FIFO0: ETM0 Mask */
+
+/** \brief TPIU ITATBCTR2 Register Definitions */
+#define TPIU_ITATBCTR2_ATREADY2_Pos         0U                                         /*!< TPIU ITATBCTR2: ATREADY2 Position */
+#define TPIU_ITATBCTR2_ATREADY2_Msk        (1UL /*<< TPIU_ITATBCTR2_ATREADY2_Pos*/)    /*!< TPIU ITATBCTR2: ATREADY2 Mask */
+
+#define TPIU_ITATBCTR2_ATREADY1_Pos         0U                                         /*!< TPIU ITATBCTR2: ATREADY1 Position */
+#define TPIU_ITATBCTR2_ATREADY1_Msk        (1UL /*<< TPIU_ITATBCTR2_ATREADY1_Pos*/)    /*!< TPIU ITATBCTR2: ATREADY1 Mask */
+
+/** \brief TPIU Integration ITM Data Register Definitions (FIFO1) */
+#define TPIU_FIFO1_ITM_ATVALID_Pos         29U                                         /*!< TPIU FIFO1: ITM_ATVALID Position */
+#define TPIU_FIFO1_ITM_ATVALID_Msk         (1UL << TPIU_FIFO1_ITM_ATVALID_Pos)         /*!< TPIU FIFO1: ITM_ATVALID Mask */
+
+#define TPIU_FIFO1_ITM_bytecount_Pos       27U                                         /*!< TPIU FIFO1: ITM_bytecount Position */
+#define TPIU_FIFO1_ITM_bytecount_Msk       (0x3UL << TPIU_FIFO1_ITM_bytecount_Pos)     /*!< TPIU FIFO1: ITM_bytecount Mask */
+
+#define TPIU_FIFO1_ETM_ATVALID_Pos         26U                                         /*!< TPIU FIFO1: ETM_ATVALID Position */
+#define TPIU_FIFO1_ETM_ATVALID_Msk         (1UL << TPIU_FIFO1_ETM_ATVALID_Pos)         /*!< TPIU FIFO1: ETM_ATVALID Mask */
+
+#define TPIU_FIFO1_ETM_bytecount_Pos       24U                                         /*!< TPIU FIFO1: ETM_bytecount Position */
+#define TPIU_FIFO1_ETM_bytecount_Msk       (0x3UL << TPIU_FIFO1_ETM_bytecount_Pos)     /*!< TPIU FIFO1: ETM_bytecount Mask */
+
+#define TPIU_FIFO1_ITM2_Pos                16U                                         /*!< TPIU FIFO1: ITM2 Position */
+#define TPIU_FIFO1_ITM2_Msk                (0xFFUL << TPIU_FIFO1_ITM2_Pos)             /*!< TPIU FIFO1: ITM2 Mask */
+
+#define TPIU_FIFO1_ITM1_Pos                 8U                                         /*!< TPIU FIFO1: ITM1 Position */
+#define TPIU_FIFO1_ITM1_Msk                (0xFFUL << TPIU_FIFO1_ITM1_Pos)             /*!< TPIU FIFO1: ITM1 Mask */
+
+#define TPIU_FIFO1_ITM0_Pos                 0U                                         /*!< TPIU FIFO1: ITM0 Position */
+#define TPIU_FIFO1_ITM0_Msk                (0xFFUL /*<< TPIU_FIFO1_ITM0_Pos*/)         /*!< TPIU FIFO1: ITM0 Mask */
+
+/** \brief TPIU ITATBCTR0 Register Definitions */
+#define TPIU_ITATBCTR0_ATREADY2_Pos         0U                                         /*!< TPIU ITATBCTR0: ATREADY2 Position */
+#define TPIU_ITATBCTR0_ATREADY2_Msk        (1UL /*<< TPIU_ITATBCTR0_ATREADY2_Pos*/)    /*!< TPIU ITATBCTR0: ATREADY2 Mask */
+
+#define TPIU_ITATBCTR0_ATREADY1_Pos         0U                                         /*!< TPIU ITATBCTR0: ATREADY1 Position */
+#define TPIU_ITATBCTR0_ATREADY1_Msk        (1UL /*<< TPIU_ITATBCTR0_ATREADY1_Pos*/)    /*!< TPIU ITATBCTR0: ATREADY1 Mask */
+
+/** \brief TPIU Integration Mode Control Register Definitions */
+#define TPIU_ITCTRL_Mode_Pos                0U                                         /*!< TPIU ITCTRL: Mode Position */
+#define TPIU_ITCTRL_Mode_Msk               (0x3UL /*<< TPIU_ITCTRL_Mode_Pos*/)         /*!< TPIU ITCTRL: Mode Mask */
+
+/** \brief TPIU DEVID Register Definitions */
+#define TPIU_DEVID_NRZVALID_Pos            11U                                         /*!< TPIU DEVID: NRZVALID Position */
+#define TPIU_DEVID_NRZVALID_Msk            (1UL << TPIU_DEVID_NRZVALID_Pos)            /*!< TPIU DEVID: NRZVALID Mask */
+
+#define TPIU_DEVID_MANCVALID_Pos           10U                                         /*!< TPIU DEVID: MANCVALID Position */
+#define TPIU_DEVID_MANCVALID_Msk           (1UL << TPIU_DEVID_MANCVALID_Pos)           /*!< TPIU DEVID: MANCVALID Mask */
+
+#define TPIU_DEVID_PTINVALID_Pos            9U                                         /*!< TPIU DEVID: PTINVALID Position */
+#define TPIU_DEVID_PTINVALID_Msk           (1UL << TPIU_DEVID_PTINVALID_Pos)           /*!< TPIU DEVID: PTINVALID Mask */
+
+#define TPIU_DEVID_MinBufSz_Pos             6U                                         /*!< TPIU DEVID: MinBufSz Position */
+#define TPIU_DEVID_MinBufSz_Msk            (0x7UL << TPIU_DEVID_MinBufSz_Pos)          /*!< TPIU DEVID: MinBufSz Mask */
+
+#define TPIU_DEVID_AsynClkIn_Pos            5U                                         /*!< TPIU DEVID: AsynClkIn Position */
+#define TPIU_DEVID_AsynClkIn_Msk           (1UL << TPIU_DEVID_AsynClkIn_Pos)           /*!< TPIU DEVID: AsynClkIn Mask */
+
+#define TPIU_DEVID_NrTraceInput_Pos         0U                                         /*!< TPIU DEVID: NrTraceInput Position */
+#define TPIU_DEVID_NrTraceInput_Msk        (0x3FUL /*<< TPIU_DEVID_NrTraceInput_Pos*/) /*!< TPIU DEVID: NrTraceInput Mask */
+
+/** \brief TPIU DEVTYPE Register Definitions */
+#define TPIU_DEVTYPE_SubType_Pos            4U                                         /*!< TPIU DEVTYPE: SubType Position */
+#define TPIU_DEVTYPE_SubType_Msk           (0xFUL /*<< TPIU_DEVTYPE_SubType_Pos*/)     /*!< TPIU DEVTYPE: SubType Mask */
+
+#define TPIU_DEVTYPE_MajorType_Pos          0U                                         /*!< TPIU DEVTYPE: MajorType Position */
+#define TPIU_DEVTYPE_MajorType_Msk         (0xFUL << TPIU_DEVTYPE_MajorType_Pos)       /*!< TPIU DEVTYPE: MajorType Mask */
+
+/*@}*/ /* end of group CMSIS_TPIU */
+
+
+#if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_MPU     Memory Protection Unit (MPU)
+  \brief    Type definitions for the Memory Protection Unit (MPU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Memory Protection Unit (MPU).
+ */
+typedef struct
+{
+  __IM  uint32_t TYPE;                   /*!< Offset: 0x000 (R/ )  MPU Type Register */
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x004 (R/W)  MPU Control Register */
+  __IOM uint32_t RNR;                    /*!< Offset: 0x008 (R/W)  MPU Region Number Register */
+  __IOM uint32_t RBAR;                   /*!< Offset: 0x00C (R/W)  MPU Region Base Address Register */
+  __IOM uint32_t RASR;                   /*!< Offset: 0x010 (R/W)  MPU Region Attribute and Size Register */
+  __IOM uint32_t RBAR_A1;                /*!< Offset: 0x014 (R/W)  MPU Alias 1 Region Base Address Register */
+  __IOM uint32_t RASR_A1;                /*!< Offset: 0x018 (R/W)  MPU Alias 1 Region Attribute and Size Register */
+  __IOM uint32_t RBAR_A2;                /*!< Offset: 0x01C (R/W)  MPU Alias 2 Region Base Address Register */
+  __IOM uint32_t RASR_A2;                /*!< Offset: 0x020 (R/W)  MPU Alias 2 Region Attribute and Size Register */
+  __IOM uint32_t RBAR_A3;                /*!< Offset: 0x024 (R/W)  MPU Alias 3 Region Base Address Register */
+  __IOM uint32_t RASR_A3;                /*!< Offset: 0x028 (R/W)  MPU Alias 3 Region Attribute and Size Register */
+} MPU_Type;
+
+#define MPU_TYPE_RALIASES                  4U
+
+/** \brief MPU Type Register Definitions */
+#define MPU_TYPE_IREGION_Pos               16U                                            /*!< MPU TYPE: IREGION Position */
+#define MPU_TYPE_IREGION_Msk               (0xFFUL << MPU_TYPE_IREGION_Pos)               /*!< MPU TYPE: IREGION Mask */
+
+#define MPU_TYPE_DREGION_Pos                8U                                            /*!< MPU TYPE: DREGION Position */
+#define MPU_TYPE_DREGION_Msk               (0xFFUL << MPU_TYPE_DREGION_Pos)               /*!< MPU TYPE: DREGION Mask */
+
+#define MPU_TYPE_SEPARATE_Pos               0U                                            /*!< MPU TYPE: SEPARATE Position */
+#define MPU_TYPE_SEPARATE_Msk              (1UL /*<< MPU_TYPE_SEPARATE_Pos*/)             /*!< MPU TYPE: SEPARATE Mask */
+
+/** \brief MPU Control Register Definitions */
+#define MPU_CTRL_PRIVDEFENA_Pos             2U                                            /*!< MPU CTRL: PRIVDEFENA Position */
+#define MPU_CTRL_PRIVDEFENA_Msk            (1UL << MPU_CTRL_PRIVDEFENA_Pos)               /*!< MPU CTRL: PRIVDEFENA Mask */
+
+#define MPU_CTRL_HFNMIENA_Pos               1U                                            /*!< MPU CTRL: HFNMIENA Position */
+#define MPU_CTRL_HFNMIENA_Msk              (1UL << MPU_CTRL_HFNMIENA_Pos)                 /*!< MPU CTRL: HFNMIENA Mask */
+
+#define MPU_CTRL_ENABLE_Pos                 0U                                            /*!< MPU CTRL: ENABLE Position */
+#define MPU_CTRL_ENABLE_Msk                (1UL /*<< MPU_CTRL_ENABLE_Pos*/)               /*!< MPU CTRL: ENABLE Mask */
+
+/** \brief MPU Region Number Register Definitions */
+#define MPU_RNR_REGION_Pos                  0U                                            /*!< MPU RNR: REGION Position */
+#define MPU_RNR_REGION_Msk                 (0xFFUL /*<< MPU_RNR_REGION_Pos*/)             /*!< MPU RNR: REGION Mask */
+
+/** \brief MPU Region Base Address Register Definitions */
+#define MPU_RBAR_ADDR_Pos                   5U                                            /*!< MPU RBAR: ADDR Position */
+#define MPU_RBAR_ADDR_Msk                  (0x7FFFFFFUL << MPU_RBAR_ADDR_Pos)             /*!< MPU RBAR: ADDR Mask */
+
+#define MPU_RBAR_VALID_Pos                  4U                                            /*!< MPU RBAR: VALID Position */
+#define MPU_RBAR_VALID_Msk                 (1UL << MPU_RBAR_VALID_Pos)                    /*!< MPU RBAR: VALID Mask */
+
+#define MPU_RBAR_REGION_Pos                 0U                                            /*!< MPU RBAR: REGION Position */
+#define MPU_RBAR_REGION_Msk                (0xFUL /*<< MPU_RBAR_REGION_Pos*/)             /*!< MPU RBAR: REGION Mask */
+
+/** \brief MPU Region Attribute and Size Register Definitions */
+#define MPU_RASR_ATTRS_Pos                 16U                                            /*!< MPU RASR: MPU Region Attribute field Position */
+#define MPU_RASR_ATTRS_Msk                 (0xFFFFUL << MPU_RASR_ATTRS_Pos)               /*!< MPU RASR: MPU Region Attribute field Mask */
+
+#define MPU_RASR_XN_Pos                    28U                                            /*!< MPU RASR: ATTRS.XN Position */
+#define MPU_RASR_XN_Msk                    (1UL << MPU_RASR_XN_Pos)                       /*!< MPU RASR: ATTRS.XN Mask */
+
+#define MPU_RASR_AP_Pos                    24U                                            /*!< MPU RASR: ATTRS.AP Position */
+#define MPU_RASR_AP_Msk                    (0x7UL << MPU_RASR_AP_Pos)                     /*!< MPU RASR: ATTRS.AP Mask */
+
+#define MPU_RASR_TEX_Pos                   19U                                            /*!< MPU RASR: ATTRS.TEX Position */
+#define MPU_RASR_TEX_Msk                   (0x7UL << MPU_RASR_TEX_Pos)                    /*!< MPU RASR: ATTRS.TEX Mask */
+
+#define MPU_RASR_S_Pos                     18U                                            /*!< MPU RASR: ATTRS.S Position */
+#define MPU_RASR_S_Msk                     (1UL << MPU_RASR_S_Pos)                        /*!< MPU RASR: ATTRS.S Mask */
+
+#define MPU_RASR_C_Pos                     17U                                            /*!< MPU RASR: ATTRS.C Position */
+#define MPU_RASR_C_Msk                     (1UL << MPU_RASR_C_Pos)                        /*!< MPU RASR: ATTRS.C Mask */
+
+#define MPU_RASR_B_Pos                     16U                                            /*!< MPU RASR: ATTRS.B Position */
+#define MPU_RASR_B_Msk                     (1UL << MPU_RASR_B_Pos)                        /*!< MPU RASR: ATTRS.B Mask */
+
+#define MPU_RASR_SRD_Pos                    8U                                            /*!< MPU RASR: Sub-Region Disable Position */
+#define MPU_RASR_SRD_Msk                   (0xFFUL << MPU_RASR_SRD_Pos)                   /*!< MPU RASR: Sub-Region Disable Mask */
+
+#define MPU_RASR_SIZE_Pos                   1U                                            /*!< MPU RASR: Region Size Field Position */
+#define MPU_RASR_SIZE_Msk                  (0x1FUL << MPU_RASR_SIZE_Pos)                  /*!< MPU RASR: Region Size Field Mask */
+
+#define MPU_RASR_ENABLE_Pos                 0U                                            /*!< MPU RASR: Region enable bit Position */
+#define MPU_RASR_ENABLE_Msk                (1UL /*<< MPU_RASR_ENABLE_Pos*/)               /*!< MPU RASR: Region enable bit Disable Mask */
+
+/*@} end of group CMSIS_MPU */
+#endif
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_DCB       Debug Control Block
+  \brief    Type definitions for the Debug Control Block Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Debug Control Block Registers (DCB).
+ */
+typedef struct
+{
+  __IOM uint32_t DHCSR;                  /*!< Offset: 0x000 (R/W)  Debug Halting Control and Status Register */
+  __OM  uint32_t DCRSR;                  /*!< Offset: 0x004 ( /W)  Debug Core Register Selector Register */
+  __IOM uint32_t DCRDR;                  /*!< Offset: 0x008 (R/W)  Debug Core Register Data Register */
+  __IOM uint32_t DEMCR;                  /*!< Offset: 0x00C (R/W)  Debug Exception and Monitor Control Register */
+} DCB_Type;
+
+/** \brief DCB Debug Halting Control and Status Register Definitions */
+#define DCB_DHCSR_DBGKEY_Pos               16U                                            /*!< DCB DHCSR: Debug key Position */
+#define DCB_DHCSR_DBGKEY_Msk               (0xFFFFUL << DCB_DHCSR_DBGKEY_Pos)             /*!< DCB DHCSR: Debug key Mask */
+
+#define DCB_DHCSR_S_RESET_ST_Pos           25U                                            /*!< DCB DHCSR: Reset sticky status Position */
+#define DCB_DHCSR_S_RESET_ST_Msk           (1UL << DCB_DHCSR_S_RESET_ST_Pos)              /*!< DCB DHCSR: Reset sticky status Mask */
+
+#define DCB_DHCSR_S_RETIRE_ST_Pos          24U                                            /*!< DCB DHCSR: Retire sticky status Position */
+#define DCB_DHCSR_S_RETIRE_ST_Msk          (1UL << DCB_DHCSR_S_RETIRE_ST_Pos)             /*!< DCB DHCSR: Retire sticky status Mask */
+
+#define DCB_DHCSR_S_LOCKUP_Pos             19U                                            /*!< DCB DHCSR: Lockup status Position */
+#define DCB_DHCSR_S_LOCKUP_Msk             (1UL << DCB_DHCSR_S_LOCKUP_Pos)                /*!< DCB DHCSR: Lockup status Mask */
+
+#define DCB_DHCSR_S_SLEEP_Pos              18U                                            /*!< DCB DHCSR: Sleeping status Position */
+#define DCB_DHCSR_S_SLEEP_Msk              (1UL << DCB_DHCSR_S_SLEEP_Pos)                 /*!< DCB DHCSR: Sleeping status Mask */
+
+#define DCB_DHCSR_S_HALT_Pos               17U                                            /*!< DCB DHCSR: Halted status Position */
+#define DCB_DHCSR_S_HALT_Msk               (1UL << DCB_DHCSR_S_HALT_Pos)                  /*!< DCB DHCSR: Halted status Mask */
+
+#define DCB_DHCSR_S_REGRDY_Pos             16U                                            /*!< DCB DHCSR: Register ready status Position */
+#define DCB_DHCSR_S_REGRDY_Msk             (1UL << DCB_DHCSR_S_REGRDY_Pos)                /*!< DCB DHCSR: Register ready status Mask */
+
+#define DCB_DHCSR_C_SNAPSTALL_Pos           5U                                            /*!< DCB DHCSR: Snap stall control Position */
+#define DCB_DHCSR_C_SNAPSTALL_Msk          (1UL << DCB_DHCSR_C_SNAPSTALL_Pos)             /*!< DCB DHCSR: Snap stall control Mask */
+
+#define DCB_DHCSR_C_MASKINTS_Pos            3U                                            /*!< DCB DHCSR: Mask interrupts control Position */
+#define DCB_DHCSR_C_MASKINTS_Msk           (1UL << DCB_DHCSR_C_MASKINTS_Pos)              /*!< DCB DHCSR: Mask interrupts control Mask */
+
+#define DCB_DHCSR_C_STEP_Pos                2U                                            /*!< DCB DHCSR: Step control Position */
+#define DCB_DHCSR_C_STEP_Msk               (1UL << DCB_DHCSR_C_STEP_Pos)                  /*!< DCB DHCSR: Step control Mask */
+
+#define DCB_DHCSR_C_HALT_Pos                1U                                            /*!< DCB DHCSR: Halt control Position */
+#define DCB_DHCSR_C_HALT_Msk               (1UL << DCB_DHCSR_C_HALT_Pos)                  /*!< DCB DHCSR: Halt control Mask */
+
+#define DCB_DHCSR_C_DEBUGEN_Pos             0U                                            /*!< DCB DHCSR: Debug enable control Position */
+#define DCB_DHCSR_C_DEBUGEN_Msk            (1UL /*<< DCB_DHCSR_C_DEBUGEN_Pos*/)           /*!< DCB DHCSR: Debug enable control Mask */
+
+/** \brief DCB Debug Core Register Selector Register Definitions */
+#define DCB_DCRSR_REGWnR_Pos               16U                                            /*!< DCB DCRSR: Register write/not-read Position */
+#define DCB_DCRSR_REGWnR_Msk               (1UL << DCB_DCRSR_REGWnR_Pos)                  /*!< DCB DCRSR: Register write/not-read Mask */
+
+#define DCB_DCRSR_REGSEL_Pos                0U                                            /*!< DCB DCRSR: Register selector Position */
+#define DCB_DCRSR_REGSEL_Msk               (0x7FUL /*<< DCB_DCRSR_REGSEL_Pos*/)           /*!< DCB DCRSR: Register selector Mask */
+
+/** \brief DCB Debug Core Register Data Register Definitions */
+#define DCB_DCRDR_DBGTMP_Pos                0U                                            /*!< DCB DCRDR: Data temporary buffer Position */
+#define DCB_DCRDR_DBGTMP_Msk               (0xFFFFFFFFUL /*<< DCB_DCRDR_DBGTMP_Pos*/)     /*!< DCB DCRDR: Data temporary buffer Mask */
+
+/** \brief DCB Debug Exception and Monitor Control Register Definitions */
+#define DCB_DEMCR_TRCENA_Pos               24U                                            /*!< DCB DEMCR: Trace enable Position */
+#define DCB_DEMCR_TRCENA_Msk               (1UL << DCB_DEMCR_TRCENA_Pos)                  /*!< DCB DEMCR: Trace enable Mask */
+
+#define DCB_DEMCR_MON_REQ_Pos              19U                                            /*!< DCB DEMCR: Monitor request Position */
+#define DCB_DEMCR_MON_REQ_Msk              (1UL << DCB_DEMCR_MON_REQ_Pos)                 /*!< DCB DEMCR: Monitor request Mask */
+
+#define DCB_DEMCR_MON_STEP_Pos             18U                                            /*!< DCB DEMCR: Monitor step Position */
+#define DCB_DEMCR_MON_STEP_Msk             (1UL << DCB_DEMCR_MON_STEP_Pos)                /*!< DCB DEMCR: Monitor step Mask */
+
+#define DCB_DEMCR_MON_PEND_Pos             17U                                            /*!< DCB DEMCR: Monitor pend Position */
+#define DCB_DEMCR_MON_PEND_Msk             (1UL << DCB_DEMCR_MON_PEND_Pos)                /*!< DCB DEMCR: Monitor pend Mask */
+
+#define DCB_DEMCR_MON_EN_Pos               16U                                            /*!< DCB DEMCR: Monitor enable Position */
+#define DCB_DEMCR_MON_EN_Msk               (1UL << DCB_DEMCR_MON_EN_Pos)                  /*!< DCB DEMCR: Monitor enable Mask */
+
+#define DCB_DEMCR_VC_HARDERR_Pos           10U                                            /*!< DCB DEMCR: Vector Catch HardFault errors Position */
+#define DCB_DEMCR_VC_HARDERR_Msk           (1UL << DCB_DEMCR_VC_HARDERR_Pos)              /*!< DCB DEMCR: Vector Catch HardFault errors Mask */
+
+#define DCB_DEMCR_VC_INTERR_Pos             9U                                            /*!< DCB DEMCR: Vector Catch interrupt errors Position */
+#define DCB_DEMCR_VC_INTERR_Msk            (1UL << DCB_DEMCR_VC_INTERR_Pos)               /*!< DCB DEMCR: Vector Catch interrupt errors Mask */
+
+#define DCB_DEMCR_VC_BUSERR_Pos             8U                                            /*!< DCB DEMCR: Vector Catch BusFault errors Position */
+#define DCB_DEMCR_VC_BUSERR_Msk            (1UL << DCB_DEMCR_VC_BUSERR_Pos)               /*!< DCB DEMCR: Vector Catch BusFault errors Mask */
+
+#define DCB_DEMCR_VC_STATERR_Pos            7U                                            /*!< DCB DEMCR: Vector Catch state errors Position */
+#define DCB_DEMCR_VC_STATERR_Msk           (1UL << DCB_DEMCR_VC_STATERR_Pos)              /*!< DCB DEMCR: Vector Catch state errors Mask */
+
+#define DCB_DEMCR_VC_CHKERR_Pos             6U                                            /*!< DCB DEMCR: Vector Catch check errors Position */
+#define DCB_DEMCR_VC_CHKERR_Msk            (1UL << DCB_DEMCR_VC_CHKERR_Pos)               /*!< DCB DEMCR: Vector Catch check errors Mask */
+
+#define DCB_DEMCR_VC_NOCPERR_Pos            5U                                            /*!< DCB DEMCR: Vector Catch NOCP errors Position */
+#define DCB_DEMCR_VC_NOCPERR_Msk           (1UL << DCB_DEMCR_VC_NOCPERR_Pos)              /*!< DCB DEMCR: Vector Catch NOCP errors Mask */
+
+#define DCB_DEMCR_VC_MMERR_Pos              4U                                            /*!< DCB DEMCR: Vector Catch MemManage errors Position */
+#define DCB_DEMCR_VC_MMERR_Msk             (1UL << DCB_DEMCR_VC_MMERR_Pos)                /*!< DCB DEMCR: Vector Catch MemManage errors Mask */
+
+#define DCB_DEMCR_VC_CORERESET_Pos          0U                                            /*!< DCB DEMCR: Vector Catch Core reset Position */
+#define DCB_DEMCR_VC_CORERESET_Msk         (1UL /*<< DCB_DEMCR_VC_CORERESET_Pos*/)        /*!< DCB DEMCR: Vector Catch Core reset Mask */
+
+/*@} end of group CMSIS_DCB */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_core_bitfield     Core register bit field macros
+  \brief      Macros for use with bit field definitions (xxx_Pos, xxx_Msk).
+  @{
+ */
+
+/**
+  \brief   Mask and shift a bit field value for use in a register bit range.
+  \param[in] field  Name of the register bit field.
+  \param[in] value  Value of the bit field. This parameter is interpreted as an uint32_t type.
+  \return           Masked and shifted value.
+*/
+#define _VAL2FLD(field, value)    (((uint32_t)(value) << field ## _Pos) & field ## _Msk)
+
+/**
+  \brief     Mask and shift a register value to extract a bit filed value.
+  \param[in] field  Name of the register bit field.
+  \param[in] value  Value of register. This parameter is interpreted as an uint32_t type.
+  \return           Masked and shifted bit field value.
+*/
+#define _FLD2VAL(field, value)    (((uint32_t)(value) & field ## _Msk) >> field ## _Pos)
+
+/*@} end of group CMSIS_core_bitfield */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_core_base     Core Definitions
+  \brief      Definitions for base addresses, unions, and structures.
+  @{
+ */
+
+/* Memory mapping of Core Hardware */
+#define SCS_BASE            (0xE000E000UL)                            /*!< System Control Space Base Address */
+#define ITM_BASE            (0xE0000000UL)                            /*!< ITM Base Address */
+#define DWT_BASE            (0xE0001000UL)                            /*!< DWT Base Address */
+#define TPIU_BASE           (0xE0040000UL)                            /*!< TPIU Base Address */
+#define DCB_BASE            (0xE000EDF0UL)                            /*!< Core Debug Base Address */
+#define SysTick_BASE        (SCS_BASE +  0x0010UL)                    /*!< SysTick Base Address */
+#define NVIC_BASE           (SCS_BASE +  0x0100UL)                    /*!< NVIC Base Address */
+#define SCB_BASE            (SCS_BASE +  0x0D00UL)                    /*!< System Control Block Base Address */
+
+#define SCnSCB              ((SCnSCB_Type    *)     SCS_BASE      )   /*!< System control Register not in SCB */
+#define SCB                 ((SCB_Type       *)     SCB_BASE      )   /*!< SCB configuration struct */
+#define SysTick             ((SysTick_Type   *)     SysTick_BASE  )   /*!< SysTick configuration struct */
+#define NVIC                ((NVIC_Type      *)     NVIC_BASE     )   /*!< NVIC configuration struct */
+#define ITM                 ((ITM_Type       *)     ITM_BASE      )   /*!< ITM configuration struct */
+#define DWT                 ((DWT_Type       *)     DWT_BASE      )   /*!< DWT configuration struct */
+#define TPIU                ((TPIU_Type      *)     TPIU_BASE     )   /*!< TPIU configuration struct */
+#define DCB                 ((DCB_Type       *)     DCB_BASE      )   /*!< DCB configuration struct */
+
+#if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+  #define MPU_BASE          (SCS_BASE +  0x0D90UL)                    /*!< Memory Protection Unit */
+  #define MPU               ((MPU_Type       *)     MPU_BASE      )   /*!< Memory Protection Unit */
+#endif
+
+/*@} */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_register_aliases     Backwards Compatibility Aliases
+  \brief      Register alias definitions for backwards compatibility.
+  @{
+ */
+
+/*@} */
+
+
+/*******************************************************************************
+ *                Hardware Abstraction Layer
+  Core Function Interface contains:
+  - Core NVIC Functions
+  - Core SysTick Functions
+  - Core Debug Functions
+  - Core Register Access Functions
+ ******************************************************************************/
+/**
+  \defgroup CMSIS_Core_FunctionInterface Functions and Instructions Reference
+*/
+
+
+
+/* ##########################   NVIC functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_NVICFunctions NVIC Functions
+  \brief    Functions that manage interrupts and exceptions via the NVIC.
+  @{
+ */
+
+#ifdef CMSIS_NVIC_VIRTUAL
+  #ifndef CMSIS_NVIC_VIRTUAL_HEADER_FILE
+    #define CMSIS_NVIC_VIRTUAL_HEADER_FILE "cmsis_nvic_virtual.h"
+  #endif
+  #include CMSIS_NVIC_VIRTUAL_HEADER_FILE
+#else
+  #define NVIC_SetPriorityGrouping    __NVIC_SetPriorityGrouping
+  #define NVIC_GetPriorityGrouping    __NVIC_GetPriorityGrouping
+  #define NVIC_EnableIRQ              __NVIC_EnableIRQ
+  #define NVIC_GetEnableIRQ           __NVIC_GetEnableIRQ
+  #define NVIC_DisableIRQ             __NVIC_DisableIRQ
+  #define NVIC_GetPendingIRQ          __NVIC_GetPendingIRQ
+  #define NVIC_SetPendingIRQ          __NVIC_SetPendingIRQ
+  #define NVIC_ClearPendingIRQ        __NVIC_ClearPendingIRQ
+  #define NVIC_GetActive              __NVIC_GetActive
+  #define NVIC_SetPriority            __NVIC_SetPriority
+  #define NVIC_GetPriority            __NVIC_GetPriority
+  #define NVIC_SystemReset            __NVIC_SystemReset
+#endif /* CMSIS_NVIC_VIRTUAL */
+
+#ifdef CMSIS_VECTAB_VIRTUAL
+  #ifndef CMSIS_VECTAB_VIRTUAL_HEADER_FILE
+    #define CMSIS_VECTAB_VIRTUAL_HEADER_FILE "cmsis_vectab_virtual.h"
+  #endif
+  #include CMSIS_VECTAB_VIRTUAL_HEADER_FILE
+#else
+  #define NVIC_SetVector              __NVIC_SetVector
+  #define NVIC_GetVector              __NVIC_GetVector
+#endif  /* (CMSIS_VECTAB_VIRTUAL) */
+
+#define NVIC_USER_IRQ_OFFSET          16
+
+
+/* The following EXC_RETURN values are saved the LR on exception entry */
+#define EXC_RETURN_HANDLER         (0xFFFFFFF1UL)     /* return to Handler mode, uses MSP after return                               */
+#define EXC_RETURN_THREAD_MSP      (0xFFFFFFF9UL)     /* return to Thread mode, uses MSP after return                                */
+#define EXC_RETURN_THREAD_PSP      (0xFFFFFFFDUL)     /* return to Thread mode, uses PSP after return                                */
+
+
+/**
+  \brief   Set Priority Grouping
+  \details Sets the priority grouping field using the required unlock sequence.
+           The parameter PriorityGroup is assigned to the field SCB->AIRCR [10:8] PRIGROUP field.
+           Only values from 0..7 are used.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+  \param [in]      PriorityGroup  Priority grouping field.
+ */
+__STATIC_INLINE void __NVIC_SetPriorityGrouping(uint32_t PriorityGroup)
+{
+  uint32_t reg_value;
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);             /* only values 0..7 are used          */
+
+  reg_value  =  SCB->AIRCR;                                                   /* read old register configuration    */
+  reg_value &= ~((uint32_t)(SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk)); /* clear bits to change               */
+  reg_value  =  (reg_value                                   |
+                ((uint32_t)0x5FAUL << SCB_AIRCR_VECTKEY_Pos) |
+                (PriorityGroupTmp << SCB_AIRCR_PRIGROUP_Pos)  );              /* Insert write key and priority group */
+  SCB->AIRCR =  reg_value;
+}
+
+
+/**
+  \brief   Get Priority Grouping
+  \details Reads the priority grouping field from the NVIC Interrupt Controller.
+  \return                Priority grouping field (SCB->AIRCR [10:8] PRIGROUP field).
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPriorityGrouping(void)
+{
+  return ((uint32_t)((SCB->AIRCR & SCB_AIRCR_PRIGROUP_Msk) >> SCB_AIRCR_PRIGROUP_Pos));
+}
+
+
+/**
+  \brief   Enable Interrupt
+  \details Enables a device specific interrupt in the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_EnableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    __COMPILER_BARRIER();
+    NVIC->ISER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+    __COMPILER_BARRIER();
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Enable status
+  \details Returns a device specific interrupt enable status from the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt is not enabled.
+  \return             1  Interrupt is enabled.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetEnableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ISER[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Disable Interrupt
+  \details Disables a device specific interrupt in the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_DisableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ICER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+    __DSB();
+    __ISB();
+  }
+}
+
+
+/**
+  \brief   Get Pending Interrupt
+  \details Reads the NVIC pending register and returns the pending bit for the specified device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not pending.
+  \return             1  Interrupt status is pending.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ISPR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Pending Interrupt
+  \details Sets the pending bit of a device specific interrupt in the NVIC pending register.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_SetPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ISPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Clear Pending Interrupt
+  \details Clears the pending bit of a device specific interrupt in the NVIC pending register.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_ClearPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ICPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Active Interrupt
+  \details Reads the active register in the NVIC and returns the active bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not active.
+  \return             1  Interrupt status is active.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetActive(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->IABR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Interrupt Priority
+  \details Sets the priority of a device specific interrupt or a processor exception.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]      IRQn  Interrupt number.
+  \param [in]  priority  Priority to set.
+  \note    The priority cannot be set for every processor exception.
+ */
+__STATIC_INLINE void __NVIC_SetPriority(IRQn_Type IRQn, uint32_t priority)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->IPR[((uint32_t)IRQn)]               = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+  else
+  {
+    SCB->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Priority
+  \details Reads the priority of a device specific interrupt or a processor exception.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn  Interrupt number.
+  \return             Interrupt Priority.
+                      Value is aligned automatically to the implemented priority bits of the microcontroller.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPriority(IRQn_Type IRQn)
+{
+
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return(((uint32_t)NVIC->IPR[((uint32_t)IRQn)]               >> (8U - __NVIC_PRIO_BITS)));
+  }
+  else
+  {
+    return(((uint32_t)SCB->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] >> (8U - __NVIC_PRIO_BITS)));
+  }
+}
+
+
+/**
+  \brief   Encode Priority
+  \details Encodes the priority for an interrupt with the given priority group,
+           preemptive priority value, and subpriority value.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+  \param [in]     PriorityGroup  Used priority group.
+  \param [in]   PreemptPriority  Preemptive priority value (starting from 0).
+  \param [in]       SubPriority  Subpriority value (starting from 0).
+  \return                        Encoded priority. Value can be used in the function \ref NVIC_SetPriority().
+ */
+__STATIC_INLINE uint32_t NVIC_EncodePriority (uint32_t PriorityGroup, uint32_t PreemptPriority, uint32_t SubPriority)
+{
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);   /* only values 0..7 are used          */
+  uint32_t PreemptPriorityBits;
+  uint32_t SubPriorityBits;
+
+  PreemptPriorityBits = ((7UL - PriorityGroupTmp) > (uint32_t)(__NVIC_PRIO_BITS)) ? (uint32_t)(__NVIC_PRIO_BITS) : (uint32_t)(7UL - PriorityGroupTmp);
+  SubPriorityBits     = ((PriorityGroupTmp + (uint32_t)(__NVIC_PRIO_BITS)) < (uint32_t)7UL) ? (uint32_t)0UL : (uint32_t)((PriorityGroupTmp - 7UL) + (uint32_t)(__NVIC_PRIO_BITS));
+
+  return (
+           ((PreemptPriority & (uint32_t)((1UL << (PreemptPriorityBits)) - 1UL)) << SubPriorityBits) |
+           ((SubPriority     & (uint32_t)((1UL << (SubPriorityBits    )) - 1UL)))
+         );
+}
+
+
+/**
+  \brief   Decode Priority
+  \details Decodes an interrupt priority value with a given priority group to
+           preemptive priority value and subpriority value.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS) the smallest possible priority group is set.
+  \param [in]         Priority   Priority value, which can be retrieved with the function \ref NVIC_GetPriority().
+  \param [in]     PriorityGroup  Used priority group.
+  \param [out] pPreemptPriority  Preemptive priority value (starting from 0).
+  \param [out]     pSubPriority  Subpriority value (starting from 0).
+ */
+__STATIC_INLINE void NVIC_DecodePriority (uint32_t Priority, uint32_t PriorityGroup, uint32_t* const pPreemptPriority, uint32_t* const pSubPriority)
+{
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);   /* only values 0..7 are used          */
+  uint32_t PreemptPriorityBits;
+  uint32_t SubPriorityBits;
+
+  PreemptPriorityBits = ((7UL - PriorityGroupTmp) > (uint32_t)(__NVIC_PRIO_BITS)) ? (uint32_t)(__NVIC_PRIO_BITS) : (uint32_t)(7UL - PriorityGroupTmp);
+  SubPriorityBits     = ((PriorityGroupTmp + (uint32_t)(__NVIC_PRIO_BITS)) < (uint32_t)7UL) ? (uint32_t)0UL : (uint32_t)((PriorityGroupTmp - 7UL) + (uint32_t)(__NVIC_PRIO_BITS));
+
+  *pPreemptPriority = (Priority >> SubPriorityBits) & (uint32_t)((1UL << (PreemptPriorityBits)) - 1UL);
+  *pSubPriority     = (Priority                   ) & (uint32_t)((1UL << (SubPriorityBits    )) - 1UL);
+}
+
+
+/**
+  \brief   Set Interrupt Vector
+  \details Sets an interrupt vector in SRAM based interrupt vector table.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+           VTOR must been relocated to SRAM before.
+  \param [in]   IRQn      Interrupt number
+  \param [in]   vector    Address of interrupt handler function
+ */
+__STATIC_INLINE void __NVIC_SetVector(IRQn_Type IRQn, uint32_t vector)
+{
+  uint32_t *vectors = (uint32_t *) ((uintptr_t) SCB->VTOR);
+  vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET] = vector;
+  /* ARM Application Note 321 states that the M3 does not require the architectural barrier */
+}
+
+
+/**
+  \brief   Get Interrupt Vector
+  \details Reads an interrupt vector from interrupt vector table.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn      Interrupt number.
+  \return                 Address of interrupt handler function
+ */
+__STATIC_INLINE uint32_t __NVIC_GetVector(IRQn_Type IRQn)
+{
+  uint32_t *vectors = (uint32_t *) ((uintptr_t) SCB->VTOR);
+  return vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET];
+}
+
+
+/**
+  \brief   System Reset
+  \details Initiates a system reset request to reset the MCU.
+ */
+__NO_RETURN __STATIC_INLINE void __NVIC_SystemReset(void)
+{
+  __DSB();                                                          /* Ensure all outstanding memory accesses included
+                                                                       buffered write are completed before reset */
+  SCB->AIRCR  = (uint32_t)((0x5FAUL << SCB_AIRCR_VECTKEY_Pos)    |
+                           (SCB->AIRCR & SCB_AIRCR_PRIGROUP_Msk) |
+                            SCB_AIRCR_SYSRESETREQ_Msk    );         /* Keep priority group unchanged */
+  __DSB();                                                          /* Ensure completion of memory access */
+
+  for(;;)                                                           /* wait until reset */
+  {
+    __NOP();
+  }
+}
+
+/*@} end of CMSIS_Core_NVICFunctions */
+
+
+/* ##########################  MPU functions  #################################### */
+
+#if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+
+#include "m-profile/armv7m_mpu.h"
+
+#endif
+
+
+/* ##########################  FPU functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_FpuFunctions FPU Functions
+  \brief    Function that provides FPU type.
+  @{
+ */
+
+/**
+  \brief   get FPU type
+  \details returns the FPU type
+  \returns
+   - \b  0: No FPU
+   - \b  1: Single precision FPU
+   - \b  2: Double + Single precision FPU
+ */
+__STATIC_INLINE uint32_t SCB_GetFPUType(void)
+{
+    return 0U;           /* No FPU */
+}
+
+/*@} end of CMSIS_Core_FpuFunctions */
+
+
+/* ##################################    SysTick function  ############################################ */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_SysTickFunctions SysTick Functions
+  \brief    Functions that configure the System.
+  @{
+ */
+
+#if defined (__Vendor_SysTickConfig) && (__Vendor_SysTickConfig == 0U)
+
+/**
+  \brief   System Tick Configuration
+  \details Initializes the System Timer and its interrupt, and starts the System Tick Timer.
+           Counter is in free running mode to generate periodic interrupts.
+  \param [in]  ticks  Number of ticks between two interrupts.
+  \return          0  Function succeeded.
+  \return          1  Function failed.
+  \note    When the variable <b>__Vendor_SysTickConfig</b> is set to 1, then the
+           function <b>SysTick_Config</b> is not included. In this case, the file <b><i>device</i>.h</b>
+           must contain a vendor-specific implementation of this function.
+ */
+__STATIC_INLINE uint32_t SysTick_Config(uint32_t ticks)
+{
+  if ((ticks - 1UL) > SysTick_LOAD_RELOAD_Msk)
+  {
+    return (1UL);                                                   /* Reload value impossible */
+  }
+
+  SysTick->LOAD  = (uint32_t)(ticks - 1UL);                         /* set reload register */
+  NVIC_SetPriority (SysTick_IRQn, (1UL << __NVIC_PRIO_BITS) - 1UL); /* set Priority for Systick Interrupt */
+  SysTick->VAL   = 0UL;                                             /* Load the SysTick Counter Value */
+  SysTick->CTRL  = SysTick_CTRL_CLKSOURCE_Msk |
+                   SysTick_CTRL_TICKINT_Msk   |
+                   SysTick_CTRL_ENABLE_Msk;                         /* Enable SysTick IRQ and SysTick Timer */
+  return (0UL);                                                     /* Function successful */
+}
+
+#endif
+
+/*@} end of CMSIS_Core_SysTickFunctions */
+
+
+
+/* ##################################### Debug In/Output function ########################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_core_DebugFunctions ITM Functions
+  \brief    Functions that access the ITM debug interface.
+  @{
+ */
+
+extern volatile int32_t ITM_RxBuffer;                              /*!< External variable to receive characters. */
+#define                 ITM_RXBUFFER_EMPTY  ((int32_t)0x5AA55AA5U) /*!< Value identifying \ref ITM_RxBuffer is ready for next character. */
+
+
+/**
+  \brief   ITM Send Character
+  \details Transmits a character via the ITM channel 0, and
+           \li Just returns when no debugger is connected that has booked the output.
+           \li Is blocking when a debugger is connected, but the previous character sent has not been transmitted.
+  \param [in]     ch  Character to transmit.
+  \returns            Character to transmit.
+ */
+__STATIC_INLINE uint32_t ITM_SendChar (uint32_t ch)
+{
+  if (((ITM->TCR & ITM_TCR_ITMENA_Msk) != 0UL) &&      /* ITM enabled */
+      ((ITM->TER & 1UL               ) != 0UL)   )     /* ITM Port #0 enabled */
+  {
+    while (ITM->PORT[0U].u32 == 0UL)
+    {
+      __NOP();
+    }
+    ITM->PORT[0U].u8 = (uint8_t)ch;
+  }
+  return (ch);
+}
+
+
+/**
+  \brief   ITM Receive Character
+  \details Inputs a character via the external variable \ref ITM_RxBuffer.
+  \return             Received character.
+  \return         -1  No character pending.
+ */
+__STATIC_INLINE int32_t ITM_ReceiveChar (void)
+{
+  int32_t ch = -1;                           /* no character available */
+
+  if (ITM_RxBuffer != ITM_RXBUFFER_EMPTY)
+  {
+    ch = ITM_RxBuffer;
+    ITM_RxBuffer = ITM_RXBUFFER_EMPTY;       /* ready for next character */
+  }
+
+  return (ch);
+}
+
+
+/**
+  \brief   ITM Check Character
+  \details Checks whether a character is pending for reading in the variable \ref ITM_RxBuffer.
+  \return          0  No character available.
+  \return          1  Character available.
+ */
+__STATIC_INLINE int32_t ITM_CheckChar (void)
+{
+
+  if (ITM_RxBuffer == ITM_RXBUFFER_EMPTY)
+  {
+    return (0);                              /* no character available */
+  }
+  else
+  {
+    return (1);                              /*    character available */
+  }
+}
+
+/*@} end of CMSIS_core_DebugFunctions */
+
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_SC300_H_DEPENDANT */
+
+#endif /* __CMSIS_GENERIC */

--- a/platform/ext/cmsis/CMSIS/Core/Include/core_starmc1.h
+++ b/platform/ext/cmsis/CMSIS/Core/Include/core_starmc1.h
@@ -1,0 +1,3607 @@
+/*
+ * Copyright (c) 2009-2023 Arm Limited.
+ * Copyright (c) 2018-2022 Arm China.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS ArmChina STAR-MC1 Core Peripheral Access Layer Header File
+ */
+
+#if   defined ( __ICCARM__ )
+  #pragma system_include                        /* treat file as system include file for MISRA check */
+#elif defined (__clang__)
+  #pragma clang system_header                   /* treat file as system include file */
+#elif defined ( __GNUC__ )
+  #pragma GCC diagnostic ignored "-Wpedantic"   /* disable pedantic warning due to unnamed structs/unions */
+#endif
+
+#ifndef __CORE_STAR_H_GENERIC
+#define __CORE_STAR_H_GENERIC
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/**
+  \page CMSIS_MISRA_Exceptions  MISRA-C:2004 Compliance Exceptions
+  CMSIS violates the following MISRA-C:2004 rules:
+
+   \li Required Rule 8.5, object/function definition in header file.<br>
+     Function definitions in header files are used to allow 'inlining'.
+
+   \li Required Rule 18.4, declaration of union type or object of union type: '{...}'.<br>
+     Unions are used for effective representation of core registers.
+
+   \li Advisory Rule 19.7, Function-like macro defined.<br>
+     Function-like macros are used to allow more efficient code.
+ */
+
+
+/*******************************************************************************
+ *                 CMSIS definitions
+ ******************************************************************************/
+/**
+  \ingroup STAR-MC1
+  @{
+ */
+
+#include "cmsis_version.h"
+
+/* Macro Define for STAR-MC1 */
+
+#define __STAR_MC                 (1U)                                /*!< STAR-MC Core */
+
+/** __FPU_USED indicates whether an FPU is used or not.
+    For this, __FPU_PRESENT has to be checked prior to making use of FPU specific registers and functions.
+*/
+#if defined ( __CC_ARM )
+  #if defined (__TARGET_FPU_VFP)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+  #if defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1U)
+    #if defined (__DSP_PRESENT) && (__DSP_PRESENT == 1U)
+      #define __DSP_USED       1U
+    #else
+      #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
+      #define __DSP_USED         0U
+    #endif
+  #else
+    #define __DSP_USED         0U
+  #endif
+
+#elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #if defined (__ARM_FP)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+  #if defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1U)
+    #if defined (__DSP_PRESENT) && (__DSP_PRESENT == 1U)
+      #define __DSP_USED       1U
+    #else
+      #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
+      #define __DSP_USED       0U
+    #endif
+  #else
+    #define __DSP_USED         0U
+  #endif
+
+#elif defined (__ti__)
+  #if defined (__ARM_FP)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+  #if defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1U)
+    #if defined (__DSP_PRESENT) && (__DSP_PRESENT == 1U)
+      #define __DSP_USED       1U
+    #else
+      #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
+      #define __DSP_USED       0U
+    #endif
+  #else
+    #define __DSP_USED         0U
+  #endif
+
+#elif defined ( __GNUC__ )
+  #if defined (__VFP_FP__) && !defined(__SOFTFP__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+  #if defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1U)
+    #if defined (__DSP_PRESENT) && (__DSP_PRESENT == 1U)
+      #define __DSP_USED       1U
+    #else
+      #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
+      #define __DSP_USED         0U
+    #endif
+  #else
+    #define __DSP_USED         0U
+  #endif
+
+#elif defined ( __ICCARM__ )
+  #if defined (__ARMVFP__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+  #if defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1U)
+    #if defined (__DSP_PRESENT) && (__DSP_PRESENT == 1U)
+      #define __DSP_USED       1U
+    #else
+      #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
+      #define __DSP_USED         0U
+    #endif
+  #else
+    #define __DSP_USED         0U
+  #endif
+
+#elif defined ( __TI_ARM__ )
+  #if defined (__TI_VFP_SUPPORT__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#elif defined ( __TASKING__ )
+  #if defined (__FPU_VFP__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#elif defined ( __CSMC__ )
+  #if ( __CSMC__ & 0x400U)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#endif
+
+#include "cmsis_compiler.h"               /* CMSIS compiler specific defines */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_STAR_H_GENERIC */
+
+#ifndef __CMSIS_GENERIC
+
+#ifndef __CORE_STAR_H_DEPENDANT
+#define __CORE_STAR_H_DEPENDANT
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* check device defines and use defaults */
+#if defined __CHECK_DEVICE_DEFINES
+  #ifndef __STAR_REV
+    #define __STAR_REV                0x0000U
+    #warning "__STAR_REV not defined in device header file; using default!"
+  #endif
+
+  #ifndef __FPU_PRESENT
+    #define __FPU_PRESENT             0U
+    #warning "__FPU_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __MPU_PRESENT
+    #define __MPU_PRESENT             0U
+    #warning "__MPU_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __SAUREGION_PRESENT
+    #define __SAUREGION_PRESENT       0U
+    #warning "__SAUREGION_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __DSP_PRESENT
+    #define __DSP_PRESENT             0U
+    #warning "__DSP_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __ICACHE_PRESENT
+    #define __ICACHE_PRESENT          0U
+    #warning "__ICACHE_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __DCACHE_PRESENT
+    #define __DCACHE_PRESENT          0U
+    #warning "__DCACHE_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __DTCM_PRESENT
+    #define __DTCM_PRESENT            0U
+    #warning "__DTCM_PRESENT        not defined in device header file; using default!"
+  #endif
+
+  #ifndef __NVIC_PRIO_BITS
+    #define __NVIC_PRIO_BITS          3U
+    #warning "__NVIC_PRIO_BITS not defined in device header file; using default!"
+  #endif
+
+  #ifndef __Vendor_SysTickConfig
+    #define __Vendor_SysTickConfig    0U
+    #warning "__Vendor_SysTickConfig not defined in device header file; using default!"
+  #endif
+#endif
+
+/* IO definitions (access restrictions to peripheral registers) */
+/**
+    \defgroup CMSIS_glob_defs CMSIS Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+*/
+#ifdef __cplusplus
+  #define   __I     volatile             /*!< Defines 'read only' permissions */
+#else
+  #define   __I     volatile const       /*!< Defines 'read only' permissions */
+#endif
+#define     __O     volatile             /*!< Defines 'write only' permissions */
+#define     __IO    volatile             /*!< Defines 'read / write' permissions */
+
+/* following defines should be used for structure members */
+#define     __IM     volatile const      /*! Defines 'read only' structure member permissions */
+#define     __OM     volatile            /*! Defines 'write only' structure member permissions */
+#define     __IOM    volatile            /*! Defines 'read / write' structure member permissions */
+
+/*@} end of group STAR-MC1 */
+
+
+
+/*******************************************************************************
+ *                 Register Abstraction
+  Core Register contain:
+  - Core Register
+  - Core NVIC Register
+  - Core SCB Register
+  - Core SysTick Register
+  - Core Debug Register
+  - Core MPU Register
+  - Core SAU Register
+  - Core FPU Register
+ ******************************************************************************/
+/**
+  \defgroup CMSIS_core_register Defines and Type Definitions
+  \brief Type definitions and defines for STAR-MC1 processor based devices.
+*/
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_CORE  Status and Control Registers
+  \brief      Core Register type definitions.
+  @{
+ */
+
+/**
+  \brief  Union type to access the Application Program Status Register (APSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t _reserved0:16;              /*!< bit:  0..15  Reserved */
+    uint32_t GE:4;                       /*!< bit: 16..19  Greater than or Equal flags */
+    uint32_t _reserved1:7;               /*!< bit: 20..26  Reserved */
+    uint32_t Q:1;                        /*!< bit:     27  Saturation condition flag */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} APSR_Type;
+
+/** \brief APSR Register Definitions */
+#define APSR_N_Pos                         31U                                            /*!< APSR: N Position */
+#define APSR_N_Msk                         (1UL << APSR_N_Pos)                            /*!< APSR: N Mask */
+
+#define APSR_Z_Pos                         30U                                            /*!< APSR: Z Position */
+#define APSR_Z_Msk                         (1UL << APSR_Z_Pos)                            /*!< APSR: Z Mask */
+
+#define APSR_C_Pos                         29U                                            /*!< APSR: C Position */
+#define APSR_C_Msk                         (1UL << APSR_C_Pos)                            /*!< APSR: C Mask */
+
+#define APSR_V_Pos                         28U                                            /*!< APSR: V Position */
+#define APSR_V_Msk                         (1UL << APSR_V_Pos)                            /*!< APSR: V Mask */
+
+#define APSR_Q_Pos                         27U                                            /*!< APSR: Q Position */
+#define APSR_Q_Msk                         (1UL << APSR_Q_Pos)                            /*!< APSR: Q Mask */
+
+#define APSR_GE_Pos                        16U                                            /*!< APSR: GE Position */
+#define APSR_GE_Msk                        (0xFUL << APSR_GE_Pos)                         /*!< APSR: GE Mask */
+
+
+/**
+  \brief  Union type to access the Interrupt Program Status Register (IPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number */
+    uint32_t _reserved0:23;              /*!< bit:  9..31  Reserved */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} IPSR_Type;
+
+/** \brief IPSR Register Definitions */
+#define IPSR_ISR_Pos                        0U                                            /*!< IPSR: ISR Position */
+#define IPSR_ISR_Msk                       (0x1FFUL /*<< IPSR_ISR_Pos*/)                  /*!< IPSR: ISR Mask */
+
+
+/**
+  \brief  Union type to access the Special-Purpose Program Status Registers (xPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number */
+    uint32_t _reserved0:7;               /*!< bit:  9..15  Reserved */
+    uint32_t GE:4;                       /*!< bit: 16..19  Greater than or Equal flags */
+    uint32_t _reserved1:4;               /*!< bit: 20..23  Reserved */
+    uint32_t T:1;                        /*!< bit:     24  Thumb bit        (read 0) */
+    uint32_t IT:2;                       /*!< bit: 25..26  saved IT state   (read 0) */
+    uint32_t Q:1;                        /*!< bit:     27  Saturation condition flag */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} xPSR_Type;
+
+/** \brief xPSR Register Definitions */
+#define xPSR_N_Pos                         31U                                            /*!< xPSR: N Position */
+#define xPSR_N_Msk                         (1UL << xPSR_N_Pos)                            /*!< xPSR: N Mask */
+
+#define xPSR_Z_Pos                         30U                                            /*!< xPSR: Z Position */
+#define xPSR_Z_Msk                         (1UL << xPSR_Z_Pos)                            /*!< xPSR: Z Mask */
+
+#define xPSR_C_Pos                         29U                                            /*!< xPSR: C Position */
+#define xPSR_C_Msk                         (1UL << xPSR_C_Pos)                            /*!< xPSR: C Mask */
+
+#define xPSR_V_Pos                         28U                                            /*!< xPSR: V Position */
+#define xPSR_V_Msk                         (1UL << xPSR_V_Pos)                            /*!< xPSR: V Mask */
+
+#define xPSR_Q_Pos                         27U                                            /*!< xPSR: Q Position */
+#define xPSR_Q_Msk                         (1UL << xPSR_Q_Pos)                            /*!< xPSR: Q Mask */
+
+#define xPSR_IT_Pos                        25U                                            /*!< xPSR: IT Position */
+#define xPSR_IT_Msk                        (3UL << xPSR_IT_Pos)                           /*!< xPSR: IT Mask */
+
+#define xPSR_T_Pos                         24U                                            /*!< xPSR: T Position */
+#define xPSR_T_Msk                         (1UL << xPSR_T_Pos)                            /*!< xPSR: T Mask */
+
+#define xPSR_GE_Pos                        16U                                            /*!< xPSR: GE Position */
+#define xPSR_GE_Msk                        (0xFUL << xPSR_GE_Pos)                         /*!< xPSR: GE Mask */
+
+#define xPSR_ISR_Pos                        0U                                            /*!< xPSR: ISR Position */
+#define xPSR_ISR_Msk                       (0x1FFUL /*<< xPSR_ISR_Pos*/)                  /*!< xPSR: ISR Mask */
+
+
+/**
+  \brief  Union type to access the Control Registers (CONTROL).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t nPRIV:1;                    /*!< bit:      0  Execution privilege in Thread mode */
+    uint32_t SPSEL:1;                    /*!< bit:      1  Stack-pointer select */
+    uint32_t FPCA:1;                     /*!< bit:      2  Floating-point context active */
+    uint32_t SFPA:1;                     /*!< bit:      3  Secure floating-point active */
+    uint32_t _reserved1:28;              /*!< bit:  4..31  Reserved */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} CONTROL_Type;
+
+/** \brief CONTROL Register Definitions */
+#define CONTROL_SFPA_Pos                    3U                                            /*!< CONTROL: SFPA Position */
+#define CONTROL_SFPA_Msk                   (1UL << CONTROL_SFPA_Pos)                      /*!< CONTROL: SFPA Mask */
+
+#define CONTROL_FPCA_Pos                    2U                                            /*!< CONTROL: FPCA Position */
+#define CONTROL_FPCA_Msk                   (1UL << CONTROL_FPCA_Pos)                      /*!< CONTROL: FPCA Mask */
+
+#define CONTROL_SPSEL_Pos                   1U                                            /*!< CONTROL: SPSEL Position */
+#define CONTROL_SPSEL_Msk                  (1UL << CONTROL_SPSEL_Pos)                     /*!< CONTROL: SPSEL Mask */
+
+#define CONTROL_nPRIV_Pos                   0U                                            /*!< CONTROL: nPRIV Position */
+#define CONTROL_nPRIV_Msk                  (1UL /*<< CONTROL_nPRIV_Pos*/)                 /*!< CONTROL: nPRIV Mask */
+
+/*@} end of group CMSIS_CORE */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_NVIC  Nested Vectored Interrupt Controller (NVIC)
+  \brief      Type definitions for the NVIC Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Nested Vectored Interrupt Controller (NVIC).
+ */
+typedef struct
+{
+  __IOM uint32_t ISER[16U];              /*!< Offset: 0x000 (R/W)  Interrupt Set Enable Register */
+        uint32_t RESERVED0[16U];
+  __IOM uint32_t ICER[16U];              /*!< Offset: 0x080 (R/W)  Interrupt Clear Enable Register */
+        uint32_t RESERVED1[16U];
+  __IOM uint32_t ISPR[16U];              /*!< Offset: 0x100 (R/W)  Interrupt Set Pending Register */
+        uint32_t RESERVED2[16U];
+  __IOM uint32_t ICPR[16U];              /*!< Offset: 0x180 (R/W)  Interrupt Clear Pending Register */
+        uint32_t RESERVED3[16U];
+  __IOM uint32_t IABR[16U];              /*!< Offset: 0x200 (R/W)  Interrupt Active bit Register */
+        uint32_t RESERVED4[16U];
+  __IOM uint32_t ITNS[16U];              /*!< Offset: 0x280 (R/W)  Interrupt Non-Secure State Register */
+        uint32_t RESERVED5[16U];
+  __IOM uint8_t  IPR[496U];              /*!< Offset: 0x300 (R/W)  Interrupt Priority Register (8Bit wide) */
+        uint32_t RESERVED6[580U];
+  __OM  uint32_t STIR;                   /*!< Offset: 0xE00 ( /W)  Software Trigger Interrupt Register */
+}  NVIC_Type;
+
+/** \brief NVIC Software Triggered Interrupt Register Definitions */
+#define NVIC_STIR_INTID_Pos                 0U                                         /*!< STIR: INTLINESNUM Position */
+#define NVIC_STIR_INTID_Msk                (0x1FFUL /*<< NVIC_STIR_INTID_Pos*/)        /*!< STIR: INTLINESNUM Mask */
+
+/*@} end of group CMSIS_NVIC */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SCB     System Control Block (SCB)
+  \brief    Type definitions for the System Control Block Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Control Block (SCB).
+ */
+typedef struct
+{
+  __IM  uint32_t CPUID;                  /*!< Offset: 0x000 (R/ )  CPUID Base Register */
+  __IOM uint32_t ICSR;                   /*!< Offset: 0x004 (R/W)  Interrupt Control and State Register */
+  __IOM uint32_t VTOR;                   /*!< Offset: 0x008 (R/W)  Vector Table Offset Register */
+  __IOM uint32_t AIRCR;                  /*!< Offset: 0x00C (R/W)  Application Interrupt and Reset Control Register */
+  __IOM uint32_t SCR;                    /*!< Offset: 0x010 (R/W)  System Control Register */
+  __IOM uint32_t CCR;                    /*!< Offset: 0x014 (R/W)  Configuration Control Register */
+  __IOM uint8_t  SHPR[12U];              /*!< Offset: 0x018 (R/W)  System Handlers Priority Registers (4-7, 8-11, 12-15) */
+  __IOM uint32_t SHCSR;                  /*!< Offset: 0x024 (R/W)  System Handler Control and State Register */
+  __IOM uint32_t CFSR;                   /*!< Offset: 0x028 (R/W)  Configurable Fault Status Register */
+  __IOM uint32_t HFSR;                   /*!< Offset: 0x02C (R/W)  HardFault Status Register */
+  __IOM uint32_t DFSR;                   /*!< Offset: 0x030 (R/W)  Debug Fault Status Register */
+  __IOM uint32_t MMFAR;                  /*!< Offset: 0x034 (R/W)  MemManage Fault Address Register */
+  __IOM uint32_t BFAR;                   /*!< Offset: 0x038 (R/W)  BusFault Address Register */
+  __IOM uint32_t AFSR;                   /*!< Offset: 0x03C (R/W)  Auxiliary Fault Status Register */
+  __IM  uint32_t ID_PFR[2U];             /*!< Offset: 0x040 (R/ )  Processor Feature Register */
+  __IM  uint32_t ID_DFR;                 /*!< Offset: 0x048 (R/ )  Debug Feature Register */
+  __IM  uint32_t ID_AFR;                 /*!< Offset: 0x04C (R/ )  Auxiliary Feature Register */
+  __IM  uint32_t ID_MMFR[4U];            /*!< Offset: 0x050 (R/ )  Memory Model Feature Register */
+  __IM  uint32_t ID_ISAR[5U];            /*!< Offset: 0x060 (R/ )  Instruction Set Attributes Register */
+        uint32_t RESERVED0[1U];
+  __IM  uint32_t CLIDR;                  /*!< Offset: 0x078 (R/ )  Cache Level ID register */
+  __IM  uint32_t CTR;                    /*!< Offset: 0x07C (R/ )  Cache Type register */
+  __IM  uint32_t CCSIDR;                 /*!< Offset: 0x080 (R/ )  Cache Size ID Register */
+  __IOM uint32_t CSSELR;                 /*!< Offset: 0x084 (R/W)  Cache Size Selection Register */
+  __IOM uint32_t CPACR;                  /*!< Offset: 0x088 (R/W)  Coprocessor Access Control Register */
+  __IOM uint32_t NSACR;                  /*!< Offset: 0x08C (R/W)  Non-Secure Access Control Register */
+        uint32_t RESERVED_ADD1[21U];
+  __IOM uint32_t SFSR;                   /*!< Offset: 0x0E4 (R/W)  Secure Fault Status Register */
+  __IOM uint32_t SFAR;                   /*!< Offset: 0x0E8 (R/W)  Secure Fault Address Register */
+        uint32_t RESERVED3[69U];
+  __OM  uint32_t STIR;                   /*!< Offset: F00-D00=0x200 ( /W)  Software Triggered Interrupt Register */
+        uint32_t RESERVED4[15U];
+  __IM  uint32_t MVFR0;                  /*!< Offset: 0x240 (R/ )  Media and VFP Feature Register 0 */
+  __IM  uint32_t MVFR1;                  /*!< Offset: 0x244 (R/ )  Media and VFP Feature Register 1 */
+  __IM  uint32_t MVFR2;                  /*!< Offset: 0x248 (R/ )  Media and VFP Feature Register 2 */
+        uint32_t RESERVED5[1U];
+  __OM  uint32_t ICIALLU;                /*!< Offset: 0x250 ( /W)  I-Cache Invalidate All to PoU */
+        uint32_t RESERVED6[1U];
+  __OM  uint32_t ICIMVAU;                /*!< Offset: 0x258 ( /W)  I-Cache Invalidate by MVA to PoU */
+  __OM  uint32_t DCIMVAC;                /*!< Offset: 0x25C ( /W)  D-Cache Invalidate by MVA to PoC */
+  __OM  uint32_t DCISW;                  /*!< Offset: 0x260 ( /W)  D-Cache Invalidate by Set-way */
+  __OM  uint32_t DCCMVAU;                /*!< Offset: 0x264 ( /W)  D-Cache Clean by MVA to PoU */
+  __OM  uint32_t DCCMVAC;                /*!< Offset: 0x268 ( /W)  D-Cache Clean by MVA to PoC */
+  __OM  uint32_t DCCSW;                  /*!< Offset: 0x26C ( /W)  D-Cache Clean by Set-way */
+  __OM  uint32_t DCCIMVAC;               /*!< Offset: 0x270 ( /W)  D-Cache Clean and Invalidate by MVA to PoC */
+  __OM  uint32_t DCCISW;                 /*!< Offset: 0x274 ( /W)  D-Cache Clean and Invalidate by Set-way */
+} SCB_Type;
+
+typedef struct
+{
+  __IOM uint32_t CACR;                   /*!< Offset: 0x0 (R/W)  L1 Cache Control Register */
+  __IOM uint32_t ITCMCR;                 /*!< Offset: 0x10 (R/W)  Instruction Tightly-Coupled Memory Control Register */
+  __IOM uint32_t DTCMCR;                 /*!< Offset: 0x14 (R/W)  Data Tightly-Coupled Memory Control Registers */
+} EMSS_Type;
+
+/** \brief SCB CPUID Register Definitions */
+#define SCB_CPUID_IMPLEMENTER_Pos          24U                                            /*!< SCB CPUID: IMPLEMENTER Position */
+#define SCB_CPUID_IMPLEMENTER_Msk          (0xFFUL << SCB_CPUID_IMPLEMENTER_Pos)          /*!< SCB CPUID: IMPLEMENTER Mask */
+
+#define SCB_CPUID_VARIANT_Pos              20U                                            /*!< SCB CPUID: VARIANT Position */
+#define SCB_CPUID_VARIANT_Msk              (0xFUL << SCB_CPUID_VARIANT_Pos)               /*!< SCB CPUID: VARIANT Mask */
+
+#define SCB_CPUID_ARCHITECTURE_Pos         16U                                            /*!< SCB CPUID: ARCHITECTURE Position */
+#define SCB_CPUID_ARCHITECTURE_Msk         (0xFUL << SCB_CPUID_ARCHITECTURE_Pos)          /*!< SCB CPUID: ARCHITECTURE Mask */
+
+#define SCB_CPUID_PARTNO_Pos                4U                                            /*!< SCB CPUID: PARTNO Position */
+#define SCB_CPUID_PARTNO_Msk               (0xFFFUL << SCB_CPUID_PARTNO_Pos)              /*!< SCB CPUID: PARTNO Mask */
+
+#define SCB_CPUID_REVISION_Pos              0U                                            /*!< SCB CPUID: REVISION Position */
+#define SCB_CPUID_REVISION_Msk             (0xFUL /*<< SCB_CPUID_REVISION_Pos*/)          /*!< SCB CPUID: REVISION Mask */
+
+/** \brief SCB Interrupt Control State Register Definitions */
+#define SCB_ICSR_PENDNMISET_Pos            31U                                            /*!< SCB ICSR: PENDNMISET Position */
+#define SCB_ICSR_PENDNMISET_Msk            (1UL << SCB_ICSR_PENDNMISET_Pos)               /*!< SCB ICSR: PENDNMISET Mask */
+
+#define SCB_ICSR_NMIPENDSET_Pos            SCB_ICSR_PENDNMISET_Pos                        /*!< SCB ICSR: NMIPENDSET Position, backward compatibility */
+#define SCB_ICSR_NMIPENDSET_Msk            SCB_ICSR_PENDNMISET_Msk                        /*!< SCB ICSR: NMIPENDSET Mask, backward compatibility */
+
+#define SCB_ICSR_PENDNMICLR_Pos            30U                                            /*!< SCB ICSR: PENDNMICLR Position */
+#define SCB_ICSR_PENDNMICLR_Msk            (1UL << SCB_ICSR_PENDNMICLR_Pos)               /*!< SCB ICSR: PENDNMICLR Mask */
+
+#define SCB_ICSR_PENDSVSET_Pos             28U                                            /*!< SCB ICSR: PENDSVSET Position */
+#define SCB_ICSR_PENDSVSET_Msk             (1UL << SCB_ICSR_PENDSVSET_Pos)                /*!< SCB ICSR: PENDSVSET Mask */
+
+#define SCB_ICSR_PENDSVCLR_Pos             27U                                            /*!< SCB ICSR: PENDSVCLR Position */
+#define SCB_ICSR_PENDSVCLR_Msk             (1UL << SCB_ICSR_PENDSVCLR_Pos)                /*!< SCB ICSR: PENDSVCLR Mask */
+
+#define SCB_ICSR_PENDSTSET_Pos             26U                                            /*!< SCB ICSR: PENDSTSET Position */
+#define SCB_ICSR_PENDSTSET_Msk             (1UL << SCB_ICSR_PENDSTSET_Pos)                /*!< SCB ICSR: PENDSTSET Mask */
+
+#define SCB_ICSR_PENDSTCLR_Pos             25U                                            /*!< SCB ICSR: PENDSTCLR Position */
+#define SCB_ICSR_PENDSTCLR_Msk             (1UL << SCB_ICSR_PENDSTCLR_Pos)                /*!< SCB ICSR: PENDSTCLR Mask */
+
+#define SCB_ICSR_STTNS_Pos                 24U                                            /*!< SCB ICSR: STTNS Position (Security Extension) */
+#define SCB_ICSR_STTNS_Msk                 (1UL << SCB_ICSR_STTNS_Pos)                    /*!< SCB ICSR: STTNS Mask (Security Extension) */
+
+#define SCB_ICSR_ISRPREEMPT_Pos            23U                                            /*!< SCB ICSR: ISRPREEMPT Position */
+#define SCB_ICSR_ISRPREEMPT_Msk            (1UL << SCB_ICSR_ISRPREEMPT_Pos)               /*!< SCB ICSR: ISRPREEMPT Mask */
+
+#define SCB_ICSR_ISRPENDING_Pos            22U                                            /*!< SCB ICSR: ISRPENDING Position */
+#define SCB_ICSR_ISRPENDING_Msk            (1UL << SCB_ICSR_ISRPENDING_Pos)               /*!< SCB ICSR: ISRPENDING Mask */
+
+#define SCB_ICSR_VECTPENDING_Pos           12U                                            /*!< SCB ICSR: VECTPENDING Position */
+#define SCB_ICSR_VECTPENDING_Msk           (0x1FFUL << SCB_ICSR_VECTPENDING_Pos)          /*!< SCB ICSR: VECTPENDING Mask */
+
+#define SCB_ICSR_RETTOBASE_Pos             11U                                            /*!< SCB ICSR: RETTOBASE Position */
+#define SCB_ICSR_RETTOBASE_Msk             (1UL << SCB_ICSR_RETTOBASE_Pos)                /*!< SCB ICSR: RETTOBASE Mask */
+
+#define SCB_ICSR_VECTACTIVE_Pos             0U                                            /*!< SCB ICSR: VECTACTIVE Position */
+#define SCB_ICSR_VECTACTIVE_Msk            (0x1FFUL /*<< SCB_ICSR_VECTACTIVE_Pos*/)       /*!< SCB ICSR: VECTACTIVE Mask */
+
+/** \brief SCB Vector Table Offset Register Definitions */
+#define SCB_VTOR_TBLOFF_Pos                 7U                                            /*!< SCB VTOR: TBLOFF Position */
+#define SCB_VTOR_TBLOFF_Msk                (0x1FFFFFFUL << SCB_VTOR_TBLOFF_Pos)           /*!< SCB VTOR: TBLOFF Mask */
+
+/** \brief SCB Application Interrupt and Reset Control Register Definitions */
+#define SCB_AIRCR_VECTKEY_Pos              16U                                            /*!< SCB AIRCR: VECTKEY Position */
+#define SCB_AIRCR_VECTKEY_Msk              (0xFFFFUL << SCB_AIRCR_VECTKEY_Pos)            /*!< SCB AIRCR: VECTKEY Mask */
+
+#define SCB_AIRCR_VECTKEYSTAT_Pos          16U                                            /*!< SCB AIRCR: VECTKEYSTAT Position */
+#define SCB_AIRCR_VECTKEYSTAT_Msk          (0xFFFFUL << SCB_AIRCR_VECTKEYSTAT_Pos)        /*!< SCB AIRCR: VECTKEYSTAT Mask */
+
+#define SCB_AIRCR_ENDIANESS_Pos            15U                                            /*!< SCB AIRCR: ENDIANESS Position */
+#define SCB_AIRCR_ENDIANESS_Msk            (1UL << SCB_AIRCR_ENDIANESS_Pos)               /*!< SCB AIRCR: ENDIANESS Mask */
+
+#define SCB_AIRCR_PRIS_Pos                 14U                                            /*!< SCB AIRCR: PRIS Position */
+#define SCB_AIRCR_PRIS_Msk                 (1UL << SCB_AIRCR_PRIS_Pos)                    /*!< SCB AIRCR: PRIS Mask */
+
+#define SCB_AIRCR_BFHFNMINS_Pos            13U                                            /*!< SCB AIRCR: BFHFNMINS Position */
+#define SCB_AIRCR_BFHFNMINS_Msk            (1UL << SCB_AIRCR_BFHFNMINS_Pos)               /*!< SCB AIRCR: BFHFNMINS Mask */
+
+#define SCB_AIRCR_PRIGROUP_Pos              8U                                            /*!< SCB AIRCR: PRIGROUP Position */
+#define SCB_AIRCR_PRIGROUP_Msk             (7UL << SCB_AIRCR_PRIGROUP_Pos)                /*!< SCB AIRCR: PRIGROUP Mask */
+
+#define SCB_AIRCR_SYSRESETREQS_Pos          3U                                            /*!< SCB AIRCR: SYSRESETREQS Position */
+#define SCB_AIRCR_SYSRESETREQS_Msk         (1UL << SCB_AIRCR_SYSRESETREQS_Pos)            /*!< SCB AIRCR: SYSRESETREQS Mask */
+
+#define SCB_AIRCR_SYSRESETREQ_Pos           2U                                            /*!< SCB AIRCR: SYSRESETREQ Position */
+#define SCB_AIRCR_SYSRESETREQ_Msk          (1UL << SCB_AIRCR_SYSRESETREQ_Pos)             /*!< SCB AIRCR: SYSRESETREQ Mask */
+
+#define SCB_AIRCR_VECTCLRACTIVE_Pos         1U                                            /*!< SCB AIRCR: VECTCLRACTIVE Position */
+#define SCB_AIRCR_VECTCLRACTIVE_Msk        (1UL << SCB_AIRCR_VECTCLRACTIVE_Pos)           /*!< SCB AIRCR: VECTCLRACTIVE Mask */
+
+/** \brief SCB System Control Register Definitions */
+#define SCB_SCR_SEVONPEND_Pos               4U                                            /*!< SCB SCR: SEVONPEND Position */
+#define SCB_SCR_SEVONPEND_Msk              (1UL << SCB_SCR_SEVONPEND_Pos)                 /*!< SCB SCR: SEVONPEND Mask */
+
+#define SCB_SCR_SLEEPDEEPS_Pos              3U                                            /*!< SCB SCR: SLEEPDEEPS Position */
+#define SCB_SCR_SLEEPDEEPS_Msk             (1UL << SCB_SCR_SLEEPDEEPS_Pos)                /*!< SCB SCR: SLEEPDEEPS Mask */
+
+#define SCB_SCR_SLEEPDEEP_Pos               2U                                            /*!< SCB SCR: SLEEPDEEP Position */
+#define SCB_SCR_SLEEPDEEP_Msk              (1UL << SCB_SCR_SLEEPDEEP_Pos)                 /*!< SCB SCR: SLEEPDEEP Mask */
+
+#define SCB_SCR_SLEEPONEXIT_Pos             1U                                            /*!< SCB SCR: SLEEPONEXIT Position */
+#define SCB_SCR_SLEEPONEXIT_Msk            (1UL << SCB_SCR_SLEEPONEXIT_Pos)               /*!< SCB SCR: SLEEPONEXIT Mask */
+
+/** \brief SCB Configuration Control Register Definitions */
+#define SCB_CCR_BP_Pos                     18U                                            /*!< SCB CCR: BP Position */
+#define SCB_CCR_BP_Msk                     (1UL << SCB_CCR_BP_Pos)                        /*!< SCB CCR: BP Mask */
+
+#define SCB_CCR_IC_Pos                     17U                                            /*!< SCB CCR: IC Position */
+#define SCB_CCR_IC_Msk                     (1UL << SCB_CCR_IC_Pos)                        /*!< SCB CCR: IC Mask */
+
+#define SCB_CCR_DC_Pos                     16U                                            /*!< SCB CCR: DC Position */
+#define SCB_CCR_DC_Msk                     (1UL << SCB_CCR_DC_Pos)                        /*!< SCB CCR: DC Mask */
+
+#define SCB_CCR_STKOFHFNMIGN_Pos           10U                                            /*!< SCB CCR: STKOFHFNMIGN Position */
+#define SCB_CCR_STKOFHFNMIGN_Msk           (1UL << SCB_CCR_STKOFHFNMIGN_Pos)              /*!< SCB CCR: STKOFHFNMIGN Mask */
+
+#define SCB_CCR_BFHFNMIGN_Pos               8U                                            /*!< SCB CCR: BFHFNMIGN Position */
+#define SCB_CCR_BFHFNMIGN_Msk              (1UL << SCB_CCR_BFHFNMIGN_Pos)                 /*!< SCB CCR: BFHFNMIGN Mask */
+
+#define SCB_CCR_DIV_0_TRP_Pos               4U                                            /*!< SCB CCR: DIV_0_TRP Position */
+#define SCB_CCR_DIV_0_TRP_Msk              (1UL << SCB_CCR_DIV_0_TRP_Pos)                 /*!< SCB CCR: DIV_0_TRP Mask */
+
+#define SCB_CCR_UNALIGN_TRP_Pos             3U                                            /*!< SCB CCR: UNALIGN_TRP Position */
+#define SCB_CCR_UNALIGN_TRP_Msk            (1UL << SCB_CCR_UNALIGN_TRP_Pos)               /*!< SCB CCR: UNALIGN_TRP Mask */
+
+#define SCB_CCR_USERSETMPEND_Pos            1U                                            /*!< SCB CCR: USERSETMPEND Position */
+#define SCB_CCR_USERSETMPEND_Msk           (1UL << SCB_CCR_USERSETMPEND_Pos)              /*!< SCB CCR: USERSETMPEND Mask */
+
+/** \brief SCB System Handler Control and State Register Definitions */
+#define SCB_SHCSR_HARDFAULTPENDED_Pos      21U                                            /*!< SCB SHCSR: HARDFAULTPENDED Position */
+#define SCB_SHCSR_HARDFAULTPENDED_Msk      (1UL << SCB_SHCSR_HARDFAULTPENDED_Pos)         /*!< SCB SHCSR: HARDFAULTPENDED Mask */
+
+#define SCB_SHCSR_SECUREFAULTPENDED_Pos    20U                                            /*!< SCB SHCSR: SECUREFAULTPENDED Position */
+#define SCB_SHCSR_SECUREFAULTPENDED_Msk    (1UL << SCB_SHCSR_SECUREFAULTPENDED_Pos)       /*!< SCB SHCSR: SECUREFAULTPENDED Mask */
+
+#define SCB_SHCSR_SECUREFAULTENA_Pos       19U                                            /*!< SCB SHCSR: SECUREFAULTENA Position */
+#define SCB_SHCSR_SECUREFAULTENA_Msk       (1UL << SCB_SHCSR_SECUREFAULTENA_Pos)          /*!< SCB SHCSR: SECUREFAULTENA Mask */
+
+#define SCB_SHCSR_USGFAULTENA_Pos          18U                                            /*!< SCB SHCSR: USGFAULTENA Position */
+#define SCB_SHCSR_USGFAULTENA_Msk          (1UL << SCB_SHCSR_USGFAULTENA_Pos)             /*!< SCB SHCSR: USGFAULTENA Mask */
+
+#define SCB_SHCSR_BUSFAULTENA_Pos          17U                                            /*!< SCB SHCSR: BUSFAULTENA Position */
+#define SCB_SHCSR_BUSFAULTENA_Msk          (1UL << SCB_SHCSR_BUSFAULTENA_Pos)             /*!< SCB SHCSR: BUSFAULTENA Mask */
+
+#define SCB_SHCSR_MEMFAULTENA_Pos          16U                                            /*!< SCB SHCSR: MEMFAULTENA Position */
+#define SCB_SHCSR_MEMFAULTENA_Msk          (1UL << SCB_SHCSR_MEMFAULTENA_Pos)             /*!< SCB SHCSR: MEMFAULTENA Mask */
+
+#define SCB_SHCSR_SVCALLPENDED_Pos         15U                                            /*!< SCB SHCSR: SVCALLPENDED Position */
+#define SCB_SHCSR_SVCALLPENDED_Msk         (1UL << SCB_SHCSR_SVCALLPENDED_Pos)            /*!< SCB SHCSR: SVCALLPENDED Mask */
+
+#define SCB_SHCSR_BUSFAULTPENDED_Pos       14U                                            /*!< SCB SHCSR: BUSFAULTPENDED Position */
+#define SCB_SHCSR_BUSFAULTPENDED_Msk       (1UL << SCB_SHCSR_BUSFAULTPENDED_Pos)          /*!< SCB SHCSR: BUSFAULTPENDED Mask */
+
+#define SCB_SHCSR_MEMFAULTPENDED_Pos       13U                                            /*!< SCB SHCSR: MEMFAULTPENDED Position */
+#define SCB_SHCSR_MEMFAULTPENDED_Msk       (1UL << SCB_SHCSR_MEMFAULTPENDED_Pos)          /*!< SCB SHCSR: MEMFAULTPENDED Mask */
+
+#define SCB_SHCSR_USGFAULTPENDED_Pos       12U                                            /*!< SCB SHCSR: USGFAULTPENDED Position */
+#define SCB_SHCSR_USGFAULTPENDED_Msk       (1UL << SCB_SHCSR_USGFAULTPENDED_Pos)          /*!< SCB SHCSR: USGFAULTPENDED Mask */
+
+#define SCB_SHCSR_SYSTICKACT_Pos           11U                                            /*!< SCB SHCSR: SYSTICKACT Position */
+#define SCB_SHCSR_SYSTICKACT_Msk           (1UL << SCB_SHCSR_SYSTICKACT_Pos)              /*!< SCB SHCSR: SYSTICKACT Mask */
+
+#define SCB_SHCSR_PENDSVACT_Pos            10U                                            /*!< SCB SHCSR: PENDSVACT Position */
+#define SCB_SHCSR_PENDSVACT_Msk            (1UL << SCB_SHCSR_PENDSVACT_Pos)               /*!< SCB SHCSR: PENDSVACT Mask */
+
+#define SCB_SHCSR_MONITORACT_Pos            8U                                            /*!< SCB SHCSR: MONITORACT Position */
+#define SCB_SHCSR_MONITORACT_Msk           (1UL << SCB_SHCSR_MONITORACT_Pos)              /*!< SCB SHCSR: MONITORACT Mask */
+
+#define SCB_SHCSR_SVCALLACT_Pos             7U                                            /*!< SCB SHCSR: SVCALLACT Position */
+#define SCB_SHCSR_SVCALLACT_Msk            (1UL << SCB_SHCSR_SVCALLACT_Pos)               /*!< SCB SHCSR: SVCALLACT Mask */
+
+#define SCB_SHCSR_NMIACT_Pos                5U                                            /*!< SCB SHCSR: NMIACT Position */
+#define SCB_SHCSR_NMIACT_Msk               (1UL << SCB_SHCSR_NMIACT_Pos)                  /*!< SCB SHCSR: NMIACT Mask */
+
+#define SCB_SHCSR_SECUREFAULTACT_Pos        4U                                            /*!< SCB SHCSR: SECUREFAULTACT Position */
+#define SCB_SHCSR_SECUREFAULTACT_Msk       (1UL << SCB_SHCSR_SECUREFAULTACT_Pos)          /*!< SCB SHCSR: SECUREFAULTACT Mask */
+
+#define SCB_SHCSR_USGFAULTACT_Pos           3U                                            /*!< SCB SHCSR: USGFAULTACT Position */
+#define SCB_SHCSR_USGFAULTACT_Msk          (1UL << SCB_SHCSR_USGFAULTACT_Pos)             /*!< SCB SHCSR: USGFAULTACT Mask */
+
+#define SCB_SHCSR_HARDFAULTACT_Pos          2U                                            /*!< SCB SHCSR: HARDFAULTACT Position */
+#define SCB_SHCSR_HARDFAULTACT_Msk         (1UL << SCB_SHCSR_HARDFAULTACT_Pos)            /*!< SCB SHCSR: HARDFAULTACT Mask */
+
+#define SCB_SHCSR_BUSFAULTACT_Pos           1U                                            /*!< SCB SHCSR: BUSFAULTACT Position */
+#define SCB_SHCSR_BUSFAULTACT_Msk          (1UL << SCB_SHCSR_BUSFAULTACT_Pos)             /*!< SCB SHCSR: BUSFAULTACT Mask */
+
+#define SCB_SHCSR_MEMFAULTACT_Pos           0U                                            /*!< SCB SHCSR: MEMFAULTACT Position */
+#define SCB_SHCSR_MEMFAULTACT_Msk          (1UL /*<< SCB_SHCSR_MEMFAULTACT_Pos*/)         /*!< SCB SHCSR: MEMFAULTACT Mask */
+
+/** \brief SCB Configurable Fault Status Register Definitions */
+#define SCB_CFSR_USGFAULTSR_Pos            16U                                            /*!< SCB CFSR: Usage Fault Status Register Position */
+#define SCB_CFSR_USGFAULTSR_Msk            (0xFFFFUL << SCB_CFSR_USGFAULTSR_Pos)          /*!< SCB CFSR: Usage Fault Status Register Mask */
+
+#define SCB_CFSR_BUSFAULTSR_Pos             8U                                            /*!< SCB CFSR: Bus Fault Status Register Position */
+#define SCB_CFSR_BUSFAULTSR_Msk            (0xFFUL << SCB_CFSR_BUSFAULTSR_Pos)            /*!< SCB CFSR: Bus Fault Status Register Mask */
+
+#define SCB_CFSR_MEMFAULTSR_Pos             0U                                            /*!< SCB CFSR: Memory Manage Fault Status Register Position */
+#define SCB_CFSR_MEMFAULTSR_Msk            (0xFFUL /*<< SCB_CFSR_MEMFAULTSR_Pos*/)        /*!< SCB CFSR: Memory Manage Fault Status Register Mask */
+
+/** \brief SCB MemManage Fault Status Register Definitions (part of SCB Configurable Fault Status Register) */
+#define SCB_CFSR_MMARVALID_Pos             (SCB_CFSR_MEMFAULTSR_Pos + 7U)                 /*!< SCB CFSR (MMFSR): MMARVALID Position */
+#define SCB_CFSR_MMARVALID_Msk             (1UL << SCB_CFSR_MMARVALID_Pos)                /*!< SCB CFSR (MMFSR): MMARVALID Mask */
+
+#define SCB_CFSR_MLSPERR_Pos               (SCB_CFSR_MEMFAULTSR_Pos + 5U)                 /*!< SCB CFSR (MMFSR): MLSPERR Position */
+#define SCB_CFSR_MLSPERR_Msk               (1UL << SCB_CFSR_MLSPERR_Pos)                  /*!< SCB CFSR (MMFSR): MLSPERR Mask */
+
+#define SCB_CFSR_MSTKERR_Pos               (SCB_CFSR_MEMFAULTSR_Pos + 4U)                 /*!< SCB CFSR (MMFSR): MSTKERR Position */
+#define SCB_CFSR_MSTKERR_Msk               (1UL << SCB_CFSR_MSTKERR_Pos)                  /*!< SCB CFSR (MMFSR): MSTKERR Mask */
+
+#define SCB_CFSR_MUNSTKERR_Pos             (SCB_CFSR_MEMFAULTSR_Pos + 3U)                 /*!< SCB CFSR (MMFSR): MUNSTKERR Position */
+#define SCB_CFSR_MUNSTKERR_Msk             (1UL << SCB_CFSR_MUNSTKERR_Pos)                /*!< SCB CFSR (MMFSR): MUNSTKERR Mask */
+
+#define SCB_CFSR_DACCVIOL_Pos              (SCB_CFSR_MEMFAULTSR_Pos + 1U)                 /*!< SCB CFSR (MMFSR): DACCVIOL Position */
+#define SCB_CFSR_DACCVIOL_Msk              (1UL << SCB_CFSR_DACCVIOL_Pos)                 /*!< SCB CFSR (MMFSR): DACCVIOL Mask */
+
+#define SCB_CFSR_IACCVIOL_Pos              (SCB_CFSR_MEMFAULTSR_Pos + 0U)                 /*!< SCB CFSR (MMFSR): IACCVIOL Position */
+#define SCB_CFSR_IACCVIOL_Msk              (1UL /*<< SCB_CFSR_IACCVIOL_Pos*/)             /*!< SCB CFSR (MMFSR): IACCVIOL Mask */
+
+/** \brief SCB BusFault Status Register Definitions (part of SCB Configurable Fault Status Register) */
+#define SCB_CFSR_BFARVALID_Pos            (SCB_CFSR_BUSFAULTSR_Pos + 7U)                  /*!< SCB CFSR (BFSR): BFARVALID Position */
+#define SCB_CFSR_BFARVALID_Msk            (1UL << SCB_CFSR_BFARVALID_Pos)                 /*!< SCB CFSR (BFSR): BFARVALID Mask */
+
+#define SCB_CFSR_LSPERR_Pos               (SCB_CFSR_BUSFAULTSR_Pos + 5U)                  /*!< SCB CFSR (BFSR): LSPERR Position */
+#define SCB_CFSR_LSPERR_Msk               (1UL << SCB_CFSR_LSPERR_Pos)                    /*!< SCB CFSR (BFSR): LSPERR Mask */
+
+#define SCB_CFSR_STKERR_Pos               (SCB_CFSR_BUSFAULTSR_Pos + 4U)                  /*!< SCB CFSR (BFSR): STKERR Position */
+#define SCB_CFSR_STKERR_Msk               (1UL << SCB_CFSR_STKERR_Pos)                    /*!< SCB CFSR (BFSR): STKERR Mask */
+
+#define SCB_CFSR_UNSTKERR_Pos             (SCB_CFSR_BUSFAULTSR_Pos + 3U)                  /*!< SCB CFSR (BFSR): UNSTKERR Position */
+#define SCB_CFSR_UNSTKERR_Msk             (1UL << SCB_CFSR_UNSTKERR_Pos)                  /*!< SCB CFSR (BFSR): UNSTKERR Mask */
+
+#define SCB_CFSR_IMPRECISERR_Pos          (SCB_CFSR_BUSFAULTSR_Pos + 2U)                  /*!< SCB CFSR (BFSR): IMPRECISERR Position */
+#define SCB_CFSR_IMPRECISERR_Msk          (1UL << SCB_CFSR_IMPRECISERR_Pos)               /*!< SCB CFSR (BFSR): IMPRECISERR Mask */
+
+#define SCB_CFSR_PRECISERR_Pos            (SCB_CFSR_BUSFAULTSR_Pos + 1U)                  /*!< SCB CFSR (BFSR): PRECISERR Position */
+#define SCB_CFSR_PRECISERR_Msk            (1UL << SCB_CFSR_PRECISERR_Pos)                 /*!< SCB CFSR (BFSR): PRECISERR Mask */
+
+#define SCB_CFSR_IBUSERR_Pos              (SCB_CFSR_BUSFAULTSR_Pos + 0U)                  /*!< SCB CFSR (BFSR): IBUSERR Position */
+#define SCB_CFSR_IBUSERR_Msk              (1UL << SCB_CFSR_IBUSERR_Pos)                   /*!< SCB CFSR (BFSR): IBUSERR Mask */
+
+/** \brief SCB UsageFault Status Register Definitions (part of SCB Configurable Fault Status Register) */
+#define SCB_CFSR_DIVBYZERO_Pos            (SCB_CFSR_USGFAULTSR_Pos + 9U)                  /*!< SCB CFSR (UFSR): DIVBYZERO Position */
+#define SCB_CFSR_DIVBYZERO_Msk            (1UL << SCB_CFSR_DIVBYZERO_Pos)                 /*!< SCB CFSR (UFSR): DIVBYZERO Mask */
+
+#define SCB_CFSR_UNALIGNED_Pos            (SCB_CFSR_USGFAULTSR_Pos + 8U)                  /*!< SCB CFSR (UFSR): UNALIGNED Position */
+#define SCB_CFSR_UNALIGNED_Msk            (1UL << SCB_CFSR_UNALIGNED_Pos)                 /*!< SCB CFSR (UFSR): UNALIGNED Mask */
+
+#define SCB_CFSR_STKOF_Pos                (SCB_CFSR_USGFAULTSR_Pos + 4U)                  /*!< SCB CFSR (UFSR): STKOF Position */
+#define SCB_CFSR_STKOF_Msk                (1UL << SCB_CFSR_STKOF_Pos)                     /*!< SCB CFSR (UFSR): STKOF Mask */
+
+#define SCB_CFSR_NOCP_Pos                 (SCB_CFSR_USGFAULTSR_Pos + 3U)                  /*!< SCB CFSR (UFSR): NOCP Position */
+#define SCB_CFSR_NOCP_Msk                 (1UL << SCB_CFSR_NOCP_Pos)                      /*!< SCB CFSR (UFSR): NOCP Mask */
+
+#define SCB_CFSR_INVPC_Pos                (SCB_CFSR_USGFAULTSR_Pos + 2U)                  /*!< SCB CFSR (UFSR): INVPC Position */
+#define SCB_CFSR_INVPC_Msk                (1UL << SCB_CFSR_INVPC_Pos)                     /*!< SCB CFSR (UFSR): INVPC Mask */
+
+#define SCB_CFSR_INVSTATE_Pos             (SCB_CFSR_USGFAULTSR_Pos + 1U)                  /*!< SCB CFSR (UFSR): INVSTATE Position */
+#define SCB_CFSR_INVSTATE_Msk             (1UL << SCB_CFSR_INVSTATE_Pos)                  /*!< SCB CFSR (UFSR): INVSTATE Mask */
+
+#define SCB_CFSR_UNDEFINSTR_Pos           (SCB_CFSR_USGFAULTSR_Pos + 0U)                  /*!< SCB CFSR (UFSR): UNDEFINSTR Position */
+#define SCB_CFSR_UNDEFINSTR_Msk           (1UL << SCB_CFSR_UNDEFINSTR_Pos)                /*!< SCB CFSR (UFSR): UNDEFINSTR Mask */
+
+/** \brief SCB Hard Fault Status Register Definitions */
+#define SCB_HFSR_DEBUGEVT_Pos              31U                                            /*!< SCB HFSR: DEBUGEVT Position */
+#define SCB_HFSR_DEBUGEVT_Msk              (1UL << SCB_HFSR_DEBUGEVT_Pos)                 /*!< SCB HFSR: DEBUGEVT Mask */
+
+#define SCB_HFSR_FORCED_Pos                30U                                            /*!< SCB HFSR: FORCED Position */
+#define SCB_HFSR_FORCED_Msk                (1UL << SCB_HFSR_FORCED_Pos)                   /*!< SCB HFSR: FORCED Mask */
+
+#define SCB_HFSR_VECTTBL_Pos                1U                                            /*!< SCB HFSR: VECTTBL Position */
+#define SCB_HFSR_VECTTBL_Msk               (1UL << SCB_HFSR_VECTTBL_Pos)                  /*!< SCB HFSR: VECTTBL Mask */
+
+/** \brief SCB Debug Fault Status Register Definitions */
+#define SCB_DFSR_EXTERNAL_Pos               4U                                            /*!< SCB DFSR: EXTERNAL Position */
+#define SCB_DFSR_EXTERNAL_Msk              (1UL << SCB_DFSR_EXTERNAL_Pos)                 /*!< SCB DFSR: EXTERNAL Mask */
+
+#define SCB_DFSR_VCATCH_Pos                 3U                                            /*!< SCB DFSR: VCATCH Position */
+#define SCB_DFSR_VCATCH_Msk                (1UL << SCB_DFSR_VCATCH_Pos)                   /*!< SCB DFSR: VCATCH Mask */
+
+#define SCB_DFSR_DWTTRAP_Pos                2U                                            /*!< SCB DFSR: DWTTRAP Position */
+#define SCB_DFSR_DWTTRAP_Msk               (1UL << SCB_DFSR_DWTTRAP_Pos)                  /*!< SCB DFSR: DWTTRAP Mask */
+
+#define SCB_DFSR_BKPT_Pos                   1U                                            /*!< SCB DFSR: BKPT Position */
+#define SCB_DFSR_BKPT_Msk                  (1UL << SCB_DFSR_BKPT_Pos)                     /*!< SCB DFSR: BKPT Mask */
+
+#define SCB_DFSR_HALTED_Pos                 0U                                            /*!< SCB DFSR: HALTED Position */
+#define SCB_DFSR_HALTED_Msk                (1UL /*<< SCB_DFSR_HALTED_Pos*/)               /*!< SCB DFSR: HALTED Mask */
+
+/** \brief SCB Non-Secure Access Control Register Definitions */
+#define SCB_NSACR_CP11_Pos                 11U                                            /*!< SCB NSACR: CP11 Position */
+#define SCB_NSACR_CP11_Msk                 (1UL << SCB_NSACR_CP11_Pos)                    /*!< SCB NSACR: CP11 Mask */
+
+#define SCB_NSACR_CP10_Pos                 10U                                            /*!< SCB NSACR: CP10 Position */
+#define SCB_NSACR_CP10_Msk                 (1UL << SCB_NSACR_CP10_Pos)                    /*!< SCB NSACR: CP10 Mask */
+
+#define SCB_NSACR_CPn_Pos                   0U                                            /*!< SCB NSACR: CPn Position */
+#define SCB_NSACR_CPn_Msk                  (1UL /*<< SCB_NSACR_CPn_Pos*/)                 /*!< SCB NSACR: CPn Mask */
+
+/** \brief SCB Cache Level ID Register Definitions */
+#define SCB_CLIDR_LOUU_Pos                 27U                                            /*!< SCB CLIDR: LoUU Position */
+#define SCB_CLIDR_LOUU_Msk                 (7UL << SCB_CLIDR_LOUU_Pos)                    /*!< SCB CLIDR: LoUU Mask */
+
+#define SCB_CLIDR_LOC_Pos                  24U                                            /*!< SCB CLIDR: LoC Position */
+#define SCB_CLIDR_LOC_Msk                  (7UL << SCB_CLIDR_LOC_Pos)                     /*!< SCB CLIDR: LoC Mask */
+
+#define SCB_CLIDR_IC_Pos                   0U                                             /*!< SCB CLIDR: IC Position */
+#define SCB_CLIDR_IC_Msk                   (1UL << SCB_CLIDR_IC_Pos)                      /*!< SCB CLIDR: IC Mask */
+
+#define SCB_CLIDR_DC_Pos                   1U                                             /*!< SCB CLIDR: DC Position */
+#define SCB_CLIDR_DC_Msk                   (1UL << SCB_CLIDR_DC_Pos)                      /*!< SCB CLIDR: DC Mask */
+
+/** \brief SCB Cache Type Register Definitions */
+#define SCB_CTR_FORMAT_Pos                 29U                                            /*!< SCB CTR: Format Position */
+#define SCB_CTR_FORMAT_Msk                 (7UL << SCB_CTR_FORMAT_Pos)                    /*!< SCB CTR: Format Mask */
+
+#define SCB_CTR_CWG_Pos                    24U                                            /*!< SCB CTR: CWG Position */
+#define SCB_CTR_CWG_Msk                    (0xFUL << SCB_CTR_CWG_Pos)                     /*!< SCB CTR: CWG Mask */
+
+#define SCB_CTR_ERG_Pos                    20U                                            /*!< SCB CTR: ERG Position */
+#define SCB_CTR_ERG_Msk                    (0xFUL << SCB_CTR_ERG_Pos)                     /*!< SCB CTR: ERG Mask */
+
+#define SCB_CTR_DMINLINE_Pos               16U                                            /*!< SCB CTR: DminLine Position */
+#define SCB_CTR_DMINLINE_Msk               (0xFUL << SCB_CTR_DMINLINE_Pos)                /*!< SCB CTR: DminLine Mask */
+
+#define SCB_CTR_IMINLINE_Pos                0U                                            /*!< SCB CTR: ImInLine Position */
+#define SCB_CTR_IMINLINE_Msk               (0xFUL /*<< SCB_CTR_IMINLINE_Pos*/)            /*!< SCB CTR: ImInLine Mask */
+
+/** \brief SCB Cache Size ID Register Definitions */
+#define SCB_CCSIDR_WT_Pos                  31U                                            /*!< SCB CCSIDR: WT Position */
+#define SCB_CCSIDR_WT_Msk                  (1UL << SCB_CCSIDR_WT_Pos)                     /*!< SCB CCSIDR: WT Mask */
+
+#define SCB_CCSIDR_WB_Pos                  30U                                            /*!< SCB CCSIDR: WB Position */
+#define SCB_CCSIDR_WB_Msk                  (1UL << SCB_CCSIDR_WB_Pos)                     /*!< SCB CCSIDR: WB Mask */
+
+#define SCB_CCSIDR_RA_Pos                  29U                                            /*!< SCB CCSIDR: RA Position */
+#define SCB_CCSIDR_RA_Msk                  (1UL << SCB_CCSIDR_RA_Pos)                     /*!< SCB CCSIDR: RA Mask */
+
+#define SCB_CCSIDR_WA_Pos                  28U                                            /*!< SCB CCSIDR: WA Position */
+#define SCB_CCSIDR_WA_Msk                  (1UL << SCB_CCSIDR_WA_Pos)                     /*!< SCB CCSIDR: WA Mask */
+
+#define SCB_CCSIDR_NUMSETS_Pos             13U                                            /*!< SCB CCSIDR: NumSets Position */
+#define SCB_CCSIDR_NUMSETS_Msk             (0x7FFFUL << SCB_CCSIDR_NUMSETS_Pos)           /*!< SCB CCSIDR: NumSets Mask */
+
+#define SCB_CCSIDR_ASSOCIATIVITY_Pos        3U                                            /*!< SCB CCSIDR: Associativity Position */
+#define SCB_CCSIDR_ASSOCIATIVITY_Msk       (0x3FFUL << SCB_CCSIDR_ASSOCIATIVITY_Pos)      /*!< SCB CCSIDR: Associativity Mask */
+
+#define SCB_CCSIDR_LINESIZE_Pos             0U                                            /*!< SCB CCSIDR: LineSize Position */
+#define SCB_CCSIDR_LINESIZE_Msk            (7UL /*<< SCB_CCSIDR_LINESIZE_Pos*/)           /*!< SCB CCSIDR: LineSize Mask */
+
+/** \brief SCB Cache Size Selection Register Definitions */
+#define SCB_CSSELR_LEVEL_Pos                1U                                            /*!< SCB CSSELR: Level Position */
+#define SCB_CSSELR_LEVEL_Msk               (7UL << SCB_CSSELR_LEVEL_Pos)                  /*!< SCB CSSELR: Level Mask */
+
+#define SCB_CSSELR_IND_Pos                  0U                                            /*!< SCB CSSELR: InD Position */
+#define SCB_CSSELR_IND_Msk                 (1UL /*<< SCB_CSSELR_IND_Pos*/)                /*!< SCB CSSELR: InD Mask */
+
+/** \brief SCB Software Triggered Interrupt Register Definitions */
+#define SCB_STIR_INTID_Pos                  0U                                            /*!< SCB STIR: INTID Position */
+#define SCB_STIR_INTID_Msk                 (0x1FFUL /*<< SCB_STIR_INTID_Pos*/)            /*!< SCB STIR: INTID Mask */
+
+/** \brief SCB D-Cache line Invalidate by Set-way Register Definitions */
+#define SCB_DCISW_LEVEL_Pos                1U                                             /*!< SCB DCISW: Level Position */
+#define SCB_DCISW_LEVEL_Msk                (7UL << SCB_DCISW_LEVEL_Pos)                   /*!< SCB DCISW: Level Mask */
+
+#define SCB_DCISW_WAY_Pos                  30U                                            /*!< SCB DCISW: Way Position */
+#define SCB_DCISW_WAY_Msk                  (3UL << SCB_DCISW_WAY_Pos)                     /*!< SCB DCISW: Way Mask */
+
+#define SCB_DCISW_SET_Pos                   5U                                            /*!< SCB DCISW: Set Position */
+#define SCB_DCISW_SET_Msk                  (0xFFUL << SCB_DCISW_SET_Pos)                 /*!< SCB DCISW: Set Mask */
+
+/** \brief SCB D-Cache Clean line by Set-way Register Definitions */
+#define SCB_DCCSW_LEVEL_Pos                1U                                             /*!< SCB DCCSW: Level Position */
+#define SCB_DCCSW_LEVEL_Msk                (7UL << SCB_DCCSW_LEVEL_Pos)                   /*!< SCB DCCSW: Level Mask */
+
+#define SCB_DCCSW_WAY_Pos                  30U                                            /*!< SCB DCCSW: Way Position */
+#define SCB_DCCSW_WAY_Msk                  (3UL << SCB_DCCSW_WAY_Pos)                     /*!< SCB DCCSW: Way Mask */
+
+#define SCB_DCCSW_SET_Pos                   5U                                            /*!< SCB DCCSW: Set Position */
+#define SCB_DCCSW_SET_Msk                  (0xFFUL << SCB_DCCSW_SET_Pos)                 /*!< SCB DCCSW: Set Mask */
+
+/** \brief SCB D-Cache Clean and Invalidate by Set-way Register Definitions */
+#define SCB_DCCISW_LEVEL_Pos               1U                                             /*!< SCB DCCISW: Level Position */
+#define SCB_DCCISW_LEVEL_Msk               (7UL << SCB_DCCISW_LEVEL_Pos)                  /*!< SCB DCCISW: Level Mask */
+
+#define SCB_DCCISW_WAY_Pos                 30U                                            /*!< SCB DCCISW: Way Position */
+#define SCB_DCCISW_WAY_Msk                 (3UL << SCB_DCCISW_WAY_Pos)                    /*!< SCB DCCISW: Way Mask */
+
+#define SCB_DCCISW_SET_Pos                  5U                                            /*!< SCB DCCISW: Set Position */
+#define SCB_DCCISW_SET_Msk                 (0xFFUL << SCB_DCCISW_SET_Pos)                /*!< SCB DCCISW: Set Mask */
+
+/* ArmChina: Implementation Defined */
+/** \brief Instruction Tightly-Coupled Memory Control Register Definitions */
+#define SCB_ITCMCR_SZ_Pos                   3U                                            /*!< SCB ITCMCR: SZ Position */
+#define SCB_ITCMCR_SZ_Msk                  (0xFUL << SCB_ITCMCR_SZ_Pos)                   /*!< SCB ITCMCR: SZ Mask */
+
+#define SCB_ITCMCR_EN_Pos                   0U                                            /*!< SCB ITCMCR: EN Position */
+#define SCB_ITCMCR_EN_Msk                  (1UL /*<< SCB_ITCMCR_EN_Pos*/)                 /*!< SCB ITCMCR: EN Mask */
+
+/** \brief Data Tightly-Coupled Memory Control Register Definitions */
+#define SCB_DTCMCR_SZ_Pos                   3U                                            /*!< SCB DTCMCR: SZ Position */
+#define SCB_DTCMCR_SZ_Msk                  (0xFUL << SCB_DTCMCR_SZ_Pos)                   /*!< SCB DTCMCR: SZ Mask */
+
+#define SCB_DTCMCR_EN_Pos                   0U                                            /*!< SCB DTCMCR: EN Position */
+#define SCB_DTCMCR_EN_Msk                  (1UL /*<< SCB_DTCMCR_EN_Pos*/)                 /*!< SCB DTCMCR: EN Mask */
+
+/** \brief L1 Cache Control Register Definitions */
+#define SCB_CACR_DCCLEAN_Pos                16U                                            /*!< SCB CACR: DCCLEAN Position */
+#define SCB_CACR_DCCLEAN_Msk               (1UL << SCB_CACR_FORCEWT_Pos)                  /*!< SCB CACR: DCCLEAN Mask */
+
+#define SCB_CACR_ICACTIVE_Pos                13U                                            /*!< SCB CACR: ICACTIVE Position */
+#define SCB_CACR_ICACTIVE_Msk               (1UL << SCB_CACR_FORCEWT_Pos)                  /*!< SCB CACR: ICACTIVE Mask */
+
+#define SCB_CACR_DCACTIVE_Pos                12U                                            /*!< SCB CACR: DCACTIVE Position */
+#define SCB_CACR_DCACTIVE_Msk               (1UL << SCB_CACR_FORCEWT_Pos)                  /*!< SCB CACR: DCACTIVE Mask */
+
+#define SCB_CACR_FORCEWT_Pos                2U                                            /*!< SCB CACR: FORCEWT Position */
+#define SCB_CACR_FORCEWT_Msk               (1UL << SCB_CACR_FORCEWT_Pos)                  /*!< SCB CACR: FORCEWT Mask */
+
+/*@} end of group CMSIS_SCB */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SCnSCB System Controls not in SCB (SCnSCB)
+  \brief    Type definitions for the System Control and ID Register not in the SCB
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Control and ID Register not in the SCB.
+ */
+typedef struct
+{
+        uint32_t RESERVED0[1U];
+  __IM  uint32_t ICTR;                   /*!< Offset: 0x004 (R/ )  Interrupt Controller Type Register */
+  __IOM uint32_t ACTLR;                  /*!< Offset: 0x008 (R/W)  Auxiliary Control Register */
+  __IOM uint32_t CPPWR;                  /*!< Offset: 0x00C (R/W)  Coprocessor Power Control  Register */
+} SCnSCB_Type;
+
+/** \brief SCnSCB Interrupt Controller Type Register Definitions */
+#define SCnSCB_ICTR_INTLINESNUM_Pos         0U                                         /*!< ICTR: INTLINESNUM Position */
+#define SCnSCB_ICTR_INTLINESNUM_Msk        (0xFUL /*<< SCnSCB_ICTR_INTLINESNUM_Pos*/)  /*!< ICTR: INTLINESNUM Mask */
+
+/*@} end of group CMSIS_SCnotSCB */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SysTick     System Tick Timer (SysTick)
+  \brief    Type definitions for the System Timer Registers.
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Timer (SysTick).
+ */
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  SysTick Control and Status Register */
+  __IOM uint32_t LOAD;                   /*!< Offset: 0x004 (R/W)  SysTick Reload Value Register */
+  __IOM uint32_t VAL;                    /*!< Offset: 0x008 (R/W)  SysTick Current Value Register */
+  __IM  uint32_t CALIB;                  /*!< Offset: 0x00C (R/ )  SysTick Calibration Register */
+} SysTick_Type;
+
+/** \brief SysTick Control / Status Register Definitions */
+#define SysTick_CTRL_COUNTFLAG_Pos         16U                                            /*!< SysTick CTRL: COUNTFLAG Position */
+#define SysTick_CTRL_COUNTFLAG_Msk         (1UL << SysTick_CTRL_COUNTFLAG_Pos)            /*!< SysTick CTRL: COUNTFLAG Mask */
+
+#define SysTick_CTRL_CLKSOURCE_Pos          2U                                            /*!< SysTick CTRL: CLKSOURCE Position */
+#define SysTick_CTRL_CLKSOURCE_Msk         (1UL << SysTick_CTRL_CLKSOURCE_Pos)            /*!< SysTick CTRL: CLKSOURCE Mask */
+
+#define SysTick_CTRL_TICKINT_Pos            1U                                            /*!< SysTick CTRL: TICKINT Position */
+#define SysTick_CTRL_TICKINT_Msk           (1UL << SysTick_CTRL_TICKINT_Pos)              /*!< SysTick CTRL: TICKINT Mask */
+
+#define SysTick_CTRL_ENABLE_Pos             0U                                            /*!< SysTick CTRL: ENABLE Position */
+#define SysTick_CTRL_ENABLE_Msk            (1UL /*<< SysTick_CTRL_ENABLE_Pos*/)           /*!< SysTick CTRL: ENABLE Mask */
+
+/** \brief SysTick Reload Register Definitions */
+#define SysTick_LOAD_RELOAD_Pos             0U                                            /*!< SysTick LOAD: RELOAD Position */
+#define SysTick_LOAD_RELOAD_Msk            (0xFFFFFFUL /*<< SysTick_LOAD_RELOAD_Pos*/)    /*!< SysTick LOAD: RELOAD Mask */
+
+/** \brief SysTick Current Register Definitions */
+#define SysTick_VAL_CURRENT_Pos             0U                                            /*!< SysTick VAL: CURRENT Position */
+#define SysTick_VAL_CURRENT_Msk            (0xFFFFFFUL /*<< SysTick_VAL_CURRENT_Pos*/)    /*!< SysTick VAL: CURRENT Mask */
+
+/** \brief SysTick Calibration Register Definitions */
+#define SysTick_CALIB_NOREF_Pos            31U                                            /*!< SysTick CALIB: NOREF Position */
+#define SysTick_CALIB_NOREF_Msk            (1UL << SysTick_CALIB_NOREF_Pos)               /*!< SysTick CALIB: NOREF Mask */
+
+#define SysTick_CALIB_SKEW_Pos             30U                                            /*!< SysTick CALIB: SKEW Position */
+#define SysTick_CALIB_SKEW_Msk             (1UL << SysTick_CALIB_SKEW_Pos)                /*!< SysTick CALIB: SKEW Mask */
+
+#define SysTick_CALIB_TENMS_Pos             0U                                            /*!< SysTick CALIB: TENMS Position */
+#define SysTick_CALIB_TENMS_Msk            (0xFFFFFFUL /*<< SysTick_CALIB_TENMS_Pos*/)    /*!< SysTick CALIB: TENMS Mask */
+
+/*@} end of group CMSIS_SysTick */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_ITM     Instrumentation Trace Macrocell (ITM)
+  \brief    Type definitions for the Instrumentation Trace Macrocell (ITM)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Instrumentation Trace Macrocell Register (ITM).
+ */
+typedef struct
+{
+  __OM  union
+  {
+    __OM  uint8_t    u8;                 /*!< Offset: 0x000 ( /W)  Stimulus Port 8-bit */
+    __OM  uint16_t   u16;                /*!< Offset: 0x000 ( /W)  Stimulus Port 16-bit */
+    __OM  uint32_t   u32;                /*!< Offset: 0x000 ( /W)  Stimulus Port 32-bit */
+  }  PORT [32U];                         /*!< Offset: 0x000 ( /W)  Stimulus Port Registers */
+        uint32_t RESERVED0[864U];
+  __IOM uint32_t TER;                    /*!< Offset: 0xE00 (R/W)  Trace Enable Register */
+        uint32_t RESERVED1[15U];
+  __IOM uint32_t TPR;                    /*!< Offset: 0xE40 (R/W)  Trace Privilege Register */
+        uint32_t RESERVED2[15U];
+  __IOM uint32_t TCR;                    /*!< Offset: 0xE80 (R/W)  Trace Control Register */
+        uint32_t RESERVED3[32U];
+        uint32_t RESERVED4[43U];
+  __OM  uint32_t LAR;                    /*!< Offset: 0xFB0 ( /W)  Lock Access Register */
+  __IM  uint32_t LSR;                    /*!< Offset: 0xFB4 (R/ )  Lock Status Register */
+        uint32_t RESERVED5[1U];
+  __IM  uint32_t DEVARCH;                /*!< Offset: 0xFBC (R/ )  Device Architecture Register */
+} ITM_Type;
+
+/** \brief ITM Stimulus Port Register Definitions */
+#define ITM_STIM_DISABLED_Pos               1U                                            /*!< ITM STIM: DISABLED Position */
+#define ITM_STIM_DISABLED_Msk              (1UL << ITM_STIM_DISABLED_Pos)                 /*!< ITM STIM: DISABLED Mask */
+
+#define ITM_STIM_FIFOREADY_Pos              0U                                            /*!< ITM STIM: FIFOREADY Position */
+#define ITM_STIM_FIFOREADY_Msk             (1UL /*<< ITM_STIM_FIFOREADY_Pos*/)            /*!< ITM STIM: FIFOREADY Mask */
+
+/** \brief ITM Trace Privilege Register Definitions */
+#define ITM_TPR_PRIVMASK_Pos                0U                                            /*!< ITM TPR: PRIVMASK Position */
+#define ITM_TPR_PRIVMASK_Msk               (0xFFFFFFFFUL /*<< ITM_TPR_PRIVMASK_Pos*/)     /*!< ITM TPR: PRIVMASK Mask */
+
+/** \brief ITM Trace Control Register Definitions */
+#define ITM_TCR_BUSY_Pos                   23U                                            /*!< ITM TCR: BUSY Position */
+#define ITM_TCR_BUSY_Msk                   (1UL << ITM_TCR_BUSY_Pos)                      /*!< ITM TCR: BUSY Mask */
+
+#define ITM_TCR_TRACEBUSID_Pos             16U                                            /*!< ITM TCR: ATBID Position */
+#define ITM_TCR_TRACEBUSID_Msk             (0x7FUL << ITM_TCR_TRACEBUSID_Pos)             /*!< ITM TCR: ATBID Mask */
+
+#define ITM_TCR_GTSFREQ_Pos                10U                                            /*!< ITM TCR: Global timestamp frequency Position */
+#define ITM_TCR_GTSFREQ_Msk                (3UL << ITM_TCR_GTSFREQ_Pos)                   /*!< ITM TCR: Global timestamp frequency Mask */
+
+#define ITM_TCR_TSPRESCALE_Pos              8U                                            /*!< ITM TCR: TSPRESCALE Position */
+#define ITM_TCR_TSPRESCALE_Msk             (3UL << ITM_TCR_TSPRESCALE_Pos)                /*!< ITM TCR: TSPRESCALE Mask */
+
+#define ITM_TCR_STALLENA_Pos                5U                                            /*!< ITM TCR: STALLENA Position */
+#define ITM_TCR_STALLENA_Msk               (1UL << ITM_TCR_STALLENA_Pos)                  /*!< ITM TCR: STALLENA Mask */
+
+#define ITM_TCR_SWOENA_Pos                  4U                                            /*!< ITM TCR: SWOENA Position */
+#define ITM_TCR_SWOENA_Msk                 (1UL << ITM_TCR_SWOENA_Pos)                    /*!< ITM TCR: SWOENA Mask */
+
+#define ITM_TCR_DWTENA_Pos                  3U                                            /*!< ITM TCR: DWTENA Position */
+#define ITM_TCR_DWTENA_Msk                 (1UL << ITM_TCR_DWTENA_Pos)                    /*!< ITM TCR: DWTENA Mask */
+
+#define ITM_TCR_SYNCENA_Pos                 2U                                            /*!< ITM TCR: SYNCENA Position */
+#define ITM_TCR_SYNCENA_Msk                (1UL << ITM_TCR_SYNCENA_Pos)                   /*!< ITM TCR: SYNCENA Mask */
+
+#define ITM_TCR_TSENA_Pos                   1U                                            /*!< ITM TCR: TSENA Position */
+#define ITM_TCR_TSENA_Msk                  (1UL << ITM_TCR_TSENA_Pos)                     /*!< ITM TCR: TSENA Mask */
+
+#define ITM_TCR_ITMENA_Pos                  0U                                            /*!< ITM TCR: ITM Enable bit Position */
+#define ITM_TCR_ITMENA_Msk                 (1UL /*<< ITM_TCR_ITMENA_Pos*/)                /*!< ITM TCR: ITM Enable bit Mask */
+
+/** \brief ITM Lock Status Register Definitions */
+#define ITM_LSR_ByteAcc_Pos                 2U                                            /*!< ITM LSR: ByteAcc Position */
+#define ITM_LSR_ByteAcc_Msk                (1UL << ITM_LSR_ByteAcc_Pos)                   /*!< ITM LSR: ByteAcc Mask */
+
+#define ITM_LSR_Access_Pos                  1U                                            /*!< ITM LSR: Access Position */
+#define ITM_LSR_Access_Msk                 (1UL << ITM_LSR_Access_Pos)                    /*!< ITM LSR: Access Mask */
+
+#define ITM_LSR_Present_Pos                 0U                                            /*!< ITM LSR: Present Position */
+#define ITM_LSR_Present_Msk                (1UL /*<< ITM_LSR_Present_Pos*/)               /*!< ITM LSR: Present Mask */
+
+/*@}*/ /* end of group CMSIS_ITM */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_DWT     Data Watchpoint and Trace (DWT)
+  \brief    Type definitions for the Data Watchpoint and Trace (DWT)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Data Watchpoint and Trace Register (DWT).
+ */
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  Control Register */
+  __IOM uint32_t CYCCNT;                 /*!< Offset: 0x004 (R/W)  Cycle Count Register */
+  __IOM uint32_t CPICNT;                 /*!< Offset: 0x008 (R/W)  CPI Count Register */
+  __IOM uint32_t EXCCNT;                 /*!< Offset: 0x00C (R/W)  Exception Overhead Count Register */
+  __IOM uint32_t SLEEPCNT;               /*!< Offset: 0x010 (R/W)  Sleep Count Register */
+  __IOM uint32_t LSUCNT;                 /*!< Offset: 0x014 (R/W)  LSU Count Register */
+  __IOM uint32_t FOLDCNT;                /*!< Offset: 0x018 (R/W)  Folded-instruction Count Register */
+  __IM  uint32_t PCSR;                   /*!< Offset: 0x01C (R/ )  Program Counter Sample Register */
+  __IOM uint32_t COMP0;                  /*!< Offset: 0x020 (R/W)  Comparator Register 0 */
+        uint32_t RESERVED1[1U];
+  __IOM uint32_t FUNCTION0;              /*!< Offset: 0x028 (R/W)  Function Register 0 */
+        uint32_t RESERVED2[1U];
+  __IOM uint32_t COMP1;                  /*!< Offset: 0x030 (R/W)  Comparator Register 1 */
+        uint32_t RESERVED3[1U];
+  __IOM uint32_t FUNCTION1;              /*!< Offset: 0x038 (R/W)  Function Register 1 */
+        uint32_t RESERVED4[1U];
+  __IOM uint32_t COMP2;                  /*!< Offset: 0x040 (R/W)  Comparator Register 2 */
+        uint32_t RESERVED5[1U];
+  __IOM uint32_t FUNCTION2;              /*!< Offset: 0x048 (R/W)  Function Register 2 */
+        uint32_t RESERVED6[1U];
+  __IOM uint32_t COMP3;                  /*!< Offset: 0x050 (R/W)  Comparator Register 3 */
+        uint32_t RESERVED7[1U];
+  __IOM uint32_t FUNCTION3;              /*!< Offset: 0x058 (R/W)  Function Register 3 */
+        uint32_t RESERVED8[1U];
+  __IOM uint32_t COMP4;                  /*!< Offset: 0x060 (R/W)  Comparator Register 4 */
+        uint32_t RESERVED9[1U];
+  __IOM uint32_t FUNCTION4;              /*!< Offset: 0x068 (R/W)  Function Register 4 */
+        uint32_t RESERVED10[1U];
+  __IOM uint32_t COMP5;                  /*!< Offset: 0x070 (R/W)  Comparator Register 5 */
+        uint32_t RESERVED11[1U];
+  __IOM uint32_t FUNCTION5;              /*!< Offset: 0x078 (R/W)  Function Register 5 */
+        uint32_t RESERVED12[1U];
+  __IOM uint32_t COMP6;                  /*!< Offset: 0x080 (R/W)  Comparator Register 6 */
+        uint32_t RESERVED13[1U];
+  __IOM uint32_t FUNCTION6;              /*!< Offset: 0x088 (R/W)  Function Register 6 */
+        uint32_t RESERVED14[1U];
+  __IOM uint32_t COMP7;                  /*!< Offset: 0x090 (R/W)  Comparator Register 7 */
+        uint32_t RESERVED15[1U];
+  __IOM uint32_t FUNCTION7;              /*!< Offset: 0x098 (R/W)  Function Register 7 */
+        uint32_t RESERVED16[1U];
+  __IOM uint32_t COMP8;                  /*!< Offset: 0x0A0 (R/W)  Comparator Register 8 */
+        uint32_t RESERVED17[1U];
+  __IOM uint32_t FUNCTION8;              /*!< Offset: 0x0A8 (R/W)  Function Register 8 */
+        uint32_t RESERVED18[1U];
+  __IOM uint32_t COMP9;                  /*!< Offset: 0x0B0 (R/W)  Comparator Register 9 */
+        uint32_t RESERVED19[1U];
+  __IOM uint32_t FUNCTION9;              /*!< Offset: 0x0B8 (R/W)  Function Register 9 */
+        uint32_t RESERVED20[1U];
+  __IOM uint32_t COMP10;                 /*!< Offset: 0x0C0 (R/W)  Comparator Register 10 */
+        uint32_t RESERVED21[1U];
+  __IOM uint32_t FUNCTION10;             /*!< Offset: 0x0C8 (R/W)  Function Register 10 */
+        uint32_t RESERVED22[1U];
+  __IOM uint32_t COMP11;                 /*!< Offset: 0x0D0 (R/W)  Comparator Register 11 */
+        uint32_t RESERVED23[1U];
+  __IOM uint32_t FUNCTION11;             /*!< Offset: 0x0D8 (R/W)  Function Register 11 */
+        uint32_t RESERVED24[1U];
+  __IOM uint32_t COMP12;                 /*!< Offset: 0x0E0 (R/W)  Comparator Register 12 */
+        uint32_t RESERVED25[1U];
+  __IOM uint32_t FUNCTION12;             /*!< Offset: 0x0E8 (R/W)  Function Register 12 */
+        uint32_t RESERVED26[1U];
+  __IOM uint32_t COMP13;                 /*!< Offset: 0x0F0 (R/W)  Comparator Register 13 */
+        uint32_t RESERVED27[1U];
+  __IOM uint32_t FUNCTION13;             /*!< Offset: 0x0F8 (R/W)  Function Register 13 */
+        uint32_t RESERVED28[1U];
+  __IOM uint32_t COMP14;                 /*!< Offset: 0x100 (R/W)  Comparator Register 14 */
+        uint32_t RESERVED29[1U];
+  __IOM uint32_t FUNCTION14;             /*!< Offset: 0x108 (R/W)  Function Register 14 */
+        uint32_t RESERVED30[1U];
+  __IOM uint32_t COMP15;                 /*!< Offset: 0x110 (R/W)  Comparator Register 15 */
+        uint32_t RESERVED31[1U];
+  __IOM uint32_t FUNCTION15;             /*!< Offset: 0x118 (R/W)  Function Register 15 */
+        uint32_t RESERVED32[934U];
+  __IM  uint32_t LSR;                    /*!< Offset: 0xFB4 (R  )  Lock Status Register */
+        uint32_t RESERVED33[1U];
+  __IM  uint32_t DEVARCH;                /*!< Offset: 0xFBC (R/ )  Device Architecture Register */
+} DWT_Type;
+
+/** \brief DWT Control Register Definitions */
+#define DWT_CTRL_NUMCOMP_Pos               28U                                         /*!< DWT CTRL: NUMCOMP Position */
+#define DWT_CTRL_NUMCOMP_Msk               (0xFUL << DWT_CTRL_NUMCOMP_Pos)             /*!< DWT CTRL: NUMCOMP Mask */
+
+#define DWT_CTRL_NOTRCPKT_Pos              27U                                         /*!< DWT CTRL: NOTRCPKT Position */
+#define DWT_CTRL_NOTRCPKT_Msk              (1UL << DWT_CTRL_NOTRCPKT_Pos)              /*!< DWT CTRL: NOTRCPKT Mask */
+
+#define DWT_CTRL_NOEXTTRIG_Pos             26U                                         /*!< DWT CTRL: NOEXTTRIG Position */
+#define DWT_CTRL_NOEXTTRIG_Msk             (1UL << DWT_CTRL_NOEXTTRIG_Pos)             /*!< DWT CTRL: NOEXTTRIG Mask */
+
+#define DWT_CTRL_NOCYCCNT_Pos              25U                                         /*!< DWT CTRL: NOCYCCNT Position */
+#define DWT_CTRL_NOCYCCNT_Msk              (1UL << DWT_CTRL_NOCYCCNT_Pos)              /*!< DWT CTRL: NOCYCCNT Mask */
+
+#define DWT_CTRL_NOPRFCNT_Pos              24U                                         /*!< DWT CTRL: NOPRFCNT Position */
+#define DWT_CTRL_NOPRFCNT_Msk              (1UL << DWT_CTRL_NOPRFCNT_Pos)              /*!< DWT CTRL: NOPRFCNT Mask */
+
+#define DWT_CTRL_CYCDISS_Pos               23U                                         /*!< DWT CTRL: CYCDISS Position */
+#define DWT_CTRL_CYCDISS_Msk               (1UL << DWT_CTRL_CYCDISS_Pos)               /*!< DWT CTRL: CYCDISS Mask */
+
+#define DWT_CTRL_CYCEVTENA_Pos             22U                                         /*!< DWT CTRL: CYCEVTENA Position */
+#define DWT_CTRL_CYCEVTENA_Msk             (1UL << DWT_CTRL_CYCEVTENA_Pos)             /*!< DWT CTRL: CYCEVTENA Mask */
+
+#define DWT_CTRL_FOLDEVTENA_Pos            21U                                         /*!< DWT CTRL: FOLDEVTENA Position */
+#define DWT_CTRL_FOLDEVTENA_Msk            (1UL << DWT_CTRL_FOLDEVTENA_Pos)            /*!< DWT CTRL: FOLDEVTENA Mask */
+
+#define DWT_CTRL_LSUEVTENA_Pos             20U                                         /*!< DWT CTRL: LSUEVTENA Position */
+#define DWT_CTRL_LSUEVTENA_Msk             (1UL << DWT_CTRL_LSUEVTENA_Pos)             /*!< DWT CTRL: LSUEVTENA Mask */
+
+#define DWT_CTRL_SLEEPEVTENA_Pos           19U                                         /*!< DWT CTRL: SLEEPEVTENA Position */
+#define DWT_CTRL_SLEEPEVTENA_Msk           (1UL << DWT_CTRL_SLEEPEVTENA_Pos)           /*!< DWT CTRL: SLEEPEVTENA Mask */
+
+#define DWT_CTRL_EXCEVTENA_Pos             18U                                         /*!< DWT CTRL: EXCEVTENA Position */
+#define DWT_CTRL_EXCEVTENA_Msk             (1UL << DWT_CTRL_EXCEVTENA_Pos)             /*!< DWT CTRL: EXCEVTENA Mask */
+
+#define DWT_CTRL_CPIEVTENA_Pos             17U                                         /*!< DWT CTRL: CPIEVTENA Position */
+#define DWT_CTRL_CPIEVTENA_Msk             (1UL << DWT_CTRL_CPIEVTENA_Pos)             /*!< DWT CTRL: CPIEVTENA Mask */
+
+#define DWT_CTRL_EXCTRCENA_Pos             16U                                         /*!< DWT CTRL: EXCTRCENA Position */
+#define DWT_CTRL_EXCTRCENA_Msk             (1UL << DWT_CTRL_EXCTRCENA_Pos)             /*!< DWT CTRL: EXCTRCENA Mask */
+
+#define DWT_CTRL_PCSAMPLENA_Pos            12U                                         /*!< DWT CTRL: PCSAMPLENA Position */
+#define DWT_CTRL_PCSAMPLENA_Msk            (1UL << DWT_CTRL_PCSAMPLENA_Pos)            /*!< DWT CTRL: PCSAMPLENA Mask */
+
+#define DWT_CTRL_SYNCTAP_Pos               10U                                         /*!< DWT CTRL: SYNCTAP Position */
+#define DWT_CTRL_SYNCTAP_Msk               (0x3UL << DWT_CTRL_SYNCTAP_Pos)             /*!< DWT CTRL: SYNCTAP Mask */
+
+#define DWT_CTRL_CYCTAP_Pos                 9U                                         /*!< DWT CTRL: CYCTAP Position */
+#define DWT_CTRL_CYCTAP_Msk                (1UL << DWT_CTRL_CYCTAP_Pos)                /*!< DWT CTRL: CYCTAP Mask */
+
+#define DWT_CTRL_POSTINIT_Pos               5U                                         /*!< DWT CTRL: POSTINIT Position */
+#define DWT_CTRL_POSTINIT_Msk              (0xFUL << DWT_CTRL_POSTINIT_Pos)            /*!< DWT CTRL: POSTINIT Mask */
+
+#define DWT_CTRL_POSTPRESET_Pos             1U                                         /*!< DWT CTRL: POSTPRESET Position */
+#define DWT_CTRL_POSTPRESET_Msk            (0xFUL << DWT_CTRL_POSTPRESET_Pos)          /*!< DWT CTRL: POSTPRESET Mask */
+
+#define DWT_CTRL_CYCCNTENA_Pos              0U                                         /*!< DWT CTRL: CYCCNTENA Position */
+#define DWT_CTRL_CYCCNTENA_Msk             (1UL /*<< DWT_CTRL_CYCCNTENA_Pos*/)         /*!< DWT CTRL: CYCCNTENA Mask */
+
+/** \brief DWT CPI Count Register Definitions */
+#define DWT_CPICNT_CPICNT_Pos               0U                                         /*!< DWT CPICNT: CPICNT Position */
+#define DWT_CPICNT_CPICNT_Msk              (0xFFUL /*<< DWT_CPICNT_CPICNT_Pos*/)       /*!< DWT CPICNT: CPICNT Mask */
+
+/** \brief DWT Exception Overhead Count Register Definitions */
+#define DWT_EXCCNT_EXCCNT_Pos               0U                                         /*!< DWT EXCCNT: EXCCNT Position */
+#define DWT_EXCCNT_EXCCNT_Msk              (0xFFUL /*<< DWT_EXCCNT_EXCCNT_Pos*/)       /*!< DWT EXCCNT: EXCCNT Mask */
+
+/** \brief DWT Sleep Count Register Definitions */
+#define DWT_SLEEPCNT_SLEEPCNT_Pos           0U                                         /*!< DWT SLEEPCNT: SLEEPCNT Position */
+#define DWT_SLEEPCNT_SLEEPCNT_Msk          (0xFFUL /*<< DWT_SLEEPCNT_SLEEPCNT_Pos*/)   /*!< DWT SLEEPCNT: SLEEPCNT Mask */
+
+/** \brief DWT LSU Count Register Definitions */
+#define DWT_LSUCNT_LSUCNT_Pos               0U                                         /*!< DWT LSUCNT: LSUCNT Position */
+#define DWT_LSUCNT_LSUCNT_Msk              (0xFFUL /*<< DWT_LSUCNT_LSUCNT_Pos*/)       /*!< DWT LSUCNT: LSUCNT Mask */
+
+/** \brief DWT Folded-instruction Count Register Definitions */
+#define DWT_FOLDCNT_FOLDCNT_Pos             0U                                         /*!< DWT FOLDCNT: FOLDCNT Position */
+#define DWT_FOLDCNT_FOLDCNT_Msk            (0xFFUL /*<< DWT_FOLDCNT_FOLDCNT_Pos*/)     /*!< DWT FOLDCNT: FOLDCNT Mask */
+
+/** \brief DWT Comparator Function Register Definitions */
+#define DWT_FUNCTION_ID_Pos                27U                                         /*!< DWT FUNCTION: ID Position */
+#define DWT_FUNCTION_ID_Msk                (0x1FUL << DWT_FUNCTION_ID_Pos)             /*!< DWT FUNCTION: ID Mask */
+
+#define DWT_FUNCTION_MATCHED_Pos           24U                                         /*!< DWT FUNCTION: MATCHED Position */
+#define DWT_FUNCTION_MATCHED_Msk           (1UL << DWT_FUNCTION_MATCHED_Pos)           /*!< DWT FUNCTION: MATCHED Mask */
+
+#define DWT_FUNCTION_DATAVSIZE_Pos         10U                                         /*!< DWT FUNCTION: DATAVSIZE Position */
+#define DWT_FUNCTION_DATAVSIZE_Msk         (0x3UL << DWT_FUNCTION_DATAVSIZE_Pos)       /*!< DWT FUNCTION: DATAVSIZE Mask */
+
+#define DWT_FUNCTION_ACTION_Pos             4U                                         /*!< DWT FUNCTION: ACTION Position */
+#define DWT_FUNCTION_ACTION_Msk            (1UL << DWT_FUNCTION_ACTION_Pos)            /*!< DWT FUNCTION: ACTION Mask */
+
+#define DWT_FUNCTION_MATCH_Pos              0U                                         /*!< DWT FUNCTION: MATCH Position */
+#define DWT_FUNCTION_MATCH_Msk             (0xFUL /*<< DWT_FUNCTION_MATCH_Pos*/)       /*!< DWT FUNCTION: MATCH Mask */
+
+/*@}*/ /* end of group CMSIS_DWT */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_TPIU     Trace Port Interface Unit (TPIU)
+  \brief    Type definitions for the Trace Port Interface Unit (TPIU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Trace Port Interface Unit Register (TPIU).
+ */
+typedef struct
+{
+  __IM  uint32_t SSPSR;                  /*!< Offset: 0x000 (R/ )  Supported Parallel Port Size Register */
+  __IOM uint32_t CSPSR;                  /*!< Offset: 0x004 (R/W)  Current Parallel Port Size Register */
+        uint32_t RESERVED0[2U];
+  __IOM uint32_t ACPR;                   /*!< Offset: 0x010 (R/W)  Asynchronous Clock Prescaler Register */
+        uint32_t RESERVED1[55U];
+  __IOM uint32_t SPPR;                   /*!< Offset: 0x0F0 (R/W)  Selected Pin Protocol Register */
+        uint32_t RESERVED2[131U];
+  __IM  uint32_t FFSR;                   /*!< Offset: 0x300 (R/ )  Formatter and Flush Status Register */
+  __IOM uint32_t FFCR;                   /*!< Offset: 0x304 (R/W)  Formatter and Flush Control Register */
+  __IOM uint32_t PSCR;                   /*!< Offset: 0x308 (R/W)  Periodic Synchronization Control Register */
+        uint32_t RESERVED3[759U];
+  __IM  uint32_t TRIGGER;                /*!< Offset: 0xEE8 (R/ )  TRIGGER Register */
+  __IM  uint32_t ITFTTD0;                /*!< Offset: 0xEEC (R/ )  Integration Test FIFO Test Data 0 Register */
+  __IOM uint32_t ITATBCTR2;              /*!< Offset: 0xEF0 (R/W)  Integration Test ATB Control Register 2 */
+        uint32_t RESERVED4[1U];
+  __IM  uint32_t ITATBCTR0;              /*!< Offset: 0xEF8 (R/ )  Integration Test ATB Control Register 0 */
+  __IM  uint32_t ITFTTD1;                /*!< Offset: 0xEFC (R/ )  Integration Test FIFO Test Data 1 Register */
+  __IOM uint32_t ITCTRL;                 /*!< Offset: 0xF00 (R/W)  Integration Mode Control */
+        uint32_t RESERVED5[39U];
+  __IOM uint32_t CLAIMSET;               /*!< Offset: 0xFA0 (R/W)  Claim tag set */
+  __IOM uint32_t CLAIMCLR;               /*!< Offset: 0xFA4 (R/W)  Claim tag clear */
+        uint32_t RESERVED7[8U];
+  __IM  uint32_t DEVID;                  /*!< Offset: 0xFC8 (R/ )  Device Configuration Register */
+  __IM  uint32_t DEVTYPE;                /*!< Offset: 0xFCC (R/ )  Device Type Identifier Register */
+} TPIU_Type;
+
+/** \brief TPIU Asynchronous Clock Prescaler Register Definitions */
+#define TPIU_ACPR_PRESCALER_Pos             0U                                         /*!< TPIU ACPR: PRESCALER Position */
+#define TPIU_ACPR_PRESCALER_Msk            (0x1FFFUL /*<< TPIU_ACPR_PRESCALER_Pos*/)   /*!< TPIU ACPR: PRESCALER Mask */
+
+/** \brief TPIU Selected Pin Protocol Register Definitions */
+#define TPIU_SPPR_TXMODE_Pos                0U                                         /*!< TPIU SPPR: TXMODE Position */
+#define TPIU_SPPR_TXMODE_Msk               (0x3UL /*<< TPIU_SPPR_TXMODE_Pos*/)         /*!< TPIU SPPR: TXMODE Mask */
+
+/** \brief TPIU Formatter and Flush Status Register Definitions */
+#define TPIU_FFSR_FtNonStop_Pos             3U                                         /*!< TPIU FFSR: FtNonStop Position */
+#define TPIU_FFSR_FtNonStop_Msk            (1UL << TPIU_FFSR_FtNonStop_Pos)            /*!< TPIU FFSR: FtNonStop Mask */
+
+#define TPIU_FFSR_TCPresent_Pos             2U                                         /*!< TPIU FFSR: TCPresent Position */
+#define TPIU_FFSR_TCPresent_Msk            (1UL << TPIU_FFSR_TCPresent_Pos)            /*!< TPIU FFSR: TCPresent Mask */
+
+#define TPIU_FFSR_FtStopped_Pos             1U                                         /*!< TPIU FFSR: FtStopped Position */
+#define TPIU_FFSR_FtStopped_Msk            (1UL << TPIU_FFSR_FtStopped_Pos)            /*!< TPIU FFSR: FtStopped Mask */
+
+#define TPIU_FFSR_FlInProg_Pos              0U                                         /*!< TPIU FFSR: FlInProg Position */
+#define TPIU_FFSR_FlInProg_Msk             (1UL /*<< TPIU_FFSR_FlInProg_Pos*/)         /*!< TPIU FFSR: FlInProg Mask */
+
+/** \brief TPIU Formatter and Flush Control Register Definitions */
+#define TPIU_FFCR_TrigIn_Pos                8U                                         /*!< TPIU FFCR: TrigIn Position */
+#define TPIU_FFCR_TrigIn_Msk               (1UL << TPIU_FFCR_TrigIn_Pos)               /*!< TPIU FFCR: TrigIn Mask */
+
+#define TPIU_FFCR_FOnMan_Pos                6U                                         /*!< TPIU FFCR: FOnMan Position */
+#define TPIU_FFCR_FOnMan_Msk               (1UL << TPIU_FFCR_FOnMan_Pos)               /*!< TPIU FFCR: FOnMan Mask */
+
+#define TPIU_FFCR_EnFCont_Pos               1U                                         /*!< TPIU FFCR: EnFCont Position */
+#define TPIU_FFCR_EnFCont_Msk              (1UL << TPIU_FFCR_EnFCont_Pos)              /*!< TPIU FFCR: EnFCont Mask */
+
+/** \brief TPIU Periodic Synchronization Control Register Definitions */
+#define TPIU_PSCR_PSCount_Pos               0U                                         /*!< TPIU PSCR: PSCount Position */
+#define TPIU_PSCR_PSCount_Msk              (0x1FUL /*<< TPIU_PSCR_PSCount_Pos*/)       /*!< TPIU PSCR: TPSCount Mask */
+
+/** \brief TPIU TRIGGER Register Definitions */
+#define TPIU_TRIGGER_TRIGGER_Pos            0U                                         /*!< TPIU TRIGGER: TRIGGER Position */
+#define TPIU_TRIGGER_TRIGGER_Msk           (1UL /*<< TPIU_TRIGGER_TRIGGER_Pos*/)       /*!< TPIU TRIGGER: TRIGGER Mask */
+
+/** \brief TPIU Integration Test FIFO Test Data 0 Register Definitions */
+#define TPIU_ITFTTD0_ATB_IF2_ATVALID_Pos   29U                                         /*!< TPIU ITFTTD0: ATB Interface 2 ATVALIDPosition */
+#define TPIU_ITFTTD0_ATB_IF2_ATVALID_Msk   (0x3UL << TPIU_ITFTTD0_ATB_IF2_ATVALID_Pos) /*!< TPIU ITFTTD0: ATB Interface 2 ATVALID Mask */
+
+#define TPIU_ITFTTD0_ATB_IF2_bytecount_Pos 27U                                         /*!< TPIU ITFTTD0: ATB Interface 2 byte count Position */
+#define TPIU_ITFTTD0_ATB_IF2_bytecount_Msk (0x3UL << TPIU_ITFTTD0_ATB_IF2_bytecount_Pos) /*!< TPIU ITFTTD0: ATB Interface 2 byte count Mask */
+
+#define TPIU_ITFTTD0_ATB_IF1_ATVALID_Pos   26U                                         /*!< TPIU ITFTTD0: ATB Interface 1 ATVALID Position */
+#define TPIU_ITFTTD0_ATB_IF1_ATVALID_Msk   (0x3UL << TPIU_ITFTTD0_ATB_IF1_ATVALID_Pos) /*!< TPIU ITFTTD0: ATB Interface 1 ATVALID Mask */
+
+#define TPIU_ITFTTD0_ATB_IF1_bytecount_Pos 24U                                         /*!< TPIU ITFTTD0: ATB Interface 1 byte count Position */
+#define TPIU_ITFTTD0_ATB_IF1_bytecount_Msk (0x3UL << TPIU_ITFTTD0_ATB_IF1_bytecount_Pos) /*!< TPIU ITFTTD0: ATB Interface 1 byte countt Mask */
+
+#define TPIU_ITFTTD0_ATB_IF1_data2_Pos     16U                                         /*!< TPIU ITFTTD0: ATB Interface 1 data2 Position */
+#define TPIU_ITFTTD0_ATB_IF1_data2_Msk     (0xFFUL << TPIU_ITFTTD0_ATB_IF1_data1_Pos)  /*!< TPIU ITFTTD0: ATB Interface 1 data2 Mask */
+
+#define TPIU_ITFTTD0_ATB_IF1_data1_Pos      8U                                         /*!< TPIU ITFTTD0: ATB Interface 1 data1 Position */
+#define TPIU_ITFTTD0_ATB_IF1_data1_Msk     (0xFFUL << TPIU_ITFTTD0_ATB_IF1_data1_Pos)  /*!< TPIU ITFTTD0: ATB Interface 1 data1 Mask */
+
+#define TPIU_ITFTTD0_ATB_IF1_data0_Pos      0U                                         /*!< TPIU ITFTTD0: ATB Interface 1 data0 Position */
+#define TPIU_ITFTTD0_ATB_IF1_data0_Msk     (0xFFUL /*<< TPIU_ITFTTD0_ATB_IF1_data0_Pos*/) /*!< TPIU ITFTTD0: ATB Interface 1 data0 Mask */
+
+/** \brief TPIU Integration Test ATB Control Register 2 Register Definitions */
+#define TPIU_ITATBCTR2_AFVALID2S_Pos        1U                                         /*!< TPIU ITATBCTR2: AFVALID2S Position */
+#define TPIU_ITATBCTR2_AFVALID2S_Msk       (1UL << TPIU_ITATBCTR2_AFVALID2S_Pos)       /*!< TPIU ITATBCTR2: AFVALID2SS Mask */
+
+#define TPIU_ITATBCTR2_AFVALID1S_Pos        1U                                         /*!< TPIU ITATBCTR2: AFVALID1S Position */
+#define TPIU_ITATBCTR2_AFVALID1S_Msk       (1UL << TPIU_ITATBCTR2_AFVALID1S_Pos)       /*!< TPIU ITATBCTR2: AFVALID1SS Mask */
+
+#define TPIU_ITATBCTR2_ATREADY2S_Pos        0U                                         /*!< TPIU ITATBCTR2: ATREADY2S Position */
+#define TPIU_ITATBCTR2_ATREADY2S_Msk       (1UL /*<< TPIU_ITATBCTR2_ATREADY2S_Pos*/)   /*!< TPIU ITATBCTR2: ATREADY2S Mask */
+
+#define TPIU_ITATBCTR2_ATREADY1S_Pos        0U                                         /*!< TPIU ITATBCTR2: ATREADY1S Position */
+#define TPIU_ITATBCTR2_ATREADY1S_Msk       (1UL /*<< TPIU_ITATBCTR2_ATREADY1S_Pos*/)   /*!< TPIU ITATBCTR2: ATREADY1S Mask */
+
+/** \brief TPIU Integration Test FIFO Test Data 1 Register Definitions */
+#define TPIU_ITFTTD1_ATB_IF2_ATVALID_Pos   29U                                         /*!< TPIU ITFTTD1: ATB Interface 2 ATVALID Position */
+#define TPIU_ITFTTD1_ATB_IF2_ATVALID_Msk   (0x3UL << TPIU_ITFTTD1_ATB_IF2_ATVALID_Pos) /*!< TPIU ITFTTD1: ATB Interface 2 ATVALID Mask */
+
+#define TPIU_ITFTTD1_ATB_IF2_bytecount_Pos 27U                                         /*!< TPIU ITFTTD1: ATB Interface 2 byte count Position */
+#define TPIU_ITFTTD1_ATB_IF2_bytecount_Msk (0x3UL << TPIU_ITFTTD1_ATB_IF2_bytecount_Pos) /*!< TPIU ITFTTD1: ATB Interface 2 byte count Mask */
+
+#define TPIU_ITFTTD1_ATB_IF1_ATVALID_Pos   26U                                         /*!< TPIU ITFTTD1: ATB Interface 1 ATVALID Position */
+#define TPIU_ITFTTD1_ATB_IF1_ATVALID_Msk   (0x3UL << TPIU_ITFTTD1_ATB_IF1_ATVALID_Pos) /*!< TPIU ITFTTD1: ATB Interface 1 ATVALID Mask */
+
+#define TPIU_ITFTTD1_ATB_IF1_bytecount_Pos 24U                                         /*!< TPIU ITFTTD1: ATB Interface 1 byte count Position */
+#define TPIU_ITFTTD1_ATB_IF1_bytecount_Msk (0x3UL << TPIU_ITFTTD1_ATB_IF1_bytecount_Pos) /*!< TPIU ITFTTD1: ATB Interface 1 byte countt Mask */
+
+#define TPIU_ITFTTD1_ATB_IF2_data2_Pos     16U                                         /*!< TPIU ITFTTD1: ATB Interface 2 data2 Position */
+#define TPIU_ITFTTD1_ATB_IF2_data2_Msk     (0xFFUL << TPIU_ITFTTD1_ATB_IF2_data1_Pos)  /*!< TPIU ITFTTD1: ATB Interface 2 data2 Mask */
+
+#define TPIU_ITFTTD1_ATB_IF2_data1_Pos      8U                                         /*!< TPIU ITFTTD1: ATB Interface 2 data1 Position */
+#define TPIU_ITFTTD1_ATB_IF2_data1_Msk     (0xFFUL << TPIU_ITFTTD1_ATB_IF2_data1_Pos)  /*!< TPIU ITFTTD1: ATB Interface 2 data1 Mask */
+
+#define TPIU_ITFTTD1_ATB_IF2_data0_Pos      0U                                         /*!< TPIU ITFTTD1: ATB Interface 2 data0 Position */
+#define TPIU_ITFTTD1_ATB_IF2_data0_Msk     (0xFFUL /*<< TPIU_ITFTTD1_ATB_IF2_data0_Pos*/) /*!< TPIU ITFTTD1: ATB Interface 2 data0 Mask */
+
+/** \brief TPIU Integration Test ATB Control Register 0 Definitions */
+#define TPIU_ITATBCTR0_AFVALID2S_Pos        1U                                         /*!< TPIU ITATBCTR0: AFVALID2S Position */
+#define TPIU_ITATBCTR0_AFVALID2S_Msk       (1UL << TPIU_ITATBCTR0_AFVALID2S_Pos)       /*!< TPIU ITATBCTR0: AFVALID2SS Mask */
+
+#define TPIU_ITATBCTR0_AFVALID1S_Pos        1U                                         /*!< TPIU ITATBCTR0: AFVALID1S Position */
+#define TPIU_ITATBCTR0_AFVALID1S_Msk       (1UL << TPIU_ITATBCTR0_AFVALID1S_Pos)       /*!< TPIU ITATBCTR0: AFVALID1SS Mask */
+
+#define TPIU_ITATBCTR0_ATREADY2S_Pos        0U                                         /*!< TPIU ITATBCTR0: ATREADY2S Position */
+#define TPIU_ITATBCTR0_ATREADY2S_Msk       (1UL /*<< TPIU_ITATBCTR0_ATREADY2S_Pos*/)   /*!< TPIU ITATBCTR0: ATREADY2S Mask */
+
+#define TPIU_ITATBCTR0_ATREADY1S_Pos        0U                                         /*!< TPIU ITATBCTR0: ATREADY1S Position */
+#define TPIU_ITATBCTR0_ATREADY1S_Msk       (1UL /*<< TPIU_ITATBCTR0_ATREADY1S_Pos*/)   /*!< TPIU ITATBCTR0: ATREADY1S Mask */
+
+/** \brief TPIU Integration Mode Control Register Definitions */
+#define TPIU_ITCTRL_Mode_Pos                0U                                         /*!< TPIU ITCTRL: Mode Position */
+#define TPIU_ITCTRL_Mode_Msk               (0x3UL /*<< TPIU_ITCTRL_Mode_Pos*/)         /*!< TPIU ITCTRL: Mode Mask */
+
+/** \brief TPIU DEVID Register Definitions */
+#define TPIU_DEVID_NRZVALID_Pos            11U                                         /*!< TPIU DEVID: NRZVALID Position */
+#define TPIU_DEVID_NRZVALID_Msk            (1UL << TPIU_DEVID_NRZVALID_Pos)            /*!< TPIU DEVID: NRZVALID Mask */
+
+#define TPIU_DEVID_MANCVALID_Pos           10U                                         /*!< TPIU DEVID: MANCVALID Position */
+#define TPIU_DEVID_MANCVALID_Msk           (1UL << TPIU_DEVID_MANCVALID_Pos)           /*!< TPIU DEVID: MANCVALID Mask */
+
+#define TPIU_DEVID_PTINVALID_Pos            9U                                         /*!< TPIU DEVID: PTINVALID Position */
+#define TPIU_DEVID_PTINVALID_Msk           (1UL << TPIU_DEVID_PTINVALID_Pos)           /*!< TPIU DEVID: PTINVALID Mask */
+
+#define TPIU_DEVID_FIFOSZ_Pos               6U                                         /*!< TPIU DEVID: FIFOSZ Position */
+#define TPIU_DEVID_FIFOSZ_Msk              (0x7UL << TPIU_DEVID_FIFOSZ_Pos)            /*!< TPIU DEVID: FIFOSZ Mask */
+
+#define TPIU_DEVID_NrTraceInput_Pos         0U                                         /*!< TPIU DEVID: NrTraceInput Position */
+#define TPIU_DEVID_NrTraceInput_Msk        (0x3FUL /*<< TPIU_DEVID_NrTraceInput_Pos*/) /*!< TPIU DEVID: NrTraceInput Mask */
+
+/** \brief TPIU DEVTYPE Register Definitions */
+#define TPIU_DEVTYPE_SubType_Pos            4U                                         /*!< TPIU DEVTYPE: SubType Position */
+#define TPIU_DEVTYPE_SubType_Msk           (0xFUL /*<< TPIU_DEVTYPE_SubType_Pos*/)     /*!< TPIU DEVTYPE: SubType Mask */
+
+#define TPIU_DEVTYPE_MajorType_Pos          0U                                         /*!< TPIU DEVTYPE: MajorType Position */
+#define TPIU_DEVTYPE_MajorType_Msk         (0xFUL << TPIU_DEVTYPE_MajorType_Pos)       /*!< TPIU DEVTYPE: MajorType Mask */
+
+/*@}*/ /* end of group CMSIS_TPIU */
+
+
+#if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_MPU     Memory Protection Unit (MPU)
+  \brief    Type definitions for the Memory Protection Unit (MPU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Memory Protection Unit (MPU).
+ */
+typedef struct
+{
+  __IM  uint32_t TYPE;                   /*!< Offset: 0x000 (R/ )  MPU Type Register */
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x004 (R/W)  MPU Control Register */
+  __IOM uint32_t RNR;                    /*!< Offset: 0x008 (R/W)  MPU Region Number Register */
+  __IOM uint32_t RBAR;                   /*!< Offset: 0x00C (R/W)  MPU Region Base Address Register */
+  __IOM uint32_t RLAR;                   /*!< Offset: 0x010 (R/W)  MPU Region Limit Address Register */
+  __IOM uint32_t RBAR_A1;                /*!< Offset: 0x014 (R/W)  MPU Region Base Address Register Alias 1 */
+  __IOM uint32_t RLAR_A1;                /*!< Offset: 0x018 (R/W)  MPU Region Limit Address Register Alias 1 */
+  __IOM uint32_t RBAR_A2;                /*!< Offset: 0x01C (R/W)  MPU Region Base Address Register Alias 2 */
+  __IOM uint32_t RLAR_A2;                /*!< Offset: 0x020 (R/W)  MPU Region Limit Address Register Alias 2 */
+  __IOM uint32_t RBAR_A3;                /*!< Offset: 0x024 (R/W)  MPU Region Base Address Register Alias 3 */
+  __IOM uint32_t RLAR_A3;                /*!< Offset: 0x028 (R/W)  MPU Region Limit Address Register Alias 3 */
+        uint32_t RESERVED0[1];
+  union {
+  __IOM uint32_t MAIR[2];
+  struct {
+  __IOM uint32_t MAIR0;                  /*!< Offset: 0x030 (R/W)  MPU Memory Attribute Indirection Register 0 */
+  __IOM uint32_t MAIR1;                  /*!< Offset: 0x034 (R/W)  MPU Memory Attribute Indirection Register 1 */
+  };
+  };
+} MPU_Type;
+
+#define MPU_TYPE_RALIASES                  4U
+
+/** \brief MPU Type Register Definitions */
+#define MPU_TYPE_IREGION_Pos               16U                                            /*!< MPU TYPE: IREGION Position */
+#define MPU_TYPE_IREGION_Msk               (0xFFUL << MPU_TYPE_IREGION_Pos)               /*!< MPU TYPE: IREGION Mask */
+
+#define MPU_TYPE_DREGION_Pos                8U                                            /*!< MPU TYPE: DREGION Position */
+#define MPU_TYPE_DREGION_Msk               (0xFFUL << MPU_TYPE_DREGION_Pos)               /*!< MPU TYPE: DREGION Mask */
+
+#define MPU_TYPE_SEPARATE_Pos               0U                                            /*!< MPU TYPE: SEPARATE Position */
+#define MPU_TYPE_SEPARATE_Msk              (1UL /*<< MPU_TYPE_SEPARATE_Pos*/)             /*!< MPU TYPE: SEPARATE Mask */
+
+/** \brief MPU Control Register Definitions */
+#define MPU_CTRL_PRIVDEFENA_Pos             2U                                            /*!< MPU CTRL: PRIVDEFENA Position */
+#define MPU_CTRL_PRIVDEFENA_Msk            (1UL << MPU_CTRL_PRIVDEFENA_Pos)               /*!< MPU CTRL: PRIVDEFENA Mask */
+
+#define MPU_CTRL_HFNMIENA_Pos               1U                                            /*!< MPU CTRL: HFNMIENA Position */
+#define MPU_CTRL_HFNMIENA_Msk              (1UL << MPU_CTRL_HFNMIENA_Pos)                 /*!< MPU CTRL: HFNMIENA Mask */
+
+#define MPU_CTRL_ENABLE_Pos                 0U                                            /*!< MPU CTRL: ENABLE Position */
+#define MPU_CTRL_ENABLE_Msk                (1UL /*<< MPU_CTRL_ENABLE_Pos*/)               /*!< MPU CTRL: ENABLE Mask */
+
+/** \brief MPU Region Number Register Definitions */
+#define MPU_RNR_REGION_Pos                  0U                                            /*!< MPU RNR: REGION Position */
+#define MPU_RNR_REGION_Msk                 (0xFFUL /*<< MPU_RNR_REGION_Pos*/)             /*!< MPU RNR: REGION Mask */
+
+/** \brief MPU Region Base Address Register Definitions */
+#define MPU_RBAR_BASE_Pos                   5U                                            /*!< MPU RBAR: BASE Position */
+#define MPU_RBAR_BASE_Msk                  (0x7FFFFFFUL << MPU_RBAR_BASE_Pos)             /*!< MPU RBAR: BASE Mask */
+
+#define MPU_RBAR_SH_Pos                     3U                                            /*!< MPU RBAR: SH Position */
+#define MPU_RBAR_SH_Msk                    (0x3UL << MPU_RBAR_SH_Pos)                     /*!< MPU RBAR: SH Mask */
+
+#define MPU_RBAR_AP_Pos                     1U                                            /*!< MPU RBAR: AP Position */
+#define MPU_RBAR_AP_Msk                    (0x3UL << MPU_RBAR_AP_Pos)                     /*!< MPU RBAR: AP Mask */
+
+#define MPU_RBAR_XN_Pos                     0U                                            /*!< MPU RBAR: XN Position */
+#define MPU_RBAR_XN_Msk                    (01UL /*<< MPU_RBAR_XN_Pos*/)                  /*!< MPU RBAR: XN Mask */
+
+/** \brief MPU Region Limit Address Register Definitions */
+#define MPU_RLAR_LIMIT_Pos                  5U                                            /*!< MPU RLAR: LIMIT Position */
+#define MPU_RLAR_LIMIT_Msk                 (0x7FFFFFFUL << MPU_RLAR_LIMIT_Pos)            /*!< MPU RLAR: LIMIT Mask */
+
+#define MPU_RLAR_AttrIndx_Pos               1U                                            /*!< MPU RLAR: AttrIndx Position */
+#define MPU_RLAR_AttrIndx_Msk              (0x7UL << MPU_RLAR_AttrIndx_Pos)               /*!< MPU RLAR: AttrIndx Mask */
+
+#define MPU_RLAR_EN_Pos                     0U                                            /*!< MPU RLAR: Region enable bit Position */
+#define MPU_RLAR_EN_Msk                    (1UL /*<< MPU_RLAR_EN_Pos*/)                   /*!< MPU RLAR: Region enable bit Mask */
+
+/** \brief MPU Memory Attribute Indirection Register 0 Definitions */
+#define MPU_MAIR0_Attr3_Pos                24U                                            /*!< MPU MAIR0: Attr3 Position */
+#define MPU_MAIR0_Attr3_Msk                (0xFFUL << MPU_MAIR0_Attr3_Pos)                /*!< MPU MAIR0: Attr3 Mask */
+
+#define MPU_MAIR0_Attr2_Pos                16U                                            /*!< MPU MAIR0: Attr2 Position */
+#define MPU_MAIR0_Attr2_Msk                (0xFFUL << MPU_MAIR0_Attr2_Pos)                /*!< MPU MAIR0: Attr2 Mask */
+
+#define MPU_MAIR0_Attr1_Pos                 8U                                            /*!< MPU MAIR0: Attr1 Position */
+#define MPU_MAIR0_Attr1_Msk                (0xFFUL << MPU_MAIR0_Attr1_Pos)                /*!< MPU MAIR0: Attr1 Mask */
+
+#define MPU_MAIR0_Attr0_Pos                 0U                                            /*!< MPU MAIR0: Attr0 Position */
+#define MPU_MAIR0_Attr0_Msk                (0xFFUL /*<< MPU_MAIR0_Attr0_Pos*/)            /*!< MPU MAIR0: Attr0 Mask */
+
+/** \brief MPU Memory Attribute Indirection Register 1 Definitions */
+#define MPU_MAIR1_Attr7_Pos                24U                                            /*!< MPU MAIR1: Attr7 Position */
+#define MPU_MAIR1_Attr7_Msk                (0xFFUL << MPU_MAIR1_Attr7_Pos)                /*!< MPU MAIR1: Attr7 Mask */
+
+#define MPU_MAIR1_Attr6_Pos                16U                                            /*!< MPU MAIR1: Attr6 Position */
+#define MPU_MAIR1_Attr6_Msk                (0xFFUL << MPU_MAIR1_Attr6_Pos)                /*!< MPU MAIR1: Attr6 Mask */
+
+#define MPU_MAIR1_Attr5_Pos                 8U                                            /*!< MPU MAIR1: Attr5 Position */
+#define MPU_MAIR1_Attr5_Msk                (0xFFUL << MPU_MAIR1_Attr5_Pos)                /*!< MPU MAIR1: Attr5 Mask */
+
+#define MPU_MAIR1_Attr4_Pos                 0U                                            /*!< MPU MAIR1: Attr4 Position */
+#define MPU_MAIR1_Attr4_Msk                (0xFFUL /*<< MPU_MAIR1_Attr4_Pos*/)            /*!< MPU MAIR1: Attr4 Mask */
+
+/*@} end of group CMSIS_MPU */
+#endif
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SAU     Security Attribution Unit (SAU)
+  \brief    Type definitions for the Security Attribution Unit (SAU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Security Attribution Unit (SAU).
+ */
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  SAU Control Register */
+  __IM  uint32_t TYPE;                   /*!< Offset: 0x004 (R/ )  SAU Type Register */
+#if defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U)
+  __IOM uint32_t RNR;                    /*!< Offset: 0x008 (R/W)  SAU Region Number Register */
+  __IOM uint32_t RBAR;                   /*!< Offset: 0x00C (R/W)  SAU Region Base Address Register */
+  __IOM uint32_t RLAR;                   /*!< Offset: 0x010 (R/W)  SAU Region Limit Address Register */
+#else
+        uint32_t RESERVED0[3];
+#endif
+  __IOM uint32_t SFSR;                   /*!< Offset: 0x014 (R/W)  Secure Fault Status Register */
+  __IOM uint32_t SFAR;                   /*!< Offset: 0x018 (R/W)  Secure Fault Address Register */
+} SAU_Type;
+
+/** \brief SAU Control Register Definitions */
+#define SAU_CTRL_ALLNS_Pos                  1U                                            /*!< SAU CTRL: ALLNS Position */
+#define SAU_CTRL_ALLNS_Msk                 (1UL << SAU_CTRL_ALLNS_Pos)                    /*!< SAU CTRL: ALLNS Mask */
+
+#define SAU_CTRL_ENABLE_Pos                 0U                                            /*!< SAU CTRL: ENABLE Position */
+#define SAU_CTRL_ENABLE_Msk                (1UL /*<< SAU_CTRL_ENABLE_Pos*/)               /*!< SAU CTRL: ENABLE Mask */
+
+/** \brief SAU Type Register Definitions */
+#define SAU_TYPE_SREGION_Pos                0U                                            /*!< SAU TYPE: SREGION Position */
+#define SAU_TYPE_SREGION_Msk               (0xFFUL /*<< SAU_TYPE_SREGION_Pos*/)           /*!< SAU TYPE: SREGION Mask */
+
+#if defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U)
+/** \brief SAU Region Number Register Definitions */
+#define SAU_RNR_REGION_Pos                  0U                                            /*!< SAU RNR: REGION Position */
+#define SAU_RNR_REGION_Msk                 (0xFFUL /*<< SAU_RNR_REGION_Pos*/)             /*!< SAU RNR: REGION Mask */
+
+/** \brief SAU Region Base Address Register Definitions */
+#define SAU_RBAR_BADDR_Pos                  5U                                            /*!< SAU RBAR: BADDR Position */
+#define SAU_RBAR_BADDR_Msk                 (0x7FFFFFFUL << SAU_RBAR_BADDR_Pos)            /*!< SAU RBAR: BADDR Mask */
+
+/** \brief SAU Region Limit Address Register Definitions */
+#define SAU_RLAR_LADDR_Pos                  5U                                            /*!< SAU RLAR: LADDR Position */
+#define SAU_RLAR_LADDR_Msk                 (0x7FFFFFFUL << SAU_RLAR_LADDR_Pos)            /*!< SAU RLAR: LADDR Mask */
+
+#define SAU_RLAR_NSC_Pos                    1U                                            /*!< SAU RLAR: NSC Position */
+#define SAU_RLAR_NSC_Msk                   (1UL << SAU_RLAR_NSC_Pos)                      /*!< SAU RLAR: NSC Mask */
+
+#define SAU_RLAR_ENABLE_Pos                 0U                                            /*!< SAU RLAR: ENABLE Position */
+#define SAU_RLAR_ENABLE_Msk                (1UL /*<< SAU_RLAR_ENABLE_Pos*/)               /*!< SAU RLAR: ENABLE Mask */
+
+#endif /* defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U) */
+
+/** \brief SAU Secure Fault Status Register Definitions */
+#define SAU_SFSR_LSERR_Pos                  7U                                            /*!< SAU SFSR: LSERR Position */
+#define SAU_SFSR_LSERR_Msk                 (1UL << SAU_SFSR_LSERR_Pos)                    /*!< SAU SFSR: LSERR Mask */
+
+#define SAU_SFSR_SFARVALID_Pos              6U                                            /*!< SAU SFSR: SFARVALID Position */
+#define SAU_SFSR_SFARVALID_Msk             (1UL << SAU_SFSR_SFARVALID_Pos)                /*!< SAU SFSR: SFARVALID Mask */
+
+#define SAU_SFSR_LSPERR_Pos                 5U                                            /*!< SAU SFSR: LSPERR Position */
+#define SAU_SFSR_LSPERR_Msk                (1UL << SAU_SFSR_LSPERR_Pos)                   /*!< SAU SFSR: LSPERR Mask */
+
+#define SAU_SFSR_INVTRAN_Pos                4U                                            /*!< SAU SFSR: INVTRAN Position */
+#define SAU_SFSR_INVTRAN_Msk               (1UL << SAU_SFSR_INVTRAN_Pos)                  /*!< SAU SFSR: INVTRAN Mask */
+
+#define SAU_SFSR_AUVIOL_Pos                 3U                                            /*!< SAU SFSR: AUVIOL Position */
+#define SAU_SFSR_AUVIOL_Msk                (1UL << SAU_SFSR_AUVIOL_Pos)                   /*!< SAU SFSR: AUVIOL Mask */
+
+#define SAU_SFSR_INVER_Pos                  2U                                            /*!< SAU SFSR: INVER Position */
+#define SAU_SFSR_INVER_Msk                 (1UL << SAU_SFSR_INVER_Pos)                    /*!< SAU SFSR: INVER Mask */
+
+#define SAU_SFSR_INVIS_Pos                  1U                                            /*!< SAU SFSR: INVIS Position */
+#define SAU_SFSR_INVIS_Msk                 (1UL << SAU_SFSR_INVIS_Pos)                    /*!< SAU SFSR: INVIS Mask */
+
+#define SAU_SFSR_INVEP_Pos                  0U                                            /*!< SAU SFSR: INVEP Position */
+#define SAU_SFSR_INVEP_Msk                 (1UL /*<< SAU_SFSR_INVEP_Pos*/)                /*!< SAU SFSR: INVEP Mask */
+
+/*@} end of group CMSIS_SAU */
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_FPU     Floating Point Unit (FPU)
+  \brief    Type definitions for the Floating Point Unit (FPU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Floating Point Unit (FPU).
+ */
+typedef struct
+{
+        uint32_t RESERVED0[1U];
+  __IOM uint32_t FPCCR;                  /*!< Offset: 0x004 (R/W)  Floating-Point Context Control Register */
+  __IOM uint32_t FPCAR;                  /*!< Offset: 0x008 (R/W)  Floating-Point Context Address Register */
+  __IOM uint32_t FPDSCR;                 /*!< Offset: 0x00C (R/W)  Floating-Point Default Status Control Register */
+  __IM  uint32_t MVFR0;                  /*!< Offset: 0x010 (R/ )  Media and VFP Feature Register 0 */
+  __IM  uint32_t MVFR1;                  /*!< Offset: 0x014 (R/ )  Media and VFP Feature Register 1 */
+  __IM  uint32_t MVFR2;                  /*!< Offset: 0x018 (R/ )  Media and VFP Feature Register 2 */
+} FPU_Type;
+
+/** \brief FPU Floating-Point Context Control Register Definitions */
+#define FPU_FPCCR_ASPEN_Pos                31U                                            /*!< FPCCR: ASPEN bit Position */
+#define FPU_FPCCR_ASPEN_Msk                (1UL << FPU_FPCCR_ASPEN_Pos)                   /*!< FPCCR: ASPEN bit Mask */
+
+#define FPU_FPCCR_LSPEN_Pos                30U                                            /*!< FPCCR: LSPEN Position */
+#define FPU_FPCCR_LSPEN_Msk                (1UL << FPU_FPCCR_LSPEN_Pos)                   /*!< FPCCR: LSPEN bit Mask */
+
+#define FPU_FPCCR_LSPENS_Pos               29U                                            /*!< FPCCR: LSPENS Position */
+#define FPU_FPCCR_LSPENS_Msk               (1UL << FPU_FPCCR_LSPENS_Pos)                  /*!< FPCCR: LSPENS bit Mask */
+
+#define FPU_FPCCR_CLRONRET_Pos             28U                                            /*!< FPCCR: CLRONRET Position */
+#define FPU_FPCCR_CLRONRET_Msk             (1UL << FPU_FPCCR_CLRONRET_Pos)                /*!< FPCCR: CLRONRET bit Mask */
+
+#define FPU_FPCCR_CLRONRETS_Pos            27U                                            /*!< FPCCR: CLRONRETS Position */
+#define FPU_FPCCR_CLRONRETS_Msk            (1UL << FPU_FPCCR_CLRONRETS_Pos)               /*!< FPCCR: CLRONRETS bit Mask */
+
+#define FPU_FPCCR_TS_Pos                   26U                                            /*!< FPCCR: TS Position */
+#define FPU_FPCCR_TS_Msk                   (1UL << FPU_FPCCR_TS_Pos)                      /*!< FPCCR: TS bit Mask */
+
+#define FPU_FPCCR_UFRDY_Pos                10U                                            /*!< FPCCR: UFRDY Position */
+#define FPU_FPCCR_UFRDY_Msk                (1UL << FPU_FPCCR_UFRDY_Pos)                   /*!< FPCCR: UFRDY bit Mask */
+
+#define FPU_FPCCR_SPLIMVIOL_Pos             9U                                            /*!< FPCCR: SPLIMVIOL Position */
+#define FPU_FPCCR_SPLIMVIOL_Msk            (1UL << FPU_FPCCR_SPLIMVIOL_Pos)               /*!< FPCCR: SPLIMVIOL bit Mask */
+
+#define FPU_FPCCR_MONRDY_Pos                8U                                            /*!< FPCCR: MONRDY Position */
+#define FPU_FPCCR_MONRDY_Msk               (1UL << FPU_FPCCR_MONRDY_Pos)                  /*!< FPCCR: MONRDY bit Mask */
+
+#define FPU_FPCCR_SFRDY_Pos                 7U                                            /*!< FPCCR: SFRDY Position */
+#define FPU_FPCCR_SFRDY_Msk                (1UL << FPU_FPCCR_SFRDY_Pos)                   /*!< FPCCR: SFRDY bit Mask */
+
+#define FPU_FPCCR_BFRDY_Pos                 6U                                            /*!< FPCCR: BFRDY Position */
+#define FPU_FPCCR_BFRDY_Msk                (1UL << FPU_FPCCR_BFRDY_Pos)                   /*!< FPCCR: BFRDY bit Mask */
+
+#define FPU_FPCCR_MMRDY_Pos                 5U                                            /*!< FPCCR: MMRDY Position */
+#define FPU_FPCCR_MMRDY_Msk                (1UL << FPU_FPCCR_MMRDY_Pos)                   /*!< FPCCR: MMRDY bit Mask */
+
+#define FPU_FPCCR_HFRDY_Pos                 4U                                            /*!< FPCCR: HFRDY Position */
+#define FPU_FPCCR_HFRDY_Msk                (1UL << FPU_FPCCR_HFRDY_Pos)                   /*!< FPCCR: HFRDY bit Mask */
+
+#define FPU_FPCCR_THREAD_Pos                3U                                            /*!< FPCCR: processor mode bit Position */
+#define FPU_FPCCR_THREAD_Msk               (1UL << FPU_FPCCR_THREAD_Pos)                  /*!< FPCCR: processor mode active bit Mask */
+
+#define FPU_FPCCR_S_Pos                     2U                                            /*!< FPCCR: Security status of the FP context bit Position */
+#define FPU_FPCCR_S_Msk                    (1UL << FPU_FPCCR_S_Pos)                       /*!< FPCCR: Security status of the FP context bit Mask */
+
+#define FPU_FPCCR_USER_Pos                  1U                                            /*!< FPCCR: privilege level bit Position */
+#define FPU_FPCCR_USER_Msk                 (1UL << FPU_FPCCR_USER_Pos)                    /*!< FPCCR: privilege level bit Mask */
+
+#define FPU_FPCCR_LSPACT_Pos                0U                                            /*!< FPCCR: Lazy state preservation active bit Position */
+#define FPU_FPCCR_LSPACT_Msk               (1UL /*<< FPU_FPCCR_LSPACT_Pos*/)              /*!< FPCCR: Lazy state preservation active bit Mask */
+
+/** \brief FPU Floating-Point Context Address Register Definitions */
+#define FPU_FPCAR_ADDRESS_Pos               3U                                            /*!< FPCAR: ADDRESS bit Position */
+#define FPU_FPCAR_ADDRESS_Msk              (0x1FFFFFFFUL << FPU_FPCAR_ADDRESS_Pos)        /*!< FPCAR: ADDRESS bit Mask */
+
+/** \brief FPU Floating-Point Default Status Control Register Definitions */
+#define FPU_FPDSCR_AHP_Pos                 26U                                            /*!< FPDSCR: AHP bit Position */
+#define FPU_FPDSCR_AHP_Msk                 (1UL << FPU_FPDSCR_AHP_Pos)                    /*!< FPDSCR: AHP bit Mask */
+
+#define FPU_FPDSCR_DN_Pos                  25U                                            /*!< FPDSCR: DN bit Position */
+#define FPU_FPDSCR_DN_Msk                  (1UL << FPU_FPDSCR_DN_Pos)                     /*!< FPDSCR: DN bit Mask */
+
+#define FPU_FPDSCR_FZ_Pos                  24U                                            /*!< FPDSCR: FZ bit Position */
+#define FPU_FPDSCR_FZ_Msk                  (1UL << FPU_FPDSCR_FZ_Pos)                     /*!< FPDSCR: FZ bit Mask */
+
+#define FPU_FPDSCR_RMode_Pos               22U                                            /*!< FPDSCR: RMode bit Position */
+#define FPU_FPDSCR_RMode_Msk               (3UL << FPU_FPDSCR_RMode_Pos)                  /*!< FPDSCR: RMode bit Mask */
+
+/** \brief FPU Media and VFP Feature Register 0 Definitions */
+#define FPU_MVFR0_FPRound_Pos              28U                                            /*!< MVFR0: Rounding modes bits Position */
+#define FPU_MVFR0_FPRound_Msk              (0xFUL << FPU_MVFR0_FPRound_Pos)               /*!< MVFR0: Rounding modes bits Mask */
+
+#define FPU_MVFR0_FPShortvec_Pos           24U                                            /*!< MVFR0: Short vectors bits Position */
+#define FPU_MVFR0_FPShortvec_Msk          (0xFUL << FPU_MVFR0_FPShortvec_Pos)             /*!< MVFR0: Short vectors bits Mask */
+
+#define FPU_MVFR0_FPSqrt_Pos               20U                                            /*!< MVFR0: Square root bits Position */
+#define FPU_MVFR0_FPSqrt_Msk               (0xFUL << FPU_MVFR0_FPSqrt_Pos)                /*!< MVFR0: Square root bits Mask */
+
+#define FPU_MVFR0_FPDivide_Pos             16U                                            /*!< MVFR0: Divide bits Position */
+#define FPU_MVFR0_FPDivide_Msk             (0xFUL << FPU_MVFR0_FPDivide_Pos)              /*!< MVFR0: Divide bits Mask */
+
+#define FPU_MVFR0_FPExceptrap_Pos    12U                                                  /*!< MVFR0: Exception trapping bits Position */
+#define FPU_MVFR0_FPExceptrap_Msk    (0xFUL << FPU_MVFR0_FPExceptrap_Pos)                 /*!< MVFR0: Exception trapping bits Mask */
+
+#define FPU_MVFR0_FPDP_Pos                  8U                                            /*!< MVFR0: Double-precision bits Position */
+#define FPU_MVFR0_FPDP_Msk                 (0xFUL << FPU_MVFR0_FPDP_Pos)                  /*!< MVFR0: Double-precision bits Mask */
+
+#define FPU_MVFR0_FPSP_Pos                  4U                                            /*!< MVFR0: Single-precision bits Position */
+#define FPU_MVFR0_FPSP_Msk                 (0xFUL << FPU_MVFR0_FPSP_Pos)                  /*!< MVFR0: Single-precision bits Mask */
+
+#define FPU_MVFR0_SIMDReg_Pos               0U                                            /*!< MVFR0: SIMD registers bits Position */
+#define FPU_MVFR0_SIMDReg_Msk              (0xFUL /*<< FPU_MVFR0_SIMDReg_Pos*/)           /*!< MVFR0: SIMD registers bits Mask */
+
+/** \brief FPU Media and VFP Feature Register 1 Definitions */
+#define FPU_MVFR1_FMAC_Pos                 28U                                            /*!< MVFR1: Fused MAC bits Position */
+#define FPU_MVFR1_FMAC_Msk                 (0xFUL << FPU_MVFR1_FMAC_Pos)                  /*!< MVFR1: Fused MAC bits Mask */
+
+#define FPU_MVFR1_FPHP_Pos                 24U                                            /*!< MVFR1: FP HPFP bits Position */
+#define FPU_MVFR1_FPHP_Msk                 (0xFUL << FPU_MVFR1_FPHP_Pos)                  /*!< MVFR1: FP HPFP bits Mask */
+
+#define FPU_MVFR1_FPDNaN_Pos                4U                                            /*!< MVFR1: D_NaN mode bits Position */
+#define FPU_MVFR1_FPDNaN_Msk               (0xFUL << FPU_MVFR1_FPDNaN_Pos)                /*!< MVFR1: D_NaN mode bits Mask */
+
+#define FPU_MVFR1_FPFtZ_Pos                 0U                                            /*!< MVFR1: FtZ mode bits Position */
+#define FPU_MVFR1_FPFtZ_Msk                (0xFUL /*<< FPU_MVFR1_FPFtZ_Pos*/)             /*!< MVFR1: FtZ mode bits Mask */
+
+/** \brief FPU Media and VFP Feature Register 2 Definitions */
+#define FPU_MVFR2_FPMisc_Pos                4U                                            /*!< MVFR2: VFP Misc bits Position */
+#define FPU_MVFR2_FPMisc_Msk               (0xFUL << FPU_MVFR2_FPMisc_Pos)                /*!< MVFR2: VFP Misc bits Mask */
+
+/*@} end of group CMSIS_FPU */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_DCB       Debug Control Block
+  \brief    Type definitions for the Debug Control Block Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Debug Control Block Registers (DCB).
+ */
+typedef struct
+{
+  __IOM uint32_t DHCSR;                  /*!< Offset: 0x000 (R/W)  Debug Halting Control and Status Register */
+  __OM  uint32_t DCRSR;                  /*!< Offset: 0x004 ( /W)  Debug Core Register Selector Register */
+  __IOM uint32_t DCRDR;                  /*!< Offset: 0x008 (R/W)  Debug Core Register Data Register */
+  __IOM uint32_t DEMCR;                  /*!< Offset: 0x00C (R/W)  Debug Exception and Monitor Control Register */
+        uint32_t RESERVED0[1U];
+  __IOM uint32_t DAUTHCTRL;              /*!< Offset: 0x014 (R/W)  Debug Authentication Control Register */
+  __IOM uint32_t DSCSR;                  /*!< Offset: 0x018 (R/W)  Debug Security Control and Status Register */
+} DCB_Type;
+
+/** \brief DCB Debug Halting Control and Status Register Definitions */
+#define DCB_DHCSR_DBGKEY_Pos               16U                                            /*!< DCB DHCSR: Debug key Position */
+#define DCB_DHCSR_DBGKEY_Msk               (0xFFFFUL << DCB_DHCSR_DBGKEY_Pos)             /*!< DCB DHCSR: Debug key Mask */
+
+#define DCB_DHCSR_S_RESTART_ST_Pos         26U                                            /*!< DCB DHCSR: Restart sticky status Position */
+#define DCB_DHCSR_S_RESTART_ST_Msk         (1UL << DCB_DHCSR_S_RESTART_ST_Pos)            /*!< DCB DHCSR: Restart sticky status Mask */
+
+#define DCB_DHCSR_S_RESET_ST_Pos           25U                                            /*!< DCB DHCSR: Reset sticky status Position */
+#define DCB_DHCSR_S_RESET_ST_Msk           (1UL << DCB_DHCSR_S_RESET_ST_Pos)              /*!< DCB DHCSR: Reset sticky status Mask */
+
+#define DCB_DHCSR_S_RETIRE_ST_Pos          24U                                            /*!< DCB DHCSR: Retire sticky status Position */
+#define DCB_DHCSR_S_RETIRE_ST_Msk          (1UL << DCB_DHCSR_S_RETIRE_ST_Pos)             /*!< DCB DHCSR: Retire sticky status Mask */
+
+#define DCB_DHCSR_S_SDE_Pos                20U                                            /*!< DCB DHCSR: Secure debug enabled Position */
+#define DCB_DHCSR_S_SDE_Msk                (1UL << DCB_DHCSR_S_SDE_Pos)                   /*!< DCB DHCSR: Secure debug enabled Mask */
+
+#define DCB_DHCSR_S_LOCKUP_Pos             19U                                            /*!< DCB DHCSR: Lockup status Position */
+#define DCB_DHCSR_S_LOCKUP_Msk             (1UL << DCB_DHCSR_S_LOCKUP_Pos)                /*!< DCB DHCSR: Lockup status Mask */
+
+#define DCB_DHCSR_S_SLEEP_Pos              18U                                            /*!< DCB DHCSR: Sleeping status Position */
+#define DCB_DHCSR_S_SLEEP_Msk              (1UL << DCB_DHCSR_S_SLEEP_Pos)                 /*!< DCB DHCSR: Sleeping status Mask */
+
+#define DCB_DHCSR_S_HALT_Pos               17U                                            /*!< DCB DHCSR: Halted status Position */
+#define DCB_DHCSR_S_HALT_Msk               (1UL << DCB_DHCSR_S_HALT_Pos)                  /*!< DCB DHCSR: Halted status Mask */
+
+#define DCB_DHCSR_S_REGRDY_Pos             16U                                            /*!< DCB DHCSR: Register ready status Position */
+#define DCB_DHCSR_S_REGRDY_Msk             (1UL << DCB_DHCSR_S_REGRDY_Pos)                /*!< DCB DHCSR: Register ready status Mask */
+
+#define DCB_DHCSR_C_SNAPSTALL_Pos           5U                                            /*!< DCB DHCSR: Snap stall control Position */
+#define DCB_DHCSR_C_SNAPSTALL_Msk          (1UL << DCB_DHCSR_C_SNAPSTALL_Pos)             /*!< DCB DHCSR: Snap stall control Mask */
+
+#define DCB_DHCSR_C_MASKINTS_Pos            3U                                            /*!< DCB DHCSR: Mask interrupts control Position */
+#define DCB_DHCSR_C_MASKINTS_Msk           (1UL << DCB_DHCSR_C_MASKINTS_Pos)              /*!< DCB DHCSR: Mask interrupts control Mask */
+
+#define DCB_DHCSR_C_STEP_Pos                2U                                            /*!< DCB DHCSR: Step control Position */
+#define DCB_DHCSR_C_STEP_Msk               (1UL << DCB_DHCSR_C_STEP_Pos)                  /*!< DCB DHCSR: Step control Mask */
+
+#define DCB_DHCSR_C_HALT_Pos                1U                                            /*!< DCB DHCSR: Halt control Position */
+#define DCB_DHCSR_C_HALT_Msk               (1UL << DCB_DHCSR_C_HALT_Pos)                  /*!< DCB DHCSR: Halt control Mask */
+
+#define DCB_DHCSR_C_DEBUGEN_Pos             0U                                            /*!< DCB DHCSR: Debug enable control Position */
+#define DCB_DHCSR_C_DEBUGEN_Msk            (1UL /*<< DCB_DHCSR_C_DEBUGEN_Pos*/)           /*!< DCB DHCSR: Debug enable control Mask */
+
+/** \brief DCB Debug Core Register Selector Register Definitions */
+#define DCB_DCRSR_REGWnR_Pos               16U                                            /*!< DCB DCRSR: Register write/not-read Position */
+#define DCB_DCRSR_REGWnR_Msk               (1UL << DCB_DCRSR_REGWnR_Pos)                  /*!< DCB DCRSR: Register write/not-read Mask */
+
+#define DCB_DCRSR_REGSEL_Pos                0U                                            /*!< DCB DCRSR: Register selector Position */
+#define DCB_DCRSR_REGSEL_Msk               (0x7FUL /*<< DCB_DCRSR_REGSEL_Pos*/)           /*!< DCB DCRSR: Register selector Mask */
+
+/** \brief DCB Debug Core Register Data Register Definitions */
+#define DCB_DCRDR_DBGTMP_Pos                0U                                            /*!< DCB DCRDR: Data temporary buffer Position */
+#define DCB_DCRDR_DBGTMP_Msk               (0xFFFFFFFFUL /*<< DCB_DCRDR_DBGTMP_Pos*/)     /*!< DCB DCRDR: Data temporary buffer Mask */
+
+/** \brief DCB Debug Exception and Monitor Control Register Definitions */
+#define DCB_DEMCR_TRCENA_Pos               24U                                            /*!< DCB DEMCR: Trace enable Position */
+#define DCB_DEMCR_TRCENA_Msk               (1UL << DCB_DEMCR_TRCENA_Pos)                  /*!< DCB DEMCR: Trace enable Mask */
+
+#define DCB_DEMCR_MONPRKEY_Pos             23U                                            /*!< DCB DEMCR: Monitor pend req key Position */
+#define DCB_DEMCR_MONPRKEY_Msk             (1UL << DCB_DEMCR_MONPRKEY_Pos)                /*!< DCB DEMCR: Monitor pend req key Mask */
+
+#define DCB_DEMCR_UMON_EN_Pos              21U                                            /*!< DCB DEMCR: Unprivileged monitor enable Position */
+#define DCB_DEMCR_UMON_EN_Msk              (1UL << DCB_DEMCR_UMON_EN_Pos)                 /*!< DCB DEMCR: Unprivileged monitor enable Mask */
+
+#define DCB_DEMCR_SDME_Pos                 20U                                            /*!< DCB DEMCR: Secure DebugMonitor enable Position */
+#define DCB_DEMCR_SDME_Msk                 (1UL << DCB_DEMCR_SDME_Pos)                    /*!< DCB DEMCR: Secure DebugMonitor enable Mask */
+
+#define DCB_DEMCR_MON_REQ_Pos              19U                                            /*!< DCB DEMCR: Monitor request Position */
+#define DCB_DEMCR_MON_REQ_Msk              (1UL << DCB_DEMCR_MON_REQ_Pos)                 /*!< DCB DEMCR: Monitor request Mask */
+
+#define DCB_DEMCR_MON_STEP_Pos             18U                                            /*!< DCB DEMCR: Monitor step Position */
+#define DCB_DEMCR_MON_STEP_Msk             (1UL << DCB_DEMCR_MON_STEP_Pos)                /*!< DCB DEMCR: Monitor step Mask */
+
+#define DCB_DEMCR_MON_PEND_Pos             17U                                            /*!< DCB DEMCR: Monitor pend Position */
+#define DCB_DEMCR_MON_PEND_Msk             (1UL << DCB_DEMCR_MON_PEND_Pos)                /*!< DCB DEMCR: Monitor pend Mask */
+
+#define DCB_DEMCR_MON_EN_Pos               16U                                            /*!< DCB DEMCR: Monitor enable Position */
+#define DCB_DEMCR_MON_EN_Msk               (1UL << DCB_DEMCR_MON_EN_Pos)                  /*!< DCB DEMCR: Monitor enable Mask */
+
+#define DCB_DEMCR_VC_SFERR_Pos             11U                                            /*!< DCB DEMCR: Vector Catch SecureFault Position */
+#define DCB_DEMCR_VC_SFERR_Msk             (1UL << DCB_DEMCR_VC_SFERR_Pos)                /*!< DCB DEMCR: Vector Catch SecureFault Mask */
+
+#define DCB_DEMCR_VC_HARDERR_Pos           10U                                            /*!< DCB DEMCR: Vector Catch HardFault errors Position */
+#define DCB_DEMCR_VC_HARDERR_Msk           (1UL << DCB_DEMCR_VC_HARDERR_Pos)              /*!< DCB DEMCR: Vector Catch HardFault errors Mask */
+
+#define DCB_DEMCR_VC_INTERR_Pos             9U                                            /*!< DCB DEMCR: Vector Catch interrupt errors Position */
+#define DCB_DEMCR_VC_INTERR_Msk            (1UL << DCB_DEMCR_VC_INTERR_Pos)               /*!< DCB DEMCR: Vector Catch interrupt errors Mask */
+
+#define DCB_DEMCR_VC_BUSERR_Pos             8U                                            /*!< DCB DEMCR: Vector Catch BusFault errors Position */
+#define DCB_DEMCR_VC_BUSERR_Msk            (1UL << DCB_DEMCR_VC_BUSERR_Pos)               /*!< DCB DEMCR: Vector Catch BusFault errors Mask */
+
+#define DCB_DEMCR_VC_STATERR_Pos            7U                                            /*!< DCB DEMCR: Vector Catch state errors Position */
+#define DCB_DEMCR_VC_STATERR_Msk           (1UL << DCB_DEMCR_VC_STATERR_Pos)              /*!< DCB DEMCR: Vector Catch state errors Mask */
+
+#define DCB_DEMCR_VC_CHKERR_Pos             6U                                            /*!< DCB DEMCR: Vector Catch check errors Position */
+#define DCB_DEMCR_VC_CHKERR_Msk            (1UL << DCB_DEMCR_VC_CHKERR_Pos)               /*!< DCB DEMCR: Vector Catch check errors Mask */
+
+#define DCB_DEMCR_VC_NOCPERR_Pos            5U                                            /*!< DCB DEMCR: Vector Catch NOCP errors Position */
+#define DCB_DEMCR_VC_NOCPERR_Msk           (1UL << DCB_DEMCR_VC_NOCPERR_Pos)              /*!< DCB DEMCR: Vector Catch NOCP errors Mask */
+
+#define DCB_DEMCR_VC_MMERR_Pos              4U                                            /*!< DCB DEMCR: Vector Catch MemManage errors Position */
+#define DCB_DEMCR_VC_MMERR_Msk             (1UL << DCB_DEMCR_VC_MMERR_Pos)                /*!< DCB DEMCR: Vector Catch MemManage errors Mask */
+
+#define DCB_DEMCR_VC_CORERESET_Pos          0U                                            /*!< DCB DEMCR: Vector Catch Core reset Position */
+#define DCB_DEMCR_VC_CORERESET_Msk         (1UL /*<< DCB_DEMCR_VC_CORERESET_Pos*/)        /*!< DCB DEMCR: Vector Catch Core reset Mask */
+
+/** \brief DCB Debug Authentication Control Register Definitions */
+#define DCB_DAUTHCTRL_INTSPNIDEN_Pos        3U                                            /*!< DCB DAUTHCTRL: Internal Secure non-invasive debug enable Position */
+#define DCB_DAUTHCTRL_INTSPNIDEN_Msk       (1UL << DCB_DAUTHCTRL_INTSPNIDEN_Pos)          /*!< DCB DAUTHCTRL: Internal Secure non-invasive debug enable Mask */
+
+#define DCB_DAUTHCTRL_SPNIDENSEL_Pos        2U                                            /*!< DCB DAUTHCTRL: Secure non-invasive debug enable select Position */
+#define DCB_DAUTHCTRL_SPNIDENSEL_Msk       (1UL << DCB_DAUTHCTRL_SPNIDENSEL_Pos)          /*!< DCB DAUTHCTRL: Secure non-invasive debug enable select Mask */
+
+#define DCB_DAUTHCTRL_INTSPIDEN_Pos         1U                                            /*!< DCB DAUTHCTRL: Internal Secure invasive debug enable Position */
+#define DCB_DAUTHCTRL_INTSPIDEN_Msk        (1UL << DCB_DAUTHCTRL_INTSPIDEN_Pos)           /*!< DCB DAUTHCTRL: Internal Secure invasive debug enable Mask */
+
+#define DCB_DAUTHCTRL_SPIDENSEL_Pos         0U                                            /*!< DCB DAUTHCTRL: Secure invasive debug enable select Position */
+#define DCB_DAUTHCTRL_SPIDENSEL_Msk        (1UL /*<< DCB_DAUTHCTRL_SPIDENSEL_Pos*/)       /*!< DCB DAUTHCTRL: Secure invasive debug enable select Mask */
+
+/** \brief DCB Debug Security Control and Status Register Definitions */
+#define DCB_DSCSR_CDSKEY_Pos               17U                                            /*!< DCB DSCSR: CDS write-enable key Position */
+#define DCB_DSCSR_CDSKEY_Msk               (1UL << DCB_DSCSR_CDSKEY_Pos)                  /*!< DCB DSCSR: CDS write-enable key Mask */
+
+#define DCB_DSCSR_CDS_Pos                  16U                                            /*!< DCB DSCSR: Current domain Secure Position */
+#define DCB_DSCSR_CDS_Msk                  (1UL << DCB_DSCSR_CDS_Pos)                     /*!< DCB DSCSR: Current domain Secure Mask */
+
+#define DCB_DSCSR_SBRSEL_Pos                1U                                            /*!< DCB DSCSR: Secure banked register select Position */
+#define DCB_DSCSR_SBRSEL_Msk               (1UL << DCB_DSCSR_SBRSEL_Pos)                  /*!< DCB DSCSR: Secure banked register select Mask */
+
+#define DCB_DSCSR_SBRSELEN_Pos              0U                                            /*!< DCB DSCSR: Secure banked register select enable Position */
+#define DCB_DSCSR_SBRSELEN_Msk             (1UL /*<< DCB_DSCSR_SBRSELEN_Pos*/)            /*!< DCB DSCSR: Secure banked register select enable Mask */
+
+/*@} end of group CMSIS_DCB */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_DIB       Debug Identification Block
+  \brief    Type definitions for the Debug Identification Block Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Debug Identification Block Registers (DIB).
+ */
+typedef struct
+{
+  __OM  uint32_t DLAR;                   /*!< Offset: 0x000 ( /W)  SCS Software Lock Access Register */
+  __IM  uint32_t DLSR;                   /*!< Offset: 0x004 (R/ )  SCS Software Lock Status Register */
+  __IM  uint32_t DAUTHSTATUS;            /*!< Offset: 0x008 (R/ )  Debug Authentication Status Register */
+  __IM  uint32_t DDEVARCH;               /*!< Offset: 0x00C (R/ )  SCS Device Architecture Register */
+  __IM  uint32_t DDEVTYPE;               /*!< Offset: 0x010 (R/ )  SCS Device Type Register */
+} DIB_Type;
+
+/** \brief DIB SCS Software Lock Access Register Definitions */
+#define DIB_DLAR_KEY_Pos                    0U                                            /*!< DIB DLAR: KEY Position */
+#define DIB_DLAR_KEY_Msk                   (0xFFFFFFFFUL /*<< DIB_DLAR_KEY_Pos */)        /*!< DIB DLAR: KEY Mask */
+
+/** \brief DIB SCS Software Lock Status Register Definitions */
+#define DIB_DLSR_nTT_Pos                    2U                                            /*!< DIB DLSR: Not thirty-two bit Position */
+#define DIB_DLSR_nTT_Msk                   (1UL << DIB_DLSR_nTT_Pos )                     /*!< DIB DLSR: Not thirty-two bit Mask */
+
+#define DIB_DLSR_SLK_Pos                    1U                                            /*!< DIB DLSR: Software Lock status Position */
+#define DIB_DLSR_SLK_Msk                   (1UL << DIB_DLSR_SLK_Pos )                     /*!< DIB DLSR: Software Lock status Mask */
+
+#define DIB_DLSR_SLI_Pos                    0U                                            /*!< DIB DLSR: Software Lock implemented Position */
+#define DIB_DLSR_SLI_Msk                   (1UL /*<< DIB_DLSR_SLI_Pos*/)                  /*!< DIB DLSR: Software Lock implemented Mask */
+
+/** \brief DIB Debug Authentication Status Register Definitions */
+#define DIB_DAUTHSTATUS_SNID_Pos            6U                                            /*!< DIB DAUTHSTATUS: Secure Non-invasive Debug Position */
+#define DIB_DAUTHSTATUS_SNID_Msk           (0x3UL << DIB_DAUTHSTATUS_SNID_Pos )           /*!< DIB DAUTHSTATUS: Secure Non-invasive Debug Mask */
+
+#define DIB_DAUTHSTATUS_SID_Pos             4U                                            /*!< DIB DAUTHSTATUS: Secure Invasive Debug Position */
+#define DIB_DAUTHSTATUS_SID_Msk            (0x3UL << DIB_DAUTHSTATUS_SID_Pos )            /*!< DIB DAUTHSTATUS: Secure Invasive Debug Mask */
+
+#define DIB_DAUTHSTATUS_NSNID_Pos           2U                                            /*!< DIB DAUTHSTATUS: Non-secure Non-invasive Debug Position */
+#define DIB_DAUTHSTATUS_NSNID_Msk          (0x3UL << DIB_DAUTHSTATUS_NSNID_Pos )          /*!< DIB DAUTHSTATUS: Non-secure Non-invasive Debug Mask */
+
+#define DIB_DAUTHSTATUS_NSID_Pos            0U                                            /*!< DIB DAUTHSTATUS: Non-secure Invasive Debug Position */
+#define DIB_DAUTHSTATUS_NSID_Msk           (0x3UL /*<< DIB_DAUTHSTATUS_NSID_Pos*/)        /*!< DIB DAUTHSTATUS: Non-secure Invasive Debug Mask */
+
+/** \brief DIB SCS Device Architecture Register Definitions */
+#define DIB_DDEVARCH_ARCHITECT_Pos         21U                                            /*!< DIB DDEVARCH: Architect Position */
+#define DIB_DDEVARCH_ARCHITECT_Msk         (0x7FFUL << DIB_DDEVARCH_ARCHITECT_Pos )       /*!< DIB DDEVARCH: Architect Mask */
+
+#define DIB_DDEVARCH_PRESENT_Pos           20U                                            /*!< DIB DDEVARCH: DEVARCH Present Position */
+#define DIB_DDEVARCH_PRESENT_Msk           (0x1FUL << DIB_DDEVARCH_PRESENT_Pos )          /*!< DIB DDEVARCH: DEVARCH Present Mask */
+
+#define DIB_DDEVARCH_REVISION_Pos          16U                                            /*!< DIB DDEVARCH: Revision Position */
+#define DIB_DDEVARCH_REVISION_Msk          (0xFUL << DIB_DDEVARCH_REVISION_Pos )          /*!< DIB DDEVARCH: Revision Mask */
+
+#define DIB_DDEVARCH_ARCHVER_Pos           12U                                            /*!< DIB DDEVARCH: Architecture Version Position */
+#define DIB_DDEVARCH_ARCHVER_Msk           (0xFUL << DIB_DDEVARCH_ARCHVER_Pos )           /*!< DIB DDEVARCH: Architecture Version Mask */
+
+#define DIB_DDEVARCH_ARCHPART_Pos           0U                                            /*!< DIB DDEVARCH: Architecture Part Position */
+#define DIB_DDEVARCH_ARCHPART_Msk          (0xFFFUL /*<< DIB_DDEVARCH_ARCHPART_Pos*/)     /*!< DIB DDEVARCH: Architecture Part Mask */
+
+/** \brief DIB SCS Device Type Register Definitions */
+#define DIB_DDEVTYPE_SUB_Pos                4U                                            /*!< DIB DDEVTYPE: Sub-type Position */
+#define DIB_DDEVTYPE_SUB_Msk               (0xFUL << DIB_DDEVTYPE_SUB_Pos )               /*!< DIB DDEVTYPE: Sub-type Mask */
+
+#define DIB_DDEVTYPE_MAJOR_Pos              0U                                            /*!< DIB DDEVTYPE: Major type Position */
+#define DIB_DDEVTYPE_MAJOR_Msk             (0xFUL /*<< DIB_DDEVTYPE_MAJOR_Pos*/)          /*!< DIB DDEVTYPE: Major type Mask */
+
+/*@} end of group CMSIS_DIB */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_core_bitfield     Core register bit field macros
+  \brief      Macros for use with bit field definitions (xxx_Pos, xxx_Msk).
+  @{
+ */
+
+/**
+  \brief   Mask and shift a bit field value for use in a register bit range.
+  \param[in] field  Name of the register bit field.
+  \param[in] value  Value of the bit field. This parameter is interpreted as an uint32_t type.
+  \return           Masked and shifted value.
+*/
+#define _VAL2FLD(field, value)    (((uint32_t)(value) << field ## _Pos) & field ## _Msk)
+
+/**
+  \brief     Mask and shift a register value to extract a bit filed value.
+  \param[in] field  Name of the register bit field.
+  \param[in] value  Value of register. This parameter is interpreted as an uint32_t type.
+  \return           Masked and shifted bit field value.
+*/
+#define _FLD2VAL(field, value)    (((uint32_t)(value) & field ## _Msk) >> field ## _Pos)
+
+/*@} end of group CMSIS_core_bitfield */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_core_base     Core Definitions
+  \brief      Definitions for base addresses, unions, and structures.
+  @{
+ */
+
+/* Memory mapping of Core Hardware */
+  #define SCS_BASE            (0xE000E000UL)                             /*!< System Control Space Base Address */
+  #define ITM_BASE            (0xE0000000UL)                             /*!< ITM Base Address */
+  #define DWT_BASE            (0xE0001000UL)                             /*!< DWT Base Address */
+  #define TPIU_BASE           (0xE0040000UL)                             /*!< TPIU Base Address */
+  #define DCB_BASE            (0xE000EDF0UL)                             /*!< DCB Base Address */
+  #define DIB_BASE            (0xE000EFB0UL)                             /*!< DIB Base Address */
+  #define EMSS_BASE           (0xE001E000UL)                             /*!<Enhanced Memory SubSystem Base Address */
+
+  #define SysTick_BASE        (SCS_BASE +  0x0010UL)                     /*!< SysTick Base Address */
+  #define NVIC_BASE           (SCS_BASE +  0x0100UL)                     /*!< NVIC Base Address */
+  #define SCB_BASE            (SCS_BASE +  0x0D00UL)                     /*!< System Control Block Base Address */
+
+  #define SCnSCB              ((SCnSCB_Type    *)     SCS_BASE         ) /*!< System control Register not in SCB */
+  #define SCB                 ((SCB_Type       *)     SCB_BASE         ) /*!< SCB configuration struct */
+  #define SysTick             ((SysTick_Type   *)     SysTick_BASE     ) /*!< SysTick configuration struct */
+  #define NVIC                ((NVIC_Type      *)     NVIC_BASE        ) /*!< NVIC configuration struct */
+  #define ITM                 ((ITM_Type       *)     ITM_BASE         ) /*!< ITM configuration struct */
+  #define DWT                 ((DWT_Type       *)     DWT_BASE         ) /*!< DWT configuration struct */
+  #define TPIU                ((TPIU_Type      *)     TPIU_BASE        ) /*!< TPIU configuration struct */
+  #define DCB                 ((DCB_Type       *)     DCB_BASE         ) /*!< DCB configuration struct */
+  #define DIB                 ((DIB_Type       *)     DIB_BASE         ) /*!< DIB configuration struct */
+  #define EMSS                ((EMSS_Type      *)     EMSS_BASE        ) /*!<Ehanced MSS Registers struct */
+
+  #if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+    #define MPU_BASE          (SCS_BASE +  0x0D90UL)                     /*!< Memory Protection Unit */
+    #define MPU               ((MPU_Type       *)     MPU_BASE         ) /*!< Memory Protection Unit */
+  #endif
+
+  #if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+    #define SAU_BASE          (SCS_BASE +  0x0DD0UL)                     /*!< Security Attribution Unit */
+    #define SAU               ((SAU_Type       *)     SAU_BASE         ) /*!< Security Attribution Unit */
+  #endif
+
+  #define FPU_BASE            (SCS_BASE +  0x0F30UL)                     /*!< Floating Point Unit */
+  #define FPU                 ((FPU_Type       *)     FPU_BASE         ) /*!< Floating Point Unit */
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  #define SCS_BASE_NS         (0xE002E000UL)                             /*!< System Control Space Base Address (non-secure address space) */
+  #define DCB_BASE_NS         (0xE002EDF0UL)                             /*!< DCB Base Address                  (non-secure address space) */
+  #define DIB_BASE_NS         (0xE002EFB0UL)                             /*!< DIB Base Address                  (non-secure address space) */
+  #define SysTick_BASE_NS     (SCS_BASE_NS +  0x0010UL)                  /*!< SysTick Base Address              (non-secure address space) */
+  #define NVIC_BASE_NS        (SCS_BASE_NS +  0x0100UL)                  /*!< NVIC Base Address                 (non-secure address space) */
+  #define SCB_BASE_NS         (SCS_BASE_NS +  0x0D00UL)                  /*!< System Control Block Base Address (non-secure address space) */
+
+  #define SCnSCB_NS           ((SCnSCB_Type    *)     SCS_BASE_NS      ) /*!< System control Register not in SCB(non-secure address space) */
+  #define SCB_NS              ((SCB_Type       *)     SCB_BASE_NS      ) /*!< SCB configuration struct          (non-secure address space) */
+  #define SysTick_NS          ((SysTick_Type   *)     SysTick_BASE_NS  ) /*!< SysTick configuration struct      (non-secure address space) */
+  #define NVIC_NS             ((NVIC_Type      *)     NVIC_BASE_NS     ) /*!< NVIC configuration struct         (non-secure address space) */
+  #define DCB_NS              ((DCB_Type       *)     DCB_BASE_NS      ) /*!< DCB configuration struct          (non-secure address space) */
+  #define DIB_NS              ((DIB_Type       *)     DIB_BASE_NS      ) /*!< DIB configuration struct          (non-secure address space) */
+
+  #if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+    #define MPU_BASE_NS       (SCS_BASE_NS +  0x0D90UL)                  /*!< Memory Protection Unit            (non-secure address space) */
+    #define MPU_NS            ((MPU_Type       *)     MPU_BASE_NS      ) /*!< Memory Protection Unit            (non-secure address space) */
+  #endif
+
+  #define FPU_BASE_NS         (SCS_BASE_NS +  0x0F30UL)                  /*!< Floating Point Unit               (non-secure address space) */
+  #define FPU_NS              ((FPU_Type       *)     FPU_BASE_NS      ) /*!< Floating Point Unit               (non-secure address space) */
+
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+/*@} */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_register_aliases     Backwards Compatibility Aliases
+  \brief      Register alias definitions for backwards compatibility.
+  @{
+ */
+
+/*@} */
+
+
+/*******************************************************************************
+ *                Hardware Abstraction Layer
+  Core Function Interface contains:
+  - Core NVIC Functions
+  - Core SysTick Functions
+  - Core Debug Functions
+  - Core Register Access Functions
+ ******************************************************************************/
+/**
+  \defgroup CMSIS_Core_FunctionInterface Functions and Instructions Reference
+*/
+
+
+
+/* ##########################   NVIC functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_NVICFunctions NVIC Functions
+  \brief    Functions that manage interrupts and exceptions via the NVIC.
+  @{
+ */
+
+#ifdef CMSIS_NVIC_VIRTUAL
+  #ifndef CMSIS_NVIC_VIRTUAL_HEADER_FILE
+    #define CMSIS_NVIC_VIRTUAL_HEADER_FILE "cmsis_nvic_virtual.h"
+  #endif
+  #include CMSIS_NVIC_VIRTUAL_HEADER_FILE
+#else
+  #define NVIC_SetPriorityGrouping    __NVIC_SetPriorityGrouping
+  #define NVIC_GetPriorityGrouping    __NVIC_GetPriorityGrouping
+  #define NVIC_EnableIRQ              __NVIC_EnableIRQ
+  #define NVIC_GetEnableIRQ           __NVIC_GetEnableIRQ
+  #define NVIC_DisableIRQ             __NVIC_DisableIRQ
+  #define NVIC_GetPendingIRQ          __NVIC_GetPendingIRQ
+  #define NVIC_SetPendingIRQ          __NVIC_SetPendingIRQ
+  #define NVIC_ClearPendingIRQ        __NVIC_ClearPendingIRQ
+  #define NVIC_GetActive              __NVIC_GetActive
+  #define NVIC_SetPriority            __NVIC_SetPriority
+  #define NVIC_GetPriority            __NVIC_GetPriority
+  #define NVIC_SystemReset            __NVIC_SystemReset
+  #define SW_SystemReset              __SW_SystemReset
+#endif /* CMSIS_NVIC_VIRTUAL */
+
+#ifdef CMSIS_VECTAB_VIRTUAL
+  #ifndef CMSIS_VECTAB_VIRTUAL_HEADER_FILE
+    #define CMSIS_VECTAB_VIRTUAL_HEADER_FILE "cmsis_vectab_virtual.h"
+  #endif
+  #include CMSIS_VECTAB_VIRTUAL_HEADER_FILE
+#else
+  #define NVIC_SetVector              __NVIC_SetVector
+  #define NVIC_GetVector              __NVIC_GetVector
+#endif  /* (CMSIS_VECTAB_VIRTUAL) */
+
+#define NVIC_USER_IRQ_OFFSET          16
+
+
+/* Special LR values for Secure/Non-Secure call handling and exception handling                                               */
+
+/* Function Return Payload (from ARMv8-M Architecture Reference Manual) LR value on entry from Secure BLXNS                   */
+#define FNC_RETURN                 (0xFEFFFFFFUL)     /* bit [0] ignored when processing a branch                             */
+
+/* The following EXC_RETURN mask values are used to evaluate the LR on exception entry */
+#define EXC_RETURN_PREFIX          (0xFF000000UL)     /* bits [31:24] set to indicate an EXC_RETURN value                     */
+#define EXC_RETURN_S               (0x00000040UL)     /* bit [6] stack used to push registers: 0=Non-secure 1=Secure          */
+#define EXC_RETURN_DCRS            (0x00000020UL)     /* bit [5] stacking rules for called registers: 0=skipped 1=saved       */
+#define EXC_RETURN_FTYPE           (0x00000010UL)     /* bit [4] allocate stack for floating-point context: 0=done 1=skipped  */
+#define EXC_RETURN_MODE            (0x00000008UL)     /* bit [3] processor mode for return: 0=Handler mode 1=Thread mode      */
+#define EXC_RETURN_SPSEL           (0x00000004UL)     /* bit [2] stack pointer used to restore context: 0=MSP 1=PSP           */
+#define EXC_RETURN_ES              (0x00000001UL)     /* bit [0] security state exception was taken to: 0=Non-secure 1=Secure */
+
+/* Integrity Signature (from ARMv8-M Architecture Reference Manual) for exception context stacking                            */
+#if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)  /* Value for processors with floating-point extension:                  */
+#define EXC_INTEGRITY_SIGNATURE     (0xFEFA125AUL)     /* bit [0] SFTC must match LR bit[4] EXC_RETURN_FTYPE                   */
+#else
+#define EXC_INTEGRITY_SIGNATURE     (0xFEFA125BUL)     /* Value for processors without floating-point extension                */
+#endif
+
+
+/**
+  \brief   Set Priority Grouping
+  \details Sets the priority grouping field using the required unlock sequence.
+           The parameter PriorityGroup is assigned to the field SCB->AIRCR [10:8] PRIGROUP field.
+           Only values from 0..7 are used.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+  \param [in]      PriorityGroup  Priority grouping field.
+ */
+__STATIC_INLINE void __NVIC_SetPriorityGrouping(uint32_t PriorityGroup)
+{
+  uint32_t reg_value;
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);             /* only values 0..7 are used          */
+
+  reg_value  =  SCB->AIRCR;                                                   /* read old register configuration    */
+  reg_value &= ~((uint32_t)(SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk)); /* clear bits to change               */
+  reg_value  =  (reg_value                                   |
+                ((uint32_t)0x5FAUL << SCB_AIRCR_VECTKEY_Pos) |
+                (PriorityGroupTmp << SCB_AIRCR_PRIGROUP_Pos)  );              /* Insert write key and priority group */
+  SCB->AIRCR =  reg_value;
+}
+
+
+/**
+  \brief   Get Priority Grouping
+  \details Reads the priority grouping field from the NVIC Interrupt Controller.
+  \return                Priority grouping field (SCB->AIRCR [10:8] PRIGROUP field).
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPriorityGrouping(void)
+{
+  return ((uint32_t)((SCB->AIRCR & SCB_AIRCR_PRIGROUP_Msk) >> SCB_AIRCR_PRIGROUP_Pos));
+}
+
+
+/**
+  \brief   Enable Interrupt
+  \details Enables a device specific interrupt in the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_EnableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    __COMPILER_BARRIER();
+    NVIC->ISER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+    __COMPILER_BARRIER();
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Enable status
+  \details Returns a device specific interrupt enable status from the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt is not enabled.
+  \return             1  Interrupt is enabled.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetEnableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ISER[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Disable Interrupt
+  \details Disables a device specific interrupt in the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_DisableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ICER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+    __DSB();
+    __ISB();
+  }
+}
+
+
+/**
+  \brief   Get Pending Interrupt
+  \details Reads the NVIC pending register and returns the pending bit for the specified device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not pending.
+  \return             1  Interrupt status is pending.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ISPR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Pending Interrupt
+  \details Sets the pending bit of a device specific interrupt in the NVIC pending register.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_SetPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ISPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Clear Pending Interrupt
+  \details Clears the pending bit of a device specific interrupt in the NVIC pending register.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_ClearPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ICPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Active Interrupt
+  \details Reads the active register in the NVIC and returns the active bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not active.
+  \return             1  Interrupt status is active.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetActive(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->IABR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   Get Interrupt Target State
+  \details Reads the interrupt target field in the NVIC and returns the interrupt target bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  if interrupt is assigned to Secure
+  \return             1  if interrupt is assigned to Non Secure
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t NVIC_GetTargetState(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Interrupt Target State
+  \details Sets the interrupt target field in the NVIC and returns the interrupt target bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  if interrupt is assigned to Secure
+                      1  if interrupt is assigned to Non Secure
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t NVIC_SetTargetState(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] |=  ((uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL)));
+    return((uint32_t)(((NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Clear Interrupt Target State
+  \details Clears the interrupt target field in the NVIC and returns the interrupt target bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  if interrupt is assigned to Secure
+                      1  if interrupt is assigned to Non Secure
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t NVIC_ClearTargetState(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] &= ~((uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL)));
+    return((uint32_t)(((NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+
+/**
+  \brief   Set Interrupt Priority
+  \details Sets the priority of a device specific interrupt or a processor exception.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]      IRQn  Interrupt number.
+  \param [in]  priority  Priority to set.
+  \note    The priority cannot be set for every processor exception.
+ */
+__STATIC_INLINE void __NVIC_SetPriority(IRQn_Type IRQn, uint32_t priority)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->IPR[((uint32_t)IRQn)]               = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+  else
+  {
+    SCB->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Priority
+  \details Reads the priority of a device specific interrupt or a processor exception.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn  Interrupt number.
+  \return             Interrupt Priority.
+                      Value is aligned automatically to the implemented priority bits of the microcontroller.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPriority(IRQn_Type IRQn)
+{
+
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return(((uint32_t)NVIC->IPR[((uint32_t)IRQn)]               >> (8U - __NVIC_PRIO_BITS)));
+  }
+  else
+  {
+    return(((uint32_t)SCB->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] >> (8U - __NVIC_PRIO_BITS)));
+  }
+}
+
+
+/**
+  \brief   Encode Priority
+  \details Encodes the priority for an interrupt with the given priority group,
+           preemptive priority value, and subpriority value.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+  \param [in]     PriorityGroup  Used priority group.
+  \param [in]   PreemptPriority  Preemptive priority value (starting from 0).
+  \param [in]       SubPriority  Subpriority value (starting from 0).
+  \return                        Encoded priority. Value can be used in the function \ref NVIC_SetPriority().
+ */
+__STATIC_INLINE uint32_t NVIC_EncodePriority (uint32_t PriorityGroup, uint32_t PreemptPriority, uint32_t SubPriority)
+{
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);   /* only values 0..7 are used          */
+  uint32_t PreemptPriorityBits;
+  uint32_t SubPriorityBits;
+
+  PreemptPriorityBits = ((7UL - PriorityGroupTmp) > (uint32_t)(__NVIC_PRIO_BITS)) ? (uint32_t)(__NVIC_PRIO_BITS) : (uint32_t)(7UL - PriorityGroupTmp);
+  SubPriorityBits     = ((PriorityGroupTmp + (uint32_t)(__NVIC_PRIO_BITS)) < (uint32_t)7UL) ? (uint32_t)0UL : (uint32_t)((PriorityGroupTmp - 7UL) + (uint32_t)(__NVIC_PRIO_BITS));
+
+  return (
+           ((PreemptPriority & (uint32_t)((1UL << (PreemptPriorityBits)) - 1UL)) << SubPriorityBits) |
+           ((SubPriority     & (uint32_t)((1UL << (SubPriorityBits    )) - 1UL)))
+         );
+}
+
+
+/**
+  \brief   Decode Priority
+  \details Decodes an interrupt priority value with a given priority group to
+           preemptive priority value and subpriority value.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS) the smallest possible priority group is set.
+  \param [in]         Priority   Priority value, which can be retrieved with the function \ref NVIC_GetPriority().
+  \param [in]     PriorityGroup  Used priority group.
+  \param [out] pPreemptPriority  Preemptive priority value (starting from 0).
+  \param [out]     pSubPriority  Subpriority value (starting from 0).
+ */
+__STATIC_INLINE void NVIC_DecodePriority (uint32_t Priority, uint32_t PriorityGroup, uint32_t* const pPreemptPriority, uint32_t* const pSubPriority)
+{
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);   /* only values 0..7 are used          */
+  uint32_t PreemptPriorityBits;
+  uint32_t SubPriorityBits;
+
+  PreemptPriorityBits = ((7UL - PriorityGroupTmp) > (uint32_t)(__NVIC_PRIO_BITS)) ? (uint32_t)(__NVIC_PRIO_BITS) : (uint32_t)(7UL - PriorityGroupTmp);
+  SubPriorityBits     = ((PriorityGroupTmp + (uint32_t)(__NVIC_PRIO_BITS)) < (uint32_t)7UL) ? (uint32_t)0UL : (uint32_t)((PriorityGroupTmp - 7UL) + (uint32_t)(__NVIC_PRIO_BITS));
+
+  *pPreemptPriority = (Priority >> SubPriorityBits) & (uint32_t)((1UL << (PreemptPriorityBits)) - 1UL);
+  *pSubPriority     = (Priority                   ) & (uint32_t)((1UL << (SubPriorityBits    )) - 1UL);
+}
+
+
+/**
+  \brief   Set Interrupt Vector
+  \details Sets an interrupt vector in SRAM based interrupt vector table.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+           VTOR must been relocated to SRAM before.
+  \param [in]   IRQn      Interrupt number
+  \param [in]   vector    Address of interrupt handler function
+ */
+__STATIC_INLINE void __NVIC_SetVector(IRQn_Type IRQn, uint32_t vector)
+{
+  uint32_t *vectors = (uint32_t *) ((uintptr_t) SCB->VTOR);
+  vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET] = vector;
+  __DSB();
+}
+
+
+/**
+  \brief   Get Interrupt Vector
+  \details Reads an interrupt vector from interrupt vector table.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn      Interrupt number.
+  \return                 Address of interrupt handler function
+ */
+__STATIC_INLINE uint32_t __NVIC_GetVector(IRQn_Type IRQn)
+{
+  uint32_t *vectors = (uint32_t *) ((uintptr_t) SCB->VTOR);
+  return vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET];
+}
+
+
+/**
+  \brief   System Reset
+  \details Initiates a system reset request to reset the MCU.
+ */
+__NO_RETURN __STATIC_INLINE void __NVIC_SystemReset(void)
+{
+  __DSB();                                                          /* Ensure all outstanding memory accesses included
+                                                                       buffered write are completed before reset */
+  SCB->AIRCR  = (uint32_t)((0x5FAUL << SCB_AIRCR_VECTKEY_Pos)    |
+                           (SCB->AIRCR & SCB_AIRCR_PRIGROUP_Msk) |
+                            SCB_AIRCR_SYSRESETREQ_Msk    );         /* Keep priority group unchanged */
+  __DSB();                                                          /* Ensure completion of memory access */
+
+  for(;;)                                                           /* wait until reset */
+  {
+    __NOP();
+  }
+}
+
+/**
+  \brief   Software Reset
+  \details Initiates a system reset request to reset the CPU.
+ */
+__NO_RETURN __STATIC_INLINE void __SW_SystemReset(void)
+{
+  __DSB();                                                          /* Ensure all outstanding memory accesses including
+                                                                       buffered write are completed before reset */
+  SCB->AIRCR  = (uint32_t)((0x5FAUL << SCB_AIRCR_VECTKEY_Pos)    |
+                           (SCB->AIRCR & SCB_AIRCR_BFHFNMINS_Msk) | /* Keep BFHFNMINS unchanged. Use this Reset function in case your case need to keep it */
+                           (SCB->AIRCR & SCB_AIRCR_PRIGROUP_Msk) | /* Keep priority group unchanged */
+                            SCB_AIRCR_SYSRESETREQ_Msk    );
+  __DSB();                                                          /* Ensure completion of memory access */
+
+  for(;;)                                                           /* wait until reset */
+  {
+    __NOP();
+  }
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   Set Priority Grouping (non-secure)
+  \details Sets the non-secure priority grouping field when in secure state using the required unlock sequence.
+           The parameter PriorityGroup is assigned to the field SCB->AIRCR [10:8] PRIGROUP field.
+           Only values from 0..7 are used.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+  \param [in]      PriorityGroup  Priority grouping field.
+ */
+__STATIC_INLINE void TZ_NVIC_SetPriorityGrouping_NS(uint32_t PriorityGroup)
+{
+  uint32_t reg_value;
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);             /* only values 0..7 are used          */
+
+  reg_value  =  SCB_NS->AIRCR;                                                /* read old register configuration    */
+  reg_value &= ~((uint32_t)(SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk)); /* clear bits to change               */
+  reg_value  =  (reg_value                                   |
+                ((uint32_t)0x5FAUL << SCB_AIRCR_VECTKEY_Pos) |
+                (PriorityGroupTmp << SCB_AIRCR_PRIGROUP_Pos)  );              /* Insert write key and priority group */
+  SCB_NS->AIRCR =  reg_value;
+}
+
+
+/**
+  \brief   Get Priority Grouping (non-secure)
+  \details Reads the priority grouping field from the non-secure NVIC when in secure state.
+  \return                Priority grouping field (SCB->AIRCR [10:8] PRIGROUP field).
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetPriorityGrouping_NS(void)
+{
+  return ((uint32_t)((SCB_NS->AIRCR & SCB_AIRCR_PRIGROUP_Msk) >> SCB_AIRCR_PRIGROUP_Pos));
+}
+
+
+/**
+  \brief   Enable Interrupt (non-secure)
+  \details Enables a device specific interrupt in the non-secure NVIC interrupt controller when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void TZ_NVIC_EnableIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->ISER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Enable status (non-secure)
+  \details Returns a device specific interrupt enable status from the non-secure NVIC interrupt controller when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt is not enabled.
+  \return             1  Interrupt is enabled.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetEnableIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC_NS->ISER[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Disable Interrupt (non-secure)
+  \details Disables a device specific interrupt in the non-secure NVIC interrupt controller when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void TZ_NVIC_DisableIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->ICER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Pending Interrupt (non-secure)
+  \details Reads the NVIC pending register in the non-secure NVIC when in secure state and returns the pending bit for the specified device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not pending.
+  \return             1  Interrupt status is pending.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetPendingIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC_NS->ISPR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Pending Interrupt (non-secure)
+  \details Sets the pending bit of a device specific interrupt in the non-secure NVIC pending register when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void TZ_NVIC_SetPendingIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->ISPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Clear Pending Interrupt (non-secure)
+  \details Clears the pending bit of a device specific interrupt in the non-secure NVIC pending register when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void TZ_NVIC_ClearPendingIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->ICPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Active Interrupt (non-secure)
+  \details Reads the active register in non-secure NVIC when in secure state and returns the active bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not active.
+  \return             1  Interrupt status is active.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetActive_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC_NS->IABR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Interrupt Priority (non-secure)
+  \details Sets the priority of a non-secure device specific interrupt or a non-secure processor exception when in secure state.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]      IRQn  Interrupt number.
+  \param [in]  priority  Priority to set.
+  \note    The priority cannot be set for every non-secure processor exception.
+ */
+__STATIC_INLINE void TZ_NVIC_SetPriority_NS(IRQn_Type IRQn, uint32_t priority)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->IPR[((uint32_t)IRQn)]               = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+  else
+  {
+    SCB_NS->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Priority (non-secure)
+  \details Reads the priority of a non-secure device specific interrupt or a non-secure processor exception when in secure state.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn  Interrupt number.
+  \return             Interrupt Priority. Value is aligned automatically to the implemented priority bits of the microcontroller.
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetPriority_NS(IRQn_Type IRQn)
+{
+
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return(((uint32_t)NVIC_NS->IPR[((uint32_t)IRQn)]               >> (8U - __NVIC_PRIO_BITS)));
+  }
+  else
+  {
+    return(((uint32_t)SCB_NS->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] >> (8U - __NVIC_PRIO_BITS)));
+  }
+}
+#endif /*  defined (__ARM_FEATURE_CMSE) &&(__ARM_FEATURE_CMSE == 3U) */
+
+/*@} end of CMSIS_Core_NVICFunctions */
+
+/* ##########################  MPU functions  #################################### */
+
+#if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+
+  #include "m-profile/armv8m_mpu.h"
+
+#endif
+
+
+/* ##########################  FPU functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_FpuFunctions FPU Functions
+  \brief    Function that provides FPU type.
+  @{
+ */
+
+/**
+  \brief   get FPU type
+  \details returns the FPU type
+  \returns
+   - \b  0: No FPU
+   - \b  1: Single precision FPU
+   - \b  2: Double + Single precision FPU
+ */
+__STATIC_INLINE uint32_t SCB_GetFPUType(void)
+{
+  uint32_t mvfr0;
+
+  mvfr0 = FPU->MVFR0;
+  if      ((mvfr0 & (FPU_MVFR0_FPSP_Msk | FPU_MVFR0_FPDP_Msk)) == 0x220U)
+  {
+    return 2U;           /* Double + Single precision FPU */
+  }
+  else if ((mvfr0 & (FPU_MVFR0_FPSP_Msk | FPU_MVFR0_FPDP_Msk)) == 0x020U)
+  {
+    return 1U;           /* Single precision FPU */
+  }
+  else
+  {
+    return 0U;           /* No FPU */
+  }
+}
+
+/*@} end of CMSIS_Core_FpuFunctions */
+
+
+
+/* ##########################   SAU functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_SAUFunctions SAU Functions
+  \brief    Functions that configure the SAU.
+  @{
+ */
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+
+/**
+  \brief   Enable SAU
+  \details Enables the Security Attribution Unit (SAU).
+ */
+__STATIC_INLINE void TZ_SAU_Enable(void)
+{
+    SAU->CTRL |=  (SAU_CTRL_ENABLE_Msk);
+}
+
+
+
+/**
+  \brief   Disable SAU
+  \details Disables the Security Attribution Unit (SAU).
+ */
+__STATIC_INLINE void TZ_SAU_Disable(void)
+{
+    SAU->CTRL &= ~(SAU_CTRL_ENABLE_Msk);
+}
+
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+/*@} end of CMSIS_Core_SAUFunctions */
+
+
+
+
+/* ##################################    Debug Control function  ############################################ */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_DCBFunctions Debug Control Functions
+  \brief    Functions that access the Debug Control Block.
+  @{
+ */
+
+
+/**
+  \brief   Set Debug Authentication Control Register
+  \details writes to Debug Authentication Control register.
+  \param [in]  value  value to be writen.
+ */
+__STATIC_INLINE void DCB_SetAuthCtrl(uint32_t value)
+{
+    __DSB();
+    __ISB();
+    DCB->DAUTHCTRL = value;
+    __DSB();
+    __ISB();
+}
+
+
+/**
+  \brief   Get Debug Authentication Control Register
+  \details Reads Debug Authentication Control register.
+  \return             Debug Authentication Control Register.
+ */
+__STATIC_INLINE uint32_t DCB_GetAuthCtrl(void)
+{
+    return (DCB->DAUTHCTRL);
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   Set Debug Authentication Control Register (non-secure)
+  \details writes to non-secure Debug Authentication Control register when in secure state.
+  \param [in]  value  value to be writen
+ */
+__STATIC_INLINE void TZ_DCB_SetAuthCtrl_NS(uint32_t value)
+{
+    __DSB();
+    __ISB();
+    DCB_NS->DAUTHCTRL = value;
+    __DSB();
+    __ISB();
+}
+
+
+/**
+  \brief   Get Debug Authentication Control Register (non-secure)
+  \details Reads non-secure Debug Authentication Control register when in secure state.
+  \return             Debug Authentication Control Register.
+ */
+__STATIC_INLINE uint32_t TZ_DCB_GetAuthCtrl_NS(void)
+{
+    return (DCB_NS->DAUTHCTRL);
+}
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+/*@} end of CMSIS_Core_DCBFunctions */
+
+
+
+
+/* ##################################    Debug Identification function  ############################################ */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_DIBFunctions Debug Identification Functions
+  \brief    Functions that access the Debug Identification Block.
+  @{
+ */
+
+
+/**
+  \brief   Get Debug Authentication Status Register
+  \details Reads Debug Authentication Status register.
+  \return             Debug Authentication Status Register.
+ */
+__STATIC_INLINE uint32_t DIB_GetAuthStatus(void)
+{
+    return (DIB->DAUTHSTATUS);
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   Get Debug Authentication Status Register (non-secure)
+  \details Reads non-secure Debug Authentication Status register when in secure state.
+  \return             Debug Authentication Status Register.
+ */
+__STATIC_INLINE uint32_t TZ_DIB_GetAuthStatus_NS(void)
+{
+    return (DIB_NS->DAUTHSTATUS);
+}
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+/*@} end of CMSIS_Core_DCBFunctions */
+
+
+#if ((defined (__ICACHE_PRESENT) && (__ICACHE_PRESENT == 1U)) || \
+     (defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)))
+
+/* ##########################  Cache functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_CacheFunctions Cache Functions
+  \brief    Functions that configure Instruction and Data cache.
+  @{
+ */
+
+/* Cache Size ID Register Macros */
+#define CCSIDR_WAYS(x)         (((x) & SCB_CCSIDR_ASSOCIATIVITY_Msk) >> SCB_CCSIDR_ASSOCIATIVITY_Pos)
+#define CCSIDR_SETS(x)         (((x) & SCB_CCSIDR_NUMSETS_Msk      ) >> SCB_CCSIDR_NUMSETS_Pos      )
+
+#define __SCB_DCACHE_LINE_SIZE  32U /*!< STAR-MC1 cache line size is fixed to 32 bytes (8 words). See also register SCB_CCSIDR */
+#define __SCB_ICACHE_LINE_SIZE  32U /*!< STAR-MC1 cache line size is fixed to 32 bytes (8 words). See also register SCB_CCSIDR */
+
+/**
+  \brief   Enable I-Cache
+  \details Turns on I-Cache
+  */
+__STATIC_FORCEINLINE void SCB_EnableICache (void)
+{
+  #if defined (__ICACHE_PRESENT) && (__ICACHE_PRESENT == 1U)
+    if (SCB->CCR & SCB_CCR_IC_Msk) return;  /* return if ICache is already enabled */
+
+    __DSB();
+    __ISB();
+    SCB->ICIALLU = 0UL;                     /* invalidate I-Cache */
+    __DSB();
+    __ISB();
+    SCB->CCR |=  (uint32_t)SCB_CCR_IC_Msk;  /* enable I-Cache */
+    __DSB();
+    __ISB();
+  #endif
+}
+
+
+/**
+  \brief   Disable I-Cache
+  \details Turns off I-Cache
+  */
+__STATIC_FORCEINLINE void SCB_DisableICache (void)
+{
+  #if defined (__ICACHE_PRESENT) && (__ICACHE_PRESENT == 1U)
+    __DSB();
+    __ISB();
+    SCB->CCR &= ~(uint32_t)SCB_CCR_IC_Msk;  /* disable I-Cache */
+    SCB->ICIALLU = 0UL;                     /* invalidate I-Cache */
+    __DSB();
+    __ISB();
+  #endif
+}
+
+
+/**
+  \brief   Invalidate I-Cache
+  \details Invalidates I-Cache
+  */
+__STATIC_FORCEINLINE void SCB_InvalidateICache (void)
+{
+  #if defined (__ICACHE_PRESENT) && (__ICACHE_PRESENT == 1U)
+    __DSB();
+    __ISB();
+    SCB->ICIALLU = 0UL;
+    __DSB();
+    __ISB();
+  #endif
+}
+
+
+/**
+  \brief   I-Cache Invalidate by address
+  \details Invalidates I-Cache for the given address.
+           I-Cache is invalidated starting from a 32 byte aligned address in 32 byte granularity.
+           I-Cache memory blocks which are part of given address + given size are invalidated.
+  \param[in]   addr    address
+  \param[in]   isize   size of memory block (in number of bytes)
+*/
+__STATIC_FORCEINLINE void SCB_InvalidateICache_by_Addr (void *addr, int32_t isize)
+{
+  #if defined (__ICACHE_PRESENT) && (__ICACHE_PRESENT == 1U)
+    if ( isize > 0 ) {
+       int32_t op_size = isize + (((uint32_t)addr) & (__SCB_ICACHE_LINE_SIZE - 1U));
+      uint32_t op_addr = (uint32_t)addr /* & ~(__SCB_ICACHE_LINE_SIZE - 1U) */;
+
+      __DSB();
+
+      do {
+        SCB->ICIMVAU = op_addr;             /* register accepts only 32byte aligned values, only bits 31..5 are valid */
+        op_addr += __SCB_ICACHE_LINE_SIZE;
+        op_size -= __SCB_ICACHE_LINE_SIZE;
+      } while ( op_size > 0 );
+
+      __DSB();
+      __ISB();
+    }
+  #endif
+}
+
+
+/**
+  \brief   Enable D-Cache
+  \details Turns on D-Cache
+  */
+__STATIC_FORCEINLINE void SCB_EnableDCache (void)
+{
+  #if defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
+    uint32_t ccsidr;
+    uint32_t sets;
+    uint32_t ways;
+
+    if (SCB->CCR & SCB_CCR_DC_Msk) return;  /* return if DCache is already enabled */
+
+    SCB->CSSELR = 0U;                       /* select Level 1 data cache */
+    __DSB();
+
+    ccsidr = SCB->CCSIDR;
+
+                                            /* invalidate D-Cache */
+    sets = (uint32_t)(CCSIDR_SETS(ccsidr));
+    do {
+      ways = (uint32_t)(CCSIDR_WAYS(ccsidr));
+      do {
+        SCB->DCISW = (((sets << SCB_DCISW_SET_Pos) & SCB_DCISW_SET_Msk) |
+                      ((ways << SCB_DCISW_WAY_Pos) & SCB_DCISW_WAY_Msk)  );
+        #if defined ( __CC_ARM )
+          __schedule_barrier();
+        #endif
+      } while (ways-- != 0U);
+    } while(sets-- != 0U);
+    __DSB();
+
+    SCB->CCR |=  (uint32_t)SCB_CCR_DC_Msk;  /* enable D-Cache */
+
+    __DSB();
+    __ISB();
+  #endif
+}
+
+
+/**
+  \brief   Disable D-Cache
+  \details Turns off D-Cache
+  */
+__STATIC_FORCEINLINE void SCB_DisableDCache (void)
+{
+  #if defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
+    uint32_t ccsidr;
+    uint32_t sets;
+    uint32_t ways;
+
+    SCB->CSSELR = 0U;                       /* select Level 1 data cache */
+    __DSB();
+
+    SCB->CCR &= ~(uint32_t)SCB_CCR_DC_Msk;  /* disable D-Cache */
+    __DSB();
+
+    ccsidr = SCB->CCSIDR;
+
+                                            /* clean & invalidate D-Cache */
+    sets = (uint32_t)(CCSIDR_SETS(ccsidr));
+    do {
+      ways = (uint32_t)(CCSIDR_WAYS(ccsidr));
+      do {
+        SCB->DCCISW = (((sets << SCB_DCCISW_SET_Pos) & SCB_DCCISW_SET_Msk) |
+                       ((ways << SCB_DCCISW_WAY_Pos) & SCB_DCCISW_WAY_Msk)  );
+        #if defined ( __CC_ARM )
+          __schedule_barrier();
+        #endif
+      } while (ways-- != 0U);
+    } while(sets-- != 0U);
+
+    __DSB();
+    __ISB();
+  #endif
+}
+
+
+/**
+  \brief   Invalidate D-Cache
+  \details Invalidates D-Cache
+  */
+__STATIC_FORCEINLINE void SCB_InvalidateDCache (void)
+{
+  #if defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
+    uint32_t ccsidr;
+    uint32_t sets;
+    uint32_t ways;
+
+    SCB->CSSELR = 0U;                       /* select Level 1 data cache */
+    __DSB();
+
+    ccsidr = SCB->CCSIDR;
+
+                                            /* invalidate D-Cache */
+    sets = (uint32_t)(CCSIDR_SETS(ccsidr));
+    do {
+      ways = (uint32_t)(CCSIDR_WAYS(ccsidr));
+      do {
+        SCB->DCISW = (((sets << SCB_DCISW_SET_Pos) & SCB_DCISW_SET_Msk) |
+                      ((ways << SCB_DCISW_WAY_Pos) & SCB_DCISW_WAY_Msk)  );
+        #if defined ( __CC_ARM )
+          __schedule_barrier();
+        #endif
+      } while (ways-- != 0U);
+    } while(sets-- != 0U);
+
+    __DSB();
+    __ISB();
+  #endif
+}
+
+
+/**
+  \brief   Clean D-Cache
+  \details Cleans D-Cache
+  */
+__STATIC_FORCEINLINE void SCB_CleanDCache (void)
+{
+  #if defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
+    uint32_t ccsidr;
+    uint32_t sets;
+    uint32_t ways;
+
+    SCB->CSSELR = 0U;                       /* select Level 1 data cache */
+    __DSB();
+
+    ccsidr = SCB->CCSIDR;
+
+                                            /* clean D-Cache */
+    sets = (uint32_t)(CCSIDR_SETS(ccsidr));
+    do {
+      ways = (uint32_t)(CCSIDR_WAYS(ccsidr));
+      do {
+        SCB->DCCSW = (((sets << SCB_DCCSW_SET_Pos) & SCB_DCCSW_SET_Msk) |
+                      ((ways << SCB_DCCSW_WAY_Pos) & SCB_DCCSW_WAY_Msk)  );
+        #if defined ( __CC_ARM )
+          __schedule_barrier();
+        #endif
+      } while (ways-- != 0U);
+    } while(sets-- != 0U);
+
+    __DSB();
+    __ISB();
+  #endif
+}
+
+
+/**
+  \brief   Clean & Invalidate D-Cache
+  \details Cleans and Invalidates D-Cache
+  */
+__STATIC_FORCEINLINE void SCB_CleanInvalidateDCache (void)
+{
+  #if defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
+    uint32_t ccsidr;
+    uint32_t sets;
+    uint32_t ways;
+
+    SCB->CSSELR = 0U;                       /* select Level 1 data cache */
+    __DSB();
+
+    ccsidr = SCB->CCSIDR;
+
+                                            /* clean & invalidate D-Cache */
+    sets = (uint32_t)(CCSIDR_SETS(ccsidr));
+    do {
+      ways = (uint32_t)(CCSIDR_WAYS(ccsidr));
+      do {
+        SCB->DCCISW = (((sets << SCB_DCCISW_SET_Pos) & SCB_DCCISW_SET_Msk) |
+                       ((ways << SCB_DCCISW_WAY_Pos) & SCB_DCCISW_WAY_Msk)  );
+        #if defined ( __CC_ARM )
+          __schedule_barrier();
+        #endif
+      } while (ways-- != 0U);
+    } while(sets-- != 0U);
+
+    __DSB();
+    __ISB();
+  #endif
+}
+
+
+/**
+  \brief   D-Cache Invalidate by address
+  \details Invalidates D-Cache for the given address.
+           D-Cache is invalidated starting from a 32 byte aligned address in 32 byte granularity.
+           D-Cache memory blocks which are part of given address + given size are invalidated.
+  \param[in]   addr    address
+  \param[in]   dsize   size of memory block (in number of bytes)
+*/
+__STATIC_FORCEINLINE void SCB_InvalidateDCache_by_Addr (void *addr, int32_t dsize)
+{
+  #if defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
+    if ( dsize > 0 ) {
+       int32_t op_size = dsize + (((uint32_t)addr) & (__SCB_DCACHE_LINE_SIZE - 1U));
+      uint32_t op_addr = (uint32_t)addr /* & ~(__SCB_DCACHE_LINE_SIZE - 1U) */;
+
+      __DSB();
+
+      do {
+        SCB->DCIMVAC = op_addr;             /* register accepts only 32byte aligned values, only bits 31..5 are valid */
+        op_addr += __SCB_DCACHE_LINE_SIZE;
+        op_size -= __SCB_DCACHE_LINE_SIZE;
+      } while ( op_size > 0 );
+
+      __DSB();
+      __ISB();
+    }
+  #endif
+}
+
+
+/**
+  \brief   D-Cache Clean by address
+  \details Cleans D-Cache for the given address
+           D-Cache is cleaned starting from a 32 byte aligned address in 32 byte granularity.
+           D-Cache memory blocks which are part of given address + given size are cleaned.
+  \param[in]   addr    address
+  \param[in]   dsize   size of memory block (in number of bytes)
+*/
+__STATIC_FORCEINLINE void SCB_CleanDCache_by_Addr (uint32_t *addr, int32_t dsize)
+{
+  #if defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
+    if ( dsize > 0 ) {
+       int32_t op_size = dsize + (((uint32_t)addr) & (__SCB_DCACHE_LINE_SIZE - 1U));
+      uint32_t op_addr = (uint32_t)addr /* & ~(__SCB_DCACHE_LINE_SIZE - 1U) */;
+
+      __DSB();
+
+      do {
+        SCB->DCCMVAC = op_addr;             /* register accepts only 32byte aligned values, only bits 31..5 are valid */
+        op_addr += __SCB_DCACHE_LINE_SIZE;
+        op_size -= __SCB_DCACHE_LINE_SIZE;
+      } while ( op_size > 0 );
+
+      __DSB();
+      __ISB();
+    }
+  #endif
+}
+
+
+/**
+  \brief   D-Cache Clean and Invalidate by address
+  \details Cleans and invalidates D_Cache for the given address
+           D-Cache is cleaned and invalidated starting from a 32 byte aligned address in 32 byte granularity.
+           D-Cache memory blocks which are part of given address + given size are cleaned and invalidated.
+  \param[in]   addr    address (aligned to 32-byte boundary)
+  \param[in]   dsize   size of memory block (in number of bytes)
+*/
+__STATIC_FORCEINLINE void SCB_CleanInvalidateDCache_by_Addr (uint32_t *addr, int32_t dsize)
+{
+  #if defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
+    if ( dsize > 0 ) {
+       int32_t op_size = dsize + (((uint32_t)addr) & (__SCB_DCACHE_LINE_SIZE - 1U));
+      uint32_t op_addr = (uint32_t)addr /* & ~(__SCB_DCACHE_LINE_SIZE - 1U) */;
+
+      __DSB();
+
+      do {
+        SCB->DCCIMVAC = op_addr;            /* register accepts only 32byte aligned values, only bits 31..5 are valid */
+        op_addr +=          __SCB_DCACHE_LINE_SIZE;
+        op_size -=          __SCB_DCACHE_LINE_SIZE;
+      } while ( op_size > 0 );
+
+      __DSB();
+      __ISB();
+    }
+  #endif
+}
+
+/*@} end of CMSIS_Core_CacheFunctions */
+#endif
+
+
+/* ##################################    SysTick function  ############################################ */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_SysTickFunctions SysTick Functions
+  \brief    Functions that configure the System.
+  @{
+ */
+
+#if defined (__Vendor_SysTickConfig) && (__Vendor_SysTickConfig == 0U)
+
+/**
+  \brief   System Tick Configuration
+  \details Initializes the System Timer and its interrupt, and starts the System Tick Timer.
+           Counter is in free running mode to generate periodic interrupts.
+  \param [in]  ticks  Number of ticks between two interrupts.
+  \return          0  Function succeeded.
+  \return          1  Function failed.
+  \note    When the variable <b>__Vendor_SysTickConfig</b> is set to 1, then the
+           function <b>SysTick_Config</b> is not included. In this case, the file <b><i>device</i>.h</b>
+           must contain a vendor-specific implementation of this function.
+ */
+__STATIC_INLINE uint32_t SysTick_Config(uint32_t ticks)
+{
+  if ((ticks - 1UL) > SysTick_LOAD_RELOAD_Msk)
+  {
+    return (1UL);                                                   /* Reload value impossible */
+  }
+
+  SysTick->LOAD  = (uint32_t)(ticks - 1UL);                         /* set reload register */
+  NVIC_SetPriority (SysTick_IRQn, (1UL << __NVIC_PRIO_BITS) - 1UL); /* set Priority for Systick Interrupt */
+  SysTick->VAL   = 0UL;                                             /* Load the SysTick Counter Value */
+  SysTick->CTRL  = SysTick_CTRL_CLKSOURCE_Msk |
+                   SysTick_CTRL_TICKINT_Msk   |
+                   SysTick_CTRL_ENABLE_Msk;                         /* Enable SysTick IRQ and SysTick Timer */
+  return (0UL);                                                     /* Function successful */
+}
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   System Tick Configuration (non-secure)
+  \details Initializes the non-secure System Timer and its interrupt when in secure state, and starts the System Tick Timer.
+           Counter is in free running mode to generate periodic interrupts.
+  \param [in]  ticks  Number of ticks between two interrupts.
+  \return          0  Function succeeded.
+  \return          1  Function failed.
+  \note    When the variable <b>__Vendor_SysTickConfig</b> is set to 1, then the
+           function <b>TZ_SysTick_Config_NS</b> is not included. In this case, the file <b><i>device</i>.h</b>
+           must contain a vendor-specific implementation of this function.
+
+ */
+__STATIC_INLINE uint32_t TZ_SysTick_Config_NS(uint32_t ticks)
+{
+  if ((ticks - 1UL) > SysTick_LOAD_RELOAD_Msk)
+  {
+    return (1UL);                                                         /* Reload value impossible */
+  }
+
+  SysTick_NS->LOAD  = (uint32_t)(ticks - 1UL);                            /* set reload register */
+  TZ_NVIC_SetPriority_NS (SysTick_IRQn, (1UL << __NVIC_PRIO_BITS) - 1UL); /* set Priority for Systick Interrupt */
+  SysTick_NS->VAL   = 0UL;                                                /* Load the SysTick Counter Value */
+  SysTick_NS->CTRL  = SysTick_CTRL_CLKSOURCE_Msk |
+                      SysTick_CTRL_TICKINT_Msk   |
+                      SysTick_CTRL_ENABLE_Msk;                            /* Enable SysTick IRQ and SysTick Timer */
+  return (0UL);                                                           /* Function successful */
+}
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+#endif
+
+/*@} end of CMSIS_Core_SysTickFunctions */
+
+
+
+/* ##################################### Debug In/Output function ########################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_core_DebugFunctions ITM Functions
+  \brief    Functions that access the ITM debug interface.
+  @{
+ */
+
+extern volatile int32_t ITM_RxBuffer;                              /*!< External variable to receive characters. */
+#define                 ITM_RXBUFFER_EMPTY  ((int32_t)0x5AA55AA5U) /*!< Value identifying \ref ITM_RxBuffer is ready for next character. */
+
+
+/**
+  \brief   ITM Send Character
+  \details Transmits a character via the ITM channel 0, and
+           \li Just returns when no debugger is connected that has booked the output.
+           \li Is blocking when a debugger is connected, but the previous character sent has not been transmitted.
+  \param [in]     ch  Character to transmit.
+  \returns            Character to transmit.
+ */
+__STATIC_INLINE uint32_t ITM_SendChar (uint32_t ch)
+{
+  if (((ITM->TCR & ITM_TCR_ITMENA_Msk) != 0UL) &&      /* ITM enabled */
+      ((ITM->TER & 1UL               ) != 0UL)   )     /* ITM Port #0 enabled */
+  {
+    while (ITM->PORT[0U].u32 == 0UL)
+    {
+      __NOP();
+    }
+    ITM->PORT[0U].u8 = (uint8_t)ch;
+  }
+  return (ch);
+}
+
+
+/**
+  \brief   ITM Receive Character
+  \details Inputs a character via the external variable \ref ITM_RxBuffer.
+  \return             Received character.
+  \return         -1  No character pending.
+ */
+__STATIC_INLINE int32_t ITM_ReceiveChar (void)
+{
+  int32_t ch = -1;                           /* no character available */
+
+  if (ITM_RxBuffer != ITM_RXBUFFER_EMPTY)
+  {
+    ch = ITM_RxBuffer;
+    ITM_RxBuffer = ITM_RXBUFFER_EMPTY;       /* ready for next character */
+  }
+
+  return (ch);
+}
+
+
+/**
+  \brief   ITM Check Character
+  \details Checks whether a character is pending for reading in the variable \ref ITM_RxBuffer.
+  \return          0  No character available.
+  \return          1  Character available.
+ */
+__STATIC_INLINE int32_t ITM_CheckChar (void)
+{
+
+  if (ITM_RxBuffer == ITM_RXBUFFER_EMPTY)
+  {
+    return (0);                              /* no character available */
+  }
+  else
+  {
+    return (1);                              /*    character available */
+  }
+}
+
+/*@} end of CMSIS_core_DebugFunctions */
+
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_STAR_H_DEPENDANT */
+
+#endif /* __CMSIS_GENERIC */

--- a/platform/ext/cmsis/CMSIS/Core/Include/m-profile/armv7m_cachel1.h
+++ b/platform/ext/cmsis/CMSIS/Core/Include/m-profile/armv7m_cachel1.h
@@ -1,0 +1,439 @@
+/*
+ * Copyright (c) 2020-2021 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS-Core(M) Level 1 Cache API for Armv7-M and later
+ */
+
+#ifndef ARM_ARMV7M_CACHEL1_H
+#define ARM_ARMV7M_CACHEL1_H
+
+#if   defined ( __ICCARM__ )
+  #pragma system_include         /* treat file as system include file for MISRA check */
+#elif defined (__clang__)
+  #pragma clang system_header    /* treat file as system include file */
+#endif
+
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_CacheFunctions Cache Functions
+  \brief    Functions that configure Instruction and Data cache.
+  @{
+ */
+
+/* Cache Size ID Register Macros */
+#define CCSIDR_WAYS(x)         (((x) & SCB_CCSIDR_ASSOCIATIVITY_Msk) >> SCB_CCSIDR_ASSOCIATIVITY_Pos)
+#define CCSIDR_SETS(x)         (((x) & SCB_CCSIDR_NUMSETS_Msk      ) >> SCB_CCSIDR_NUMSETS_Pos      )
+
+#ifndef __SCB_DCACHE_LINE_SIZE
+#define __SCB_DCACHE_LINE_SIZE  32U /*!< Cortex-M7 cache line size is fixed to 32 bytes (8 words). See also register SCB_CCSIDR */
+#endif
+
+#ifndef __SCB_ICACHE_LINE_SIZE
+#define __SCB_ICACHE_LINE_SIZE  32U /*!< Cortex-M7 cache line size is fixed to 32 bytes (8 words). See also register SCB_CCSIDR */
+#endif
+
+/**
+  \brief   Enable I-Cache
+  \details Turns on I-Cache
+  */
+__STATIC_FORCEINLINE void SCB_EnableICache (void)
+{
+  #if defined (__ICACHE_PRESENT) && (__ICACHE_PRESENT == 1U)
+    if (SCB->CCR & SCB_CCR_IC_Msk) return;  /* return if ICache is already enabled */
+
+    __DSB();
+    __ISB();
+    SCB->ICIALLU = 0UL;                     /* invalidate I-Cache */
+    __DSB();
+    __ISB();
+    SCB->CCR |=  (uint32_t)SCB_CCR_IC_Msk;  /* enable I-Cache */
+    __DSB();
+    __ISB();
+  #endif
+}
+
+
+/**
+  \brief   Disable I-Cache
+  \details Turns off I-Cache
+  */
+__STATIC_FORCEINLINE void SCB_DisableICache (void)
+{
+  #if defined (__ICACHE_PRESENT) && (__ICACHE_PRESENT == 1U)
+    __DSB();
+    __ISB();
+    SCB->CCR &= ~(uint32_t)SCB_CCR_IC_Msk;  /* disable I-Cache */
+    SCB->ICIALLU = 0UL;                     /* invalidate I-Cache */
+    __DSB();
+    __ISB();
+  #endif
+}
+
+
+/**
+  \brief   Invalidate I-Cache
+  \details Invalidates I-Cache
+  */
+__STATIC_FORCEINLINE void SCB_InvalidateICache (void)
+{
+  #if defined (__ICACHE_PRESENT) && (__ICACHE_PRESENT == 1U)
+    __DSB();
+    __ISB();
+    SCB->ICIALLU = 0UL;
+    __DSB();
+    __ISB();
+  #endif
+}
+
+
+/**
+  \brief   I-Cache Invalidate by address
+  \details Invalidates I-Cache for the given address.
+           I-Cache is invalidated starting from a 32 byte aligned address in 32 byte granularity.
+           I-Cache memory blocks which are part of given address + given size are invalidated.
+  \param[in]   addr    address
+  \param[in]   isize   size of memory block (in number of bytes)
+*/
+__STATIC_FORCEINLINE void SCB_InvalidateICache_by_Addr (volatile void *addr, int32_t isize)
+{
+  #if defined (__ICACHE_PRESENT) && (__ICACHE_PRESENT == 1U)
+    if ( isize > 0 ) {
+       int32_t op_size = isize + (((uint32_t)addr) & (__SCB_ICACHE_LINE_SIZE - 1U));
+      uint32_t op_addr = (uint32_t)addr /* & ~(__SCB_ICACHE_LINE_SIZE - 1U) */;
+
+      __DSB();
+
+      do {
+        SCB->ICIMVAU = op_addr;             /* register accepts only 32byte aligned values, only bits 31..5 are valid */
+        op_addr += __SCB_ICACHE_LINE_SIZE;
+        op_size -= __SCB_ICACHE_LINE_SIZE;
+      } while ( op_size > 0 );
+
+      __DSB();
+      __ISB();
+    }
+  #endif
+}
+
+
+/**
+  \brief   Enable D-Cache
+  \details Turns on D-Cache
+  */
+__STATIC_FORCEINLINE void SCB_EnableDCache (void)
+{
+  #if defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
+    uint32_t ccsidr;
+    uint32_t sets;
+    uint32_t ways;
+
+    if (SCB->CCR & SCB_CCR_DC_Msk) return;  /* return if DCache is already enabled */
+
+    SCB->CSSELR = 0U;                       /* select Level 1 data cache */
+    __DSB();
+
+    ccsidr = SCB->CCSIDR;
+
+                                            /* invalidate D-Cache */
+    sets = (uint32_t)(CCSIDR_SETS(ccsidr));
+    do {
+      ways = (uint32_t)(CCSIDR_WAYS(ccsidr));
+      do {
+        SCB->DCISW = (((sets << SCB_DCISW_SET_Pos) & SCB_DCISW_SET_Msk) |
+                      ((ways << SCB_DCISW_WAY_Pos) & SCB_DCISW_WAY_Msk)  );
+        #if defined ( __CC_ARM )
+          __schedule_barrier();
+        #endif
+      } while (ways-- != 0U);
+    } while(sets-- != 0U);
+    __DSB();
+
+    SCB->CCR |=  (uint32_t)SCB_CCR_DC_Msk;  /* enable D-Cache */
+
+    __DSB();
+    __ISB();
+  #endif
+}
+
+
+/**
+  \brief   Disable D-Cache
+  \details Turns off D-Cache
+  */
+__STATIC_FORCEINLINE void SCB_DisableDCache (void)
+{
+  #if defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
+    struct {
+      uint32_t ccsidr;
+      uint32_t sets;
+      uint32_t ways;
+    } locals
+    #if ((defined(__GNUC__) || defined(__clang__)) && !defined(__OPTIMIZE__))
+       __ALIGNED(__SCB_DCACHE_LINE_SIZE)
+    #endif
+    ;
+
+    SCB->CSSELR = 0U;                       /* select Level 1 data cache */
+    __DSB();
+
+    SCB->CCR &= ~(uint32_t)SCB_CCR_DC_Msk;  /* disable D-Cache */
+    __DSB();
+
+    #if !defined(__OPTIMIZE__)
+      /*
+       * For the endless loop issue with no optimization builds.
+       * More details, see https://github.com/ARM-software/CMSIS_5/issues/620
+       *
+       * The issue only happens when local variables are in stack. If
+       * local variables are saved in general purpose register, then the function
+       * is OK.
+       *
+       * When local variables are in stack, after disabling the cache, flush the
+       * local variables cache line for data consistency.
+       */
+      /* Clean and invalidate the local variable cache. */
+    #if defined(__ICCARM__)
+    /* As we can't align the stack to the cache line size, invalidate each of the variables */
+      SCB->DCCIMVAC = (uint32_t)&locals.sets;
+      SCB->DCCIMVAC = (uint32_t)&locals.ways;
+      SCB->DCCIMVAC = (uint32_t)&locals.ccsidr;
+    #else
+      SCB->DCCIMVAC = (uint32_t)&locals;
+    #endif
+      __DSB();
+      __ISB();
+    #endif
+
+    locals.ccsidr = SCB->CCSIDR;
+                                            /* clean & invalidate D-Cache */
+    locals.sets = (uint32_t)(CCSIDR_SETS(locals.ccsidr));
+    do {
+      locals.ways = (uint32_t)(CCSIDR_WAYS(locals.ccsidr));
+      do {
+        SCB->DCCISW = (((locals.sets << SCB_DCCISW_SET_Pos) & SCB_DCCISW_SET_Msk) |
+                       ((locals.ways << SCB_DCCISW_WAY_Pos) & SCB_DCCISW_WAY_Msk)  );
+        #if defined ( __CC_ARM )
+          __schedule_barrier();
+        #endif
+      } while (locals.ways-- != 0U);
+    } while(locals.sets-- != 0U);
+
+    __DSB();
+    __ISB();
+  #endif
+}
+
+
+/**
+  \brief   Invalidate D-Cache
+  \details Invalidates D-Cache
+  */
+__STATIC_FORCEINLINE void SCB_InvalidateDCache (void)
+{
+  #if defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
+    uint32_t ccsidr;
+    uint32_t sets;
+    uint32_t ways;
+
+    SCB->CSSELR = 0U;                       /* select Level 1 data cache */
+    __DSB();
+
+    ccsidr = SCB->CCSIDR;
+
+                                            /* invalidate D-Cache */
+    sets = (uint32_t)(CCSIDR_SETS(ccsidr));
+    do {
+      ways = (uint32_t)(CCSIDR_WAYS(ccsidr));
+      do {
+        SCB->DCISW = (((sets << SCB_DCISW_SET_Pos) & SCB_DCISW_SET_Msk) |
+                      ((ways << SCB_DCISW_WAY_Pos) & SCB_DCISW_WAY_Msk)  );
+        #if defined ( __CC_ARM )
+          __schedule_barrier();
+        #endif
+      } while (ways-- != 0U);
+    } while(sets-- != 0U);
+
+    __DSB();
+    __ISB();
+  #endif
+}
+
+
+/**
+  \brief   Clean D-Cache
+  \details Cleans D-Cache
+  */
+__STATIC_FORCEINLINE void SCB_CleanDCache (void)
+{
+  #if defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
+    uint32_t ccsidr;
+    uint32_t sets;
+    uint32_t ways;
+
+    SCB->CSSELR = 0U;                       /* select Level 1 data cache */
+    __DSB();
+
+    ccsidr = SCB->CCSIDR;
+
+                                            /* clean D-Cache */
+    sets = (uint32_t)(CCSIDR_SETS(ccsidr));
+    do {
+      ways = (uint32_t)(CCSIDR_WAYS(ccsidr));
+      do {
+        SCB->DCCSW = (((sets << SCB_DCCSW_SET_Pos) & SCB_DCCSW_SET_Msk) |
+                      ((ways << SCB_DCCSW_WAY_Pos) & SCB_DCCSW_WAY_Msk)  );
+        #if defined ( __CC_ARM )
+          __schedule_barrier();
+        #endif
+      } while (ways-- != 0U);
+    } while(sets-- != 0U);
+
+    __DSB();
+    __ISB();
+  #endif
+}
+
+
+/**
+  \brief   Clean & Invalidate D-Cache
+  \details Cleans and Invalidates D-Cache
+  */
+__STATIC_FORCEINLINE void SCB_CleanInvalidateDCache (void)
+{
+  #if defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
+    uint32_t ccsidr;
+    uint32_t sets;
+    uint32_t ways;
+
+    SCB->CSSELR = 0U;                       /* select Level 1 data cache */
+    __DSB();
+
+    ccsidr = SCB->CCSIDR;
+
+                                            /* clean & invalidate D-Cache */
+    sets = (uint32_t)(CCSIDR_SETS(ccsidr));
+    do {
+      ways = (uint32_t)(CCSIDR_WAYS(ccsidr));
+      do {
+        SCB->DCCISW = (((sets << SCB_DCCISW_SET_Pos) & SCB_DCCISW_SET_Msk) |
+                       ((ways << SCB_DCCISW_WAY_Pos) & SCB_DCCISW_WAY_Msk)  );
+        #if defined ( __CC_ARM )
+          __schedule_barrier();
+        #endif
+      } while (ways-- != 0U);
+    } while(sets-- != 0U);
+
+    __DSB();
+    __ISB();
+  #endif
+}
+
+
+/**
+  \brief   D-Cache Invalidate by address
+  \details Invalidates D-Cache for the given address.
+           D-Cache is invalidated starting from a 32 byte aligned address in 32 byte granularity.
+           D-Cache memory blocks which are part of given address + given size are invalidated.
+  \param[in]   addr    address
+  \param[in]   dsize   size of memory block (in number of bytes)
+*/
+__STATIC_FORCEINLINE void SCB_InvalidateDCache_by_Addr (volatile void *addr, int32_t dsize)
+{
+  #if defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
+    if ( dsize > 0 ) {
+       int32_t op_size = dsize + (((uint32_t)addr) & (__SCB_DCACHE_LINE_SIZE - 1U));
+      uint32_t op_addr = (uint32_t)addr /* & ~(__SCB_DCACHE_LINE_SIZE - 1U) */;
+
+      __DSB();
+
+      do {
+        SCB->DCIMVAC = op_addr;             /* register accepts only 32byte aligned values, only bits 31..5 are valid */
+        op_addr += __SCB_DCACHE_LINE_SIZE;
+        op_size -= __SCB_DCACHE_LINE_SIZE;
+      } while ( op_size > 0 );
+
+      __DSB();
+      __ISB();
+    }
+  #endif
+}
+
+
+/**
+  \brief   D-Cache Clean by address
+  \details Cleans D-Cache for the given address
+           D-Cache is cleaned starting from a 32 byte aligned address in 32 byte granularity.
+           D-Cache memory blocks which are part of given address + given size are cleaned.
+  \param[in]   addr    address
+  \param[in]   dsize   size of memory block (in number of bytes)
+*/
+__STATIC_FORCEINLINE void SCB_CleanDCache_by_Addr (volatile void *addr, int32_t dsize)
+{
+  #if defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
+    if ( dsize > 0 ) {
+       int32_t op_size = dsize + (((uint32_t)addr) & (__SCB_DCACHE_LINE_SIZE - 1U));
+      uint32_t op_addr = (uint32_t)addr /* & ~(__SCB_DCACHE_LINE_SIZE - 1U) */;
+
+      __DSB();
+
+      do {
+        SCB->DCCMVAC = op_addr;             /* register accepts only 32byte aligned values, only bits 31..5 are valid */
+        op_addr += __SCB_DCACHE_LINE_SIZE;
+        op_size -= __SCB_DCACHE_LINE_SIZE;
+      } while ( op_size > 0 );
+
+      __DSB();
+      __ISB();
+    }
+  #endif
+}
+
+
+/**
+  \brief   D-Cache Clean and Invalidate by address
+  \details Cleans and invalidates D_Cache for the given address
+           D-Cache is cleaned and invalidated starting from a 32 byte aligned address in 32 byte granularity.
+           D-Cache memory blocks which are part of given address + given size are cleaned and invalidated.
+  \param[in]   addr    address (aligned to 32-byte boundary)
+  \param[in]   dsize   size of memory block (in number of bytes)
+*/
+__STATIC_FORCEINLINE void SCB_CleanInvalidateDCache_by_Addr (volatile void *addr, int32_t dsize)
+{
+  #if defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
+    if ( dsize > 0 ) {
+       int32_t op_size = dsize + (((uint32_t)addr) & (__SCB_DCACHE_LINE_SIZE - 1U));
+      uint32_t op_addr = (uint32_t)addr /* & ~(__SCB_DCACHE_LINE_SIZE - 1U) */;
+
+      __DSB();
+
+      do {
+        SCB->DCCIMVAC = op_addr;            /* register accepts only 32byte aligned values, only bits 31..5 are valid */
+        op_addr +=          __SCB_DCACHE_LINE_SIZE;
+        op_size -=          __SCB_DCACHE_LINE_SIZE;
+      } while ( op_size > 0 );
+
+      __DSB();
+      __ISB();
+    }
+  #endif
+}
+
+/*@} end of CMSIS_Core_CacheFunctions */
+
+#endif /* ARM_ARMV7M_CACHEL1_H */

--- a/platform/ext/cmsis/CMSIS/Core/Include/m-profile/armv7m_mpu.h
+++ b/platform/ext/cmsis/CMSIS/Core/Include/m-profile/armv7m_mpu.h
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2017-2020 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS-Core(M) MPU API for Armv7-M MPU
+ */
+
+#ifndef ARM_MPU_ARMV7_H
+#define ARM_MPU_ARMV7_H
+
+#if   defined ( __ICCARM__ )
+  #pragma system_include         /* treat file as system include file for MISRA check */
+#elif defined (__clang__)
+  #pragma clang system_header    /* treat file as system include file */
+#endif
+
+#define ARM_MPU_REGION_SIZE_32B      ((uint8_t)0x04U) ///!< MPU Region Size 32 Bytes
+#define ARM_MPU_REGION_SIZE_64B      ((uint8_t)0x05U) ///!< MPU Region Size 64 Bytes
+#define ARM_MPU_REGION_SIZE_128B     ((uint8_t)0x06U) ///!< MPU Region Size 128 Bytes
+#define ARM_MPU_REGION_SIZE_256B     ((uint8_t)0x07U) ///!< MPU Region Size 256 Bytes
+#define ARM_MPU_REGION_SIZE_512B     ((uint8_t)0x08U) ///!< MPU Region Size 512 Bytes
+#define ARM_MPU_REGION_SIZE_1KB      ((uint8_t)0x09U) ///!< MPU Region Size 1 KByte
+#define ARM_MPU_REGION_SIZE_2KB      ((uint8_t)0x0AU) ///!< MPU Region Size 2 KBytes
+#define ARM_MPU_REGION_SIZE_4KB      ((uint8_t)0x0BU) ///!< MPU Region Size 4 KBytes
+#define ARM_MPU_REGION_SIZE_8KB      ((uint8_t)0x0CU) ///!< MPU Region Size 8 KBytes
+#define ARM_MPU_REGION_SIZE_16KB     ((uint8_t)0x0DU) ///!< MPU Region Size 16 KBytes
+#define ARM_MPU_REGION_SIZE_32KB     ((uint8_t)0x0EU) ///!< MPU Region Size 32 KBytes
+#define ARM_MPU_REGION_SIZE_64KB     ((uint8_t)0x0FU) ///!< MPU Region Size 64 KBytes
+#define ARM_MPU_REGION_SIZE_128KB    ((uint8_t)0x10U) ///!< MPU Region Size 128 KBytes
+#define ARM_MPU_REGION_SIZE_256KB    ((uint8_t)0x11U) ///!< MPU Region Size 256 KBytes
+#define ARM_MPU_REGION_SIZE_512KB    ((uint8_t)0x12U) ///!< MPU Region Size 512 KBytes
+#define ARM_MPU_REGION_SIZE_1MB      ((uint8_t)0x13U) ///!< MPU Region Size 1 MByte
+#define ARM_MPU_REGION_SIZE_2MB      ((uint8_t)0x14U) ///!< MPU Region Size 2 MBytes
+#define ARM_MPU_REGION_SIZE_4MB      ((uint8_t)0x15U) ///!< MPU Region Size 4 MBytes
+#define ARM_MPU_REGION_SIZE_8MB      ((uint8_t)0x16U) ///!< MPU Region Size 8 MBytes
+#define ARM_MPU_REGION_SIZE_16MB     ((uint8_t)0x17U) ///!< MPU Region Size 16 MBytes
+#define ARM_MPU_REGION_SIZE_32MB     ((uint8_t)0x18U) ///!< MPU Region Size 32 MBytes
+#define ARM_MPU_REGION_SIZE_64MB     ((uint8_t)0x19U) ///!< MPU Region Size 64 MBytes
+#define ARM_MPU_REGION_SIZE_128MB    ((uint8_t)0x1AU) ///!< MPU Region Size 128 MBytes
+#define ARM_MPU_REGION_SIZE_256MB    ((uint8_t)0x1BU) ///!< MPU Region Size 256 MBytes
+#define ARM_MPU_REGION_SIZE_512MB    ((uint8_t)0x1CU) ///!< MPU Region Size 512 MBytes
+#define ARM_MPU_REGION_SIZE_1GB      ((uint8_t)0x1DU) ///!< MPU Region Size 1 GByte
+#define ARM_MPU_REGION_SIZE_2GB      ((uint8_t)0x1EU) ///!< MPU Region Size 2 GBytes
+#define ARM_MPU_REGION_SIZE_4GB      ((uint8_t)0x1FU) ///!< MPU Region Size 4 GBytes
+
+#define ARM_MPU_AP_NONE 0U ///!< MPU Access Permission no access
+#define ARM_MPU_AP_PRIV 1U ///!< MPU Access Permission privileged access only
+#define ARM_MPU_AP_URO  2U ///!< MPU Access Permission unprivileged access read-only
+#define ARM_MPU_AP_FULL 3U ///!< MPU Access Permission full access
+#define ARM_MPU_AP_PRO  5U ///!< MPU Access Permission privileged access read-only
+#define ARM_MPU_AP_RO   6U ///!< MPU Access Permission read-only access
+
+/** MPU Region Base Address Register Value
+*
+* \param Region The region to be configured, number 0 to 15.
+* \param BaseAddress The base address for the region.
+*/
+#define ARM_MPU_RBAR(Region, BaseAddress) \
+  (((BaseAddress) & MPU_RBAR_ADDR_Msk) |  \
+   ((Region) & MPU_RBAR_REGION_Msk)    |  \
+   (MPU_RBAR_VALID_Msk))
+
+/**
+* MPU Memory Access Attributes
+*
+* \param TypeExtField      Type extension field, allows you to configure memory access type, for example strongly ordered, peripheral.
+* \param IsShareable       Region is shareable between multiple bus masters.
+* \param IsCacheable       Region is cacheable, i.e. its value may be kept in cache.
+* \param IsBufferable      Region is bufferable, i.e. using write-back caching. Cacheable but non-bufferable regions use write-through policy.
+*/
+#define ARM_MPU_ACCESS_(TypeExtField, IsShareable, IsCacheable, IsBufferable)   \
+  ((((TypeExtField) << MPU_RASR_TEX_Pos) & MPU_RASR_TEX_Msk)                  | \
+   (((IsShareable)  << MPU_RASR_S_Pos)   & MPU_RASR_S_Msk)                    | \
+   (((IsCacheable)  << MPU_RASR_C_Pos)   & MPU_RASR_C_Msk)                    | \
+   (((IsBufferable) << MPU_RASR_B_Pos)   & MPU_RASR_B_Msk))
+
+/**
+* MPU Region Attribute and Size Register Value
+*
+* \param DisableExec       Instruction access disable bit, 1= disable instruction fetches.
+* \param AccessPermission  Data access permissions, allows you to configure read/write access for User and Privileged mode.
+* \param AccessAttributes  Memory access attribution, see \ref ARM_MPU_ACCESS_.
+* \param SubRegionDisable  Sub-region disable field.
+* \param Size              Region size of the region to be configured, for example 4K, 8K.
+*/
+#define ARM_MPU_RASR_EX(DisableExec, AccessPermission, AccessAttributes, SubRegionDisable, Size)    \
+  ((((DisableExec)      << MPU_RASR_XN_Pos)   & MPU_RASR_XN_Msk)                                  | \
+   (((AccessPermission) << MPU_RASR_AP_Pos)   & MPU_RASR_AP_Msk)                                  | \
+   (((AccessAttributes) & (MPU_RASR_TEX_Msk | MPU_RASR_S_Msk | MPU_RASR_C_Msk | MPU_RASR_B_Msk))) | \
+   (((SubRegionDisable) << MPU_RASR_SRD_Pos)  & MPU_RASR_SRD_Msk)                                 | \
+   (((Size)             << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)                                | \
+   (((MPU_RASR_ENABLE_Msk))))
+
+/**
+* MPU Region Attribute and Size Register Value
+*
+* \param DisableExec       Instruction access disable bit, 1= disable instruction fetches.
+* \param AccessPermission  Data access permissions, allows you to configure read/write access for User and Privileged mode.
+* \param TypeExtField      Type extension field, allows you to configure memory access type, for example strongly ordered, peripheral.
+* \param IsShareable       Region is shareable between multiple bus masters.
+* \param IsCacheable       Region is cacheable, i.e. its value may be kept in cache.
+* \param IsBufferable      Region is bufferable, i.e. using write-back caching. Cacheable but non-bufferable regions use write-through policy.
+* \param SubRegionDisable  Sub-region disable field.
+* \param Size              Region size of the region to be configured, for example 4K, 8K.
+*/
+#define ARM_MPU_RASR(DisableExec, AccessPermission, TypeExtField, IsShareable, IsCacheable, IsBufferable, SubRegionDisable, Size) \
+  ARM_MPU_RASR_EX(DisableExec, AccessPermission, ARM_MPU_ACCESS_(TypeExtField, IsShareable, IsCacheable, IsBufferable), SubRegionDisable, Size)
+
+/**
+* MPU Memory Access Attribute for strongly ordered memory.
+*  - TEX: 000b
+*  - Shareable
+*  - Non-cacheable
+*  - Non-bufferable
+*/
+#define ARM_MPU_ACCESS_ORDERED ARM_MPU_ACCESS_(0U, 1U, 0U, 0U)
+
+/**
+* MPU Memory Access Attribute for device memory.
+*  - TEX: 000b (if shareable) or 010b (if non-shareable)
+*  - Shareable or non-shareable
+*  - Non-cacheable
+*  - Bufferable (if shareable) or non-bufferable (if non-shareable)
+*
+* \param IsShareable Configures the device memory as shareable or non-shareable.
+*/
+#define ARM_MPU_ACCESS_DEVICE(IsShareable) ((IsShareable) ? ARM_MPU_ACCESS_(0U, 1U, 0U, 1U) : ARM_MPU_ACCESS_(2U, 0U, 0U, 0U))
+
+/**
+* MPU Memory Access Attribute for normal memory.
+*  - TEX: 1BBb (reflecting outer cacheability rules)
+*  - Shareable or non-shareable
+*  - Cacheable or non-cacheable (reflecting inner cacheability rules)
+*  - Bufferable or non-bufferable (reflecting inner cacheability rules)
+*
+* \param OuterCp Configures the outer cache policy.
+* \param InnerCp Configures the inner cache policy.
+* \param IsShareable Configures the memory as shareable or non-shareable.
+*/
+#define ARM_MPU_ACCESS_NORMAL(OuterCp, InnerCp, IsShareable) ARM_MPU_ACCESS_((4U | (OuterCp)), IsShareable, ((InnerCp) >> 1U), ((InnerCp) & 1U))
+
+/**
+* MPU Memory Access Attribute non-cacheable policy.
+*/
+#define ARM_MPU_CACHEP_NOCACHE 0U
+
+/**
+* MPU Memory Access Attribute write-back, write and read allocate policy.
+*/
+#define ARM_MPU_CACHEP_WB_WRA 1U
+
+/**
+* MPU Memory Access Attribute write-through, no write allocate policy.
+*/
+#define ARM_MPU_CACHEP_WT_NWA 2U
+
+/**
+* MPU Memory Access Attribute write-back, no write allocate policy.
+*/
+#define ARM_MPU_CACHEP_WB_NWA 3U
+
+
+/**
+* Struct for a single MPU Region
+*/
+typedef struct {
+  uint32_t RBAR; //!< The region base address register value (RBAR)
+  uint32_t RASR; //!< The region attribute and size register value (RASR) \ref MPU_RASR
+} ARM_MPU_Region_t;
+
+/** Enable the MPU.
+* \param MPU_Control Default access permissions for unconfigured regions.
+*/
+__STATIC_INLINE void ARM_MPU_Enable(uint32_t MPU_Control)
+{
+  __DMB();
+  MPU->CTRL = MPU_Control | MPU_CTRL_ENABLE_Msk;
+#ifdef SCB_SHCSR_MEMFAULTENA_Msk
+  SCB->SHCSR |= SCB_SHCSR_MEMFAULTENA_Msk;
+#endif
+  __DSB();
+  __ISB();
+}
+
+/** Disable the MPU.
+*/
+__STATIC_INLINE void ARM_MPU_Disable(void)
+{
+  __DMB();
+#ifdef SCB_SHCSR_MEMFAULTENA_Msk
+  SCB->SHCSR &= ~SCB_SHCSR_MEMFAULTENA_Msk;
+#endif
+  MPU->CTRL  &= ~MPU_CTRL_ENABLE_Msk;
+  __DSB();
+  __ISB();
+}
+
+/** Clear and disable the given MPU region.
+* \param rnr Region number to be cleared.
+*/
+__STATIC_INLINE void ARM_MPU_ClrRegion(uint32_t rnr)
+{
+  MPU->RNR = rnr;
+  MPU->RASR = 0U;
+}
+
+/** Configure an MPU region.
+* \param rbar Value for RBAR register.
+* \param rasr Value for RASR register.
+*/
+__STATIC_INLINE void ARM_MPU_SetRegion(uint32_t rbar, uint32_t rasr)
+{
+  MPU->RBAR = rbar;
+  MPU->RASR = rasr;
+}
+
+/** Configure the given MPU region.
+* \param rnr Region number to be configured.
+* \param rbar Value for RBAR register.
+* \param rasr Value for RASR register.
+*/
+__STATIC_INLINE void ARM_MPU_SetRegionEx(uint32_t rnr, uint32_t rbar, uint32_t rasr)
+{
+  MPU->RNR = rnr;
+  MPU->RBAR = rbar;
+  MPU->RASR = rasr;
+}
+
+/** Memcpy with strictly ordered memory access, e.g. used by code in ARM_MPU_Load().
+* \param dst Destination data is copied to.
+* \param src Source data is copied from.
+* \param len Amount of data words to be copied.
+*/
+__STATIC_INLINE void ARM_MPU_OrderedMemcpy(volatile uint32_t* dst, const uint32_t* __RESTRICT src, uint32_t len)
+{
+  uint32_t i;
+  for (i = 0U; i < len; ++i)
+  {
+    dst[i] = src[i];
+  }
+}
+
+/** Load the given number of MPU regions from a table.
+* \param table Pointer to the MPU configuration table.
+* \param cnt Amount of regions to be configured.
+*/
+__STATIC_INLINE void ARM_MPU_Load(ARM_MPU_Region_t const* table, uint32_t cnt)
+{
+  const uint32_t rowWordSize = sizeof(ARM_MPU_Region_t)/4U;
+  while (cnt > MPU_TYPE_RALIASES) {
+    ARM_MPU_OrderedMemcpy(&(MPU->RBAR), &(table->RBAR), MPU_TYPE_RALIASES*rowWordSize);
+    table += MPU_TYPE_RALIASES;
+    cnt -= MPU_TYPE_RALIASES;
+  }
+  ARM_MPU_OrderedMemcpy(&(MPU->RBAR), &(table->RBAR), cnt*rowWordSize);
+}
+
+#endif

--- a/platform/ext/cmsis/CMSIS/Core/Include/m-profile/armv81m_pac.h
+++ b/platform/ext/cmsis/CMSIS/Core/Include/m-profile/armv81m_pac.h
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2022 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS-Core(M) PAC key functions for Armv8.1-M PAC extension
+ */
+
+#ifndef PAC_ARMV81_H
+#define PAC_ARMV81_H
+
+#if   defined ( __ICCARM__ )
+  #pragma system_include         /* treat file as system include file for MISRA check */
+#elif defined (__clang__)
+  #pragma clang system_header    /* treat file as system include file */
+#endif
+
+/* ###################  PAC Key functions  ########################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_PacKeyFunctions PAC Key functions
+  \brief    Functions that access the PAC keys.
+  @{
+ */
+
+#if (defined (__ARM_FEATURE_PAUTH) && (__ARM_FEATURE_PAUTH == 1))
+
+/**
+  \brief   read the PAC key used for privileged mode
+  \details Reads the PAC key stored in the PAC_KEY_P registers.
+  \param [out]    pPacKey  128bit PAC key
+ */
+__STATIC_FORCEINLINE void __get_PAC_KEY_P (uint32_t* pPacKey) {
+  __ASM volatile (
+  "mrs   r1, pac_key_p_0\n"
+  "str   r1,[%0,#0]\n"
+  "mrs   r1, pac_key_p_1\n"
+  "str   r1,[%0,#4]\n"
+  "mrs   r1, pac_key_p_2\n"
+  "str   r1,[%0,#8]\n"
+  "mrs   r1, pac_key_p_3\n"
+  "str   r1,[%0,#12]\n"
+  : : "r" (pPacKey) : "memory", "r1"
+  );
+}
+
+/**
+  \brief   write the PAC key used for privileged mode
+  \details writes the given PAC key to the PAC_KEY_P registers.
+  \param [in]    pPacKey  128bit PAC key
+ */
+__STATIC_FORCEINLINE void __set_PAC_KEY_P (uint32_t* pPacKey) {
+  __ASM volatile (
+  "ldr   r1,[%0,#0]\n"
+  "msr   pac_key_p_0, r1\n"
+  "ldr   r1,[%0,#4]\n"
+  "msr   pac_key_p_1, r1\n"
+  "ldr   r1,[%0,#8]\n"
+  "msr   pac_key_p_2, r1\n"
+  "ldr   r1,[%0,#12]\n"
+  "msr   pac_key_p_3, r1\n"
+  : : "r" (pPacKey) : "memory", "r1"
+  );
+}
+
+/**
+  \brief   read the PAC key used for unprivileged mode
+  \details Reads the PAC key stored in the PAC_KEY_U registers.
+  \param [out]    pPacKey  128bit PAC key
+ */
+__STATIC_FORCEINLINE void __get_PAC_KEY_U (uint32_t* pPacKey) {
+  __ASM volatile (
+  "mrs   r1, pac_key_u_0\n"
+  "str   r1,[%0,#0]\n"
+  "mrs   r1, pac_key_u_1\n"
+  "str   r1,[%0,#4]\n"
+  "mrs   r1, pac_key_u_2\n"
+  "str   r1,[%0,#8]\n"
+  "mrs   r1, pac_key_u_3\n"
+  "str   r1,[%0,#12]\n"
+  : : "r" (pPacKey) : "memory", "r1"
+  );
+}
+
+/**
+  \brief   write the PAC key used for unprivileged mode
+  \details writes the given PAC key to the PAC_KEY_U registers.
+  \param [in]    pPacKey  128bit PAC key
+ */
+__STATIC_FORCEINLINE void __set_PAC_KEY_U (uint32_t* pPacKey) {
+  __ASM volatile (
+  "ldr   r1,[%0,#0]\n"
+  "msr   pac_key_u_0, r1\n"
+  "ldr   r1,[%0,#4]\n"
+  "msr   pac_key_u_1, r1\n"
+  "ldr   r1,[%0,#8]\n"
+  "msr   pac_key_u_2, r1\n"
+  "ldr   r1,[%0,#12]\n"
+  "msr   pac_key_u_3, r1\n"
+  : : "r" (pPacKey) : "memory", "r1"
+  );
+}
+
+#if (defined (__ARM_FEATURE_CMSE ) && (__ARM_FEATURE_CMSE == 3))
+
+/**
+  \brief   read the PAC key used for privileged mode (non-secure)
+  \details Reads the PAC key stored in the non-secure PAC_KEY_P registers when in secure mode.
+  \param [out]    pPacKey  128bit PAC key
+ */
+__STATIC_FORCEINLINE void __TZ_get_PAC_KEY_P_NS (uint32_t* pPacKey) {
+  __ASM volatile (
+  "mrs   r1, pac_key_p_0_ns\n"
+  "str   r1,[%0,#0]\n"
+  "mrs   r1, pac_key_p_1_ns\n"
+  "str   r1,[%0,#4]\n"
+  "mrs   r1, pac_key_p_2_ns\n"
+  "str   r1,[%0,#8]\n"
+  "mrs   r1, pac_key_p_3_ns\n"
+  "str   r1,[%0,#12]\n"
+  : : "r" (pPacKey) : "memory", "r1"
+  );
+}
+
+/**
+  \brief   write the PAC key used for privileged mode (non-secure)
+  \details writes the given PAC key to the non-secure PAC_KEY_P registers when in secure mode.
+  \param [in]    pPacKey  128bit PAC key
+ */
+__STATIC_FORCEINLINE void __TZ_set_PAC_KEY_P_NS (uint32_t* pPacKey) {
+  __ASM volatile (
+  "ldr   r1,[%0,#0]\n"
+  "msr   pac_key_p_0_ns, r1\n"
+  "ldr   r1,[%0,#4]\n"
+  "msr   pac_key_p_1_ns, r1\n"
+  "ldr   r1,[%0,#8]\n"
+  "msr   pac_key_p_2_ns, r1\n"
+  "ldr   r1,[%0,#12]\n"
+  "msr   pac_key_p_3_ns, r1\n"
+  : : "r" (pPacKey) : "memory", "r1"
+  );
+}
+
+/**
+  \brief   read the PAC key used for unprivileged mode (non-secure)
+  \details Reads the PAC key stored in the non-secure PAC_KEY_U registers when in secure mode.
+  \param [out]    pPacKey  128bit PAC key
+ */
+__STATIC_FORCEINLINE void __TZ_get_PAC_KEY_U_NS (uint32_t* pPacKey) {
+  __ASM volatile (
+  "mrs   r1, pac_key_u_0_ns\n"
+  "str   r1,[%0,#0]\n"
+  "mrs   r1, pac_key_u_1_ns\n"
+  "str   r1,[%0,#4]\n"
+  "mrs   r1, pac_key_u_2_ns\n"
+  "str   r1,[%0,#8]\n"
+  "mrs   r1, pac_key_u_3_ns\n"
+  "str   r1,[%0,#12]\n"
+  : : "r" (pPacKey) : "memory", "r1"
+  );
+}
+
+/**
+  \brief   write the PAC key used for unprivileged mode (non-secure)
+  \details writes the given PAC key to the non-secure PAC_KEY_U registers when in secure mode.
+  \param [in]    pPacKey  128bit PAC key
+ */
+__STATIC_FORCEINLINE void __TZ_set_PAC_KEY_U_NS (uint32_t* pPacKey) {
+  __ASM volatile (
+  "ldr   r1,[%0,#0]\n"
+  "msr   pac_key_u_0_ns, r1\n"
+  "ldr   r1,[%0,#4]\n"
+  "msr   pac_key_u_1_ns, r1\n"
+  "ldr   r1,[%0,#8]\n"
+  "msr   pac_key_u_2_ns, r1\n"
+  "ldr   r1,[%0,#12]\n"
+  "msr   pac_key_u_3_ns, r1\n"
+  : : "r" (pPacKey) : "memory", "r1"
+  );
+}
+
+#endif /* (defined (__ARM_FEATURE_CMSE ) && (__ARM_FEATURE_CMSE == 3)) */
+
+#endif /* (defined (__ARM_FEATURE_PAUTH) && (__ARM_FEATURE_PAUTH == 1)) */
+
+/*@} end of CMSIS_Core_PacKeyFunctions */
+
+
+#endif /* PAC_ARMV81_H */

--- a/platform/ext/cmsis/CMSIS/Core/Include/m-profile/armv8m_mpu.h
+++ b/platform/ext/cmsis/CMSIS/Core/Include/m-profile/armv8m_mpu.h
@@ -1,0 +1,421 @@
+/*
+ * Copyright (c) 2017-2022 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS-Core(M) MPU API for Armv8-M and Armv8.1-M MPU
+ */
+
+#ifndef ARM_MPU_ARMV8_H
+#define ARM_MPU_ARMV8_H
+
+#if   defined ( __ICCARM__ )
+  #pragma system_include         /* treat file as system include file for MISRA check */
+#elif defined (__clang__)
+  #pragma clang system_header    /* treat file as system include file */
+#endif
+
+/** \brief Attribute for device memory (outer only) */
+#define ARM_MPU_ATTR_DEVICE                           ( 0U )
+
+/** \brief Attribute for non-cacheable, normal memory */
+#define ARM_MPU_ATTR_NON_CACHEABLE                    ( 4U )
+
+/** \brief Attribute for Normal memory, Outer and Inner cacheability.
+* \param NT Non-Transient: Set to 1 for Non-transient data. Set to 0 for Transient data.
+* \param WB Write-Back: Set to 1 to use a Write-Back policy. Set to 0 to use a Write-Through policy.
+* \param RA Read Allocation: Set to 1 to enable cache allocation on read miss. Set to 0 to disable cache allocation on read miss.
+* \param WA Write Allocation: Set to 1 to enable cache allocation on write miss. Set to 0 to disable cache allocation on write miss.
+*/
+#define ARM_MPU_ATTR_MEMORY_(NT, WB, RA, WA) \
+  ((((NT) & 1U) << 3U) | (((WB) & 1U) << 2U) | (((RA) & 1U) << 1U) | ((WA) & 1U))
+
+/** \brief Device memory type non Gathering, non Re-ordering, non Early Write Acknowledgement */
+#define ARM_MPU_ATTR_DEVICE_nGnRnE (0U)
+
+/** \brief Device memory type non Gathering, non Re-ordering, Early Write Acknowledgement */
+#define ARM_MPU_ATTR_DEVICE_nGnRE  (1U)
+
+/** \brief Device memory type non Gathering, Re-ordering, Early Write Acknowledgement */
+#define ARM_MPU_ATTR_DEVICE_nGRE   (2U)
+
+/** \brief Device memory type Gathering, Re-ordering, Early Write Acknowledgement */
+#define ARM_MPU_ATTR_DEVICE_GRE    (3U)
+
+/** \brief Normal memory outer-cacheable and inner-cacheable attributes
+* WT = Write Through, WB = Write Back, TR = Transient, RA = Read-Allocate, WA = Write Allocate
+*/
+#define MPU_ATTR_NORMAL_OUTER_NON_CACHEABLE (0b0100)
+#define MPU_ATTR_NORMAL_OUTER_WT_TR_RA      (0b0010)
+#define MPU_ATTR_NORMAL_OUTER_WT_TR_WA      (0b0001)
+#define MPU_ATTR_NORMAL_OUTER_WT_TR_RA_WA   (0b0011)
+#define MPU_ATTR_NORMAL_OUTER_WT_RA         (0b1010)
+#define MPU_ATTR_NORMAL_OUTER_WT_WA         (0b1001)
+#define MPU_ATTR_NORMAL_OUTER_WT_RA_WA      (0b1011)
+#define MPU_ATTR_NORMAL_OUTER_WB_TR_RA      (0b0101)
+#define MPU_ATTR_NORMAL_OUTER_WB_TR_WA      (0b0110)
+#define MPU_ATTR_NORMAL_OUTER_WB_TR_RA_WA   (0b0111)
+#define MPU_ATTR_NORMAL_OUTER_WB_RA         (0b1101)
+#define MPU_ATTR_NORMAL_OUTER_WB_WA         (0b1110)
+#define MPU_ATTR_NORMAL_OUTER_WB_RA_WA      (0b1111)
+#define MPU_ATTR_NORMAL_INNER_NON_CACHEABLE (0b0100)
+#define MPU_ATTR_NORMAL_INNER_WT_TR_RA      (0b0010)
+#define MPU_ATTR_NORMAL_INNER_WT_TR_WA      (0b0001)
+#define MPU_ATTR_NORMAL_INNER_WT_TR_RA_WA   (0b0011)
+#define MPU_ATTR_NORMAL_INNER_WT_RA         (0b1010)
+#define MPU_ATTR_NORMAL_INNER_WT_WA         (0b1001)
+#define MPU_ATTR_NORMAL_INNER_WT_RA_WA      (0b1011)
+#define MPU_ATTR_NORMAL_INNER_WB_TR_RA      (0b0101)
+#define MPU_ATTR_NORMAL_INNER_WB_TR_WA      (0b0110)
+#define MPU_ATTR_NORMAL_INNER_WB_TR_RA_WA   (0b0111)
+#define MPU_ATTR_NORMAL_INNER_WB_RA         (0b1101)
+#define MPU_ATTR_NORMAL_INNER_WB_WA         (0b1110)
+#define MPU_ATTR_NORMAL_INNER_WB_RA_WA      (0b1111)
+
+/** \brief Memory Attribute
+* \param O Outer memory attributes
+* \param I O == ARM_MPU_ATTR_DEVICE: Device memory attributes, else: Inner memory attributes
+*/
+#define ARM_MPU_ATTR(O, I) ((((O) & 0xFU) << 4U) | ((((O) & 0xFU) != 0U) ? ((I) & 0xFU) : (((I) & 0x3U) << 2U)))
+
+/* \brief Specifies MAIR_ATTR number */
+#define MAIR_ATTR(x)       ((x > 7 || x < 0) ? 0 : x)
+
+/**
+ * Shareability
+ */
+/** \brief Normal memory, non-shareable  */
+#define ARM_MPU_SH_NON   (0U)
+
+/** \brief Normal memory, outer shareable  */
+#define ARM_MPU_SH_OUTER (2U)
+
+/** \brief Normal memory, inner shareable  */
+#define ARM_MPU_SH_INNER (3U)
+
+/**
+ * Access permissions
+ * AP = Access permission, RO = Read-only, RW = Read/Write, NP = Any privilege, PO = Privileged code only
+ */
+/** \brief Normal memory, read/write */
+#define ARM_MPU_AP_RW (0U)
+
+/** \brief Normal memory, read-only */
+#define ARM_MPU_AP_RO (1U)
+
+/** \brief Normal memory, any privilege level */
+#define ARM_MPU_AP_NP (1U)
+
+/** \brief Normal memory, privileged access only */
+#define ARM_MPU_AP_PO (0U)
+
+/*
+ * Execute-never
+ * XN = Execute-never, EX = Executable
+ */
+/** \brief Normal memory, Execution only permitted if read permitted */
+#define ARM_MPU_XN (1U)
+
+/** \brief Normal memory, Execution only permitted if read permitted */
+#define ARM_MPU_EX (0U)
+
+/** \brief Memory access permissions
+* \param RO Read-Only: Set to 1 for read-only memory. Set to 0 for a read/write memory.
+* \param NP Non-Privileged: Set to 1 for non-privileged memory. Set to 0 for privileged memory.
+*/
+#define ARM_MPU_AP_(RO, NP) ((((RO) & 1U) << 1U) | ((NP) & 1U))
+
+/** \brief Region Base Address Register value
+* \param BASE The base address bits [31:5] of a memory region. The value is zero extended. Effective address gets 32 byte aligned.
+* \param SH Defines the Shareability domain for this memory region.
+* \param RO Read-Only: Set to 1 for a read-only memory region. Set to 0 for a read/write memory region.
+* \param NP Non-Privileged: Set to 1 for a non-privileged memory region. Set to 0 for privileged memory region.
+* \param XN eXecute Never: Set to 1 for a non-executable memory region. Set to 0 for an executable memory region.
+*/
+#define ARM_MPU_RBAR(BASE, SH, RO, NP, XN) \
+  (((BASE) & MPU_RBAR_BASE_Msk) | \
+  (((SH) << MPU_RBAR_SH_Pos) & MPU_RBAR_SH_Msk) | \
+  ((ARM_MPU_AP_(RO, NP) << MPU_RBAR_AP_Pos) & MPU_RBAR_AP_Msk) | \
+  (((XN) << MPU_RBAR_XN_Pos) & MPU_RBAR_XN_Msk))
+
+/** \brief Region Limit Address Register value
+* \param LIMIT The limit address bits [31:5] for this memory region. The value is one extended.
+* \param IDX The attribute index to be associated with this memory region.
+*/
+#define ARM_MPU_RLAR(LIMIT, IDX) \
+  (((LIMIT) & MPU_RLAR_LIMIT_Msk) | \
+  (((IDX) << MPU_RLAR_AttrIndx_Pos) & MPU_RLAR_AttrIndx_Msk) | \
+  (MPU_RLAR_EN_Msk))
+
+#if defined(MPU_RLAR_PXN_Pos)
+
+/** \brief Region Limit Address Register with PXN value
+* \param LIMIT The limit address bits [31:5] for this memory region. The value is one extended.
+* \param PXN Privileged execute never. Defines whether code can be executed from this privileged region.
+* \param IDX The attribute index to be associated with this memory region.
+*/
+#define ARM_MPU_RLAR_PXN(LIMIT, PXN, IDX) \
+  (((LIMIT) & MPU_RLAR_LIMIT_Msk) | \
+  (((PXN) << MPU_RLAR_PXN_Pos) & MPU_RLAR_PXN_Msk) | \
+  (((IDX) << MPU_RLAR_AttrIndx_Pos) & MPU_RLAR_AttrIndx_Msk) | \
+  (MPU_RLAR_EN_Msk))
+
+#endif
+
+/**
+* Struct for a single MPU Region
+*/
+typedef struct {
+  uint32_t RBAR;                   /*!< Region Base Address Register value */
+  uint32_t RLAR;                   /*!< Region Limit Address Register value */
+} ARM_MPU_Region_t;
+
+/**
+  \brief  Read MPU Type Register
+  \return Number of MPU regions
+*/
+__STATIC_INLINE uint32_t ARM_MPU_TYPE()
+{
+  return ((MPU->TYPE) >> 8);
+}
+
+/** Enable the MPU.
+* \param MPU_Control Default access permissions for unconfigured regions.
+*/
+__STATIC_INLINE void ARM_MPU_Enable(uint32_t MPU_Control)
+{
+  __DMB();
+  MPU->CTRL = MPU_Control | MPU_CTRL_ENABLE_Msk;
+#ifdef SCB_SHCSR_MEMFAULTENA_Msk
+  SCB->SHCSR |= SCB_SHCSR_MEMFAULTENA_Msk;
+#endif
+  __DSB();
+  __ISB();
+}
+
+/** Disable the MPU.
+*/
+__STATIC_INLINE void ARM_MPU_Disable(void)
+{
+  __DMB();
+#ifdef SCB_SHCSR_MEMFAULTENA_Msk
+  SCB->SHCSR &= ~SCB_SHCSR_MEMFAULTENA_Msk;
+#endif
+  MPU->CTRL  &= ~MPU_CTRL_ENABLE_Msk;
+  __DSB();
+  __ISB();
+}
+
+#ifdef MPU_NS
+/** Enable the Non-secure MPU.
+* \param MPU_Control Default access permissions for unconfigured regions.
+*/
+__STATIC_INLINE void ARM_MPU_Enable_NS(uint32_t MPU_Control)
+{
+  __DMB();
+  MPU_NS->CTRL = MPU_Control | MPU_CTRL_ENABLE_Msk;
+#ifdef SCB_SHCSR_MEMFAULTENA_Msk
+  SCB_NS->SHCSR |= SCB_SHCSR_MEMFAULTENA_Msk;
+#endif
+  __DSB();
+  __ISB();
+}
+
+/** Disable the Non-secure MPU.
+*/
+__STATIC_INLINE void ARM_MPU_Disable_NS(void)
+{
+  __DMB();
+#ifdef SCB_SHCSR_MEMFAULTENA_Msk
+  SCB_NS->SHCSR &= ~SCB_SHCSR_MEMFAULTENA_Msk;
+#endif
+  MPU_NS->CTRL  &= ~MPU_CTRL_ENABLE_Msk;
+  __DSB();
+  __ISB();
+}
+#endif
+
+/** Set the memory attribute encoding to the given MPU.
+* \param mpu Pointer to the MPU to be configured.
+* \param idx The attribute index to be set [0-7]
+* \param attr The attribute value to be set.
+*/
+__STATIC_INLINE void ARM_MPU_SetMemAttrEx(MPU_Type* mpu, uint8_t idx, uint8_t attr)
+{
+  const uint8_t reg = idx / 4U;
+  const uint32_t pos = ((idx % 4U) * 8U);
+  const uint32_t mask = 0xFFU << pos;
+
+  if (reg >= (sizeof(mpu->MAIR) / sizeof(mpu->MAIR[0]))) {
+    return; // invalid index
+  }
+
+  mpu->MAIR[reg] = ((mpu->MAIR[reg] & ~mask) | ((attr << pos) & mask));
+}
+
+/** Set the memory attribute encoding.
+* \param idx The attribute index to be set [0-7]
+* \param attr The attribute value to be set.
+*/
+__STATIC_INLINE void ARM_MPU_SetMemAttr(uint8_t idx, uint8_t attr)
+{
+  ARM_MPU_SetMemAttrEx(MPU, idx, attr);
+}
+
+#ifdef MPU_NS
+/** Set the memory attribute encoding to the Non-secure MPU.
+* \param idx The attribute index to be set [0-7]
+* \param attr The attribute value to be set.
+*/
+__STATIC_INLINE void ARM_MPU_SetMemAttr_NS(uint8_t idx, uint8_t attr)
+{
+  ARM_MPU_SetMemAttrEx(MPU_NS, idx, attr);
+}
+#endif
+
+/** Clear and disable the given MPU region of the given MPU.
+* \param mpu Pointer to MPU to be used.
+* \param rnr Region number to be cleared.
+*/
+__STATIC_INLINE void ARM_MPU_ClrRegionEx(MPU_Type* mpu, uint32_t rnr)
+{
+  mpu->RNR = rnr;
+  mpu->RLAR = 0U;
+}
+
+/** Clear and disable the given MPU region.
+* \param rnr Region number to be cleared.
+*/
+__STATIC_INLINE void ARM_MPU_ClrRegion(uint32_t rnr)
+{
+  ARM_MPU_ClrRegionEx(MPU, rnr);
+}
+
+#ifdef MPU_NS
+/** Clear and disable the given Non-secure MPU region.
+* \param rnr Region number to be cleared.
+*/
+__STATIC_INLINE void ARM_MPU_ClrRegion_NS(uint32_t rnr)
+{
+  ARM_MPU_ClrRegionEx(MPU_NS, rnr);
+}
+#endif
+
+/** Configure the given MPU region of the given MPU.
+* \param mpu Pointer to MPU to be used.
+* \param rnr Region number to be configured.
+* \param rbar Value for RBAR register.
+* \param rlar Value for RLAR register.
+*/
+__STATIC_INLINE void ARM_MPU_SetRegionEx(MPU_Type* mpu, uint32_t rnr, uint32_t rbar, uint32_t rlar)
+{
+  mpu->RNR = rnr;
+  mpu->RBAR = rbar;
+  mpu->RLAR = rlar;
+}
+
+/** Configure the given MPU region.
+* \param rnr Region number to be configured.
+* \param rbar Value for RBAR register.
+* \param rlar Value for RLAR register.
+*/
+__STATIC_INLINE void ARM_MPU_SetRegion(uint32_t rnr, uint32_t rbar, uint32_t rlar)
+{
+  ARM_MPU_SetRegionEx(MPU, rnr, rbar, rlar);
+}
+
+#ifdef MPU_NS
+/** Configure the given Non-secure MPU region.
+* \param rnr Region number to be configured.
+* \param rbar Value for RBAR register.
+* \param rlar Value for RLAR register.
+*/
+__STATIC_INLINE void ARM_MPU_SetRegion_NS(uint32_t rnr, uint32_t rbar, uint32_t rlar)
+{
+  ARM_MPU_SetRegionEx(MPU_NS, rnr, rbar, rlar);
+}
+#endif
+
+/** Memcpy with strictly ordered memory access, e.g. used by code in ARM_MPU_LoadEx()
+* \param dst Destination data is copied to.
+* \param src Source data is copied from.
+* \param len Amount of data words to be copied.
+*/
+__STATIC_INLINE void ARM_MPU_OrderedMemcpy(volatile uint32_t* dst, const uint32_t* __RESTRICT src, uint32_t len)
+{
+  uint32_t i;
+  for (i = 0U; i < len; ++i)
+  {
+    dst[i] = src[i];
+  }
+}
+
+/** Load the given number of MPU regions from a table to the given MPU.
+* \param mpu Pointer to the MPU registers to be used.
+* \param rnr First region number to be configured.
+* \param table Pointer to the MPU configuration table.
+* \param cnt Amount of regions to be configured.
+*/
+__STATIC_INLINE void ARM_MPU_LoadEx(MPU_Type* mpu, uint32_t rnr, ARM_MPU_Region_t const* table, uint32_t cnt)
+{
+  const uint32_t rowWordSize = sizeof(ARM_MPU_Region_t)/4U;
+  if (cnt == 1U) {
+    mpu->RNR = rnr;
+    ARM_MPU_OrderedMemcpy(&(mpu->RBAR), &(table->RBAR), rowWordSize);
+  } else {
+    uint32_t rnrBase   = rnr & ~(MPU_TYPE_RALIASES-1U);
+    uint32_t rnrOffset = rnr % MPU_TYPE_RALIASES;
+
+    mpu->RNR = rnrBase;
+    while ((rnrOffset + cnt) > MPU_TYPE_RALIASES) {
+      uint32_t c = MPU_TYPE_RALIASES - rnrOffset;
+      ARM_MPU_OrderedMemcpy(&(mpu->RBAR)+(rnrOffset*2U), &(table->RBAR), c*rowWordSize);
+      table += c;
+      cnt -= c;
+      rnrOffset = 0U;
+      rnrBase += MPU_TYPE_RALIASES;
+      mpu->RNR = rnrBase;
+    }
+
+    ARM_MPU_OrderedMemcpy(&(mpu->RBAR)+(rnrOffset*2U), &(table->RBAR), cnt*rowWordSize);
+  }
+}
+
+/** Load the given number of MPU regions from a table.
+* \param rnr First region number to be configured.
+* \param table Pointer to the MPU configuration table.
+* \param cnt Amount of regions to be configured.
+*/
+__STATIC_INLINE void ARM_MPU_Load(uint32_t rnr, ARM_MPU_Region_t const* table, uint32_t cnt)
+{
+  ARM_MPU_LoadEx(MPU, rnr, table, cnt);
+}
+
+#ifdef MPU_NS
+/** Load the given number of MPU regions from a table to the Non-secure MPU.
+* \param rnr First region number to be configured.
+* \param table Pointer to the MPU configuration table.
+* \param cnt Amount of regions to be configured.
+*/
+__STATIC_INLINE void ARM_MPU_Load_NS(uint32_t rnr, ARM_MPU_Region_t const* table, uint32_t cnt)
+{
+  ARM_MPU_LoadEx(MPU_NS, rnr, table, cnt);
+}
+#endif
+
+#endif
+

--- a/platform/ext/cmsis/CMSIS/Core/Include/m-profile/armv8m_pmu.h
+++ b/platform/ext/cmsis/CMSIS/Core/Include/m-profile/armv8m_pmu.h
@@ -1,0 +1,335 @@
+/*
+ * Copyright (c) 2020 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS-Core(M) PMU API for Armv8.1-M PMU
+ */
+
+#ifndef ARM_PMU_ARMV8_H
+#define ARM_PMU_ARMV8_H
+
+#if   defined ( __ICCARM__ )
+  #pragma system_include         /* treat file as system include file for MISRA check */
+#elif defined (__clang__)
+  #pragma clang system_header    /* treat file as system include file */
+#endif
+
+/**
+ * \brief PMU Events
+ * \note  See the Armv8.1-M Architecture Reference Manual for full details on these PMU events.
+ * */
+
+#define ARM_PMU_SW_INCR                              0x0000             /*!< Software update to the PMU_SWINC register, architecturally executed and condition code check pass */
+#define ARM_PMU_L1I_CACHE_REFILL                     0x0001             /*!< L1 I-Cache refill */
+#define ARM_PMU_L1D_CACHE_REFILL                     0x0003             /*!< L1 D-Cache refill */
+#define ARM_PMU_L1D_CACHE                            0x0004             /*!< L1 D-Cache access */
+#define ARM_PMU_LD_RETIRED                           0x0006             /*!< Memory-reading instruction architecturally executed and condition code check pass */
+#define ARM_PMU_ST_RETIRED                           0x0007             /*!< Memory-writing instruction architecturally executed and condition code check pass */
+#define ARM_PMU_INST_RETIRED                         0x0008             /*!< Instruction architecturally executed */
+#define ARM_PMU_EXC_TAKEN                            0x0009             /*!< Exception entry */
+#define ARM_PMU_EXC_RETURN                           0x000A             /*!< Exception return instruction architecturally executed and the condition code check pass */
+#define ARM_PMU_PC_WRITE_RETIRED                     0x000C             /*!< Software change to the Program Counter (PC). Instruction is architecturally executed and condition code check pass */
+#define ARM_PMU_BR_IMMED_RETIRED                     0x000D             /*!< Immediate branch architecturally executed */
+#define ARM_PMU_BR_RETURN_RETIRED                    0x000E             /*!< Function return instruction architecturally executed and the condition code check pass */
+#define ARM_PMU_UNALIGNED_LDST_RETIRED               0x000F             /*!< Unaligned memory memory-reading or memory-writing instruction architecturally executed and condition code check pass */
+#define ARM_PMU_BR_MIS_PRED                          0x0010             /*!< Mispredicted or not predicted branch speculatively executed */
+#define ARM_PMU_CPU_CYCLES                           0x0011             /*!< Cycle */
+#define ARM_PMU_BR_PRED                              0x0012             /*!< Predictable branch speculatively executed */
+#define ARM_PMU_MEM_ACCESS                           0x0013             /*!< Data memory access */
+#define ARM_PMU_L1I_CACHE                            0x0014             /*!< Level 1 instruction cache access */
+#define ARM_PMU_L1D_CACHE_WB                         0x0015             /*!< Level 1 data cache write-back */
+#define ARM_PMU_L2D_CACHE                            0x0016             /*!< Level 2 data cache access */
+#define ARM_PMU_L2D_CACHE_REFILL                     0x0017             /*!< Level 2 data cache refill */
+#define ARM_PMU_L2D_CACHE_WB                         0x0018             /*!< Level 2 data cache write-back */
+#define ARM_PMU_BUS_ACCESS                           0x0019             /*!< Bus access */
+#define ARM_PMU_MEMORY_ERROR                         0x001A             /*!< Local memory error */
+#define ARM_PMU_INST_SPEC                            0x001B             /*!< Instruction speculatively executed */
+#define ARM_PMU_BUS_CYCLES                           0x001D             /*!< Bus cycles */
+#define ARM_PMU_CHAIN                                0x001E             /*!< For an odd numbered counter, increment when an overflow occurs on the preceding even-numbered counter on the same PE */
+#define ARM_PMU_L1D_CACHE_ALLOCATE                   0x001F             /*!< Level 1 data cache allocation without refill */
+#define ARM_PMU_L2D_CACHE_ALLOCATE                   0x0020             /*!< Level 2 data cache allocation without refill */
+#define ARM_PMU_BR_RETIRED                           0x0021             /*!< Branch instruction architecturally executed */
+#define ARM_PMU_BR_MIS_PRED_RETIRED                  0x0022             /*!< Mispredicted branch instruction architecturally executed */
+#define ARM_PMU_STALL_FRONTEND                       0x0023             /*!< No operation issued because of the frontend */
+#define ARM_PMU_STALL_BACKEND                        0x0024             /*!< No operation issued because of the backend */
+#define ARM_PMU_L2I_CACHE                            0x0027             /*!< Level 2 instruction cache access */
+#define ARM_PMU_L2I_CACHE_REFILL                     0x0028             /*!< Level 2 instruction cache refill */
+#define ARM_PMU_L3D_CACHE_ALLOCATE                   0x0029             /*!< Level 3 data cache allocation without refill */
+#define ARM_PMU_L3D_CACHE_REFILL                     0x002A             /*!< Level 3 data cache refill */
+#define ARM_PMU_L3D_CACHE                            0x002B             /*!< Level 3 data cache access */
+#define ARM_PMU_L3D_CACHE_WB                         0x002C             /*!< Level 3 data cache write-back */
+#define ARM_PMU_LL_CACHE_RD                          0x0036             /*!< Last level data cache read */
+#define ARM_PMU_LL_CACHE_MISS_RD                     0x0037             /*!< Last level data cache read miss */
+#define ARM_PMU_L1D_CACHE_MISS_RD                    0x0039             /*!< Level 1 data cache read miss */
+#define ARM_PMU_OP_COMPLETE                          0x003A             /*!< Operation retired */
+#define ARM_PMU_OP_SPEC                              0x003B             /*!< Operation speculatively executed */
+#define ARM_PMU_STALL                                0x003C             /*!< Stall cycle for instruction or operation not sent for execution */
+#define ARM_PMU_STALL_OP_BACKEND                     0x003D             /*!< Stall cycle for instruction or operation not sent for execution due to pipeline backend */
+#define ARM_PMU_STALL_OP_FRONTEND                    0x003E             /*!< Stall cycle for instruction or operation not sent for execution due to pipeline frontend */
+#define ARM_PMU_STALL_OP                             0x003F             /*!< Instruction or operation slots not occupied each cycle */
+#define ARM_PMU_L1D_CACHE_RD                         0x0040             /*!< Level 1 data cache read */
+#define ARM_PMU_LE_RETIRED                           0x0100             /*!< Loop end instruction executed */
+#define ARM_PMU_LE_SPEC                              0x0101             /*!< Loop end instruction speculatively executed */
+#define ARM_PMU_BF_RETIRED                           0x0104             /*!< Branch future instruction architecturally executed and condition code check pass */
+#define ARM_PMU_BF_SPEC                              0x0105             /*!< Branch future instruction speculatively executed and condition code check pass */
+#define ARM_PMU_LE_CANCEL                            0x0108             /*!< Loop end instruction not taken */
+#define ARM_PMU_BF_CANCEL                            0x0109             /*!< Branch future instruction not taken */
+#define ARM_PMU_SE_CALL_S                            0x0114             /*!< Call to secure function, resulting in Security state change */
+#define ARM_PMU_SE_CALL_NS                           0x0115             /*!< Call to non-secure function, resulting in Security state change */
+#define ARM_PMU_DWT_CMPMATCH0                        0x0118             /*!< DWT comparator 0 match */
+#define ARM_PMU_DWT_CMPMATCH1                        0x0119             /*!< DWT comparator 1 match */
+#define ARM_PMU_DWT_CMPMATCH2                        0x011A             /*!< DWT comparator 2 match */
+#define ARM_PMU_DWT_CMPMATCH3                        0x011B             /*!< DWT comparator 3 match */
+#define ARM_PMU_MVE_INST_RETIRED                     0x0200             /*!< MVE instruction architecturally executed */
+#define ARM_PMU_MVE_INST_SPEC                        0x0201             /*!< MVE instruction speculatively executed */
+#define ARM_PMU_MVE_FP_RETIRED                       0x0204             /*!< MVE floating-point instruction architecturally executed */
+#define ARM_PMU_MVE_FP_SPEC                          0x0205             /*!< MVE floating-point instruction speculatively executed */
+#define ARM_PMU_MVE_FP_HP_RETIRED                    0x0208             /*!< MVE half-precision floating-point instruction architecturally executed */
+#define ARM_PMU_MVE_FP_HP_SPEC                       0x0209             /*!< MVE half-precision floating-point instruction speculatively executed */
+#define ARM_PMU_MVE_FP_SP_RETIRED                    0x020C             /*!< MVE single-precision floating-point instruction architecturally executed */
+#define ARM_PMU_MVE_FP_SP_SPEC                       0x020D             /*!< MVE single-precision floating-point instruction speculatively executed */
+#define ARM_PMU_MVE_FP_MAC_RETIRED                   0x0214             /*!< MVE floating-point multiply or multiply-accumulate instruction architecturally executed */
+#define ARM_PMU_MVE_FP_MAC_SPEC                      0x0215             /*!< MVE floating-point multiply or multiply-accumulate instruction speculatively executed */
+#define ARM_PMU_MVE_INT_RETIRED                      0x0224             /*!< MVE integer instruction architecturally executed */
+#define ARM_PMU_MVE_INT_SPEC                         0x0225             /*!< MVE integer instruction speculatively executed */
+#define ARM_PMU_MVE_INT_MAC_RETIRED                  0x0228             /*!< MVE multiply or multiply-accumulate instruction architecturally executed */
+#define ARM_PMU_MVE_INT_MAC_SPEC                     0x0229             /*!< MVE multiply or multiply-accumulate instruction speculatively executed */
+#define ARM_PMU_MVE_LDST_RETIRED                     0x0238             /*!< MVE load or store instruction architecturally executed */
+#define ARM_PMU_MVE_LDST_SPEC                        0x0239             /*!< MVE load or store instruction speculatively executed */
+#define ARM_PMU_MVE_LD_RETIRED                       0x023C             /*!< MVE load instruction architecturally executed */
+#define ARM_PMU_MVE_LD_SPEC                          0x023D             /*!< MVE load instruction speculatively executed */
+#define ARM_PMU_MVE_ST_RETIRED                       0x0240             /*!< MVE store instruction architecturally executed */
+#define ARM_PMU_MVE_ST_SPEC                          0x0241             /*!< MVE store instruction speculatively executed */
+#define ARM_PMU_MVE_LDST_CONTIG_RETIRED              0x0244             /*!< MVE contiguous load or store instruction architecturally executed */
+#define ARM_PMU_MVE_LDST_CONTIG_SPEC                 0x0245             /*!< MVE contiguous load or store instruction speculatively executed */
+#define ARM_PMU_MVE_LD_CONTIG_RETIRED                0x0248             /*!< MVE contiguous load instruction architecturally executed */
+#define ARM_PMU_MVE_LD_CONTIG_SPEC                   0x0249             /*!< MVE contiguous load instruction speculatively executed */
+#define ARM_PMU_MVE_ST_CONTIG_RETIRED                0x024C             /*!< MVE contiguous store instruction architecturally executed */
+#define ARM_PMU_MVE_ST_CONTIG_SPEC                   0x024D             /*!< MVE contiguous store instruction speculatively executed */
+#define ARM_PMU_MVE_LDST_NONCONTIG_RETIRED           0x0250             /*!< MVE non-contiguous load or store instruction architecturally executed */
+#define ARM_PMU_MVE_LDST_NONCONTIG_SPEC              0x0251             /*!< MVE non-contiguous load or store instruction speculatively executed */
+#define ARM_PMU_MVE_LD_NONCONTIG_RETIRED             0x0254             /*!< MVE non-contiguous load instruction architecturally executed */
+#define ARM_PMU_MVE_LD_NONCONTIG_SPEC                0x0255             /*!< MVE non-contiguous load instruction speculatively executed */
+#define ARM_PMU_MVE_ST_NONCONTIG_RETIRED             0x0258             /*!< MVE non-contiguous store instruction architecturally executed */
+#define ARM_PMU_MVE_ST_NONCONTIG_SPEC                0x0259             /*!< MVE non-contiguous store instruction speculatively executed */
+#define ARM_PMU_MVE_LDST_MULTI_RETIRED               0x025C             /*!< MVE memory instruction targeting multiple registers architecturally executed */
+#define ARM_PMU_MVE_LDST_MULTI_SPEC                  0x025D             /*!< MVE memory instruction targeting multiple registers speculatively executed */
+#define ARM_PMU_MVE_LD_MULTI_RETIRED                 0x0260             /*!< MVE memory load instruction targeting multiple registers architecturally executed */
+#define ARM_PMU_MVE_LD_MULTI_SPEC                    0x0261             /*!< MVE memory load instruction targeting multiple registers speculatively executed */
+#define ARM_PMU_MVE_ST_MULTI_RETIRED                 0x0261             /*!< MVE memory store instruction targeting multiple registers architecturally executed */
+#define ARM_PMU_MVE_ST_MULTI_SPEC                    0x0265             /*!< MVE memory store instruction targeting multiple registers speculatively executed */
+#define ARM_PMU_MVE_LDST_UNALIGNED_RETIRED           0x028C             /*!< MVE unaligned memory load or store instruction architecturally executed */
+#define ARM_PMU_MVE_LDST_UNALIGNED_SPEC              0x028D             /*!< MVE unaligned memory load or store instruction speculatively executed */
+#define ARM_PMU_MVE_LD_UNALIGNED_RETIRED             0x0290             /*!< MVE unaligned load instruction architecturally executed */
+#define ARM_PMU_MVE_LD_UNALIGNED_SPEC                0x0291             /*!< MVE unaligned load instruction speculatively executed */
+#define ARM_PMU_MVE_ST_UNALIGNED_RETIRED             0x0294             /*!< MVE unaligned store instruction architecturally executed */
+#define ARM_PMU_MVE_ST_UNALIGNED_SPEC                0x0295             /*!< MVE unaligned store instruction speculatively executed */
+#define ARM_PMU_MVE_LDST_UNALIGNED_NONCONTIG_RETIRED 0x0298             /*!< MVE unaligned noncontiguous load or store instruction architecturally executed */
+#define ARM_PMU_MVE_LDST_UNALIGNED_NONCONTIG_SPEC    0x0299             /*!< MVE unaligned noncontiguous load or store instruction speculatively executed */
+#define ARM_PMU_MVE_VREDUCE_RETIRED                  0x02A0             /*!< MVE vector reduction instruction architecturally executed */
+#define ARM_PMU_MVE_VREDUCE_SPEC                     0x02A1             /*!< MVE vector reduction instruction speculatively executed */
+#define ARM_PMU_MVE_VREDUCE_FP_RETIRED               0x02A4             /*!< MVE floating-point vector reduction instruction architecturally executed */
+#define ARM_PMU_MVE_VREDUCE_FP_SPEC                  0x02A5             /*!< MVE floating-point vector reduction instruction speculatively executed */
+#define ARM_PMU_MVE_VREDUCE_INT_RETIRED              0x02A8             /*!< MVE integer vector reduction instruction architecturally executed */
+#define ARM_PMU_MVE_VREDUCE_INT_SPEC                 0x02A9             /*!< MVE integer vector reduction instruction speculatively executed */
+#define ARM_PMU_MVE_PRED                             0x02B8             /*!< Cycles where one or more predicated beats architecturally executed */
+#define ARM_PMU_MVE_STALL                            0x02CC             /*!< Stall cycles caused by an MVE instruction */
+#define ARM_PMU_MVE_STALL_RESOURCE                   0x02CD             /*!< Stall cycles caused by an MVE instruction because of resource conflicts */
+#define ARM_PMU_MVE_STALL_RESOURCE_MEM               0x02CE             /*!< Stall cycles caused by an MVE instruction because of memory resource conflicts */
+#define ARM_PMU_MVE_STALL_RESOURCE_FP                0x02CF             /*!< Stall cycles caused by an MVE instruction because of floating-point resource conflicts */
+#define ARM_PMU_MVE_STALL_RESOURCE_INT               0x02D0             /*!< Stall cycles caused by an MVE instruction because of integer resource conflicts */
+#define ARM_PMU_MVE_STALL_BREAK                      0x02D3             /*!< Stall cycles caused by an MVE chain break */
+#define ARM_PMU_MVE_STALL_DEPENDENCY                 0x02D4             /*!< Stall cycles caused by MVE register dependency */
+#define ARM_PMU_ITCM_ACCESS                          0x4007             /*!< Instruction TCM access */
+#define ARM_PMU_DTCM_ACCESS                          0x4008             /*!< Data TCM access */
+#define ARM_PMU_TRCEXTOUT0                           0x4010             /*!< ETM external output 0 */
+#define ARM_PMU_TRCEXTOUT1                           0x4011             /*!< ETM external output 1 */
+#define ARM_PMU_TRCEXTOUT2                           0x4012             /*!< ETM external output 2 */
+#define ARM_PMU_TRCEXTOUT3                           0x4013             /*!< ETM external output 3 */
+#define ARM_PMU_CTI_TRIGOUT4                         0x4018             /*!< Cross-trigger Interface output trigger 4 */
+#define ARM_PMU_CTI_TRIGOUT5                         0x4019             /*!< Cross-trigger Interface output trigger 5 */
+#define ARM_PMU_CTI_TRIGOUT6                         0x401A             /*!< Cross-trigger Interface output trigger 6 */
+#define ARM_PMU_CTI_TRIGOUT7                         0x401B             /*!< Cross-trigger Interface output trigger 7 */
+
+/** \brief PMU Functions */
+
+__STATIC_INLINE void ARM_PMU_Enable(void);
+__STATIC_INLINE void ARM_PMU_Disable(void);
+
+__STATIC_INLINE void ARM_PMU_Set_EVTYPER(uint32_t num, uint32_t type);
+
+__STATIC_INLINE void ARM_PMU_CYCCNT_Reset(void);
+__STATIC_INLINE void ARM_PMU_EVCNTR_ALL_Reset(void);
+
+__STATIC_INLINE void ARM_PMU_CNTR_Enable(uint32_t mask);
+__STATIC_INLINE void ARM_PMU_CNTR_Disable(uint32_t mask);
+
+__STATIC_INLINE uint32_t ARM_PMU_Get_CCNTR(void);
+__STATIC_INLINE uint32_t ARM_PMU_Get_EVCNTR(uint32_t num);
+
+__STATIC_INLINE uint32_t ARM_PMU_Get_CNTR_OVS(void);
+__STATIC_INLINE void ARM_PMU_Set_CNTR_OVS(uint32_t mask);
+
+__STATIC_INLINE void ARM_PMU_Set_CNTR_IRQ_Enable(uint32_t mask);
+__STATIC_INLINE void ARM_PMU_Set_CNTR_IRQ_Disable(uint32_t mask);
+
+__STATIC_INLINE void ARM_PMU_CNTR_Increment(uint32_t mask);
+
+/**
+  \brief   Enable the PMU
+*/
+__STATIC_INLINE void ARM_PMU_Enable(void)
+{
+  PMU->CTRL |= PMU_CTRL_ENABLE_Msk;
+}
+
+/**
+  \brief   Disable the PMU
+*/
+__STATIC_INLINE void ARM_PMU_Disable(void)
+{
+  PMU->CTRL &= ~PMU_CTRL_ENABLE_Msk;
+}
+
+/**
+  \brief   Set event to count for PMU eventer counter
+  \param [in]    num     Event counter (0-30) to configure
+  \param [in]    type    Event to count
+*/
+__STATIC_INLINE void ARM_PMU_Set_EVTYPER(uint32_t num, uint32_t type)
+{
+  PMU->EVTYPER[num] = type;
+}
+
+/**
+  \brief  Reset cycle counter
+*/
+__STATIC_INLINE void ARM_PMU_CYCCNT_Reset(void)
+{
+  PMU->CTRL |= PMU_CTRL_CYCCNT_RESET_Msk;
+}
+
+/**
+  \brief  Reset all event counters
+*/
+__STATIC_INLINE void ARM_PMU_EVCNTR_ALL_Reset(void)
+{
+  PMU->CTRL |= PMU_CTRL_EVENTCNT_RESET_Msk;
+}
+
+/**
+  \brief  Enable counters
+  \param [in]     mask    Counters to enable
+  \note   Enables one or more of the following:
+          - event counters (0-30)
+          - cycle counter
+*/
+__STATIC_INLINE void ARM_PMU_CNTR_Enable(uint32_t mask)
+{
+  PMU->CNTENSET = mask;
+}
+
+/**
+  \brief  Disable counters
+  \param [in]     mask    Counters to enable
+  \note   Disables one or more of the following:
+          - event counters (0-30)
+          - cycle counter
+*/
+__STATIC_INLINE void ARM_PMU_CNTR_Disable(uint32_t mask)
+{
+  PMU->CNTENCLR = mask;
+}
+
+/**
+  \brief  Read cycle counter
+  \return                 Cycle count
+*/
+__STATIC_INLINE uint32_t ARM_PMU_Get_CCNTR(void)
+{
+  return PMU->CCNTR;
+}
+
+/**
+  \brief   Read event counter
+  \param [in]     num     Event counter (0-30) to read
+  \return                 Event count
+*/
+__STATIC_INLINE uint32_t ARM_PMU_Get_EVCNTR(uint32_t num)
+{
+  return PMU_EVCNTR_CNT_Msk & PMU->EVCNTR[num];
+}
+
+/**
+  \brief   Read counter overflow status
+  \return  Counter overflow status bits for the following:
+          - event counters (0-30)
+          - cycle counter
+*/
+__STATIC_INLINE uint32_t ARM_PMU_Get_CNTR_OVS(void)
+{
+  return PMU->OVSSET;
+}
+
+/**
+  \brief   Clear counter overflow status
+  \param [in]     mask    Counter overflow status bits to clear
+  \note    Clears overflow status bits for one or more of the following:
+           - event counters (0-30)
+           - cycle counter
+*/
+__STATIC_INLINE void ARM_PMU_Set_CNTR_OVS(uint32_t mask)
+{
+  PMU->OVSCLR = mask;
+}
+
+/**
+  \brief   Enable counter overflow interrupt request
+  \param [in]     mask    Counter overflow interrupt request bits to set
+  \note    Sets overflow interrupt request bits for one or more of the following:
+           - event counters (0-30)
+           - cycle counter
+*/
+__STATIC_INLINE void ARM_PMU_Set_CNTR_IRQ_Enable(uint32_t mask)
+{
+  PMU->INTENSET = mask;
+}
+
+/**
+  \brief   Disable counter overflow interrupt request
+  \param [in]     mask    Counter overflow interrupt request bits to clear
+  \note    Clears overflow interrupt request bits for one or more of the following:
+           - event counters (0-30)
+           - cycle counter
+*/
+__STATIC_INLINE void ARM_PMU_Set_CNTR_IRQ_Disable(uint32_t mask)
+{
+  PMU->INTENCLR = mask;
+}
+
+/**
+  \brief   Software increment event counter
+  \param [in]     mask    Counters to increment
+  \note    Software increment bits for one or more event counters (0-30)
+*/
+__STATIC_INLINE void ARM_PMU_CNTR_Increment(uint32_t mask)
+{
+  PMU->SWINC = mask;
+}
+
+#endif

--- a/platform/ext/cmsis/CMSIS/Core/Include/m-profile/cmsis_armclang_m.h
+++ b/platform/ext/cmsis/CMSIS/Core/Include/m-profile/cmsis_armclang_m.h
@@ -1,0 +1,1464 @@
+/*
+ * Copyright (c) 2009-2024 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS-Core(M) Compiler ARMClang (Arm Compiler 6) Header File
+ */
+
+#ifndef __CMSIS_ARMCLANG_M_H
+#define __CMSIS_ARMCLANG_M_H
+
+#pragma clang system_header   /* treat file as system include file */
+
+#if (__ARM_ACLE >= 200)
+  #include <arm_acle.h>
+#else
+  #error Compiler must support ACLE V2.0
+#endif /* (__ARM_ACLE >= 200) */
+
+/* CMSIS compiler specific defines */
+#ifndef   __ASM
+  #define __ASM                                  __asm
+#endif
+#ifndef   __INLINE
+  #define __INLINE                               __inline
+#endif
+#ifndef   __STATIC_INLINE
+  #define __STATIC_INLINE                        static __inline
+#endif
+#ifndef   __STATIC_FORCEINLINE
+  #define __STATIC_FORCEINLINE                   __attribute__((always_inline)) static __inline
+#endif
+#ifndef   __NO_RETURN
+  #define __NO_RETURN                            __attribute__((__noreturn__))
+#endif
+#ifndef   __USED
+  #define __USED                                 __attribute__((used))
+#endif
+#ifndef   __WEAK
+  #define __WEAK                                 __attribute__((weak))
+#endif
+#ifndef   __PACKED
+  #define __PACKED                               __attribute__((packed, aligned(1)))
+#endif
+#ifndef   __PACKED_STRUCT
+  #define __PACKED_STRUCT                        struct __attribute__((packed, aligned(1)))
+#endif
+#ifndef   __PACKED_UNION
+  #define __PACKED_UNION                         union __attribute__((packed, aligned(1)))
+#endif
+#ifndef   __UNALIGNED_UINT16_WRITE
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wpacked"
+  __PACKED_STRUCT T_UINT16_WRITE { uint16_t v; };
+  #pragma clang diagnostic pop
+  #define __UNALIGNED_UINT16_WRITE(addr, val)    (void)((((struct T_UINT16_WRITE *)(void *)(addr))->v) = (val))
+#endif
+#ifndef   __UNALIGNED_UINT16_READ
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wpacked"
+  __PACKED_STRUCT T_UINT16_READ { uint16_t v; };
+  #pragma clang diagnostic pop
+  #define __UNALIGNED_UINT16_READ(addr)          (((const struct T_UINT16_READ *)(const void *)(addr))->v)
+#endif
+#ifndef   __UNALIGNED_UINT32_WRITE
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wpacked"
+  __PACKED_STRUCT T_UINT32_WRITE { uint32_t v; };
+  #pragma clang diagnostic pop
+  #define __UNALIGNED_UINT32_WRITE(addr, val)    (void)((((struct T_UINT32_WRITE *)(void *)(addr))->v) = (val))
+#endif
+#ifndef   __UNALIGNED_UINT32_READ
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wpacked"
+  __PACKED_STRUCT T_UINT32_READ { uint32_t v; };
+  #pragma clang diagnostic pop
+  #define __UNALIGNED_UINT32_READ(addr)          (((const struct T_UINT32_READ *)(const void *)(addr))->v)
+#endif
+#ifndef   __ALIGNED
+  #define __ALIGNED(x)                           __attribute__((aligned(x)))
+#endif
+#ifndef   __RESTRICT
+  #define __RESTRICT                             __restrict
+#endif
+#ifndef   __COMPILER_BARRIER
+  #define __COMPILER_BARRIER()                   __ASM volatile("":::"memory")
+#endif
+#ifndef __NO_INIT
+  #define __NO_INIT                              __attribute__ ((section (".bss.noinit")))
+#endif
+#ifndef __ALIAS
+  #define __ALIAS(x)                             __attribute__ ((alias(x)))
+#endif
+
+/* #########################  Startup and Lowlevel Init  ######################## */
+#ifndef __PROGRAM_START
+#define __PROGRAM_START           __main
+#endif
+
+#ifndef __INITIAL_SP
+#define __INITIAL_SP              Image$$ARM_LIB_STACK$$ZI$$Limit
+#endif
+
+#ifndef __STACK_LIMIT
+#define __STACK_LIMIT             Image$$ARM_LIB_STACK$$ZI$$Base
+#endif
+
+#ifndef __VECTOR_TABLE
+#define __VECTOR_TABLE            __Vectors
+#endif
+
+#ifndef __VECTOR_TABLE_ATTRIBUTE
+#define __VECTOR_TABLE_ATTRIBUTE  __attribute__((used, section("RESET")))
+#endif
+
+#if (__ARM_FEATURE_CMSE == 3)
+#ifndef __STACK_SEAL
+#define __STACK_SEAL              Image$$STACKSEAL$$ZI$$Base
+#endif
+
+#ifndef __TZ_STACK_SEAL_SIZE
+#define __TZ_STACK_SEAL_SIZE      8U
+#endif
+
+#ifndef __TZ_STACK_SEAL_VALUE
+#define __TZ_STACK_SEAL_VALUE     0xFEF5EDA5FEF5EDA5ULL
+#endif
+
+
+__STATIC_FORCEINLINE void __TZ_set_STACKSEAL_S (uint32_t* stackTop) {
+  *((uint64_t *)stackTop) = __TZ_STACK_SEAL_VALUE;
+}
+#endif
+
+
+/* ##########################  Core Instruction Access  ######################### */
+/** \defgroup CMSIS_Core_InstructionInterface CMSIS Core Instruction Interface
+  Access to dedicated instructions
+  @{
+*/
+
+/* Define macros for porting to both thumb1 and thumb2.
+ * For thumb1, use low register (r0-r7), specified by constraint "l"
+ * Otherwise, use general registers, specified by constraint "r" */
+#if defined (__thumb__) && !defined (__thumb2__)
+#define __CMSIS_GCC_OUT_REG(r) "=l" (r)
+#define __CMSIS_GCC_RW_REG(r) "+l" (r)
+#define __CMSIS_GCC_USE_REG(r) "l" (r)
+#else
+#define __CMSIS_GCC_OUT_REG(r) "=r" (r)
+#define __CMSIS_GCC_RW_REG(r) "+r" (r)
+#define __CMSIS_GCC_USE_REG(r) "r" (r)
+#endif
+
+/**
+  \brief   No Operation
+  \details No Operation does nothing. This instruction can be used for code alignment purposes.
+ */
+#define __NOP()         __nop()
+
+
+/**
+  \brief   Wait For Interrupt
+  \details Wait For Interrupt is a hint instruction that suspends execution until one of a number of events occurs.
+ */
+#define __WFI()         __wfi()
+
+
+/**
+  \brief   Wait For Event
+  \details Wait For Event is a hint instruction that permits the processor to enter
+           a low-power state until one of a number of events occurs.
+ */
+#define __WFE()         __wfe()
+
+
+/**
+  \brief   Send Event
+  \details Send Event is a hint instruction. It causes an event to be signaled to the CPU.
+ */
+#define __SEV()         __sev()
+
+
+/**
+  \brief   Instruction Synchronization Barrier
+  \details Instruction Synchronization Barrier flushes the pipeline in the processor,
+           so that all instructions following the ISB are fetched from cache or memory,
+           after the instruction has been completed.
+ */
+#define __ISB()         __isb(0xF)
+
+
+/**
+  \brief   Data Synchronization Barrier
+  \details Acts as a special kind of Data Memory Barrier.
+           It completes when all explicit memory accesses before this instruction complete.
+ */
+#define __DSB()         __dsb(0xF)
+
+
+/**
+  \brief   Data Memory Barrier
+  \details Ensures the apparent order of the explicit memory operations before
+           and after the instruction, without ensuring their completion.
+ */
+#define __DMB()         __dmb(0xF)
+
+
+/**
+  \brief   Reverse byte order (32 bit)
+  \details Reverses the byte order in unsigned integer value. For example, 0x12345678 becomes 0x78563412.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+#define __REV(value)    __rev(value)
+
+
+/**
+  \brief   Reverse byte order (16 bit)
+  \details Reverses the byte order within each halfword of a word. For example, 0x12345678 becomes 0x34127856.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+#define __REV16(value)  __rev16(value)
+
+
+/**
+  \brief   Reverse byte order (16 bit)
+  \details Reverses the byte order in a 16-bit value and returns the signed 16-bit result. For example, 0x0080 becomes 0x8000.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+#define __REVSH(value)  __revsh(value)
+
+
+/**
+  \brief   Rotate Right in unsigned value (32 bit)
+  \details Rotate Right (immediate) provides the value of the contents of a register rotated by a variable number of bits.
+  \param [in]    op1  Value to rotate
+  \param [in]    op2  Number of Bits to rotate
+  \return               Rotated value
+ */
+#define __ROR(op1, op2) __ror(op1, op2)
+
+
+/**
+  \brief   Breakpoint
+  \details Causes the processor to enter Debug state.
+           Debug tools can use this to investigate system state when the instruction at a particular address is reached.
+  \param [in]    value  is ignored by the processor.
+                 If required, a debugger can use it to store additional information about the breakpoint.
+ */
+#define __BKPT(value)   __ASM volatile ("bkpt "#value)
+
+
+/**
+  \brief   Reverse bit order of value
+  \details Reverses the bit order of the given value.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+#define __RBIT(value)   __rbit(value)
+
+
+/**
+  \brief   Count leading zeros
+  \details Counts the number of leading zeros of a data value.
+  \param [in]  value  Value to count the leading zeros
+  \return             number of leading zeros in value
+ */
+#define __CLZ(value)    __clz(value)
+
+
+#if ((__ARM_FEATURE_SAT    >= 1) && \
+     (__ARM_ARCH_ISA_THUMB >= 2)    )
+/* __ARM_FEATURE_SAT is wrong for Armv8-M Baseline devices */
+/**
+  \brief   Signed Saturate
+  \details Saturates a signed value.
+  \param [in]  value  Value to be saturated
+  \param [in]    sat  Bit position to saturate to (1..32)
+  \return             Saturated value
+ */
+#define __SSAT(value, sat) __ssat(value, sat)
+
+
+/**
+  \brief   Unsigned Saturate
+  \details Saturates an unsigned value.
+  \param [in]  value  Value to be saturated
+  \param [in]    sat  Bit position to saturate to (0..31)
+  \return             Saturated value
+ */
+#define __USAT(value, sat) __usat(value, sat)
+
+#else /* (__ARM_FEATURE_SAT >= 1) */
+/**
+  \brief   Signed Saturate
+  \details Saturates a signed value.
+  \param [in]  value  Value to be saturated
+  \param [in]    sat  Bit position to saturate to (1..32)
+  \return             Saturated value
+ */
+__STATIC_FORCEINLINE int32_t __SSAT(int32_t val, uint32_t sat)
+{
+  if ((sat >= 1U) && (sat <= 32U))
+  {
+    const int32_t max = (int32_t)((1U << (sat - 1U)) - 1U);
+    const int32_t min = -1 - max ;
+    if (val > max)
+    {
+      return (max);
+    }
+    else if (val < min)
+    {
+      return (min);
+    }
+  }
+  return (val);
+}
+
+
+/**
+  \brief   Unsigned Saturate
+  \details Saturates an unsigned value.
+  \param [in]  value  Value to be saturated
+  \param [in]    sat  Bit position to saturate to (0..31)
+  \return             Saturated value
+ */
+__STATIC_FORCEINLINE uint32_t __USAT(int32_t val, uint32_t sat)
+{
+  if (sat <= 31U)
+  {
+    const uint32_t max = ((1U << sat) - 1U);
+    if (val > (int32_t)max)
+    {
+      return (max);
+    }
+    else if (val < 0)
+    {
+      return (0U);
+    }
+  }
+  return ((uint32_t)val);
+}
+#endif /* (__ARM_FEATURE_SAT >= 1) */
+
+
+#if (__ARM_FEATURE_LDREX >= 1)
+/**
+  \brief   Remove the exclusive lock
+  \details Removes the exclusive lock which is created by LDREX.
+ */
+#define __CLREX             __builtin_arm_clrex
+
+
+/**
+  \brief   LDR Exclusive (8 bit)
+  \details Executes a exclusive LDR instruction for 8 bit value.
+  \param [in]    ptr  Pointer to data
+  \return             value of type uint8_t at (*ptr)
+ */
+#define __LDREXB        (uint8_t)__builtin_arm_ldrex
+
+
+/**
+  \brief   STR Exclusive (8 bit)
+  \details Executes a exclusive STR instruction for 8 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+#define __STREXB        (uint32_t)__builtin_arm_strex
+#endif /* (__ARM_FEATURE_LDREX >= 1) */
+
+
+#if (__ARM_FEATURE_LDREX >= 2)
+/**
+  \brief   LDR Exclusive (16 bit)
+  \details Executes a exclusive LDR instruction for 16 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint16_t at (*ptr)
+ */
+#define __LDREXH        (uint16_t)__builtin_arm_ldrex
+
+
+/**
+  \brief   STR Exclusive (16 bit)
+  \details Executes a exclusive STR instruction for 16 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+#define __STREXH        (uint32_t)__builtin_arm_strex
+#endif /* (__ARM_FEATURE_LDREX >= 2) */
+
+
+#if (__ARM_FEATURE_LDREX >= 4)
+/**
+  \brief   LDR Exclusive (32 bit)
+  \details Executes a exclusive LDR instruction for 32 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint32_t at (*ptr)
+ */
+#define __LDREXW        (uint32_t)__builtin_arm_ldrex
+
+
+/**
+  \brief   STR Exclusive (32 bit)
+  \details Executes a exclusive STR instruction for 32 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+#define __STREXW        (uint32_t)__builtin_arm_strex
+#endif /* (__ARM_FEATURE_LDREX >= 4) */
+
+
+#if (__ARM_ARCH_ISA_THUMB >= 2)
+/**
+  \brief   Rotate Right with Extend (32 bit)
+  \details Moves each bit of a bitstring right by one bit.
+           The carry input is shifted in at the left end of the bitstring.
+  \param [in]    value  Value to rotate
+  \return               Rotated value
+ */
+__STATIC_FORCEINLINE uint32_t __RRX(uint32_t value)
+{
+  uint32_t result;
+
+  __ASM volatile ("rrx %0, %1" : "=r" (result) : "r" (value));
+  return (result);
+}
+
+
+/**
+  \brief   LDRT Unprivileged (8 bit)
+  \details Executes a Unprivileged LDRT instruction for 8 bit value.
+  \param [in]    ptr  Pointer to data
+  \return             value of type uint8_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint8_t __LDRBT(volatile uint8_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldrbt %0, %1" : "=r" (result) : "Q" (*ptr) );
+  return ((uint8_t)result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   LDRT Unprivileged (16 bit)
+  \details Executes a Unprivileged LDRT instruction for 16 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint16_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint16_t __LDRHT(volatile uint16_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldrht %0, %1" : "=r" (result) : "Q" (*ptr) );
+  return ((uint16_t)result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   LDRT Unprivileged (32 bit)
+  \details Executes a Unprivileged LDRT instruction for 32 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint32_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint32_t __LDRT(volatile uint32_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldrt %0, %1" : "=r" (result) : "Q" (*ptr) );
+  return (result);
+}
+
+
+/**
+  \brief   STRT Unprivileged (8 bit)
+  \details Executes a Unprivileged STRT instruction for 8 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__STATIC_FORCEINLINE void __STRBT(uint8_t value, volatile uint8_t *ptr)
+{
+  __ASM volatile ("strbt %1, %0" : "=Q" (*ptr) : "r" ((uint32_t)value) );
+}
+
+
+/**
+  \brief   STRT Unprivileged (16 bit)
+  \details Executes a Unprivileged STRT instruction for 16 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__STATIC_FORCEINLINE void __STRHT(uint16_t value, volatile uint16_t *ptr)
+{
+  __ASM volatile ("strht %1, %0" : "=Q" (*ptr) : "r" ((uint32_t)value) );
+}
+
+
+/**
+  \brief   STRT Unprivileged (32 bit)
+  \details Executes a Unprivileged STRT instruction for 32 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__STATIC_FORCEINLINE void __STRT(uint32_t value, volatile uint32_t *ptr)
+{
+  __ASM volatile ("strt %1, %0" : "=Q" (*ptr) : "r" (value) );
+}
+#endif /* (__ARM_ARCH_ISA_THUMB >= 2) */
+
+
+#if (__ARM_ARCH >= 8)
+/**
+  \brief   Load-Acquire (8 bit)
+  \details Executes a LDAB instruction for 8 bit value.
+  \param [in]    ptr  Pointer to data
+  \return             value of type uint8_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint8_t __LDAB(volatile uint8_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldab %0, %1" : "=r" (result) : "Q" (*ptr) : "memory" );
+  return ((uint8_t)result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   Load-Acquire (16 bit)
+  \details Executes a LDAH instruction for 16 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint16_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint16_t __LDAH(volatile uint16_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldah %0, %1" : "=r" (result) : "Q" (*ptr) : "memory" );
+  return ((uint16_t)result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   Load-Acquire (32 bit)
+  \details Executes a LDA instruction for 32 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint32_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint32_t __LDA(volatile uint32_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("lda %0, %1" : "=r" (result) : "Q" (*ptr) : "memory" );
+  return (result);
+}
+
+
+/**
+  \brief   Store-Release (8 bit)
+  \details Executes a STLB instruction for 8 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__STATIC_FORCEINLINE void __STLB(uint8_t value, volatile uint8_t *ptr)
+{
+  __ASM volatile ("stlb %1, %0" : "=Q" (*ptr) : "r" ((uint32_t)value) : "memory" );
+}
+
+
+/**
+  \brief   Store-Release (16 bit)
+  \details Executes a STLH instruction for 16 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__STATIC_FORCEINLINE void __STLH(uint16_t value, volatile uint16_t *ptr)
+{
+  __ASM volatile ("stlh %1, %0" : "=Q" (*ptr) : "r" ((uint32_t)value) : "memory" );
+}
+
+
+/**
+  \brief   Store-Release (32 bit)
+  \details Executes a STL instruction for 32 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__STATIC_FORCEINLINE void __STL(uint32_t value, volatile uint32_t *ptr)
+{
+  __ASM volatile ("stl %1, %0" : "=Q" (*ptr) : "r" ((uint32_t)value) : "memory" );
+}
+
+
+/**
+  \brief   Load-Acquire Exclusive (8 bit)
+  \details Executes a LDAB exclusive instruction for 8 bit value.
+  \param [in]    ptr  Pointer to data
+  \return             value of type uint8_t at (*ptr)
+ */
+#define __LDAEXB                 (uint8_t)__builtin_arm_ldaex
+
+
+/**
+  \brief   Load-Acquire Exclusive (16 bit)
+  \details Executes a LDAH exclusive instruction for 16 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint16_t at (*ptr)
+ */
+#define __LDAEXH                 (uint16_t)__builtin_arm_ldaex
+
+
+/**
+  \brief   Load-Acquire Exclusive (32 bit)
+  \details Executes a LDA exclusive instruction for 32 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint32_t at (*ptr)
+ */
+#define __LDAEX                  (uint32_t)__builtin_arm_ldaex
+
+
+/**
+  \brief   Store-Release Exclusive (8 bit)
+  \details Executes a STLB exclusive instruction for 8 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+#define __STLEXB                 (uint32_t)__builtin_arm_stlex
+
+
+/**
+  \brief   Store-Release Exclusive (16 bit)
+  \details Executes a STLH exclusive instruction for 16 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+#define __STLEXH                 (uint32_t)__builtin_arm_stlex
+
+
+/**
+  \brief   Store-Release Exclusive (32 bit)
+  \details Executes a STL exclusive instruction for 32 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+#define __STLEX                  (uint32_t)__builtin_arm_stlex
+
+#endif /* (__ARM_ARCH >= 8) */
+
+/** @}*/ /* end of group CMSIS_Core_InstructionInterface */
+
+
+/* ###########################  Core Function Access  ########################### */
+/** \ingroup  CMSIS_Core_FunctionInterface
+    \defgroup CMSIS_Core_RegAccFunctions CMSIS Core Register Access Functions
+  @{
+ */
+
+/**
+  \brief   Enable IRQ Interrupts
+  \details Enables IRQ interrupts by clearing special-purpose register PRIMASK.
+           Can only be executed in Privileged modes.
+ */
+#ifndef __ARM_COMPAT_H
+__STATIC_FORCEINLINE void __enable_irq(void)
+{
+  __ASM volatile ("cpsie i" : : : "memory");
+}
+#endif
+
+
+/**
+  \brief   Disable IRQ Interrupts
+  \details Disables IRQ interrupts by setting special-purpose register PRIMASK.
+           Can only be executed in Privileged modes.
+ */
+#ifndef __ARM_COMPAT_H
+__STATIC_FORCEINLINE void __disable_irq(void)
+{
+  __ASM volatile ("cpsid i" : : : "memory");
+}
+#endif
+
+
+/**
+  \brief   Get Control Register
+  \details Returns the content of the Control Register.
+  \return               Control Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_CONTROL(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, control" : "=r" (result) );
+  return (result);
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Control Register (non-secure)
+  \details Returns the content of the non-secure Control Register when in secure mode.
+  \return               non-secure Control Register value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_CONTROL_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, control_ns" : "=r" (result) );
+  return (result);
+}
+#endif
+
+
+/**
+  \brief   Set Control Register
+  \details Writes the given value to the Control Register.
+  \param [in]    control  Control Register value to set
+ */
+__STATIC_FORCEINLINE void __set_CONTROL(uint32_t control)
+{
+  __ASM volatile ("MSR control, %0" : : "r" (control) : "memory");
+  __ISB();
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Set Control Register (non-secure)
+  \details Writes the given value to the non-secure Control Register when in secure state.
+  \param [in]    control  Control Register value to set
+ */
+__STATIC_FORCEINLINE void __TZ_set_CONTROL_NS(uint32_t control)
+{
+  __ASM volatile ("MSR control_ns, %0" : : "r" (control) : "memory");
+  __ISB();
+}
+#endif
+
+
+/**
+  \brief   Get IPSR Register
+  \details Returns the content of the IPSR Register.
+  \return               IPSR Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_IPSR(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, ipsr" : "=r" (result) );
+  return (result);
+}
+
+
+/**
+  \brief   Get APSR Register
+  \details Returns the content of the APSR Register.
+  \return               APSR Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_APSR(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, apsr" : "=r" (result) );
+  return (result);
+}
+
+
+/**
+  \brief   Get xPSR Register
+  \details Returns the content of the xPSR Register.
+  \return               xPSR Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_xPSR(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, xpsr" : "=r" (result) );
+  return (result);
+}
+
+
+/**
+  \brief   Get Process Stack Pointer
+  \details Returns the current value of the Process Stack Pointer (PSP).
+  \return               PSP Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_PSP(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, psp"  : "=r" (result) );
+  return (result);
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Process Stack Pointer (non-secure)
+  \details Returns the current value of the non-secure Process Stack Pointer (PSP) when in secure state.
+  \return               PSP Register value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_PSP_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, psp_ns"  : "=r" (result) );
+  return (result);
+}
+#endif
+
+
+/**
+  \brief   Set Process Stack Pointer
+  \details Assigns the given value to the Process Stack Pointer (PSP).
+  \param [in]    topOfProcStack  Process Stack Pointer value to set
+ */
+__STATIC_FORCEINLINE void __set_PSP(uint32_t topOfProcStack)
+{
+  __ASM volatile ("MSR psp, %0" : : "r" (topOfProcStack) : );
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Set Process Stack Pointer (non-secure)
+  \details Assigns the given value to the non-secure Process Stack Pointer (PSP) when in secure state.
+  \param [in]    topOfProcStack  Process Stack Pointer value to set
+ */
+__STATIC_FORCEINLINE void __TZ_set_PSP_NS(uint32_t topOfProcStack)
+{
+  __ASM volatile ("MSR psp_ns, %0" : : "r" (topOfProcStack) : );
+}
+#endif
+
+
+/**
+  \brief   Get Main Stack Pointer
+  \details Returns the current value of the Main Stack Pointer (MSP).
+  \return               MSP Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_MSP(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, msp" : "=r" (result) );
+  return (result);
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Main Stack Pointer (non-secure)
+  \details Returns the current value of the non-secure Main Stack Pointer (MSP) when in secure state.
+  \return               MSP Register value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_MSP_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, msp_ns" : "=r" (result) );
+  return (result);
+}
+#endif
+
+
+/**
+  \brief   Set Main Stack Pointer
+  \details Assigns the given value to the Main Stack Pointer (MSP).
+  \param [in]    topOfMainStack  Main Stack Pointer value to set
+ */
+__STATIC_FORCEINLINE void __set_MSP(uint32_t topOfMainStack)
+{
+  __ASM volatile ("MSR msp, %0" : : "r" (topOfMainStack) : );
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Set Main Stack Pointer (non-secure)
+  \details Assigns the given value to the non-secure Main Stack Pointer (MSP) when in secure state.
+  \param [in]    topOfMainStack  Main Stack Pointer value to set
+ */
+__STATIC_FORCEINLINE void __TZ_set_MSP_NS(uint32_t topOfMainStack)
+{
+  __ASM volatile ("MSR msp_ns, %0" : : "r" (topOfMainStack) : );
+}
+#endif
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Stack Pointer (non-secure)
+  \details Returns the current value of the non-secure Stack Pointer (SP) when in secure state.
+  \return               SP Register value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_SP_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, sp_ns" : "=r" (result) );
+  return (result);
+}
+
+
+/**
+  \brief   Set Stack Pointer (non-secure)
+  \details Assigns the given value to the non-secure Stack Pointer (SP) when in secure state.
+  \param [in]    topOfStack  Stack Pointer value to set
+ */
+__STATIC_FORCEINLINE void __TZ_set_SP_NS(uint32_t topOfStack)
+{
+  __ASM volatile ("MSR sp_ns, %0" : : "r" (topOfStack) : );
+}
+#endif
+
+
+/**
+  \brief   Get Priority Mask
+  \details Returns the current state of the priority mask bit from the Priority Mask Register.
+  \return               Priority Mask value
+ */
+__STATIC_FORCEINLINE uint32_t __get_PRIMASK(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, primask" : "=r" (result) );
+  return (result);
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Priority Mask (non-secure)
+  \details Returns the current state of the non-secure priority mask bit from the Priority Mask Register when in secure state.
+  \return               Priority Mask value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_PRIMASK_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, primask_ns" : "=r" (result) );
+  return (result);
+}
+#endif
+
+
+/**
+  \brief   Set Priority Mask
+  \details Assigns the given value to the Priority Mask Register.
+  \param [in]    priMask  Priority Mask
+ */
+__STATIC_FORCEINLINE void __set_PRIMASK(uint32_t priMask)
+{
+  __ASM volatile ("MSR primask, %0" : : "r" (priMask) : "memory");
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Set Priority Mask (non-secure)
+  \details Assigns the given value to the non-secure Priority Mask Register when in secure state.
+  \param [in]    priMask  Priority Mask
+ */
+__STATIC_FORCEINLINE void __TZ_set_PRIMASK_NS(uint32_t priMask)
+{
+  __ASM volatile ("MSR primask_ns, %0" : : "r" (priMask) : "memory");
+}
+#endif
+
+
+#if (__ARM_ARCH_ISA_THUMB >= 2)
+/**
+  \brief   Enable FIQ
+  \details Enables FIQ interrupts by clearing special-purpose register FAULTMASK.
+           Can only be executed in Privileged modes.
+ */
+__STATIC_FORCEINLINE void __enable_fault_irq(void)
+{
+  __ASM volatile ("cpsie f" : : : "memory");
+}
+
+
+/**
+  \brief   Disable FIQ
+  \details Disables FIQ interrupts by setting special-purpose register FAULTMASK.
+           Can only be executed in Privileged modes.
+ */
+__STATIC_FORCEINLINE void __disable_fault_irq(void)
+{
+  __ASM volatile ("cpsid f" : : : "memory");
+}
+
+
+/**
+  \brief   Get Base Priority
+  \details Returns the current value of the Base Priority register.
+  \return               Base Priority register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_BASEPRI(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, basepri" : "=r" (result) );
+  return (result);
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Base Priority (non-secure)
+  \details Returns the current value of the non-secure Base Priority register when in secure state.
+  \return               Base Priority register value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_BASEPRI_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, basepri_ns" : "=r" (result) );
+  return (result);
+}
+#endif
+
+
+/**
+  \brief   Set Base Priority
+  \details Assigns the given value to the Base Priority register.
+  \param [in]    basePri  Base Priority value to set
+ */
+__STATIC_FORCEINLINE void __set_BASEPRI(uint32_t basePri)
+{
+  __ASM volatile ("MSR basepri, %0" : : "r" (basePri) : "memory");
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Set Base Priority (non-secure)
+  \details Assigns the given value to the non-secure Base Priority register when in secure state.
+  \param [in]    basePri  Base Priority value to set
+ */
+__STATIC_FORCEINLINE void __TZ_set_BASEPRI_NS(uint32_t basePri)
+{
+  __ASM volatile ("MSR basepri_ns, %0" : : "r" (basePri) : "memory");
+}
+#endif
+
+
+/**
+  \brief   Set Base Priority with condition
+  \details Assigns the given value to the Base Priority register only if BASEPRI masking is disabled,
+           or the new value increases the BASEPRI priority level.
+  \param [in]    basePri  Base Priority value to set
+ */
+__STATIC_FORCEINLINE void __set_BASEPRI_MAX(uint32_t basePri)
+{
+  __ASM volatile ("MSR basepri_max, %0" : : "r" (basePri) : "memory");
+}
+
+
+/**
+  \brief   Get Fault Mask
+  \details Returns the current value of the Fault Mask register.
+  \return               Fault Mask register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_FAULTMASK(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, faultmask" : "=r" (result) );
+  return (result);
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Fault Mask (non-secure)
+  \details Returns the current value of the non-secure Fault Mask register when in secure state.
+  \return               Fault Mask register value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_FAULTMASK_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, faultmask_ns" : "=r" (result) );
+  return (result);
+}
+#endif
+
+
+/**
+  \brief   Set Fault Mask
+  \details Assigns the given value to the Fault Mask register.
+  \param [in]    faultMask  Fault Mask value to set
+ */
+__STATIC_FORCEINLINE void __set_FAULTMASK(uint32_t faultMask)
+{
+  __ASM volatile ("MSR faultmask, %0" : : "r" (faultMask) : "memory");
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Set Fault Mask (non-secure)
+  \details Assigns the given value to the non-secure Fault Mask register when in secure state.
+  \param [in]    faultMask  Fault Mask value to set
+ */
+__STATIC_FORCEINLINE void __TZ_set_FAULTMASK_NS(uint32_t faultMask)
+{
+  __ASM volatile ("MSR faultmask_ns, %0" : : "r" (faultMask) : "memory");
+}
+#endif
+
+#endif /* (__ARM_ARCH_ISA_THUMB >= 2) */
+
+
+#if (__ARM_ARCH >= 8)
+/**
+  \brief   Get Process Stack Pointer Limit
+  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
+  Stack Pointer Limit register hence zero is returned always in non-secure
+  mode.
+
+  \details Returns the current value of the Process Stack Pointer Limit (PSPLIM).
+  \return               PSPLIM Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_PSPLIM(void)
+{
+#if (((__ARM_ARCH_8M_MAIN__   < 1) && \
+      (__ARM_ARCH_8_1M_MAIN__ < 1)    ) && \
+     (__ARM_FEATURE_CMSE < 3)              )
+  /* without main extensions, the non-secure PSPLIM is RAZ/WI */
+  return (0U);
+#else
+  uint32_t result;
+  __ASM volatile ("MRS %0, psplim"  : "=r" (result) );
+  return (result);
+#endif
+}
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Process Stack Pointer Limit (non-secure)
+  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
+  Stack Pointer Limit register hence zero is returned always.
+
+  \details Returns the current value of the non-secure Process Stack Pointer Limit (PSPLIM) when in secure state.
+  \return               PSPLIM Register value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_PSPLIM_NS(void)
+{
+#if ((__ARM_ARCH_8M_MAIN__   < 1) && \
+     (__ARM_ARCH_8_1M_MAIN__ < 1)    )
+  /* without main extensions, the non-secure PSPLIM is RAZ/WI */
+  return (0U);
+#else
+  uint32_t result;
+  __ASM volatile ("MRS %0, psplim_ns"  : "=r" (result) );
+  return (result);
+#endif
+}
+#endif
+
+
+/**
+  \brief   Set Process Stack Pointer Limit
+  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
+  Stack Pointer Limit register hence the write is silently ignored in non-secure
+  mode.
+
+  \details Assigns the given value to the Process Stack Pointer Limit (PSPLIM).
+  \param [in]    ProcStackPtrLimit  Process Stack Pointer Limit value to set
+ */
+__STATIC_FORCEINLINE void __set_PSPLIM(uint32_t ProcStackPtrLimit)
+{
+#if (((__ARM_ARCH_8M_MAIN__   < 1) && \
+      (__ARM_ARCH_8_1M_MAIN__ < 1)    ) && \
+     (__ARM_FEATURE_CMSE < 3)              )
+  /* without main extensions, the non-secure PSPLIM is RAZ/WI */
+  (void)ProcStackPtrLimit;
+#else
+  __ASM volatile ("MSR psplim, %0" : : "r" (ProcStackPtrLimit));
+#endif
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Set Process Stack Pointer (non-secure)
+  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
+  Stack Pointer Limit register hence the write is silently ignored.
+
+  \details Assigns the given value to the non-secure Process Stack Pointer Limit (PSPLIM) when in secure state.
+  \param [in]    ProcStackPtrLimit  Process Stack Pointer Limit value to set
+ */
+__STATIC_FORCEINLINE void __TZ_set_PSPLIM_NS(uint32_t ProcStackPtrLimit)
+{
+#if ((__ARM_ARCH_8M_MAIN__   < 1) && \
+     (__ARM_ARCH_8_1M_MAIN__ < 1)    )
+  /* without main extensions, the non-secure PSPLIM is RAZ/WI */
+  (void)ProcStackPtrLimit;
+#else
+  __ASM volatile ("MSR psplim_ns, %0\n" : : "r" (ProcStackPtrLimit));
+#endif
+}
+#endif
+
+
+/**
+  \brief   Get Main Stack Pointer Limit
+  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
+  Stack Pointer Limit register hence zero is returned always.
+
+  \details Returns the current value of the Main Stack Pointer Limit (MSPLIM).
+  \return               MSPLIM Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_MSPLIM(void)
+{
+#if (((__ARM_ARCH_8M_MAIN__   < 1) && \
+      (__ARM_ARCH_8_1M_MAIN__ < 1)    ) && \
+     (__ARM_FEATURE_CMSE < 3)              )
+  /* without main extensions, the non-secure MSPLIM is RAZ/WI */
+  return (0U);
+#else
+  uint32_t result;
+  __ASM volatile ("MRS %0, msplim" : "=r" (result) );
+  return (result);
+#endif
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Main Stack Pointer Limit (non-secure)
+  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
+  Stack Pointer Limit register hence zero is returned always.
+
+  \details Returns the current value of the non-secure Main Stack Pointer Limit(MSPLIM) when in secure state.
+  \return               MSPLIM Register value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_MSPLIM_NS(void)
+{
+#if ((__ARM_ARCH_8M_MAIN__   < 1) && \
+     (__ARM_ARCH_8_1M_MAIN__ < 1)    )
+  /* without main extensions, the non-secure MSPLIM is RAZ/WI */
+  return (0U);
+#else
+  uint32_t result;
+  __ASM volatile ("MRS %0, msplim_ns" : "=r" (result) );
+  return (result);
+#endif
+}
+#endif
+
+
+/**
+  \brief   Set Main Stack Pointer Limit
+  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
+  Stack Pointer Limit register hence the write is silently ignored.
+
+  \details Assigns the given value to the Main Stack Pointer Limit (MSPLIM).
+  \param [in]    MainStackPtrLimit  Main Stack Pointer Limit value to set
+ */
+__STATIC_FORCEINLINE void __set_MSPLIM(uint32_t MainStackPtrLimit)
+{
+#if (((__ARM_ARCH_8M_MAIN__   < 1) && \
+      (__ARM_ARCH_8_1M_MAIN__ < 1)    ) && \
+     (__ARM_FEATURE_CMSE < 3)              )
+  /* without main extensions, the non-secure MSPLIM is RAZ/WI */
+  (void)MainStackPtrLimit;
+#else
+  __ASM volatile ("MSR msplim, %0" : : "r" (MainStackPtrLimit));
+#endif
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Set Main Stack Pointer Limit (non-secure)
+  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
+  Stack Pointer Limit register hence the write is silently ignored.
+
+  \details Assigns the given value to the non-secure Main Stack Pointer Limit (MSPLIM) when in secure state.
+  \param [in]    MainStackPtrLimit  Main Stack Pointer value to set
+ */
+__STATIC_FORCEINLINE void __TZ_set_MSPLIM_NS(uint32_t MainStackPtrLimit)
+{
+#if ((__ARM_ARCH_8M_MAIN__   < 1) && \
+     (__ARM_ARCH_8_1M_MAIN__ < 1)    )
+  /* without main extensions, the non-secure MSPLIM is RAZ/WI */
+  (void)MainStackPtrLimit;
+#else
+  __ASM volatile ("MSR msplim_ns, %0" : : "r" (MainStackPtrLimit));
+#endif
+}
+#endif
+
+#endif /* (__ARM_ARCH >= 8) */
+
+
+/**
+  \brief   Get FPSCR
+  \details Returns the current value of the Floating Point Status/Control register.
+  \return               Floating Point Status/Control register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_FPSCR(void)
+{
+#if (defined(__ARM_FP) && (__ARM_FP >= 1))
+  return (__builtin_arm_get_fpscr());
+#else
+  return (0U);
+#endif
+}
+
+
+/**
+  \brief   Set FPSCR
+  \details Assigns the given value to the Floating Point Status/Control register.
+  \param [in]    fpscr  Floating Point Status/Control value to set
+ */
+__STATIC_FORCEINLINE void __set_FPSCR(uint32_t fpscr)
+{
+#if (defined(__ARM_FP) && (__ARM_FP >= 1))
+  __builtin_arm_set_fpscr(fpscr);
+#else
+  (void)fpscr;
+#endif
+}
+
+
+/** @} end of CMSIS_Core_RegAccFunctions */
+
+
+/* ###################  Compiler specific Intrinsics  ########################### */
+/** \defgroup CMSIS_SIMD_intrinsics CMSIS SIMD Intrinsics
+  Access to dedicated SIMD instructions
+  @{
+*/
+
+#if (__ARM_FEATURE_DSP == 1)
+#define     __SADD8                 __sadd8
+#define     __QADD8                 __qadd8
+#define     __SHADD8                __shadd8
+#define     __UADD8                 __uadd8
+#define     __UQADD8                __uqadd8
+#define     __UHADD8                __uhadd8
+#define     __SSUB8                 __ssub8
+#define     __QSUB8                 __qsub8
+#define     __SHSUB8                __shsub8
+#define     __USUB8                 __usub8
+#define     __UQSUB8                __uqsub8
+#define     __UHSUB8                __uhsub8
+#define     __SADD16                __sadd16
+#define     __QADD16                __qadd16
+#define     __SHADD16               __shadd16
+#define     __UADD16                __uadd16
+#define     __UQADD16               __uqadd16
+#define     __UHADD16               __uhadd16
+#define     __SSUB16                __ssub16
+#define     __QSUB16                __qsub16
+#define     __SHSUB16               __shsub16
+#define     __USUB16                __usub16
+#define     __UQSUB16               __uqsub16
+#define     __UHSUB16               __uhsub16
+#define     __SASX                  __sasx
+#define     __QASX                  __qasx
+#define     __SHASX                 __shasx
+#define     __UASX                  __uasx
+#define     __UQASX                 __uqasx
+#define     __UHASX                 __uhasx
+#define     __SSAX                  __ssax
+#define     __QSAX                  __qsax
+#define     __SHSAX                 __shsax
+#define     __USAX                  __usax
+#define     __UQSAX                 __uqsax
+#define     __UHSAX                 __uhsax
+#define     __USAD8                 __usad8
+#define     __USADA8                __usada8
+#define     __SSAT16                __ssat16
+#define     __USAT16                __usat16
+#define     __UXTB16                __uxtb16
+#define     __UXTAB16               __uxtab16
+#define     __SXTB16                __sxtb16
+#define     __SXTAB16               __sxtab16
+#define     __SMUAD                 __smuad
+#define     __SMUADX                __smuadx
+#define     __SMLAD                 __smlad
+#define     __SMLADX                __smladx
+#define     __SMLALD                __smlald
+#define     __SMLALDX               __smlaldx
+#define     __SMUSD                 __smusd
+#define     __SMUSDX                __smusdx
+#define     __SMLSD                 __smlsd
+#define     __SMLSDX                __smlsdx
+#define     __SMLSLD                __smlsld
+#define     __SMLSLDX               __smlsldx
+#define     __SEL                   __sel
+#define     __QADD                  __qadd
+#define     __QSUB                  __qsub
+
+#define __PKHBT(ARG1,ARG2,ARG3) \
+__extension__ \
+({                          \
+  uint32_t __RES, __ARG1 = (ARG1), __ARG2 = (ARG2); \
+  __ASM ("pkhbt %0, %1, %2, lsl %3" : "=r" (__RES) :  "r" (__ARG1), "r" (__ARG2), "I" (ARG3)  ); \
+  __RES; \
+ })
+
+#define __PKHTB(ARG1,ARG2,ARG3) \
+__extension__ \
+({                          \
+  uint32_t __RES, __ARG1 = (ARG1), __ARG2 = (ARG2); \
+  if (ARG3 == 0) \
+    __ASM ("pkhtb %0, %1, %2" : "=r" (__RES) :  "r" (__ARG1), "r" (__ARG2)  ); \
+  else \
+    __ASM ("pkhtb %0, %1, %2, asr %3" : "=r" (__RES) :  "r" (__ARG1), "r" (__ARG2), "I" (ARG3)  ); \
+  __RES; \
+ })
+
+#define __SXTB16_RORn(ARG1, ARG2)        __SXTB16(__ROR(ARG1, ARG2))
+
+#define __SXTAB16_RORn(ARG1, ARG2, ARG3) __SXTAB16(ARG1, __ROR(ARG2, ARG3))
+
+__STATIC_FORCEINLINE int32_t __SMMLA (int32_t op1, int32_t op2, int32_t op3)
+{
+  int32_t result;
+
+  __ASM volatile ("smmla %0, %1, %2, %3" : "=r" (result): "r"  (op1), "r" (op2), "r" (op3) );
+  return (result);
+}
+
+#endif /* (__ARM_FEATURE_DSP == 1) */
+/** @} end of group CMSIS_SIMD_intrinsics */
+
+
+#endif /* __CMSIS_ARMCLANG_M_H */

--- a/platform/ext/cmsis/CMSIS/Core/Include/m-profile/cmsis_clang_m.h
+++ b/platform/ext/cmsis/CMSIS/Core/Include/m-profile/cmsis_clang_m.h
@@ -1,0 +1,1465 @@
+/*
+ * Copyright (c) 2009-2024 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS-Core(M) Compiler LLVM/Clang Header File
+ */
+
+#ifndef __CMSIS_CLANG_M_H
+#define __CMSIS_CLANG_M_H
+
+#pragma clang system_header   /* treat file as system include file */
+
+#if (__ARM_ACLE >= 200)
+  #include <arm_acle.h>
+#else
+  #error Compiler must support ACLE V2.0
+#endif /* (__ARM_ACLE >= 200) */
+
+/* Fallback for __has_builtin */
+#ifndef __has_builtin
+  #define __has_builtin(x) (0)
+#endif
+
+/* CMSIS compiler specific defines */
+#ifndef   __ASM
+  #define __ASM                                  __asm
+#endif
+#ifndef   __INLINE
+  #define __INLINE                               inline
+#endif
+#ifndef   __STATIC_INLINE
+  #define __STATIC_INLINE                        static inline
+#endif
+#ifndef   __STATIC_FORCEINLINE
+  #define __STATIC_FORCEINLINE                   __attribute__((always_inline)) static inline
+#endif
+#ifndef   __NO_RETURN
+  #define __NO_RETURN                            __attribute__((__noreturn__))
+#endif
+#ifndef   __USED
+  #define __USED                                 __attribute__((used))
+#endif
+#ifndef   __WEAK
+  #define __WEAK                                 __attribute__((weak))
+#endif
+#ifndef   __PACKED
+  #define __PACKED                               __attribute__((packed, aligned(1)))
+#endif
+#ifndef   __PACKED_STRUCT
+  #define __PACKED_STRUCT                        struct __attribute__((packed, aligned(1)))
+#endif
+#ifndef   __PACKED_UNION
+  #define __PACKED_UNION                         union __attribute__((packed, aligned(1)))
+#endif
+#ifndef   __UNALIGNED_UINT16_WRITE
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wpacked"
+  __PACKED_STRUCT T_UINT16_WRITE { uint16_t v; };
+  #pragma clang diagnostic pop
+  #define __UNALIGNED_UINT16_WRITE(addr, val)    (void)((((struct T_UINT16_WRITE *)(void *)(addr))->v) = (val))
+#endif
+#ifndef   __UNALIGNED_UINT16_READ
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wpacked"
+  __PACKED_STRUCT T_UINT16_READ { uint16_t v; };
+  #pragma clang diagnostic pop
+  #define __UNALIGNED_UINT16_READ(addr)          (((const struct T_UINT16_READ *)(const void *)(addr))->v)
+#endif
+#ifndef   __UNALIGNED_UINT32_WRITE
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wpacked"
+  __PACKED_STRUCT T_UINT32_WRITE { uint32_t v; };
+  #pragma clang diagnostic pop
+  #define __UNALIGNED_UINT32_WRITE(addr, val)    (void)((((struct T_UINT32_WRITE *)(void *)(addr))->v) = (val))
+#endif
+#ifndef   __UNALIGNED_UINT32_READ
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wpacked"
+  __PACKED_STRUCT T_UINT32_READ { uint32_t v; };
+  #pragma clang diagnostic pop
+  #define __UNALIGNED_UINT32_READ(addr)          (((const struct T_UINT32_READ *)(const void *)(addr))->v)
+#endif
+#ifndef   __ALIGNED
+  #define __ALIGNED(x)                           __attribute__((aligned(x)))
+#endif
+#ifndef   __RESTRICT
+  #define __RESTRICT                             __restrict
+#endif
+#ifndef   __COMPILER_BARRIER
+  #define __COMPILER_BARRIER()                   __ASM volatile("":::"memory")
+#endif
+#ifndef __NO_INIT
+  #define __NO_INIT                              __attribute__ ((section (".noinit")))
+#endif
+#ifndef __ALIAS
+  #define __ALIAS(x)                             __attribute__ ((alias(x)))
+#endif
+
+/* #########################  Startup and Lowlevel Init  ######################## */
+#ifndef __PROGRAM_START
+#define __PROGRAM_START           _start
+#endif
+
+#ifndef __INITIAL_SP
+#define __INITIAL_SP              __stack
+#endif
+
+#ifndef __STACK_LIMIT
+#define __STACK_LIMIT             __stack_limit
+#endif
+
+#ifndef __VECTOR_TABLE
+#define __VECTOR_TABLE            __Vectors
+#endif
+
+#ifndef __VECTOR_TABLE_ATTRIBUTE
+#define __VECTOR_TABLE_ATTRIBUTE  __attribute__((used, section(".vectors")))
+#endif
+
+#if (__ARM_FEATURE_CMSE == 3)
+#ifndef __STACK_SEAL
+#define __STACK_SEAL              __stack_seal
+#endif
+
+#ifndef __TZ_STACK_SEAL_SIZE
+#define __TZ_STACK_SEAL_SIZE      8U
+#endif
+
+#ifndef __TZ_STACK_SEAL_VALUE
+#define __TZ_STACK_SEAL_VALUE     0xFEF5EDA5FEF5EDA5ULL
+#endif
+
+
+__STATIC_FORCEINLINE void __TZ_set_STACKSEAL_S (uint32_t* stackTop) {
+  *((uint64_t *)stackTop) = __TZ_STACK_SEAL_VALUE;
+}
+#endif
+
+
+/* ##########################  Core Instruction Access  ######################### */
+/** \defgroup CMSIS_Core_InstructionInterface CMSIS Core Instruction Interface
+  Access to dedicated instructions
+  @{
+*/
+
+/* Define macros for porting to both thumb1 and thumb2.
+ * For thumb1, use low register (r0-r7), specified by constraint "l"
+ * Otherwise, use general registers, specified by constraint "r" */
+#if defined (__thumb__) && !defined (__thumb2__)
+#define __CMSIS_GCC_OUT_REG(r) "=l" (r)
+#define __CMSIS_GCC_RW_REG(r) "+l" (r)
+#define __CMSIS_GCC_USE_REG(r) "l" (r)
+#else
+#define __CMSIS_GCC_OUT_REG(r) "=r" (r)
+#define __CMSIS_GCC_RW_REG(r) "+r" (r)
+#define __CMSIS_GCC_USE_REG(r) "r" (r)
+#endif
+
+/**
+  \brief   No Operation
+  \details No Operation does nothing. This instruction can be used for code alignment purposes.
+ */
+#define __NOP()         __nop()
+
+
+/**
+  \brief   Wait For Interrupt
+  \details Wait For Interrupt is a hint instruction that suspends execution until one of a number of events occurs.
+ */
+#define __WFI()         __wfi()
+
+
+/**
+  \brief   Wait For Event
+  \details Wait For Event is a hint instruction that permits the processor to enter
+           a low-power state until one of a number of events occurs.
+ */
+#define __WFE()         __wfe()
+
+
+/**
+  \brief   Send Event
+  \details Send Event is a hint instruction. It causes an event to be signaled to the CPU.
+ */
+#define __SEV()         __sev()
+
+
+/**
+  \brief   Instruction Synchronization Barrier
+  \details Instruction Synchronization Barrier flushes the pipeline in the processor,
+           so that all instructions following the ISB are fetched from cache or memory,
+           after the instruction has been completed.
+ */
+#define __ISB()         __isb(0xF)
+
+
+/**
+  \brief   Data Synchronization Barrier
+  \details Acts as a special kind of Data Memory Barrier.
+           It completes when all explicit memory accesses before this instruction complete.
+ */
+#define __DSB()         __dsb(0xF)
+
+
+/**
+  \brief   Data Memory Barrier
+  \details Ensures the apparent order of the explicit memory operations before
+           and after the instruction, without ensuring their completion.
+ */
+#define __DMB()         __dmb(0xF)
+
+
+/**
+  \brief   Reverse byte order (32 bit)
+  \details Reverses the byte order in unsigned integer value. For example, 0x12345678 becomes 0x78563412.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+#define __REV(value)    __rev(value)
+
+
+/**
+  \brief   Reverse byte order (16 bit)
+  \details Reverses the byte order within each halfword of a word. For example, 0x12345678 becomes 0x34127856.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+#define __REV16(value)  __rev16(value)
+
+
+/**
+  \brief   Reverse byte order (16 bit)
+  \details Reverses the byte order in a 16-bit value and returns the signed 16-bit result. For example, 0x0080 becomes 0x8000.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+#define __REVSH(value)  __revsh(value)
+
+
+/**
+  \brief   Rotate Right in unsigned value (32 bit)
+  \details Rotate Right (immediate) provides the value of the contents of a register rotated by a variable number of bits.
+  \param [in]    op1  Value to rotate
+  \param [in]    op2  Number of Bits to rotate
+  \return               Rotated value
+ */
+#define __ROR(op1, op2) __ror(op1, op2)
+
+
+/**
+  \brief   Breakpoint
+  \details Causes the processor to enter Debug state.
+           Debug tools can use this to investigate system state when the instruction at a particular address is reached.
+  \param [in]    value  is ignored by the processor.
+                 If required, a debugger can use it to store additional information about the breakpoint.
+ */
+#define __BKPT(value)   __ASM volatile ("bkpt "#value)
+
+
+/**
+  \brief   Reverse bit order of value
+  \details Reverses the bit order of the given value.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+#define __RBIT(value)   __rbit(value)
+
+
+/**
+  \brief   Count leading zeros
+  \details Counts the number of leading zeros of a data value.
+  \param [in]  value  Value to count the leading zeros
+  \return             number of leading zeros in value
+ */
+#define __CLZ(value)    __clz(value)
+
+
+#if ((__ARM_FEATURE_SAT    >= 1) && \
+     (__ARM_ARCH_ISA_THUMB >= 2)    )
+/* __ARM_FEATURE_SAT is wrong for Armv8-M Baseline devices */
+/**
+  \brief   Signed Saturate
+  \details Saturates a signed value.
+  \param [in]  value  Value to be saturated
+  \param [in]    sat  Bit position to saturate to (1..32)
+  \return             Saturated value
+ */
+#define __SSAT(value, sat) __ssat(value, sat)
+
+
+/**
+  \brief   Unsigned Saturate
+  \details Saturates an unsigned value.
+  \param [in]  value  Value to be saturated
+  \param [in]    sat  Bit position to saturate to (0..31)
+  \return             Saturated value
+ */
+#define __USAT(value, sat) __usat(value, sat)
+
+#else /* (__ARM_FEATURE_SAT >= 1) */
+/**
+  \brief   Signed Saturate
+  \details Saturates a signed value.
+  \param [in]  value  Value to be saturated
+  \param [in]    sat  Bit position to saturate to (1..32)
+  \return             Saturated value
+ */
+__STATIC_FORCEINLINE int32_t __SSAT(int32_t val, uint32_t sat)
+{
+  if ((sat >= 1U) && (sat <= 32U))
+  {
+    const int32_t max = (int32_t)((1U << (sat - 1U)) - 1U);
+    const int32_t min = -1 - max ;
+    if (val > max)
+    {
+      return (max);
+    }
+    else if (val < min)
+    {
+      return (min);
+    }
+  }
+  return (val);
+}
+
+
+/**
+  \brief   Unsigned Saturate
+  \details Saturates an unsigned value.
+  \param [in]  value  Value to be saturated
+  \param [in]    sat  Bit position to saturate to (0..31)
+  \return             Saturated value
+ */
+__STATIC_FORCEINLINE uint32_t __USAT(int32_t val, uint32_t sat)
+{
+  if (sat <= 31U)
+  {
+    const uint32_t max = ((1U << sat) - 1U);
+    if (val > (int32_t)max)
+    {
+      return (max);
+    }
+    else if (val < 0)
+    {
+      return (0U);
+    }
+  }
+  return ((uint32_t)val);
+}
+#endif /* (__ARM_FEATURE_SAT >= 1) */
+
+
+#if (__ARM_FEATURE_LDREX >= 1)
+/**
+  \brief   Remove the exclusive lock
+  \details Removes the exclusive lock which is created by LDREX.
+ */
+#define __CLREX             __builtin_arm_clrex
+
+
+/**
+  \brief   LDR Exclusive (8 bit)
+  \details Executes a exclusive LDR instruction for 8 bit value.
+  \param [in]    ptr  Pointer to data
+  \return             value of type uint8_t at (*ptr)
+ */
+#define __LDREXB        (uint8_t)__builtin_arm_ldrex
+
+
+/**
+  \brief   STR Exclusive (8 bit)
+  \details Executes a exclusive STR instruction for 8 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+#define __STREXB        (uint32_t)__builtin_arm_strex
+#endif /* (__ARM_FEATURE_LDREX >= 1) */
+
+
+#if (__ARM_FEATURE_LDREX >= 2)
+/**
+  \brief   LDR Exclusive (16 bit)
+  \details Executes a exclusive LDR instruction for 16 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint16_t at (*ptr)
+ */
+#define __LDREXH        (uint16_t)__builtin_arm_ldrex
+
+
+/**
+  \brief   STR Exclusive (16 bit)
+  \details Executes a exclusive STR instruction for 16 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+#define __STREXH        (uint32_t)__builtin_arm_strex
+#endif /* (__ARM_FEATURE_LDREX >= 2) */
+
+
+#if (__ARM_FEATURE_LDREX >= 4)
+/**
+  \brief   LDR Exclusive (32 bit)
+  \details Executes a exclusive LDR instruction for 32 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint32_t at (*ptr)
+ */
+#define __LDREXW        (uint32_t)__builtin_arm_ldrex
+
+
+/**
+  \brief   STR Exclusive (32 bit)
+  \details Executes a exclusive STR instruction for 32 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+#define __STREXW        (uint32_t)__builtin_arm_strex
+#endif /* (__ARM_FEATURE_LDREX >= 4) */
+
+
+#if (__ARM_ARCH_ISA_THUMB >= 2)
+/**
+  \brief   Rotate Right with Extend (32 bit)
+  \details Moves each bit of a bitstring right by one bit.
+           The carry input is shifted in at the left end of the bitstring.
+  \param [in]    value  Value to rotate
+  \return               Rotated value
+ */
+__STATIC_FORCEINLINE uint32_t __RRX(uint32_t value)
+{
+  uint32_t result;
+
+  __ASM volatile ("rrx %0, %1" : "=r" (result) : "r" (value));
+  return (result);
+}
+
+
+/**
+  \brief   LDRT Unprivileged (8 bit)
+  \details Executes a Unprivileged LDRT instruction for 8 bit value.
+  \param [in]    ptr  Pointer to data
+  \return             value of type uint8_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint8_t __LDRBT(volatile uint8_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldrbt %0, %1" : "=r" (result) : "Q" (*ptr) );
+  return ((uint8_t)result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   LDRT Unprivileged (16 bit)
+  \details Executes a Unprivileged LDRT instruction for 16 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint16_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint16_t __LDRHT(volatile uint16_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldrht %0, %1" : "=r" (result) : "Q" (*ptr) );
+  return ((uint16_t)result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   LDRT Unprivileged (32 bit)
+  \details Executes a Unprivileged LDRT instruction for 32 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint32_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint32_t __LDRT(volatile uint32_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldrt %0, %1" : "=r" (result) : "Q" (*ptr) );
+  return (result);
+}
+
+
+/**
+  \brief   STRT Unprivileged (8 bit)
+  \details Executes a Unprivileged STRT instruction for 8 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__STATIC_FORCEINLINE void __STRBT(uint8_t value, volatile uint8_t *ptr)
+{
+  __ASM volatile ("strbt %1, %0" : "=Q" (*ptr) : "r" ((uint32_t)value) );
+}
+
+
+/**
+  \brief   STRT Unprivileged (16 bit)
+  \details Executes a Unprivileged STRT instruction for 16 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__STATIC_FORCEINLINE void __STRHT(uint16_t value, volatile uint16_t *ptr)
+{
+  __ASM volatile ("strht %1, %0" : "=Q" (*ptr) : "r" ((uint32_t)value) );
+}
+
+
+/**
+  \brief   STRT Unprivileged (32 bit)
+  \details Executes a Unprivileged STRT instruction for 32 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__STATIC_FORCEINLINE void __STRT(uint32_t value, volatile uint32_t *ptr)
+{
+  __ASM volatile ("strt %1, %0" : "=Q" (*ptr) : "r" (value) );
+}
+#endif /* (__ARM_ARCH_ISA_THUMB >= 2) */
+
+
+#if (__ARM_ARCH >= 8)
+/**
+  \brief   Load-Acquire (8 bit)
+  \details Executes a LDAB instruction for 8 bit value.
+  \param [in]    ptr  Pointer to data
+  \return             value of type uint8_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint8_t __LDAB(volatile uint8_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldab %0, %1" : "=r" (result) : "Q" (*ptr) : "memory" );
+  return ((uint8_t)result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   Load-Acquire (16 bit)
+  \details Executes a LDAH instruction for 16 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint16_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint16_t __LDAH(volatile uint16_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldah %0, %1" : "=r" (result) : "Q" (*ptr) : "memory" );
+  return ((uint16_t)result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   Load-Acquire (32 bit)
+  \details Executes a LDA instruction for 32 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint32_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint32_t __LDA(volatile uint32_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("lda %0, %1" : "=r" (result) : "Q" (*ptr) : "memory" );
+  return (result);
+}
+
+
+/**
+  \brief   Store-Release (8 bit)
+  \details Executes a STLB instruction for 8 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__STATIC_FORCEINLINE void __STLB(uint8_t value, volatile uint8_t *ptr)
+{
+  __ASM volatile ("stlb %1, %0" : "=Q" (*ptr) : "r" ((uint32_t)value) : "memory" );
+}
+
+
+/**
+  \brief   Store-Release (16 bit)
+  \details Executes a STLH instruction for 16 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__STATIC_FORCEINLINE void __STLH(uint16_t value, volatile uint16_t *ptr)
+{
+  __ASM volatile ("stlh %1, %0" : "=Q" (*ptr) : "r" ((uint32_t)value) : "memory" );
+}
+
+
+/**
+  \brief   Store-Release (32 bit)
+  \details Executes a STL instruction for 32 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__STATIC_FORCEINLINE void __STL(uint32_t value, volatile uint32_t *ptr)
+{
+  __ASM volatile ("stl %1, %0" : "=Q" (*ptr) : "r" ((uint32_t)value) : "memory" );
+}
+
+
+/**
+  \brief   Load-Acquire Exclusive (8 bit)
+  \details Executes a LDAB exclusive instruction for 8 bit value.
+  \param [in]    ptr  Pointer to data
+  \return             value of type uint8_t at (*ptr)
+ */
+#define __LDAEXB                 (uint8_t)__builtin_arm_ldaex
+
+
+/**
+  \brief   Load-Acquire Exclusive (16 bit)
+  \details Executes a LDAH exclusive instruction for 16 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint16_t at (*ptr)
+ */
+#define __LDAEXH                 (uint16_t)__builtin_arm_ldaex
+
+
+/**
+  \brief   Load-Acquire Exclusive (32 bit)
+  \details Executes a LDA exclusive instruction for 32 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint32_t at (*ptr)
+ */
+#define __LDAEX                  (uint32_t)__builtin_arm_ldaex
+
+
+/**
+  \brief   Store-Release Exclusive (8 bit)
+  \details Executes a STLB exclusive instruction for 8 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+#define __STLEXB                 (uint32_t)__builtin_arm_stlex
+
+
+/**
+  \brief   Store-Release Exclusive (16 bit)
+  \details Executes a STLH exclusive instruction for 16 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+#define __STLEXH                 (uint32_t)__builtin_arm_stlex
+
+
+/**
+  \brief   Store-Release Exclusive (32 bit)
+  \details Executes a STL exclusive instruction for 32 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+#define __STLEX                  (uint32_t)__builtin_arm_stlex
+
+#endif /* (__ARM_ARCH >= 8) */
+
+/** @}*/ /* end of group CMSIS_Core_InstructionInterface */
+
+
+/* ###########################  Core Function Access  ########################### */
+/** \ingroup  CMSIS_Core_FunctionInterface
+    \defgroup CMSIS_Core_RegAccFunctions CMSIS Core Register Access Functions
+  @{
+ */
+
+/**
+  \brief   Enable IRQ Interrupts
+  \details Enables IRQ interrupts by clearing special-purpose register PRIMASK.
+           Can only be executed in Privileged modes.
+ */
+__STATIC_FORCEINLINE void __enable_irq(void)
+{
+  __ASM volatile ("cpsie i" : : : "memory");
+}
+
+
+/**
+  \brief   Disable IRQ Interrupts
+  \details Disables IRQ interrupts by setting special-purpose register PRIMASK.
+           Can only be executed in Privileged modes.
+ */
+__STATIC_FORCEINLINE void __disable_irq(void)
+{
+  __ASM volatile ("cpsid i" : : : "memory");
+}
+
+
+/**
+  \brief   Get Control Register
+  \details Returns the content of the Control Register.
+  \return               Control Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_CONTROL(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, control" : "=r" (result) );
+  return (result);
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Control Register (non-secure)
+  \details Returns the content of the non-secure Control Register when in secure mode.
+  \return               non-secure Control Register value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_CONTROL_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, control_ns" : "=r" (result) );
+  return (result);
+}
+#endif
+
+
+/**
+  \brief   Set Control Register
+  \details Writes the given value to the Control Register.
+  \param [in]    control  Control Register value to set
+ */
+__STATIC_FORCEINLINE void __set_CONTROL(uint32_t control)
+{
+  __ASM volatile ("MSR control, %0" : : "r" (control) : "memory");
+  __ISB();
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Set Control Register (non-secure)
+  \details Writes the given value to the non-secure Control Register when in secure state.
+  \param [in]    control  Control Register value to set
+ */
+__STATIC_FORCEINLINE void __TZ_set_CONTROL_NS(uint32_t control)
+{
+  __ASM volatile ("MSR control_ns, %0" : : "r" (control) : "memory");
+  __ISB();
+}
+#endif
+
+
+/**
+  \brief   Get IPSR Register
+  \details Returns the content of the IPSR Register.
+  \return               IPSR Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_IPSR(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, ipsr" : "=r" (result) );
+  return (result);
+}
+
+
+/**
+  \brief   Get APSR Register
+  \details Returns the content of the APSR Register.
+  \return               APSR Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_APSR(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, apsr" : "=r" (result) );
+  return (result);
+}
+
+
+/**
+  \brief   Get xPSR Register
+  \details Returns the content of the xPSR Register.
+  \return               xPSR Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_xPSR(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, xpsr" : "=r" (result) );
+  return (result);
+}
+
+
+/**
+  \brief   Get Process Stack Pointer
+  \details Returns the current value of the Process Stack Pointer (PSP).
+  \return               PSP Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_PSP(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, psp"  : "=r" (result) );
+  return (result);
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Process Stack Pointer (non-secure)
+  \details Returns the current value of the non-secure Process Stack Pointer (PSP) when in secure state.
+  \return               PSP Register value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_PSP_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, psp_ns"  : "=r" (result) );
+  return (result);
+}
+#endif
+
+
+/**
+  \brief   Set Process Stack Pointer
+  \details Assigns the given value to the Process Stack Pointer (PSP).
+  \param [in]    topOfProcStack  Process Stack Pointer value to set
+ */
+__STATIC_FORCEINLINE void __set_PSP(uint32_t topOfProcStack)
+{
+  __ASM volatile ("MSR psp, %0" : : "r" (topOfProcStack) : );
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Set Process Stack Pointer (non-secure)
+  \details Assigns the given value to the non-secure Process Stack Pointer (PSP) when in secure state.
+  \param [in]    topOfProcStack  Process Stack Pointer value to set
+ */
+__STATIC_FORCEINLINE void __TZ_set_PSP_NS(uint32_t topOfProcStack)
+{
+  __ASM volatile ("MSR psp_ns, %0" : : "r" (topOfProcStack) : );
+}
+#endif
+
+
+/**
+  \brief   Get Main Stack Pointer
+  \details Returns the current value of the Main Stack Pointer (MSP).
+  \return               MSP Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_MSP(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, msp" : "=r" (result) );
+  return (result);
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Main Stack Pointer (non-secure)
+  \details Returns the current value of the non-secure Main Stack Pointer (MSP) when in secure state.
+  \return               MSP Register value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_MSP_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, msp_ns" : "=r" (result) );
+  return (result);
+}
+#endif
+
+
+/**
+  \brief   Set Main Stack Pointer
+  \details Assigns the given value to the Main Stack Pointer (MSP).
+  \param [in]    topOfMainStack  Main Stack Pointer value to set
+ */
+__STATIC_FORCEINLINE void __set_MSP(uint32_t topOfMainStack)
+{
+  __ASM volatile ("MSR msp, %0" : : "r" (topOfMainStack) : );
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Set Main Stack Pointer (non-secure)
+  \details Assigns the given value to the non-secure Main Stack Pointer (MSP) when in secure state.
+  \param [in]    topOfMainStack  Main Stack Pointer value to set
+ */
+__STATIC_FORCEINLINE void __TZ_set_MSP_NS(uint32_t topOfMainStack)
+{
+  __ASM volatile ("MSR msp_ns, %0" : : "r" (topOfMainStack) : );
+}
+#endif
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Stack Pointer (non-secure)
+  \details Returns the current value of the non-secure Stack Pointer (SP) when in secure state.
+  \return               SP Register value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_SP_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, sp_ns" : "=r" (result) );
+  return (result);
+}
+
+
+/**
+  \brief   Set Stack Pointer (non-secure)
+  \details Assigns the given value to the non-secure Stack Pointer (SP) when in secure state.
+  \param [in]    topOfStack  Stack Pointer value to set
+ */
+__STATIC_FORCEINLINE void __TZ_set_SP_NS(uint32_t topOfStack)
+{
+  __ASM volatile ("MSR sp_ns, %0" : : "r" (topOfStack) : );
+}
+#endif
+
+
+/**
+  \brief   Get Priority Mask
+  \details Returns the current state of the priority mask bit from the Priority Mask Register.
+  \return               Priority Mask value
+ */
+__STATIC_FORCEINLINE uint32_t __get_PRIMASK(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, primask" : "=r" (result) );
+  return (result);
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Priority Mask (non-secure)
+  \details Returns the current state of the non-secure priority mask bit from the Priority Mask Register when in secure state.
+  \return               Priority Mask value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_PRIMASK_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, primask_ns" : "=r" (result) );
+  return (result);
+}
+#endif
+
+
+/**
+  \brief   Set Priority Mask
+  \details Assigns the given value to the Priority Mask Register.
+  \param [in]    priMask  Priority Mask
+ */
+__STATIC_FORCEINLINE void __set_PRIMASK(uint32_t priMask)
+{
+  __ASM volatile ("MSR primask, %0" : : "r" (priMask) : "memory");
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Set Priority Mask (non-secure)
+  \details Assigns the given value to the non-secure Priority Mask Register when in secure state.
+  \param [in]    priMask  Priority Mask
+ */
+__STATIC_FORCEINLINE void __TZ_set_PRIMASK_NS(uint32_t priMask)
+{
+  __ASM volatile ("MSR primask_ns, %0" : : "r" (priMask) : "memory");
+}
+#endif
+
+
+#if (__ARM_ARCH_ISA_THUMB >= 2)
+/**
+  \brief   Enable FIQ
+  \details Enables FIQ interrupts by clearing special-purpose register FAULTMASK.
+           Can only be executed in Privileged modes.
+ */
+__STATIC_FORCEINLINE void __enable_fault_irq(void)
+{
+  __ASM volatile ("cpsie f" : : : "memory");
+}
+
+
+/**
+  \brief   Disable FIQ
+  \details Disables FIQ interrupts by setting special-purpose register FAULTMASK.
+           Can only be executed in Privileged modes.
+ */
+__STATIC_FORCEINLINE void __disable_fault_irq(void)
+{
+  __ASM volatile ("cpsid f" : : : "memory");
+}
+
+
+/**
+  \brief   Get Base Priority
+  \details Returns the current value of the Base Priority register.
+  \return               Base Priority register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_BASEPRI(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, basepri" : "=r" (result) );
+  return (result);
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Base Priority (non-secure)
+  \details Returns the current value of the non-secure Base Priority register when in secure state.
+  \return               Base Priority register value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_BASEPRI_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, basepri_ns" : "=r" (result) );
+  return (result);
+}
+#endif
+
+
+/**
+  \brief   Set Base Priority
+  \details Assigns the given value to the Base Priority register.
+  \param [in]    basePri  Base Priority value to set
+ */
+__STATIC_FORCEINLINE void __set_BASEPRI(uint32_t basePri)
+{
+  __ASM volatile ("MSR basepri, %0" : : "r" (basePri) : "memory");
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Set Base Priority (non-secure)
+  \details Assigns the given value to the non-secure Base Priority register when in secure state.
+  \param [in]    basePri  Base Priority value to set
+ */
+__STATIC_FORCEINLINE void __TZ_set_BASEPRI_NS(uint32_t basePri)
+{
+  __ASM volatile ("MSR basepri_ns, %0" : : "r" (basePri) : "memory");
+}
+#endif
+
+
+/**
+  \brief   Set Base Priority with condition
+  \details Assigns the given value to the Base Priority register only if BASEPRI masking is disabled,
+           or the new value increases the BASEPRI priority level.
+  \param [in]    basePri  Base Priority value to set
+ */
+__STATIC_FORCEINLINE void __set_BASEPRI_MAX(uint32_t basePri)
+{
+  __ASM volatile ("MSR basepri_max, %0" : : "r" (basePri) : "memory");
+}
+
+
+/**
+  \brief   Get Fault Mask
+  \details Returns the current value of the Fault Mask register.
+  \return               Fault Mask register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_FAULTMASK(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, faultmask" : "=r" (result) );
+  return (result);
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Fault Mask (non-secure)
+  \details Returns the current value of the non-secure Fault Mask register when in secure state.
+  \return               Fault Mask register value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_FAULTMASK_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, faultmask_ns" : "=r" (result) );
+  return (result);
+}
+#endif
+
+
+/**
+  \brief   Set Fault Mask
+  \details Assigns the given value to the Fault Mask register.
+  \param [in]    faultMask  Fault Mask value to set
+ */
+__STATIC_FORCEINLINE void __set_FAULTMASK(uint32_t faultMask)
+{
+  __ASM volatile ("MSR faultmask, %0" : : "r" (faultMask) : "memory");
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Set Fault Mask (non-secure)
+  \details Assigns the given value to the non-secure Fault Mask register when in secure state.
+  \param [in]    faultMask  Fault Mask value to set
+ */
+__STATIC_FORCEINLINE void __TZ_set_FAULTMASK_NS(uint32_t faultMask)
+{
+  __ASM volatile ("MSR faultmask_ns, %0" : : "r" (faultMask) : "memory");
+}
+#endif
+
+#endif /* (__ARM_ARCH_ISA_THUMB >= 2) */
+
+
+#if (__ARM_ARCH >= 8)
+/**
+  \brief   Get Process Stack Pointer Limit
+  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
+  Stack Pointer Limit register hence zero is returned always in non-secure
+  mode.
+
+  \details Returns the current value of the Process Stack Pointer Limit (PSPLIM).
+  \return               PSPLIM Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_PSPLIM(void)
+{
+#if (((__ARM_ARCH_8M_MAIN__   < 1) && \
+      (__ARM_ARCH_8_1M_MAIN__ < 1)    ) && \
+     (__ARM_FEATURE_CMSE < 3)              )
+  /* without main extensions, the non-secure PSPLIM is RAZ/WI */
+  return (0U);
+#else
+  uint32_t result;
+  __ASM volatile ("MRS %0, psplim"  : "=r" (result) );
+  return (result);
+#endif
+}
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Process Stack Pointer Limit (non-secure)
+  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
+  Stack Pointer Limit register hence zero is returned always.
+
+  \details Returns the current value of the non-secure Process Stack Pointer Limit (PSPLIM) when in secure state.
+  \return               PSPLIM Register value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_PSPLIM_NS(void)
+{
+#if ((__ARM_ARCH_8M_MAIN__   < 1) && \
+     (__ARM_ARCH_8_1M_MAIN__ < 1)    )
+  /* without main extensions, the non-secure PSPLIM is RAZ/WI */
+  return (0U);
+#else
+  uint32_t result;
+  __ASM volatile ("MRS %0, psplim_ns"  : "=r" (result) );
+  return (result);
+#endif
+}
+#endif
+
+
+/**
+  \brief   Set Process Stack Pointer Limit
+  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
+  Stack Pointer Limit register hence the write is silently ignored in non-secure
+  mode.
+
+  \details Assigns the given value to the Process Stack Pointer Limit (PSPLIM).
+  \param [in]    ProcStackPtrLimit  Process Stack Pointer Limit value to set
+ */
+__STATIC_FORCEINLINE void __set_PSPLIM(uint32_t ProcStackPtrLimit)
+{
+#if (((__ARM_ARCH_8M_MAIN__   < 1) && \
+      (__ARM_ARCH_8_1M_MAIN__ < 1)    ) && \
+     (__ARM_FEATURE_CMSE < 3)              )
+  /* without main extensions, the non-secure PSPLIM is RAZ/WI */
+  (void)ProcStackPtrLimit;
+#else
+  __ASM volatile ("MSR psplim, %0" : : "r" (ProcStackPtrLimit));
+#endif
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Set Process Stack Pointer (non-secure)
+  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
+  Stack Pointer Limit register hence the write is silently ignored.
+
+  \details Assigns the given value to the non-secure Process Stack Pointer Limit (PSPLIM) when in secure state.
+  \param [in]    ProcStackPtrLimit  Process Stack Pointer Limit value to set
+ */
+__STATIC_FORCEINLINE void __TZ_set_PSPLIM_NS(uint32_t ProcStackPtrLimit)
+{
+#if ((__ARM_ARCH_8M_MAIN__   < 1) && \
+     (__ARM_ARCH_8_1M_MAIN__ < 1)    )
+  /* without main extensions, the non-secure PSPLIM is RAZ/WI */
+  (void)ProcStackPtrLimit;
+#else
+  __ASM volatile ("MSR psplim_ns, %0\n" : : "r" (ProcStackPtrLimit));
+#endif
+}
+#endif
+
+
+/**
+  \brief   Get Main Stack Pointer Limit
+  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
+  Stack Pointer Limit register hence zero is returned always.
+
+  \details Returns the current value of the Main Stack Pointer Limit (MSPLIM).
+  \return               MSPLIM Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_MSPLIM(void)
+{
+#if (((__ARM_ARCH_8M_MAIN__   < 1) && \
+      (__ARM_ARCH_8_1M_MAIN__ < 1)    ) && \
+     (__ARM_FEATURE_CMSE < 3)              )
+  /* without main extensions, the non-secure MSPLIM is RAZ/WI */
+  return (0U);
+#else
+  uint32_t result;
+  __ASM volatile ("MRS %0, msplim" : "=r" (result) );
+  return (result);
+#endif
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Main Stack Pointer Limit (non-secure)
+  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
+  Stack Pointer Limit register hence zero is returned always.
+
+  \details Returns the current value of the non-secure Main Stack Pointer Limit(MSPLIM) when in secure state.
+  \return               MSPLIM Register value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_MSPLIM_NS(void)
+{
+#if ((__ARM_ARCH_8M_MAIN__   < 1) && \
+     (__ARM_ARCH_8_1M_MAIN__ < 1)    )
+  /* without main extensions, the non-secure MSPLIM is RAZ/WI */
+  return (0U);
+#else
+  uint32_t result;
+  __ASM volatile ("MRS %0, msplim_ns" : "=r" (result) );
+  return (result);
+#endif
+}
+#endif
+
+
+/**
+  \brief   Set Main Stack Pointer Limit
+  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
+  Stack Pointer Limit register hence the write is silently ignored.
+
+  \details Assigns the given value to the Main Stack Pointer Limit (MSPLIM).
+  \param [in]    MainStackPtrLimit  Main Stack Pointer Limit value to set
+ */
+__STATIC_FORCEINLINE void __set_MSPLIM(uint32_t MainStackPtrLimit)
+{
+#if (((__ARM_ARCH_8M_MAIN__   < 1) && \
+      (__ARM_ARCH_8_1M_MAIN__ < 1)    ) && \
+     (__ARM_FEATURE_CMSE < 3)              )
+  /* without main extensions, the non-secure MSPLIM is RAZ/WI */
+  (void)MainStackPtrLimit;
+#else
+  __ASM volatile ("MSR msplim, %0" : : "r" (MainStackPtrLimit));
+#endif
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Set Main Stack Pointer Limit (non-secure)
+  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
+  Stack Pointer Limit register hence the write is silently ignored.
+
+  \details Assigns the given value to the non-secure Main Stack Pointer Limit (MSPLIM) when in secure state.
+  \param [in]    MainStackPtrLimit  Main Stack Pointer value to set
+ */
+__STATIC_FORCEINLINE void __TZ_set_MSPLIM_NS(uint32_t MainStackPtrLimit)
+{
+#if ((__ARM_ARCH_8M_MAIN__   < 1) && \
+     (__ARM_ARCH_8_1M_MAIN__ < 1)    )
+  /* without main extensions, the non-secure MSPLIM is RAZ/WI */
+  (void)MainStackPtrLimit;
+#else
+  __ASM volatile ("MSR msplim_ns, %0" : : "r" (MainStackPtrLimit));
+#endif
+}
+#endif
+
+#endif /* (__ARM_ARCH >= 8) */
+
+
+/**
+  \brief   Get FPSCR
+  \details Returns the current value of the Floating Point Status/Control register.
+  \return               Floating Point Status/Control register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_FPSCR(void)
+{
+#if (defined(__ARM_FP) && (__ARM_FP >= 1))
+  return (__builtin_arm_get_fpscr());
+#else
+  return (0U);
+#endif
+}
+
+
+/**
+  \brief   Set FPSCR
+  \details Assigns the given value to the Floating Point Status/Control register.
+  \param [in]    fpscr  Floating Point Status/Control value to set
+ */
+__STATIC_FORCEINLINE void __set_FPSCR(uint32_t fpscr)
+{
+#if (defined(__ARM_FP) && (__ARM_FP >= 1))
+  __builtin_arm_set_fpscr(fpscr);
+#else
+  (void)fpscr;
+#endif
+}
+
+
+/** @} end of CMSIS_Core_RegAccFunctions */
+
+
+/* ###################  Compiler specific Intrinsics  ########################### */
+/** \defgroup CMSIS_SIMD_intrinsics CMSIS SIMD Intrinsics
+  Access to dedicated SIMD instructions
+  @{
+*/
+
+#if (__ARM_FEATURE_DSP == 1)
+#define     __SADD8                 __sadd8
+#define     __QADD8                 __qadd8
+#define     __SHADD8                __shadd8
+#define     __UADD8                 __uadd8
+#define     __UQADD8                __uqadd8
+#define     __UHADD8                __uhadd8
+#define     __SSUB8                 __ssub8
+#define     __QSUB8                 __qsub8
+#define     __SHSUB8                __shsub8
+#define     __USUB8                 __usub8
+#define     __UQSUB8                __uqsub8
+#define     __UHSUB8                __uhsub8
+#define     __SADD16                __sadd16
+#define     __QADD16                __qadd16
+#define     __SHADD16               __shadd16
+#define     __UADD16                __uadd16
+#define     __UQADD16               __uqadd16
+#define     __UHADD16               __uhadd16
+#define     __SSUB16                __ssub16
+#define     __QSUB16                __qsub16
+#define     __SHSUB16               __shsub16
+#define     __USUB16                __usub16
+#define     __UQSUB16               __uqsub16
+#define     __UHSUB16               __uhsub16
+#define     __SASX                  __sasx
+#define     __QASX                  __qasx
+#define     __SHASX                 __shasx
+#define     __UASX                  __uasx
+#define     __UQASX                 __uqasx
+#define     __UHASX                 __uhasx
+#define     __SSAX                  __ssax
+#define     __QSAX                  __qsax
+#define     __SHSAX                 __shsax
+#define     __USAX                  __usax
+#define     __UQSAX                 __uqsax
+#define     __UHSAX                 __uhsax
+#define     __USAD8                 __usad8
+#define     __USADA8                __usada8
+#define     __SSAT16                __ssat16
+#define     __USAT16                __usat16
+#define     __UXTB16                __uxtb16
+#define     __UXTAB16               __uxtab16
+#define     __SXTB16                __sxtb16
+#define     __SXTAB16               __sxtab16
+#define     __SMUAD                 __smuad
+#define     __SMUADX                __smuadx
+#define     __SMLAD                 __smlad
+#define     __SMLADX                __smladx
+#define     __SMLALD                __smlald
+#define     __SMLALDX               __smlaldx
+#define     __SMUSD                 __smusd
+#define     __SMUSDX                __smusdx
+#define     __SMLSD                 __smlsd
+#define     __SMLSDX                __smlsdx
+#define     __SMLSLD                __smlsld
+#define     __SMLSLDX               __smlsldx
+#define     __SEL                   __sel
+#define     __QADD                  __qadd
+#define     __QSUB                  __qsub
+
+#define __PKHBT(ARG1,ARG2,ARG3) \
+__extension__ \
+({                          \
+  uint32_t __RES, __ARG1 = (ARG1), __ARG2 = (ARG2); \
+  __ASM ("pkhbt %0, %1, %2, lsl %3" : "=r" (__RES) :  "r" (__ARG1), "r" (__ARG2), "I" (ARG3)  ); \
+  __RES; \
+ })
+
+#define __PKHTB(ARG1,ARG2,ARG3) \
+__extension__ \
+({                          \
+  uint32_t __RES, __ARG1 = (ARG1), __ARG2 = (ARG2); \
+  if (ARG3 == 0) \
+    __ASM ("pkhtb %0, %1, %2" : "=r" (__RES) :  "r" (__ARG1), "r" (__ARG2)  ); \
+  else \
+    __ASM ("pkhtb %0, %1, %2, asr %3" : "=r" (__RES) :  "r" (__ARG1), "r" (__ARG2), "I" (ARG3)  ); \
+  __RES; \
+ })
+
+#define __SXTB16_RORn(ARG1, ARG2)        __SXTB16(__ROR(ARG1, ARG2))
+
+#define __SXTAB16_RORn(ARG1, ARG2, ARG3) __SXTAB16(ARG1, __ROR(ARG2, ARG3))
+
+__STATIC_FORCEINLINE int32_t __SMMLA (int32_t op1, int32_t op2, int32_t op3)
+{
+  int32_t result;
+
+  __ASM volatile ("smmla %0, %1, %2, %3" : "=r" (result): "r"  (op1), "r" (op2), "r" (op3) );
+  return (result);
+}
+
+#endif /* (__ARM_FEATURE_DSP == 1) */
+/** @} end of group CMSIS_SIMD_intrinsics */
+
+
+#endif /* __CMSIS_CLANG_M_H */

--- a/platform/ext/cmsis/CMSIS/Core/Include/m-profile/cmsis_gcc_m.h
+++ b/platform/ext/cmsis/CMSIS/Core/Include/m-profile/cmsis_gcc_m.h
@@ -1,0 +1,1674 @@
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS-Core(M) Compiler GCC Header File
+ */
+
+#ifndef __CMSIS_GCC_M_H
+#define __CMSIS_GCC_M_H
+
+/* ignore some GCC warnings */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+
+#include <arm_acle.h>
+
+/* Fallback for __has_builtin */
+#ifndef __has_builtin
+  #define __has_builtin(x) (0)
+#endif
+
+/* CMSIS compiler specific defines */
+#ifndef   __ASM
+  #define __ASM                                  __asm
+#endif
+#ifndef   __INLINE
+  #define __INLINE                               inline
+#endif
+#ifndef   __STATIC_INLINE
+  #define __STATIC_INLINE                        static inline
+#endif
+#ifndef   __STATIC_FORCEINLINE
+  #define __STATIC_FORCEINLINE                   __attribute__((always_inline)) static inline
+#endif
+#ifndef   __NO_RETURN
+  #define __NO_RETURN                            __attribute__((__noreturn__))
+#endif
+#ifndef   __USED
+  #define __USED                                 __attribute__((used))
+#endif
+#ifndef   __WEAK
+  #define __WEAK                                 __attribute__((weak))
+#endif
+#ifndef   __PACKED
+  #define __PACKED                               __attribute__((packed, aligned(1)))
+#endif
+#ifndef   __PACKED_STRUCT
+  #define __PACKED_STRUCT                        struct __attribute__((packed, aligned(1)))
+#endif
+#ifndef   __PACKED_UNION
+  #define __PACKED_UNION                         union __attribute__((packed, aligned(1)))
+#endif
+#ifndef   __UNALIGNED_UINT16_WRITE
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wpacked"
+  #pragma GCC diagnostic ignored "-Wattributes"
+  __PACKED_STRUCT T_UINT16_WRITE { uint16_t v; };
+  #pragma GCC diagnostic pop
+  #define __UNALIGNED_UINT16_WRITE(addr, val)    (void)((((struct T_UINT16_WRITE *)(void *)(addr))->v) = (val))
+#endif
+#ifndef   __UNALIGNED_UINT16_READ
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wpacked"
+  #pragma GCC diagnostic ignored "-Wattributes"
+  __PACKED_STRUCT T_UINT16_READ { uint16_t v; };
+  #pragma GCC diagnostic pop
+  #define __UNALIGNED_UINT16_READ(addr)          (((const struct T_UINT16_READ *)(const void *)(addr))->v)
+#endif
+#ifndef   __UNALIGNED_UINT32_WRITE
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wpacked"
+  #pragma GCC diagnostic ignored "-Wattributes"
+  __PACKED_STRUCT T_UINT32_WRITE { uint32_t v; };
+  #pragma GCC diagnostic pop
+  #define __UNALIGNED_UINT32_WRITE(addr, val)    (void)((((struct T_UINT32_WRITE *)(void *)(addr))->v) = (val))
+#endif
+#ifndef   __UNALIGNED_UINT32_READ
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wpacked"
+  #pragma GCC diagnostic ignored "-Wattributes"
+  __PACKED_STRUCT T_UINT32_READ { uint32_t v; };
+  #pragma GCC diagnostic pop
+  #define __UNALIGNED_UINT32_READ(addr)          (((const struct T_UINT32_READ *)(const void *)(addr))->v)
+#endif
+#ifndef   __ALIGNED
+  #define __ALIGNED(x)                           __attribute__((aligned(x)))
+#endif
+#ifndef   __RESTRICT
+  #define __RESTRICT                             __restrict
+#endif
+#ifndef   __COMPILER_BARRIER
+  #define __COMPILER_BARRIER()                   __ASM volatile("":::"memory")
+#endif
+#ifndef __NO_INIT
+  #define __NO_INIT                              __attribute__ ((section (".noinit")))
+#endif
+#ifndef __ALIAS
+  #define __ALIAS(x)                             __attribute__ ((alias(x)))
+#endif
+
+/* #########################  Startup and Lowlevel Init  ######################## */
+#ifndef __PROGRAM_START
+
+/**
+  \brief   Initializes data and bss sections
+  \details This default implementations initialized all data and additional bss
+           sections relying on .copy.table and .zero.table specified properly
+           in the used linker script.
+
+ */
+__STATIC_FORCEINLINE __NO_RETURN void __cmsis_start(void)
+{
+  extern void _start(void) __NO_RETURN;
+
+  typedef struct __copy_table {
+    uint32_t const* src;
+    uint32_t* dest;
+    uint32_t  wlen;
+  } __copy_table_t;
+
+  typedef struct __zero_table {
+    uint32_t* dest;
+    uint32_t  wlen;
+  } __zero_table_t;
+
+  extern const __copy_table_t __copy_table_start__;
+  extern const __copy_table_t __copy_table_end__;
+  extern const __zero_table_t __zero_table_start__;
+  extern const __zero_table_t __zero_table_end__;
+
+  for (__copy_table_t const* pTable = &__copy_table_start__; pTable < &__copy_table_end__; ++pTable) {
+    for(uint32_t i=0u; i<pTable->wlen; ++i) {
+      pTable->dest[i] = pTable->src[i];
+    }
+  }
+
+  for (__zero_table_t const* pTable = &__zero_table_start__; pTable < &__zero_table_end__; ++pTable) {
+    for(uint32_t i=0u; i<pTable->wlen; ++i) {
+      pTable->dest[i] = 0u;
+    }
+  }
+
+  _start();
+}
+
+#define __PROGRAM_START           __cmsis_start
+#endif
+
+#ifndef __INITIAL_SP
+#define __INITIAL_SP              __StackTop
+#endif
+
+#ifndef __STACK_LIMIT
+#define __STACK_LIMIT             __StackLimit
+#endif
+
+#ifndef __VECTOR_TABLE
+#define __VECTOR_TABLE            __Vectors
+#endif
+
+#ifndef __VECTOR_TABLE_ATTRIBUTE
+#define __VECTOR_TABLE_ATTRIBUTE  __attribute__((used, section(".vectors")))
+#endif
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
+#ifndef __STACK_SEAL
+#define __STACK_SEAL              __StackSeal
+#endif
+
+#ifndef __TZ_STACK_SEAL_SIZE
+#define __TZ_STACK_SEAL_SIZE      8U
+#endif
+
+#ifndef __TZ_STACK_SEAL_VALUE
+#define __TZ_STACK_SEAL_VALUE     0xFEF5EDA5FEF5EDA5ULL
+#endif
+
+
+__STATIC_FORCEINLINE void __TZ_set_STACKSEAL_S (uint32_t* stackTop) {
+  *((uint64_t *)stackTop) = __TZ_STACK_SEAL_VALUE;
+}
+#endif
+
+
+/* ##########################  Core Instruction Access  ######################### */
+/** \defgroup CMSIS_Core_InstructionInterface CMSIS Core Instruction Interface
+  Access to dedicated instructions
+  @{
+*/
+
+/* Define macros for porting to both thumb1 and thumb2.
+ * For thumb1, use low register (r0-r7), specified by constraint "l"
+ * Otherwise, use general registers, specified by constraint "r" */
+#if defined (__thumb__) && !defined (__thumb2__)
+#define __CMSIS_GCC_OUT_REG(r) "=l" (r)
+#define __CMSIS_GCC_RW_REG(r) "+l" (r)
+#define __CMSIS_GCC_USE_REG(r) "l" (r)
+#else
+#define __CMSIS_GCC_OUT_REG(r) "=r" (r)
+#define __CMSIS_GCC_RW_REG(r) "+r" (r)
+#define __CMSIS_GCC_USE_REG(r) "r" (r)
+#endif
+
+/**
+  \brief   No Operation
+  \details No Operation does nothing. This instruction can be used for code alignment purposes.
+ */
+#define __NOP()         __ASM volatile ("nop")
+
+
+/**
+  \brief   Wait For Interrupt
+  \details Wait For Interrupt is a hint instruction that suspends execution until one of a number of events occurs.
+ */
+#define __WFI()         __ASM volatile ("wfi":::"memory")
+
+
+/**
+  \brief   Wait For Event
+  \details Wait For Event is a hint instruction that permits the processor to enter
+           a low-power state until one of a number of events occurs.
+ */
+#define __WFE()         __ASM volatile ("wfe":::"memory")
+
+
+/**
+  \brief   Send Event
+  \details Send Event is a hint instruction. It causes an event to be signaled to the CPU.
+ */
+#define __SEV()         __ASM volatile ("sev")
+
+
+/**
+  \brief   Instruction Synchronization Barrier
+  \details Instruction Synchronization Barrier flushes the pipeline in the processor,
+           so that all instructions following the ISB are fetched from cache or memory,
+           after the instruction has been completed.
+ */
+__STATIC_FORCEINLINE void __ISB(void)
+{
+  __ASM volatile ("isb 0xF":::"memory");
+}
+
+
+/**
+  \brief   Data Synchronization Barrier
+  \details Acts as a special kind of Data Memory Barrier.
+           It completes when all explicit memory accesses before this instruction complete.
+ */
+__STATIC_FORCEINLINE void __DSB(void)
+{
+  __ASM volatile ("dsb 0xF":::"memory");
+}
+
+
+/**
+  \brief   Data Memory Barrier
+  \details Ensures the apparent order of the explicit memory operations before
+           and after the instruction, without ensuring their completion.
+ */
+__STATIC_FORCEINLINE void __DMB(void)
+{
+  __ASM volatile ("dmb 0xF":::"memory");
+}
+
+
+/**
+  \brief   Reverse byte order (32 bit)
+  \details Reverses the byte order in unsigned integer value. For example, 0x12345678 becomes 0x78563412.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+__STATIC_FORCEINLINE uint32_t __REV(uint32_t value)
+{
+  return __builtin_bswap32(value);
+}
+
+
+/**
+  \brief   Reverse byte order (16 bit)
+  \details Reverses the byte order within each halfword of a word. For example, 0x12345678 becomes 0x34127856.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+__STATIC_FORCEINLINE uint32_t __REV16(uint32_t value)
+{
+  uint32_t result;
+
+  __ASM ("rev16 %0, %1" : __CMSIS_GCC_OUT_REG (result) : __CMSIS_GCC_USE_REG (value) );
+  return (result);
+}
+
+
+/**
+  \brief   Reverse byte order (16 bit)
+  \details Reverses the byte order in a 16-bit value and returns the signed 16-bit result. For example, 0x0080 becomes 0x8000.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+__STATIC_FORCEINLINE int16_t __REVSH(int16_t value)
+{
+  return (int16_t)__builtin_bswap16(value);
+}
+
+
+/**
+  \brief   Rotate Right in unsigned value (32 bit)
+  \details Rotate Right (immediate) provides the value of the contents of a register rotated by a variable number of bits.
+  \param [in]    op1  Value to rotate
+  \param [in]    op2  Number of Bits to rotate
+  \return               Rotated value
+ */
+__STATIC_FORCEINLINE uint32_t __ROR(uint32_t op1, uint32_t op2)
+{
+  op2 %= 32U;
+  if (op2 == 0U)
+  {
+    return op1;
+  }
+  return (op1 >> op2) | (op1 << (32U - op2));
+}
+
+/**
+  \brief   Breakpoint
+  \details Causes the processor to enter Debug state.
+           Debug tools can use this to investigate system state when the instruction at a particular address is reached.
+  \param [in]    value  is ignored by the processor.
+                 If required, a debugger can use it to store additional information about the breakpoint.
+ */
+#define __BKPT(value) __ASM volatile ("bkpt "#value)
+
+
+/**
+  \brief   Reverse bit order of value
+  \details Reverses the bit order of the given value.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+__STATIC_FORCEINLINE uint32_t __RBIT(uint32_t value)
+{
+  uint32_t result;
+
+#if (__ARM_ARCH_ISA_THUMB >= 2)
+   __ASM ("rbit %0, %1" : "=r" (result) : "r" (value) );
+#else
+  uint32_t s = (4U /*sizeof(v)*/ * 8U) - 1U; /* extra shift needed at end */
+
+  result = value;                      /* r will be reversed bits of v; first get LSB of v */
+  for (value >>= 1U; value != 0U; value >>= 1U)
+  {
+    result <<= 1U;
+    result |= value & 1U;
+    s--;
+  }
+  result <<= s;                        /* shift when v's highest bits are zero */
+#endif
+  return (result);
+}
+
+
+/**
+  \brief   Count leading zeros
+  \details Counts the number of leading zeros of a data value.
+  \param [in]  value  Value to count the leading zeros
+  \return             number of leading zeros in value
+ */
+__STATIC_FORCEINLINE uint8_t __CLZ(uint32_t value)
+{
+  /* Even though __builtin_clz produces a CLZ instruction on ARM, formally
+     __builtin_clz(0) is undefined behaviour, so handle this case specially.
+     This guarantees ARM-compatible results if happening to compile on a non-ARM
+     target, and ensures the compiler doesn't decide to activate any
+     optimisations using the logic "value was passed to __builtin_clz, so it
+     is non-zero".
+     ARM GCC 7.3 and possibly earlier will optimise this test away, leaving a
+     single CLZ instruction.
+   */
+  if (value == 0U)
+  {
+    return 32U;
+  }
+  return __builtin_clz(value);
+}
+
+
+#if (__ARM_FEATURE_SAT    >= 1)
+/**
+  \brief   Signed Saturate
+  \details Saturates a signed value.
+  \param [in]  value  Value to be saturated
+  \param [in]    sat  Bit position to saturate to (1..32)
+  \return             Saturated value
+ */
+#define __SSAT(value, sat) __ssat(value, sat)
+
+
+/**
+  \brief   Unsigned Saturate
+  \details Saturates an unsigned value.
+  \param [in]  value  Value to be saturated
+  \param [in]    sat  Bit position to saturate to (0..31)
+  \return             Saturated value
+ */
+#define __USAT(value, sat) __usat(value, sat)
+
+#else /* (__ARM_FEATURE_SAT >= 1) */
+/**
+  \brief   Signed Saturate
+  \details Saturates a signed value.
+  \param [in]  value  Value to be saturated
+  \param [in]    sat  Bit position to saturate to (1..32)
+  \return             Saturated value
+ */
+__STATIC_FORCEINLINE int32_t __SSAT(int32_t val, uint32_t sat)
+{
+  if ((sat >= 1U) && (sat <= 32U))
+  {
+    const int32_t max = (int32_t)((1U << (sat - 1U)) - 1U);
+    const int32_t min = -1 - max ;
+    if (val > max)
+    {
+      return (max);
+    }
+    else if (val < min)
+    {
+      return (min);
+    }
+  }
+  return (val);
+}
+
+
+/**
+  \brief   Unsigned Saturate
+  \details Saturates an unsigned value.
+  \param [in]  value  Value to be saturated
+  \param [in]    sat  Bit position to saturate to (0..31)
+  \return             Saturated value
+ */
+__STATIC_FORCEINLINE uint32_t __USAT(int32_t val, uint32_t sat)
+{
+  if (sat <= 31U)
+  {
+    const uint32_t max = ((1U << sat) - 1U);
+    if (val > (int32_t)max)
+    {
+      return (max);
+    }
+    else if (val < 0)
+    {
+      return (0U);
+    }
+  }
+  return ((uint32_t)val);
+}
+#endif /* (__ARM_FEATURE_SAT >= 1) */
+
+
+#if (__ARM_FEATURE_LDREX >= 1)
+/**
+  \brief   Remove the exclusive lock
+  \details Removes the exclusive lock which is created by LDREX.
+ */
+__STATIC_FORCEINLINE void __CLREX(void)
+{
+  __ASM volatile ("clrex" ::: "memory");
+}
+
+
+/**
+  \brief   LDR Exclusive (8 bit)
+  \details Executes a exclusive LDR instruction for 8 bit value.
+  \param [in]    ptr  Pointer to data
+  \return             value of type uint8_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint8_t __LDREXB(volatile uint8_t *addr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldrexb %0, %1" : "=r" (result) : "Q" (*addr) );
+  return ((uint8_t) result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   STR Exclusive (8 bit)
+  \details Executes a exclusive STR instruction for 8 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+__STATIC_FORCEINLINE uint32_t __STREXB(uint8_t value, volatile uint8_t *addr)
+{
+  uint32_t result;
+
+  __ASM volatile ("strexb %0, %2, %1" : "=&r" (result), "=Q" (*addr) : "r" ((uint32_t)value) );
+  return (result);
+}
+#endif /* (__ARM_FEATURE_LDREX >= 1) */
+
+
+#if (__ARM_FEATURE_LDREX >= 2)
+/**
+  \brief   LDR Exclusive (16 bit)
+  \details Executes a exclusive LDR instruction for 16 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint16_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint16_t __LDREXH(volatile uint16_t *addr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldrexh %0, %1" : "=r" (result) : "Q" (*addr) );
+  return ((uint16_t)result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   STR Exclusive (16 bit)
+  \details Executes a exclusive STR instruction for 16 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+__STATIC_FORCEINLINE uint32_t __STREXH(uint16_t value, volatile uint16_t *addr)
+{
+  uint32_t result;
+
+  __ASM volatile ("strexh %0, %2, %1" : "=&r" (result), "=Q" (*addr) : "r" ((uint32_t)value) );
+  return (result);
+}
+#endif /* (__ARM_FEATURE_LDREX >= 2) */
+
+
+#if (__ARM_FEATURE_LDREX >= 4)
+/**
+  \brief   LDR Exclusive (32 bit)
+  \details Executes a exclusive LDR instruction for 32 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint32_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint32_t __LDREXW(volatile uint32_t *addr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldrex %0, %1" : "=r" (result) : "Q" (*addr) );
+  return (result);
+}
+
+
+/**
+  \brief   STR Exclusive (32 bit)
+  \details Executes a exclusive STR instruction for 32 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+__STATIC_FORCEINLINE uint32_t __STREXW(uint32_t value, volatile uint32_t *addr)
+{
+  uint32_t result;
+
+  __ASM volatile ("strex %0, %2, %1" : "=&r" (result), "=Q" (*addr) : "r" (value) );
+  return (result);
+}
+#endif /* (__ARM_FEATURE_LDREX >= 4) */
+
+
+#if (__ARM_ARCH_ISA_THUMB >= 2)
+/**
+  \brief   Rotate Right with Extend (32 bit)
+  \details Moves each bit of a bitstring right by one bit.
+           The carry input is shifted in at the left end of the bitstring.
+  \param [in]    value  Value to rotate
+  \return               Rotated value
+ */
+__STATIC_FORCEINLINE uint32_t __RRX(uint32_t value)
+{
+  uint32_t result;
+
+  __ASM volatile ("rrx %0, %1" : "=r" (result) : "r" (value));
+  return (result);
+}
+
+
+/**
+  \brief   LDRT Unprivileged (8 bit)
+  \details Executes a Unprivileged LDRT instruction for 8 bit value.
+  \param [in]    ptr  Pointer to data
+  \return             value of type uint8_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint8_t __LDRBT(volatile uint8_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldrbt %0, %1" : "=r" (result) : "Q" (*ptr) );
+  return ((uint8_t)result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   LDRT Unprivileged (16 bit)
+  \details Executes a Unprivileged LDRT instruction for 16 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint16_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint16_t __LDRHT(volatile uint16_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldrht %0, %1" : "=r" (result) : "Q" (*ptr) );
+  return ((uint16_t)result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   LDRT Unprivileged (32 bit)
+  \details Executes a Unprivileged LDRT instruction for 32 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint32_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint32_t __LDRT(volatile uint32_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldrt %0, %1" : "=r" (result) : "Q" (*ptr) );
+  return (result);
+}
+
+
+/**
+  \brief   STRT Unprivileged (8 bit)
+  \details Executes a Unprivileged STRT instruction for 8 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__STATIC_FORCEINLINE void __STRBT(uint8_t value, volatile uint8_t *ptr)
+{
+  __ASM volatile ("strbt %1, %0" : "=Q" (*ptr) : "r" ((uint32_t)value) );
+}
+
+
+/**
+  \brief   STRT Unprivileged (16 bit)
+  \details Executes a Unprivileged STRT instruction for 16 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__STATIC_FORCEINLINE void __STRHT(uint16_t value, volatile uint16_t *ptr)
+{
+  __ASM volatile ("strht %1, %0" : "=Q" (*ptr) : "r" ((uint32_t)value) );
+}
+
+
+/**
+  \brief   STRT Unprivileged (32 bit)
+  \details Executes a Unprivileged STRT instruction for 32 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__STATIC_FORCEINLINE void __STRT(uint32_t value, volatile uint32_t *ptr)
+{
+  __ASM volatile ("strt %1, %0" : "=Q" (*ptr) : "r" (value) );
+}
+#endif /* (__ARM_ARCH_ISA_THUMB >= 2) */
+
+
+#if (__ARM_ARCH >= 8)
+/**
+  \brief   Load-Acquire (8 bit)
+  \details Executes a LDAB instruction for 8 bit value.
+  \param [in]    ptr  Pointer to data
+  \return             value of type uint8_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint8_t __LDAB(volatile uint8_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldab %0, %1" : "=r" (result) : "Q" (*ptr) : "memory" );
+  return ((uint8_t)result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   Load-Acquire (16 bit)
+  \details Executes a LDAH instruction for 16 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint16_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint16_t __LDAH(volatile uint16_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldah %0, %1" : "=r" (result) : "Q" (*ptr) : "memory" );
+  return ((uint16_t)result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   Load-Acquire (32 bit)
+  \details Executes a LDA instruction for 32 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint32_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint32_t __LDA(volatile uint32_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("lda %0, %1" : "=r" (result) : "Q" (*ptr) : "memory" );
+  return (result);
+}
+
+
+/**
+  \brief   Store-Release (8 bit)
+  \details Executes a STLB instruction for 8 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__STATIC_FORCEINLINE void __STLB(uint8_t value, volatile uint8_t *ptr)
+{
+  __ASM volatile ("stlb %1, %0" : "=Q" (*ptr) : "r" ((uint32_t)value) : "memory" );
+}
+
+
+/**
+  \brief   Store-Release (16 bit)
+  \details Executes a STLH instruction for 16 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__STATIC_FORCEINLINE void __STLH(uint16_t value, volatile uint16_t *ptr)
+{
+  __ASM volatile ("stlh %1, %0" : "=Q" (*ptr) : "r" ((uint32_t)value) : "memory" );
+}
+
+
+/**
+  \brief   Store-Release (32 bit)
+  \details Executes a STL instruction for 32 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__STATIC_FORCEINLINE void __STL(uint32_t value, volatile uint32_t *ptr)
+{
+  __ASM volatile ("stl %1, %0" : "=Q" (*ptr) : "r" ((uint32_t)value) : "memory" );
+}
+
+
+/**
+  \brief   Load-Acquire Exclusive (8 bit)
+  \details Executes a LDAB exclusive instruction for 8 bit value.
+  \param [in]    ptr  Pointer to data
+  \return             value of type uint8_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint8_t __LDAEXB(volatile uint8_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldaexb %0, %1" : "=r" (result) : "Q" (*ptr) : "memory" );
+  return ((uint8_t)result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   Load-Acquire Exclusive (16 bit)
+  \details Executes a LDAH exclusive instruction for 16 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint16_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint16_t __LDAEXH(volatile uint16_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldaexh %0, %1" : "=r" (result) : "Q" (*ptr) : "memory" );
+  return ((uint16_t)result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   Load-Acquire Exclusive (32 bit)
+  \details Executes a LDA exclusive instruction for 32 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint32_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint32_t __LDAEX(volatile uint32_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldaex %0, %1" : "=r" (result) : "Q" (*ptr) : "memory" );
+  return (result);
+}
+
+
+/**
+  \brief   Store-Release Exclusive (8 bit)
+  \details Executes a STLB exclusive instruction for 8 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+__STATIC_FORCEINLINE uint32_t __STLEXB(uint8_t value, volatile uint8_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("stlexb %0, %2, %1" : "=&r" (result), "=Q" (*ptr) : "r" ((uint32_t)value) : "memory" );
+  return (result);
+}
+
+
+/**
+  \brief   Store-Release Exclusive (16 bit)
+  \details Executes a STLH exclusive instruction for 16 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+__STATIC_FORCEINLINE uint32_t __STLEXH(uint16_t value, volatile uint16_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("stlexh %0, %2, %1" : "=&r" (result), "=Q" (*ptr) : "r" ((uint32_t)value) : "memory" );
+  return (result);
+}
+
+
+/**
+  \brief   Store-Release Exclusive (32 bit)
+  \details Executes a STL exclusive instruction for 32 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+__STATIC_FORCEINLINE uint32_t __STLEX(uint32_t value, volatile uint32_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("stlex %0, %2, %1" : "=&r" (result), "=Q" (*ptr) : "r" ((uint32_t)value) : "memory" );
+  return (result);
+}
+
+#endif /* (__ARM_ARCH >= 8) */
+
+/** @}*/ /* end of group CMSIS_Core_InstructionInterface */
+
+
+/* ###########################  Core Function Access  ########################### */
+/** \ingroup  CMSIS_Core_FunctionInterface
+    \defgroup CMSIS_Core_RegAccFunctions CMSIS Core Register Access Functions
+  @{
+ */
+
+/**
+  \brief   Enable IRQ Interrupts
+  \details Enables IRQ interrupts by clearing special-purpose register PRIMASK.
+           Can only be executed in Privileged modes.
+ */
+__STATIC_FORCEINLINE void __enable_irq(void)
+{
+  __ASM volatile ("cpsie i" : : : "memory");
+}
+
+
+/**
+  \brief   Disable IRQ Interrupts
+  \details Disables IRQ interrupts by setting special-purpose register PRIMASK.
+           Can only be executed in Privileged modes.
+ */
+__STATIC_FORCEINLINE void __disable_irq(void)
+{
+  __ASM volatile ("cpsid i" : : : "memory");
+}
+
+
+/**
+  \brief   Get Control Register
+  \details Returns the content of the Control Register.
+  \return               Control Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_CONTROL(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, control" : "=r" (result) );
+  return (result);
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Control Register (non-secure)
+  \details Returns the content of the non-secure Control Register when in secure mode.
+  \return               non-secure Control Register value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_CONTROL_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, control_ns" : "=r" (result) );
+  return (result);
+}
+#endif
+
+
+/**
+  \brief   Set Control Register
+  \details Writes the given value to the Control Register.
+  \param [in]    control  Control Register value to set
+ */
+__STATIC_FORCEINLINE void __set_CONTROL(uint32_t control)
+{
+  __ASM volatile ("MSR control, %0" : : "r" (control) : "memory");
+  __ISB();
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Set Control Register (non-secure)
+  \details Writes the given value to the non-secure Control Register when in secure state.
+  \param [in]    control  Control Register value to set
+ */
+__STATIC_FORCEINLINE void __TZ_set_CONTROL_NS(uint32_t control)
+{
+  __ASM volatile ("MSR control_ns, %0" : : "r" (control) : "memory");
+  __ISB();
+}
+#endif
+
+
+/**
+  \brief   Get IPSR Register
+  \details Returns the content of the IPSR Register.
+  \return               IPSR Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_IPSR(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, ipsr" : "=r" (result) );
+  return (result);
+}
+
+
+/**
+  \brief   Get APSR Register
+  \details Returns the content of the APSR Register.
+  \return               APSR Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_APSR(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, apsr" : "=r" (result) );
+  return (result);
+}
+
+
+/**
+  \brief   Get xPSR Register
+  \details Returns the content of the xPSR Register.
+  \return               xPSR Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_xPSR(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, xpsr" : "=r" (result) );
+  return (result);
+}
+
+
+/**
+  \brief   Get Process Stack Pointer
+  \details Returns the current value of the Process Stack Pointer (PSP).
+  \return               PSP Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_PSP(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, psp"  : "=r" (result) );
+  return (result);
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Process Stack Pointer (non-secure)
+  \details Returns the current value of the non-secure Process Stack Pointer (PSP) when in secure state.
+  \return               PSP Register value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_PSP_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, psp_ns"  : "=r" (result) );
+  return (result);
+}
+#endif
+
+
+/**
+  \brief   Set Process Stack Pointer
+  \details Assigns the given value to the Process Stack Pointer (PSP).
+  \param [in]    topOfProcStack  Process Stack Pointer value to set
+ */
+__STATIC_FORCEINLINE void __set_PSP(uint32_t topOfProcStack)
+{
+  __ASM volatile ("MSR psp, %0" : : "r" (topOfProcStack) : );
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Set Process Stack Pointer (non-secure)
+  \details Assigns the given value to the non-secure Process Stack Pointer (PSP) when in secure state.
+  \param [in]    topOfProcStack  Process Stack Pointer value to set
+ */
+__STATIC_FORCEINLINE void __TZ_set_PSP_NS(uint32_t topOfProcStack)
+{
+  __ASM volatile ("MSR psp_ns, %0" : : "r" (topOfProcStack) : );
+}
+#endif
+
+
+/**
+  \brief   Get Main Stack Pointer
+  \details Returns the current value of the Main Stack Pointer (MSP).
+  \return               MSP Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_MSP(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, msp" : "=r" (result) );
+  return (result);
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Main Stack Pointer (non-secure)
+  \details Returns the current value of the non-secure Main Stack Pointer (MSP) when in secure state.
+  \return               MSP Register value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_MSP_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, msp_ns" : "=r" (result) );
+  return (result);
+}
+#endif
+
+
+/**
+  \brief   Set Main Stack Pointer
+  \details Assigns the given value to the Main Stack Pointer (MSP).
+  \param [in]    topOfMainStack  Main Stack Pointer value to set
+ */
+__STATIC_FORCEINLINE void __set_MSP(uint32_t topOfMainStack)
+{
+  __ASM volatile ("MSR msp, %0" : : "r" (topOfMainStack) : );
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Set Main Stack Pointer (non-secure)
+  \details Assigns the given value to the non-secure Main Stack Pointer (MSP) when in secure state.
+  \param [in]    topOfMainStack  Main Stack Pointer value to set
+ */
+__STATIC_FORCEINLINE void __TZ_set_MSP_NS(uint32_t topOfMainStack)
+{
+  __ASM volatile ("MSR msp_ns, %0" : : "r" (topOfMainStack) : );
+}
+#endif
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Stack Pointer (non-secure)
+  \details Returns the current value of the non-secure Stack Pointer (SP) when in secure state.
+  \return               SP Register value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_SP_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, sp_ns" : "=r" (result) );
+  return (result);
+}
+
+
+/**
+  \brief   Set Stack Pointer (non-secure)
+  \details Assigns the given value to the non-secure Stack Pointer (SP) when in secure state.
+  \param [in]    topOfStack  Stack Pointer value to set
+ */
+__STATIC_FORCEINLINE void __TZ_set_SP_NS(uint32_t topOfStack)
+{
+  __ASM volatile ("MSR sp_ns, %0" : : "r" (topOfStack) : );
+}
+#endif
+
+
+/**
+  \brief   Get Priority Mask
+  \details Returns the current state of the priority mask bit from the Priority Mask Register.
+  \return               Priority Mask value
+ */
+__STATIC_FORCEINLINE uint32_t __get_PRIMASK(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, primask" : "=r" (result) );
+  return (result);
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Priority Mask (non-secure)
+  \details Returns the current state of the non-secure priority mask bit from the Priority Mask Register when in secure state.
+  \return               Priority Mask value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_PRIMASK_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, primask_ns" : "=r" (result) );
+  return (result);
+}
+#endif
+
+
+/**
+  \brief   Set Priority Mask
+  \details Assigns the given value to the Priority Mask Register.
+  \param [in]    priMask  Priority Mask
+ */
+__STATIC_FORCEINLINE void __set_PRIMASK(uint32_t priMask)
+{
+  __ASM volatile ("MSR primask, %0" : : "r" (priMask) : "memory");
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Set Priority Mask (non-secure)
+  \details Assigns the given value to the non-secure Priority Mask Register when in secure state.
+  \param [in]    priMask  Priority Mask
+ */
+__STATIC_FORCEINLINE void __TZ_set_PRIMASK_NS(uint32_t priMask)
+{
+  __ASM volatile ("MSR primask_ns, %0" : : "r" (priMask) : "memory");
+}
+#endif
+
+
+#if (__ARM_ARCH_ISA_THUMB >= 2)
+/**
+  \brief   Enable FIQ
+  \details Enables FIQ interrupts by clearing special-purpose register FAULTMASK.
+           Can only be executed in Privileged modes.
+ */
+__STATIC_FORCEINLINE void __enable_fault_irq(void)
+{
+  __ASM volatile ("cpsie f" : : : "memory");
+}
+
+
+/**
+  \brief   Disable FIQ
+  \details Disables FIQ interrupts by setting special-purpose register FAULTMASK.
+           Can only be executed in Privileged modes.
+ */
+__STATIC_FORCEINLINE void __disable_fault_irq(void)
+{
+  __ASM volatile ("cpsid f" : : : "memory");
+}
+
+
+/**
+  \brief   Get Base Priority
+  \details Returns the current value of the Base Priority register.
+  \return               Base Priority register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_BASEPRI(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, basepri" : "=r" (result) );
+  return (result);
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Base Priority (non-secure)
+  \details Returns the current value of the non-secure Base Priority register when in secure state.
+  \return               Base Priority register value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_BASEPRI_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, basepri_ns" : "=r" (result) );
+  return (result);
+}
+#endif
+
+
+/**
+  \brief   Set Base Priority
+  \details Assigns the given value to the Base Priority register.
+  \param [in]    basePri  Base Priority value to set
+ */
+__STATIC_FORCEINLINE void __set_BASEPRI(uint32_t basePri)
+{
+  __ASM volatile ("MSR basepri, %0" : : "r" (basePri) : "memory");
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Set Base Priority (non-secure)
+  \details Assigns the given value to the non-secure Base Priority register when in secure state.
+  \param [in]    basePri  Base Priority value to set
+ */
+__STATIC_FORCEINLINE void __TZ_set_BASEPRI_NS(uint32_t basePri)
+{
+  __ASM volatile ("MSR basepri_ns, %0" : : "r" (basePri) : "memory");
+}
+#endif
+
+
+/**
+  \brief   Set Base Priority with condition
+  \details Assigns the given value to the Base Priority register only if BASEPRI masking is disabled,
+           or the new value increases the BASEPRI priority level.
+  \param [in]    basePri  Base Priority value to set
+ */
+__STATIC_FORCEINLINE void __set_BASEPRI_MAX(uint32_t basePri)
+{
+  __ASM volatile ("MSR basepri_max, %0" : : "r" (basePri) : "memory");
+}
+
+
+/**
+  \brief   Get Fault Mask
+  \details Returns the current value of the Fault Mask register.
+  \return               Fault Mask register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_FAULTMASK(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, faultmask" : "=r" (result) );
+  return (result);
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Fault Mask (non-secure)
+  \details Returns the current value of the non-secure Fault Mask register when in secure state.
+  \return               Fault Mask register value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_FAULTMASK_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, faultmask_ns" : "=r" (result) );
+  return (result);
+}
+#endif
+
+
+/**
+  \brief   Set Fault Mask
+  \details Assigns the given value to the Fault Mask register.
+  \param [in]    faultMask  Fault Mask value to set
+ */
+__STATIC_FORCEINLINE void __set_FAULTMASK(uint32_t faultMask)
+{
+  __ASM volatile ("MSR faultmask, %0" : : "r" (faultMask) : "memory");
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Set Fault Mask (non-secure)
+  \details Assigns the given value to the non-secure Fault Mask register when in secure state.
+  \param [in]    faultMask  Fault Mask value to set
+ */
+__STATIC_FORCEINLINE void __TZ_set_FAULTMASK_NS(uint32_t faultMask)
+{
+  __ASM volatile ("MSR faultmask_ns, %0" : : "r" (faultMask) : "memory");
+}
+#endif
+
+#endif /* (__ARM_ARCH_ISA_THUMB >= 2) */
+
+
+#if (__ARM_ARCH >= 8)
+/**
+  \brief   Get Process Stack Pointer Limit
+  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
+  Stack Pointer Limit register hence zero is returned always in non-secure
+  mode.
+
+  \details Returns the current value of the Process Stack Pointer Limit (PSPLIM).
+  \return               PSPLIM Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_PSPLIM(void)
+{
+#if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+      !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
+       (!defined (__ARM_FEATURE_CMSE  ) || (__ARM_FEATURE_CMSE   < 3)))
+  /* without main extensions, the non-secure PSPLIM is RAZ/WI */
+  return (0U);
+#else
+  uint32_t result;
+  __ASM volatile ("MRS %0, psplim"  : "=r" (result) );
+  return (result);
+#endif
+}
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Process Stack Pointer Limit (non-secure)
+  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
+  Stack Pointer Limit register hence zero is returned always.
+
+  \details Returns the current value of the non-secure Process Stack Pointer Limit (PSPLIM) when in secure state.
+  \return               PSPLIM Register value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_PSPLIM_NS(void)
+{
+#if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+      !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)))
+  /* without main extensions, the non-secure PSPLIM is RAZ/WI */
+  return (0U);
+#else
+  uint32_t result;
+  __ASM volatile ("MRS %0, psplim_ns"  : "=r" (result) );
+  return (result);
+#endif
+}
+#endif
+
+
+/**
+  \brief   Set Process Stack Pointer Limit
+  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
+  Stack Pointer Limit register hence the write is silently ignored in non-secure
+  mode.
+
+  \details Assigns the given value to the Process Stack Pointer Limit (PSPLIM).
+  \param [in]    ProcStackPtrLimit  Process Stack Pointer Limit value to set
+ */
+__STATIC_FORCEINLINE void __set_PSPLIM(uint32_t ProcStackPtrLimit)
+{
+#if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+      !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
+       (!defined (__ARM_FEATURE_CMSE  ) || (__ARM_FEATURE_CMSE   < 3)))
+  /* without main extensions, the non-secure PSPLIM is RAZ/WI */
+  (void)ProcStackPtrLimit;
+#else
+  __ASM volatile ("MSR psplim, %0" : : "r" (ProcStackPtrLimit));
+#endif
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Set Process Stack Pointer (non-secure)
+  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
+  Stack Pointer Limit register hence the write is silently ignored.
+
+  \details Assigns the given value to the non-secure Process Stack Pointer Limit (PSPLIM) when in secure state.
+  \param [in]    ProcStackPtrLimit  Process Stack Pointer Limit value to set
+ */
+__STATIC_FORCEINLINE void __TZ_set_PSPLIM_NS(uint32_t ProcStackPtrLimit)
+{
+#if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+      !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)))
+  /* without main extensions, the non-secure PSPLIM is RAZ/WI */
+  (void)ProcStackPtrLimit;
+#else
+  __ASM volatile ("MSR psplim_ns, %0\n" : : "r" (ProcStackPtrLimit));
+#endif
+}
+#endif
+
+
+/**
+  \brief   Get Main Stack Pointer Limit
+  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
+  Stack Pointer Limit register hence zero is returned always.
+
+  \details Returns the current value of the Main Stack Pointer Limit (MSPLIM).
+  \return               MSPLIM Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_MSPLIM(void)
+{
+#if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+      !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
+       (!defined (__ARM_FEATURE_CMSE  ) || (__ARM_FEATURE_CMSE   < 3)))
+  /* without main extensions, the non-secure MSPLIM is RAZ/WI */
+  return (0U);
+#else
+  uint32_t result;
+  __ASM volatile ("MRS %0, msplim" : "=r" (result) );
+  return (result);
+#endif
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Main Stack Pointer Limit (non-secure)
+  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
+  Stack Pointer Limit register hence zero is returned always.
+
+  \details Returns the current value of the non-secure Main Stack Pointer Limit(MSPLIM) when in secure state.
+  \return               MSPLIM Register value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_MSPLIM_NS(void)
+{
+#if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+      !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)))
+  /* without main extensions, the non-secure MSPLIM is RAZ/WI */
+  return (0U);
+#else
+  uint32_t result;
+  __ASM volatile ("MRS %0, msplim_ns" : "=r" (result) );
+  return (result);
+#endif
+}
+#endif
+
+
+/**
+  \brief   Set Main Stack Pointer Limit
+  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
+  Stack Pointer Limit register hence the write is silently ignored.
+
+  \details Assigns the given value to the Main Stack Pointer Limit (MSPLIM).
+  \param [in]    MainStackPtrLimit  Main Stack Pointer Limit value to set
+ */
+__STATIC_FORCEINLINE void __set_MSPLIM(uint32_t MainStackPtrLimit)
+{
+#if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+      !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
+       (!defined (__ARM_FEATURE_CMSE  ) || (__ARM_FEATURE_CMSE   < 3)))
+  /* without main extensions, the non-secure MSPLIM is RAZ/WI */
+  (void)MainStackPtrLimit;
+#else
+  __ASM volatile ("MSR msplim, %0" : : "r" (MainStackPtrLimit));
+#endif
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Set Main Stack Pointer Limit (non-secure)
+  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
+  Stack Pointer Limit register hence the write is silently ignored.
+
+  \details Assigns the given value to the non-secure Main Stack Pointer Limit (MSPLIM) when in secure state.
+  \param [in]    MainStackPtrLimit  Main Stack Pointer value to set
+ */
+__STATIC_FORCEINLINE void __TZ_set_MSPLIM_NS(uint32_t MainStackPtrLimit)
+{
+#if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+      !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)))
+  /* without main extensions, the non-secure MSPLIM is RAZ/WI */
+  (void)MainStackPtrLimit;
+#else
+  __ASM volatile ("MSR msplim_ns, %0" : : "r" (MainStackPtrLimit));
+#endif
+}
+#endif
+
+#endif /* (__ARM_ARCH >= 8) */
+
+
+/**
+  \brief   Get FPSCR
+  \details Returns the current value of the Floating Point Status/Control register.
+  \return               Floating Point Status/Control register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_FPSCR(void)
+{
+#if (defined(__ARM_FP) && (__ARM_FP >= 1))
+  return (__builtin_arm_get_fpscr());
+#else
+  return (0U);
+#endif
+}
+
+
+/**
+  \brief   Set FPSCR
+  \details Assigns the given value to the Floating Point Status/Control register.
+  \param [in]    fpscr  Floating Point Status/Control value to set
+ */
+__STATIC_FORCEINLINE void __set_FPSCR(uint32_t fpscr)
+{
+#if (defined(__ARM_FP) && (__ARM_FP >= 1))
+  __builtin_arm_set_fpscr(fpscr);
+#else
+  (void)fpscr;
+#endif
+}
+
+
+/** @} end of CMSIS_Core_RegAccFunctions */
+
+
+/* ###################  Compiler specific Intrinsics  ########################### */
+/** \defgroup CMSIS_SIMD_intrinsics CMSIS SIMD Intrinsics
+  Access to dedicated SIMD instructions
+  @{
+*/
+
+#if (__ARM_FEATURE_DSP == 1)
+#define     __SADD8                 __sadd8
+#define     __QADD8                 __qadd8
+#define     __SHADD8                __shadd8
+#define     __UADD8                 __uadd8
+#define     __UQADD8                __uqadd8
+#define     __UHADD8                __uhadd8
+#define     __SSUB8                 __ssub8
+#define     __QSUB8                 __qsub8
+#define     __SHSUB8                __shsub8
+#define     __USUB8                 __usub8
+#define     __UQSUB8                __uqsub8
+#define     __UHSUB8                __uhsub8
+#define     __SADD16                __sadd16
+#define     __QADD16                __qadd16
+#define     __SHADD16               __shadd16
+#define     __UADD16                __uadd16
+#define     __UQADD16               __uqadd16
+#define     __UHADD16               __uhadd16
+#define     __SSUB16                __ssub16
+#define     __QSUB16                __qsub16
+#define     __SHSUB16               __shsub16
+#define     __USUB16                __usub16
+#define     __UQSUB16               __uqsub16
+#define     __UHSUB16               __uhsub16
+#define     __SASX                  __sasx
+#define     __QASX                  __qasx
+#define     __SHASX                 __shasx
+#define     __UASX                  __uasx
+#define     __UQASX                 __uqasx
+#define     __UHASX                 __uhasx
+#define     __SSAX                  __ssax
+#define     __QSAX                  __qsax
+#define     __SHSAX                 __shsax
+#define     __USAX                  __usax
+#define     __UQSAX                 __uqsax
+#define     __UHSAX                 __uhsax
+#define     __USAD8                 __usad8
+#define     __USADA8                __usada8
+#define     __SSAT16                __ssat16
+#define     __USAT16                __usat16
+#define     __UXTB16                __uxtb16
+#define     __UXTAB16               __uxtab16
+#define     __SXTB16                __sxtb16
+#define     __SXTAB16               __sxtab16
+#define     __SMUAD                 __smuad
+#define     __SMUADX                __smuadx
+#define     __SMLAD                 __smlad
+#define     __SMLADX                __smladx
+#define     __SMLALD                __smlald
+#define     __SMLALDX               __smlaldx
+#define     __SMUSD                 __smusd
+#define     __SMUSDX                __smusdx
+#define     __SMLSD                 __smlsd
+#define     __SMLSDX                __smlsdx
+#define     __SMLSLD                __smlsld
+#define     __SMLSLDX               __smlsldx
+#define     __SEL                   __sel
+#define     __QADD                  __qadd
+#define     __QSUB                  __qsub
+
+#define __PKHBT(ARG1,ARG2,ARG3) \
+__extension__ \
+({                          \
+  uint32_t __RES, __ARG1 = (ARG1), __ARG2 = (ARG2); \
+  __ASM ("pkhbt %0, %1, %2, lsl %3" : "=r" (__RES) :  "r" (__ARG1), "r" (__ARG2), "I" (ARG3)  ); \
+  __RES; \
+ })
+
+#define __PKHTB(ARG1,ARG2,ARG3) \
+__extension__ \
+({                          \
+  uint32_t __RES, __ARG1 = (ARG1), __ARG2 = (ARG2); \
+  if (ARG3 == 0) \
+    __ASM ("pkhtb %0, %1, %2" : "=r" (__RES) :  "r" (__ARG1), "r" (__ARG2)  ); \
+  else \
+    __ASM ("pkhtb %0, %1, %2, asr %3" : "=r" (__RES) :  "r" (__ARG1), "r" (__ARG2), "I" (ARG3)  ); \
+  __RES; \
+ })
+
+__STATIC_FORCEINLINE uint32_t __SXTB16_RORn(uint32_t op1, uint32_t rotate)
+{
+    uint32_t result;
+    if (__builtin_constant_p(rotate) && ((rotate == 8U) || (rotate == 16U) || (rotate == 24U)))
+    {
+        __ASM volatile("sxtb16 %0, %1, ROR %2" : "=r"(result) : "r"(op1), "i"(rotate));
+    }
+    else
+    {
+        result = __SXTB16(__ROR(op1, rotate));
+    }
+    return result;
+}
+
+__STATIC_FORCEINLINE uint32_t __SXTAB16_RORn(uint32_t op1, uint32_t op2, uint32_t rotate)
+{
+    uint32_t result;
+    if (__builtin_constant_p(rotate) && ((rotate == 8U) || (rotate == 16U) || (rotate == 24U)))
+    {
+        __ASM volatile("sxtab16 %0, %1, %2, ROR %3" : "=r"(result) : "r"(op1), "r"(op2), "i"(rotate));
+    }
+    else
+    {
+        result = __SXTAB16(op1, __ROR(op2, rotate));
+    }
+    return result;
+}
+
+__STATIC_FORCEINLINE int32_t __SMMLA (int32_t op1, int32_t op2, int32_t op3)
+{
+  int32_t result;
+
+  __ASM volatile ("smmla %0, %1, %2, %3" : "=r" (result): "r"  (op1), "r" (op2), "r" (op3) );
+  return (result);
+}
+
+#endif /* (__ARM_FEATURE_DSP == 1) */
+/** @} end of group CMSIS_SIMD_intrinsics */
+
+
+#pragma GCC diagnostic pop
+
+#endif /* __CMSIS_GCC_M_H */

--- a/platform/ext/cmsis/CMSIS/Core/Include/m-profile/cmsis_iccarm_m.h
+++ b/platform/ext/cmsis/CMSIS/Core/Include/m-profile/cmsis_iccarm_m.h
@@ -1,0 +1,1041 @@
+/*
+ * Copyright (c) 2017-2021 IAR Systems
+ * Copyright (c) 2017-2024 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS-Core(M) Compiler ICCARM (IAR Compiler for Arm) Header File
+ */
+
+#ifndef __CMSIS_ICCARM_M_H__
+#define __CMSIS_ICCARM_M_H__
+
+#ifndef __ICCARM__
+  #error This file should only be compiled by ICCARM
+#endif
+
+#pragma system_include
+
+#define __IAR_FT _Pragma("inline=forced") __intrinsic
+
+#if (__VER__ >= 8000000)
+  #define __ICCARM_V8 1
+#else
+  #define __ICCARM_V8 0
+#endif
+
+#ifndef __ALIGNED
+  #if __ICCARM_V8
+    #define __ALIGNED(x) __attribute__((aligned(x)))
+  #elif (__VER__ >= 7080000)
+    /* Needs IAR language extensions */
+    #define __ALIGNED(x) __attribute__((aligned(x)))
+  #else
+    #warning No compiler specific solution for __ALIGNED.__ALIGNED is ignored.
+    #define __ALIGNED(x)
+  #endif
+#endif
+
+
+/* Define compiler macros for CPU architecture, used in CMSIS 5.
+ */
+#if __ARM_ARCH_6M__ || __ARM_ARCH_7M__ || __ARM_ARCH_7EM__ || __ARM_ARCH_8M_BASE__ || __ARM_ARCH_8M_MAIN__ || __ARM_ARCH_8_1M_MAIN__
+/* Macros already defined */
+#else
+  #if defined(__ARM8M_MAINLINE__) || defined(__ARM8EM_MAINLINE__)
+    #define __ARM_ARCH_8M_MAIN__ 1
+  #elif defined(__ARM8M_BASELINE__)
+    #define __ARM_ARCH_8M_BASE__ 1
+  #elif defined(__ARM_ARCH_PROFILE) && __ARM_ARCH_PROFILE == 'M'
+    #if __ARM_ARCH == 6
+      #define __ARM_ARCH_6M__ 1
+    #elif __ARM_ARCH == 7
+      #if __ARM_FEATURE_DSP
+        #define __ARM_ARCH_7EM__ 1
+      #else
+        #define __ARM_ARCH_7M__ 1
+      #endif
+    #elif __ARM_ARCH == 801
+      #define __ARM_ARCH_8_1M_MAIN__ 1
+    #endif /* __ARM_ARCH */
+  #endif /* __ARM_ARCH_PROFILE == 'M' */
+#endif
+
+/* Alternativ core deduction for older ICCARM's */
+#if !defined(__ARM_ARCH_6M__) && !defined(__ARM_ARCH_7M__) && !defined(__ARM_ARCH_7EM__) && \
+    !defined(__ARM_ARCH_8M_BASE__) && !defined(__ARM_ARCH_8M_MAIN__) && !defined(__ARM_ARCH_8_1M_MAIN__)
+  #if defined(__ARM6M__) && (__CORE__ == __ARM6M__)
+    #define __ARM_ARCH_6M__ 1
+  #elif defined(__ARM7M__) && (__CORE__ == __ARM7M__)
+    #define __ARM_ARCH_7M__ 1
+  #elif defined(__ARM7EM__) && (__CORE__ == __ARM7EM__)
+    #define __ARM_ARCH_7EM__  1
+  #elif defined(__ARM8M_BASELINE__) && (__CORE == __ARM8M_BASELINE__)
+    #define __ARM_ARCH_8M_BASE__ 1
+  #elif defined(__ARM8M_MAINLINE__) && (__CORE == __ARM8M_MAINLINE__)
+    #define __ARM_ARCH_8M_MAIN__ 1
+  #elif defined(__ARM8EM_MAINLINE__) && (__CORE == __ARM8EM_MAINLINE__)
+    #define __ARM_ARCH_8M_MAIN__ 1
+  #else
+    #error "Unknown target."
+  #endif
+#endif
+
+
+
+#if defined(__ARM_ARCH_6M__) && __ARM_ARCH_6M__==1
+  #define __IAR_M0_FAMILY  1
+#elif defined(__ARM_ARCH_8M_BASE__) && __ARM_ARCH_8M_BASE__==1
+  #define __IAR_M0_FAMILY  1
+#else
+  #define __IAR_M0_FAMILY  0
+#endif
+
+#ifndef __NO_INIT
+  #define __NO_INIT __attribute__ ((section (".noinit")))
+#endif
+#ifndef __ALIAS
+  #define __ALIAS(x) __attribute__ ((alias(x)))
+#endif
+
+#ifndef __ASM
+  #define __ASM __asm
+#endif
+
+#ifndef   __COMPILER_BARRIER
+  #define __COMPILER_BARRIER() __ASM volatile("":::"memory")
+#endif
+
+#ifndef __INLINE
+  #define __INLINE inline
+#endif
+
+#ifndef   __NO_RETURN
+  #if defined(__cplusplus) && __cplusplus >= 201103L
+    #define __NO_RETURN [[noreturn]]
+  #elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+    #define __NO_RETURN _Noreturn
+  #else
+    #define __NO_RETURN _Pragma("object_attribute=__noreturn")
+  #endif
+#endif
+
+#ifndef   __PACKED
+  #if __ICCARM_V8
+    #define __PACKED __attribute__((packed, aligned(1)))
+  #else
+    /* Needs IAR language extensions */
+    #define __PACKED __packed
+  #endif
+#endif
+
+#ifndef   __PACKED_STRUCT
+  #if __ICCARM_V8
+    #define __PACKED_STRUCT struct __attribute__((packed, aligned(1)))
+  #else
+    /* Needs IAR language extensions */
+    #define __PACKED_STRUCT __packed struct
+  #endif
+#endif
+
+#ifndef   __PACKED_UNION
+  #if __ICCARM_V8
+    #define __PACKED_UNION union __attribute__((packed, aligned(1)))
+  #else
+    /* Needs IAR language extensions */
+    #define __PACKED_UNION __packed union
+  #endif
+#endif
+
+#ifndef   __RESTRICT
+  #if __ICCARM_V8
+    #define __RESTRICT            __restrict
+  #else
+    /* Needs IAR language extensions */
+    #define __RESTRICT            restrict
+  #endif
+#endif
+
+#ifndef   __STATIC_INLINE
+  #define __STATIC_INLINE       static inline
+#endif
+
+#ifndef   __FORCEINLINE
+  #define __FORCEINLINE         _Pragma("inline=forced")
+#endif
+
+#ifndef   __STATIC_FORCEINLINE
+  #define __STATIC_FORCEINLINE  __FORCEINLINE __STATIC_INLINE
+#endif
+
+#ifndef __UNALIGNED_UINT16_READ
+#pragma language=save
+#pragma language=extended
+__IAR_FT uint16_t __iar_uint16_read(void const *ptr)
+{
+  return *(__packed uint16_t*)(ptr);
+}
+#pragma language=restore
+#define __UNALIGNED_UINT16_READ(PTR) __iar_uint16_read(PTR)
+#endif
+
+
+#ifndef __UNALIGNED_UINT16_WRITE
+#pragma language=save
+#pragma language=extended
+__IAR_FT void __iar_uint16_write(void const *ptr, uint16_t val)
+{
+  *(__packed uint16_t*)(ptr) = val;;
+}
+#pragma language=restore
+#define __UNALIGNED_UINT16_WRITE(PTR,VAL) __iar_uint16_write(PTR,VAL)
+#endif
+
+#ifndef __UNALIGNED_UINT32_READ
+#pragma language=save
+#pragma language=extended
+__IAR_FT uint32_t __iar_uint32_read(void const *ptr)
+{
+  return *(__packed uint32_t*)(ptr);
+}
+#pragma language=restore
+#define __UNALIGNED_UINT32_READ(PTR) __iar_uint32_read(PTR)
+#endif
+
+#ifndef __UNALIGNED_UINT32_WRITE
+#pragma language=save
+#pragma language=extended
+__IAR_FT void __iar_uint32_write(void const *ptr, uint32_t val)
+{
+  *(__packed uint32_t*)(ptr) = val;;
+}
+#pragma language=restore
+#define __UNALIGNED_UINT32_WRITE(PTR,VAL) __iar_uint32_write(PTR,VAL)
+#endif
+
+#ifndef __UNALIGNED_UINT32   /* deprecated */
+#pragma language=save
+#pragma language=extended
+__packed struct  __iar_u32 { uint32_t v; };
+#pragma language=restore
+#define __UNALIGNED_UINT32(PTR) (((struct __iar_u32 *)(PTR))->v)
+#endif
+
+#ifndef   __USED
+  #if __ICCARM_V8
+    #define __USED __attribute__((used))
+  #else
+    #define __USED _Pragma("__root")
+  #endif
+#endif
+
+#undef __WEAK                           /* undo the definition from DLib_Defaults.h */
+#ifndef   __WEAK
+  #if __ICCARM_V8
+    #define __WEAK __attribute__((weak))
+  #else
+    #define __WEAK _Pragma("__weak")
+  #endif
+#endif
+
+#ifndef __PROGRAM_START
+#define __PROGRAM_START           __iar_program_start
+#endif
+
+#ifndef __INITIAL_SP
+#define __INITIAL_SP              CSTACK$$Limit
+#endif
+
+#ifndef __STACK_LIMIT
+#define __STACK_LIMIT             CSTACK$$Base
+#endif
+
+#ifndef __VECTOR_TABLE
+#define __VECTOR_TABLE            __vector_table
+#endif
+
+#ifndef __VECTOR_TABLE_ATTRIBUTE
+#define __VECTOR_TABLE_ATTRIBUTE  @".intvec"
+#endif
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#ifndef __STACK_SEAL
+#define __STACK_SEAL              STACKSEAL$$Base
+#endif
+
+#ifndef __TZ_STACK_SEAL_SIZE
+#define __TZ_STACK_SEAL_SIZE      8U
+#endif
+
+#ifndef __TZ_STACK_SEAL_VALUE
+#define __TZ_STACK_SEAL_VALUE     0xFEF5EDA5FEF5EDA5ULL
+#endif
+
+__STATIC_FORCEINLINE void __TZ_set_STACKSEAL_S (uint32_t* stackTop) {
+  *((uint64_t *)stackTop) = __TZ_STACK_SEAL_VALUE;
+}
+#endif
+
+#ifndef __ICCARM_INTRINSICS_VERSION__
+  #define __ICCARM_INTRINSICS_VERSION__  0
+#endif
+
+#if __ICCARM_INTRINSICS_VERSION__ == 2
+
+  #if defined(__CLZ)
+    #undef __CLZ
+  #endif
+  #if defined(__REVSH)
+    #undef __REVSH
+  #endif
+  #if defined(__RBIT)
+    #undef __RBIT
+  #endif
+  #if defined(__SSAT)
+    #undef __SSAT
+  #endif
+  #if defined(__USAT)
+    #undef __USAT
+  #endif
+
+  #include "iccarm_builtin.h"
+
+  #define __disable_irq       __iar_builtin_disable_interrupt
+  #define __enable_irq        __iar_builtin_enable_interrupt
+  #define __arm_rsr           __iar_builtin_rsr
+  #define __arm_wsr           __iar_builtin_wsr
+
+
+  #if (defined(__ARM_ARCH_ISA_THUMB) && __ARM_ARCH_ISA_THUMB >= 2)
+    __IAR_FT void __disable_fault_irq()
+    {
+      __ASM volatile ("CPSID F" ::: "memory");
+    }
+
+    __IAR_FT void __enable_fault_irq()
+    {
+      __ASM volatile ("CPSIE F" ::: "memory");
+    }
+  #endif
+
+
+  #define __get_APSR()                (__arm_rsr("APSR"))
+  #define __get_BASEPRI()             (__arm_rsr("BASEPRI"))
+  #define __get_CONTROL()             (__arm_rsr("CONTROL"))
+  #define __get_FAULTMASK()           (__arm_rsr("FAULTMASK"))
+
+  #if (defined (__ARM_FP)      && (__ARM_FP >= 1))
+    #define __get_FPSCR()             (__arm_rsr("FPSCR"))
+    #define __set_FPSCR(VALUE)        (__arm_wsr("FPSCR", (VALUE)))
+  #else
+    #define __get_FPSCR()             ( 0 )
+    #define __set_FPSCR(VALUE)        ((void)VALUE)
+  #endif
+
+  #define __get_IPSR()                (__arm_rsr("IPSR"))
+  #define __get_MSP()                 (__arm_rsr("MSP"))
+  #if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+       !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
+       (!defined (__ARM_FEATURE_CMSE) || (__ARM_FEATURE_CMSE < 3)))
+    // without main extensions, the non-secure MSPLIM is RAZ/WI
+    #define __get_MSPLIM()            (0U)
+  #else
+    #define __get_MSPLIM()            (__arm_rsr("MSPLIM"))
+  #endif
+  #define __get_PRIMASK()             (__arm_rsr("PRIMASK"))
+  #define __get_PSP()                 (__arm_rsr("PSP"))
+
+  #if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+       !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
+       (!defined (__ARM_FEATURE_CMSE) || (__ARM_FEATURE_CMSE < 3)))
+    // without main extensions, the non-secure PSPLIM is RAZ/WI
+    #define __get_PSPLIM()            (0U)
+  #else
+    #define __get_PSPLIM()            (__arm_rsr("PSPLIM"))
+  #endif
+
+  #define __get_xPSR()                (__arm_rsr("xPSR"))
+
+  #define __set_BASEPRI(VALUE)        (__arm_wsr("BASEPRI", (VALUE)))
+  #define __set_BASEPRI_MAX(VALUE)    (__arm_wsr("BASEPRI_MAX", (VALUE)))
+
+__STATIC_FORCEINLINE void __set_CONTROL(uint32_t control)
+{
+  __arm_wsr("CONTROL", control);
+  __iar_builtin_ISB();
+}
+
+  #define __set_FAULTMASK(VALUE)      (__arm_wsr("FAULTMASK", (VALUE)))
+  #define __set_MSP(VALUE)            (__arm_wsr("MSP", (VALUE)))
+
+  #if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+       !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
+       (!defined (__ARM_FEATURE_CMSE) || (__ARM_FEATURE_CMSE < 3)))
+    // without main extensions, the non-secure MSPLIM is RAZ/WI
+    #define __set_MSPLIM(VALUE)       ((void)(VALUE))
+  #else
+    #define __set_MSPLIM(VALUE)       (__arm_wsr("MSPLIM", (VALUE)))
+  #endif
+  #define __set_PRIMASK(VALUE)        (__arm_wsr("PRIMASK", (VALUE)))
+  #define __set_PSP(VALUE)            (__arm_wsr("PSP", (VALUE)))
+  #if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+       !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
+       (!defined (__ARM_FEATURE_CMSE) || (__ARM_FEATURE_CMSE < 3)))
+    // without main extensions, the non-secure PSPLIM is RAZ/WI
+    #define __set_PSPLIM(VALUE)       ((void)(VALUE))
+  #else
+    #define __set_PSPLIM(VALUE)       (__arm_wsr("PSPLIM", (VALUE)))
+  #endif
+
+  #define __TZ_get_CONTROL_NS()       (__arm_rsr("CONTROL_NS"))
+
+__STATIC_FORCEINLINE void __TZ_set_CONTROL_NS(uint32_t control)
+{
+  __arm_wsr("CONTROL_NS", control);
+  __iar_builtin_ISB();
+}
+
+  #define __TZ_get_PSP_NS()           (__arm_rsr("PSP_NS"))
+  #define __TZ_set_PSP_NS(VALUE)      (__arm_wsr("PSP_NS", (VALUE)))
+  #define __TZ_get_MSP_NS()           (__arm_rsr("MSP_NS"))
+  #define __TZ_set_MSP_NS(VALUE)      (__arm_wsr("MSP_NS", (VALUE)))
+  #define __TZ_get_SP_NS()            (__arm_rsr("SP_NS"))
+  #define __TZ_set_SP_NS(VALUE)       (__arm_wsr("SP_NS", (VALUE)))
+  #define __TZ_get_PRIMASK_NS()       (__arm_rsr("PRIMASK_NS"))
+  #define __TZ_set_PRIMASK_NS(VALUE)  (__arm_wsr("PRIMASK_NS", (VALUE)))
+  #define __TZ_get_BASEPRI_NS()       (__arm_rsr("BASEPRI_NS"))
+  #define __TZ_set_BASEPRI_NS(VALUE)  (__arm_wsr("BASEPRI_NS", (VALUE)))
+  #define __TZ_get_FAULTMASK_NS()     (__arm_rsr("FAULTMASK_NS"))
+  #define __TZ_set_FAULTMASK_NS(VALUE)(__arm_wsr("FAULTMASK_NS", (VALUE)))
+
+  #if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+       !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
+       (!defined (__ARM_FEATURE_CMSE) || (__ARM_FEATURE_CMSE < 3)))
+    // without main extensions, the non-secure PSPLIM is RAZ/WI
+    #define __TZ_get_PSPLIM_NS()      (0U)
+    #define __TZ_set_PSPLIM_NS(VALUE) ((void)(VALUE))
+  #else
+    #define __TZ_get_PSPLIM_NS()      (__arm_rsr("PSPLIM_NS"))
+    #define __TZ_set_PSPLIM_NS(VALUE) (__arm_wsr("PSPLIM_NS", (VALUE)))
+  #endif
+
+  #define __TZ_get_MSPLIM_NS()        (__arm_rsr("MSPLIM_NS"))
+  #define __TZ_set_MSPLIM_NS(VALUE)   (__arm_wsr("MSPLIM_NS", (VALUE)))
+
+  #define __NOP     __iar_builtin_no_operation
+
+  #define __CLZ     __iar_builtin_CLZ
+
+  /*
+   * __iar_builtin_CLREX can be reordered w.r.t. STREX during high optimizations.
+   * As a workaround we use inline assembly and a memory barrier.
+   * (IAR issue EWARM-11901)
+   */
+  #define __CLREX()  (__ASM volatile ("CLREX" ::: "memory"))
+
+  #define __DMB     __iar_builtin_DMB
+  #define __DSB     __iar_builtin_DSB
+  #define __ISB     __iar_builtin_ISB
+
+  #define __LDREXB  __iar_builtin_LDREXB
+  #define __LDREXH  __iar_builtin_LDREXH
+  #define __LDREXW  __iar_builtin_LDREX
+
+  #define __RBIT    __iar_builtin_RBIT
+  #define __REV     __iar_builtin_REV
+  #define __REV16   __iar_builtin_REV16
+
+  __IAR_FT int16_t __REVSH(int16_t val)
+  {
+    return (int16_t) __iar_builtin_REVSH(val);
+  }
+
+  #define __ROR     __iar_builtin_ROR
+  #define __RRX     __iar_builtin_RRX
+
+  #define __SEV     __iar_builtin_SEV
+
+  #if !__IAR_M0_FAMILY
+    #define __SSAT    __iar_builtin_SSAT
+  #endif
+
+  #define __STREXB  __iar_builtin_STREXB
+  #define __STREXH  __iar_builtin_STREXH
+  #define __STREXW  __iar_builtin_STREX
+
+  #if !__IAR_M0_FAMILY
+    #define __USAT    __iar_builtin_USAT
+  #endif
+
+  #define __WFE     __iar_builtin_WFE
+  #define __WFI     __iar_builtin_WFI
+
+  #if __ARM_MEDIA__
+    #define __SADD8   __iar_builtin_SADD8
+    #define __QADD8   __iar_builtin_QADD8
+    #define __SHADD8  __iar_builtin_SHADD8
+    #define __UADD8   __iar_builtin_UADD8
+    #define __UQADD8  __iar_builtin_UQADD8
+    #define __UHADD8  __iar_builtin_UHADD8
+    #define __SSUB8   __iar_builtin_SSUB8
+    #define __QSUB8   __iar_builtin_QSUB8
+    #define __SHSUB8  __iar_builtin_SHSUB8
+    #define __USUB8   __iar_builtin_USUB8
+    #define __UQSUB8  __iar_builtin_UQSUB8
+    #define __UHSUB8  __iar_builtin_UHSUB8
+    #define __SADD16  __iar_builtin_SADD16
+    #define __QADD16  __iar_builtin_QADD16
+    #define __SHADD16 __iar_builtin_SHADD16
+    #define __UADD16  __iar_builtin_UADD16
+    #define __UQADD16 __iar_builtin_UQADD16
+    #define __UHADD16 __iar_builtin_UHADD16
+    #define __SSUB16  __iar_builtin_SSUB16
+    #define __QSUB16  __iar_builtin_QSUB16
+    #define __SHSUB16 __iar_builtin_SHSUB16
+    #define __USUB16  __iar_builtin_USUB16
+    #define __UQSUB16 __iar_builtin_UQSUB16
+    #define __UHSUB16 __iar_builtin_UHSUB16
+    #define __SASX    __iar_builtin_SASX
+    #define __QASX    __iar_builtin_QASX
+    #define __SHASX   __iar_builtin_SHASX
+    #define __UASX    __iar_builtin_UASX
+    #define __UQASX   __iar_builtin_UQASX
+    #define __UHASX   __iar_builtin_UHASX
+    #define __SSAX    __iar_builtin_SSAX
+    #define __QSAX    __iar_builtin_QSAX
+    #define __SHSAX   __iar_builtin_SHSAX
+    #define __USAX    __iar_builtin_USAX
+    #define __UQSAX   __iar_builtin_UQSAX
+    #define __UHSAX   __iar_builtin_UHSAX
+    #define __USAD8   __iar_builtin_USAD8
+    #define __USADA8  __iar_builtin_USADA8
+    #define __SSAT16  __iar_builtin_SSAT16
+    #define __USAT16  __iar_builtin_USAT16
+    #define __UXTB16  __iar_builtin_UXTB16
+    #define __UXTAB16 __iar_builtin_UXTAB16
+    #define __SXTB16  __iar_builtin_SXTB16
+    #define __SXTAB16 __iar_builtin_SXTAB16
+    #define __SMUAD   __iar_builtin_SMUAD
+    #define __SMUADX  __iar_builtin_SMUADX
+    #define __SMMLA   __iar_builtin_SMMLA
+    #define __SMLAD   __iar_builtin_SMLAD
+    #define __SMLADX  __iar_builtin_SMLADX
+    #define __SMLALD  __iar_builtin_SMLALD
+    #define __SMLALDX __iar_builtin_SMLALDX
+    #define __SMUSD   __iar_builtin_SMUSD
+    #define __SMUSDX  __iar_builtin_SMUSDX
+    #define __SMLSD   __iar_builtin_SMLSD
+    #define __SMLSDX  __iar_builtin_SMLSDX
+    #define __SMLSLD  __iar_builtin_SMLSLD
+    #define __SMLSLDX __iar_builtin_SMLSLDX
+    #define __SEL     __iar_builtin_SEL
+    #define __QADD    __iar_builtin_QADD
+    #define __QSUB    __iar_builtin_QSUB
+    #define __PKHBT   __iar_builtin_PKHBT
+    #define __PKHTB   __iar_builtin_PKHTB
+  #endif
+
+#else /* __ICCARM_INTRINSICS_VERSION__ == 2 */
+
+  #if __IAR_M0_FAMILY
+   /* Avoid clash between intrinsics.h and arm_math.h when compiling for Cortex-M0. */
+    #define __CLZ  __cmsis_iar_clz_not_active
+    #define __SSAT __cmsis_iar_ssat_not_active
+    #define __USAT __cmsis_iar_usat_not_active
+    #define __RBIT __cmsis_iar_rbit_not_active
+    #define __get_APSR  __cmsis_iar_get_APSR_not_active
+  #endif
+
+
+  #if (!((defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)) && \
+         (defined (__FPU_USED   ) && (__FPU_USED    == 1U))     ))
+    #define __get_FPSCR __cmsis_iar_get_FPSR_not_active
+    #define __set_FPSCR __cmsis_iar_set_FPSR_not_active
+  #endif
+
+  #ifdef __INTRINSICS_INCLUDED
+  #error intrinsics.h is already included previously!
+  #endif
+
+  #include <intrinsics.h>
+
+  #if __IAR_M0_FAMILY
+   /* Avoid clash between intrinsics.h and arm_math.h when compiling for Cortex-M0. */
+    #undef __CLZ
+    #undef __SSAT
+    #undef __USAT
+    #undef __RBIT
+    #undef __get_APSR
+
+    __STATIC_INLINE uint8_t __CLZ(uint32_t data)
+    {
+      if (data == 0U) { return 32U; }
+
+      uint32_t count = 0U;
+      uint32_t mask = 0x80000000U;
+
+      while ((data & mask) == 0U)
+      {
+        count += 1U;
+        mask = mask >> 1U;
+      }
+      return count;
+    }
+
+    __STATIC_INLINE uint32_t __RBIT(uint32_t v)
+    {
+      uint8_t sc = 31U;
+      uint32_t r = v;
+      for (v >>= 1U; v; v >>= 1U)
+      {
+        r <<= 1U;
+        r |= v & 1U;
+        sc--;
+      }
+      return (r << sc);
+    }
+
+    __STATIC_INLINE  uint32_t __get_APSR(void)
+    {
+      uint32_t res;
+      __asm("MRS      %0,APSR" : "=r" (res));
+      return res;
+    }
+
+  #endif
+
+  #if (!(defined (__ARM_FP)      && (__ARM_FP >= 1)))
+    #undef __get_FPSCR
+    #undef __set_FPSCR
+    #define __get_FPSCR()       (0)
+    #define __set_FPSCR(VALUE)  ((void)VALUE)
+  #endif
+
+  #pragma diag_suppress=Pe940
+  #pragma diag_suppress=Pe177
+
+  #define __enable_irq    __enable_interrupt
+  #define __disable_irq   __disable_interrupt
+  #define __NOP           __no_operation
+
+  #define __get_xPSR      __get_PSR
+
+  #if (!defined(__ARM_ARCH_6M__) || __ARM_ARCH_6M__==0)
+
+    __IAR_FT uint32_t __LDREXW(uint32_t volatile *ptr)
+    {
+      return __LDREX((unsigned long *)ptr);
+    }
+
+    __IAR_FT uint32_t __STREXW(uint32_t value, uint32_t volatile *ptr)
+    {
+      return __STREX(value, (unsigned long *)ptr);
+    }
+  #endif
+
+
+  /* __CORTEX_M is defined in core_cm0.h, core_cm3.h and core_cm4.h. */
+  #if (__CORTEX_M >= 0x03)
+
+    __IAR_FT uint32_t __RRX(uint32_t value)
+    {
+      uint32_t result;
+      __ASM volatile("RRX      %0, %1" : "=r"(result) : "r" (value));
+      return(result);
+    }
+
+    __IAR_FT void __set_BASEPRI_MAX(uint32_t value)
+    {
+      __asm volatile("MSR      BASEPRI_MAX,%0"::"r" (value));
+    }
+
+    __IAR_FT void __disable_fault_irq()
+    {
+      __ASM volatile ("CPSID F" ::: "memory");
+    }
+
+    __IAR_FT void __enable_fault_irq()
+    {
+      __ASM volatile ("CPSIE F" ::: "memory");
+    }
+
+
+  #endif /* (__CORTEX_M >= 0x03) */
+
+  __IAR_FT uint32_t __ROR(uint32_t op1, uint32_t op2)
+  {
+    return (op1 >> op2) | (op1 << ((sizeof(op1)*8)-op2));
+  }
+
+  #if ((defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) || \
+       (defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) || \
+       (defined (__ARM_ARCH_8M_BASE__ ) && (__ARM_ARCH_8M_BASE__ == 1))    )
+
+   __IAR_FT uint32_t __get_MSPLIM(void)
+    {
+      uint32_t res;
+    #if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+         !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
+         (!defined (__ARM_FEATURE_CMSE  ) || (__ARM_FEATURE_CMSE   < 3)))
+      // without main extension and secure, there is no stack limit check.
+      res = 0U;
+    #else
+      __asm volatile("MRS      %0,MSPLIM" : "=r" (res));
+    #endif
+      return res;
+    }
+
+    __IAR_FT void   __set_MSPLIM(uint32_t value)
+    {
+    #if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+         !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
+         (!defined (__ARM_FEATURE_CMSE  ) || (__ARM_FEATURE_CMSE   < 3)))
+      // without main extensions and secure, there is no stack limit check.
+      (void)value;
+    #else
+      __asm volatile("MSR      MSPLIM,%0" :: "r" (value));
+    #endif
+    }
+
+    __IAR_FT uint32_t __get_PSPLIM(void)
+    {
+      uint32_t res;
+    #if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+         !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
+         (!defined (__ARM_FEATURE_CMSE  ) || (__ARM_FEATURE_CMSE   < 3)))
+      // without main extensions and secure, there is no stack limit check.
+      res = 0U;
+    #else
+      __asm volatile("MRS      %0,PSPLIM" : "=r" (res));
+    #endif
+      return res;
+    }
+
+    __IAR_FT void   __set_PSPLIM(uint32_t value)
+    {
+    #if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+         !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
+         (!defined (__ARM_FEATURE_CMSE  ) || (__ARM_FEATURE_CMSE   < 3)))
+      // without main extensions and secure, there is no stack limit check.
+      (void)value;
+    #else
+      __asm volatile("MSR      PSPLIM,%0" :: "r" (value));
+    #endif
+    }
+
+    __IAR_FT uint32_t __TZ_get_CONTROL_NS(void)
+    {
+      uint32_t res;
+      __asm volatile("MRS      %0,CONTROL_NS" : "=r" (res));
+      return res;
+    }
+
+    __IAR_FT void   __TZ_set_CONTROL_NS(uint32_t value)
+    {
+      __asm volatile("MSR      CONTROL_NS,%0" :: "r" (value));
+      __iar_builtin_ISB();
+    }
+
+    __IAR_FT uint32_t   __TZ_get_PSP_NS(void)
+    {
+      uint32_t res;
+      __asm volatile("MRS      %0,PSP_NS" : "=r" (res));
+      return res;
+    }
+
+    __IAR_FT void   __TZ_set_PSP_NS(uint32_t value)
+    {
+      __asm volatile("MSR      PSP_NS,%0" :: "r" (value));
+    }
+
+    __IAR_FT uint32_t   __TZ_get_MSP_NS(void)
+    {
+      uint32_t res;
+      __asm volatile("MRS      %0,MSP_NS" : "=r" (res));
+      return res;
+    }
+
+    __IAR_FT void   __TZ_set_MSP_NS(uint32_t value)
+    {
+      __asm volatile("MSR      MSP_NS,%0" :: "r" (value));
+    }
+
+    __IAR_FT uint32_t   __TZ_get_SP_NS(void)
+    {
+      uint32_t res;
+      __asm volatile("MRS      %0,SP_NS" : "=r" (res));
+      return res;
+    }
+    __IAR_FT void   __TZ_set_SP_NS(uint32_t value)
+    {
+      __asm volatile("MSR      SP_NS,%0" :: "r" (value));
+    }
+
+    __IAR_FT uint32_t   __TZ_get_PRIMASK_NS(void)
+    {
+      uint32_t res;
+      __asm volatile("MRS      %0,PRIMASK_NS" : "=r" (res));
+      return res;
+    }
+
+    __IAR_FT void   __TZ_set_PRIMASK_NS(uint32_t value)
+    {
+      __asm volatile("MSR      PRIMASK_NS,%0" :: "r" (value));
+    }
+
+    __IAR_FT uint32_t   __TZ_get_BASEPRI_NS(void)
+    {
+      uint32_t res;
+      __asm volatile("MRS      %0,BASEPRI_NS" : "=r" (res));
+      return res;
+    }
+
+    __IAR_FT void   __TZ_set_BASEPRI_NS(uint32_t value)
+    {
+      __asm volatile("MSR      BASEPRI_NS,%0" :: "r" (value));
+    }
+
+    __IAR_FT uint32_t   __TZ_get_FAULTMASK_NS(void)
+    {
+      uint32_t res;
+      __asm volatile("MRS      %0,FAULTMASK_NS" : "=r" (res));
+      return res;
+    }
+
+    __IAR_FT void   __TZ_set_FAULTMASK_NS(uint32_t value)
+    {
+      __asm volatile("MSR      FAULTMASK_NS,%0" :: "r" (value));
+    }
+
+    __IAR_FT uint32_t   __TZ_get_PSPLIM_NS(void)
+    {
+      uint32_t res;
+    #if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+         !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
+         (!defined (__ARM_FEATURE_CMSE  ) || (__ARM_FEATURE_CMSE   < 3)))
+      // without main extensions, the non-secure PSPLIM is RAZ/WI
+      res = 0U;
+    #else
+      __asm volatile("MRS      %0,PSPLIM_NS" : "=r" (res));
+    #endif
+      return res;
+    }
+
+    __IAR_FT void   __TZ_set_PSPLIM_NS(uint32_t value)
+    {
+    #if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+         !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
+         (!defined (__ARM_FEATURE_CMSE  ) || (__ARM_FEATURE_CMSE   < 3)))
+      // without main extensions, the non-secure PSPLIM is RAZ/WI
+      (void)value;
+    #else
+      __asm volatile("MSR      PSPLIM_NS,%0" :: "r" (value));
+    #endif
+    }
+
+    __IAR_FT uint32_t   __TZ_get_MSPLIM_NS(void)
+    {
+      uint32_t res;
+      __asm volatile("MRS      %0,MSPLIM_NS" : "=r" (res));
+      return res;
+    }
+
+    __IAR_FT void   __TZ_set_MSPLIM_NS(uint32_t value)
+    {
+      __asm volatile("MSR      MSPLIM_NS,%0" :: "r" (value));
+    }
+
+  #endif /* __ARM_ARCH_8M_MAIN__ or __ARM_ARCH_8M_BASE__ or __ARM_ARCH_8_1M_MAIN__ */
+
+#endif   /* __ICCARM_INTRINSICS_VERSION__ == 2 */
+
+#define __BKPT(value)    __asm volatile ("BKPT     %0" : : "i"(value))
+
+#if __IAR_M0_FAMILY
+  __STATIC_INLINE int32_t __SSAT(int32_t val, uint32_t sat)
+  {
+    if ((sat >= 1U) && (sat <= 32U))
+    {
+      const int32_t max = (int32_t)((1U << (sat - 1U)) - 1U);
+      const int32_t min = -1 - max ;
+      if (val > max)
+      {
+        return max;
+      }
+      else if (val < min)
+      {
+        return min;
+      }
+    }
+    return val;
+  }
+
+  __STATIC_INLINE uint32_t __USAT(int32_t val, uint32_t sat)
+  {
+    if (sat <= 31U)
+    {
+      const uint32_t max = ((1U << sat) - 1U);
+      if (val > (int32_t)max)
+      {
+        return max;
+      }
+      else if (val < 0)
+      {
+        return 0U;
+      }
+    }
+    return (uint32_t)val;
+  }
+#endif
+
+#if (__CORTEX_M >= 0x03)   /* __CORTEX_M is defined in core_cm0.h, core_cm3.h and core_cm4.h. */
+
+  __IAR_FT uint8_t __LDRBT(volatile uint8_t *addr)
+  {
+    uint32_t res;
+    __ASM volatile ("LDRBT %0, [%1]" : "=r" (res) : "r" (addr) : "memory");
+    return ((uint8_t)res);
+  }
+
+  __IAR_FT uint16_t __LDRHT(volatile uint16_t *addr)
+  {
+    uint32_t res;
+    __ASM volatile ("LDRHT %0, [%1]" : "=r" (res) : "r" (addr) : "memory");
+    return ((uint16_t)res);
+  }
+
+  __IAR_FT uint32_t __LDRT(volatile uint32_t *addr)
+  {
+    uint32_t res;
+    __ASM volatile ("LDRT %0, [%1]" : "=r" (res) : "r" (addr) : "memory");
+    return res;
+  }
+
+  __IAR_FT void __STRBT(uint8_t value, volatile uint8_t *addr)
+  {
+    __ASM volatile ("STRBT %1, [%0]" : : "r" (addr), "r" ((uint32_t)value) : "memory");
+  }
+
+  __IAR_FT void __STRHT(uint16_t value, volatile uint16_t *addr)
+  {
+    __ASM volatile ("STRHT %1, [%0]" : : "r" (addr), "r" ((uint32_t)value) : "memory");
+  }
+
+  __IAR_FT void __STRT(uint32_t value, volatile uint32_t *addr)
+  {
+    __ASM volatile ("STRT %1, [%0]" : : "r" (addr), "r" (value) : "memory");
+  }
+
+#endif /* (__CORTEX_M >= 0x03) */
+
+#if ((defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1))     || \
+     (defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) || \
+     (defined (__ARM_ARCH_8M_BASE__ ) && (__ARM_ARCH_8M_BASE__ == 1))    )
+
+
+  __IAR_FT uint8_t __LDAB(volatile uint8_t *ptr)
+  {
+    uint32_t res;
+    __ASM volatile ("LDAB %0, [%1]" : "=r" (res) : "r" (ptr) : "memory");
+    return ((uint8_t)res);
+  }
+
+  __IAR_FT uint16_t __LDAH(volatile uint16_t *ptr)
+  {
+    uint32_t res;
+    __ASM volatile ("LDAH %0, [%1]" : "=r" (res) : "r" (ptr) : "memory");
+    return ((uint16_t)res);
+  }
+
+  __IAR_FT uint32_t __LDA(volatile uint32_t *ptr)
+  {
+    uint32_t res;
+    __ASM volatile ("LDA %0, [%1]" : "=r" (res) : "r" (ptr) : "memory");
+    return res;
+  }
+
+  __IAR_FT void __STLB(uint8_t value, volatile uint8_t *ptr)
+  {
+    __ASM volatile ("STLB %1, [%0]" :: "r" (ptr), "r" (value) : "memory");
+  }
+
+  __IAR_FT void __STLH(uint16_t value, volatile uint16_t *ptr)
+  {
+    __ASM volatile ("STLH %1, [%0]" :: "r" (ptr), "r" (value) : "memory");
+  }
+
+  __IAR_FT void __STL(uint32_t value, volatile uint32_t *ptr)
+  {
+    __ASM volatile ("STL %1, [%0]" :: "r" (ptr), "r" (value) : "memory");
+  }
+
+  __IAR_FT uint8_t __LDAEXB(volatile uint8_t *ptr)
+  {
+    uint32_t res;
+    __ASM volatile ("LDAEXB %0, [%1]" : "=r" (res) : "r" (ptr) : "memory");
+    return ((uint8_t)res);
+  }
+
+  __IAR_FT uint16_t __LDAEXH(volatile uint16_t *ptr)
+  {
+    uint32_t res;
+    __ASM volatile ("LDAEXH %0, [%1]" : "=r" (res) : "r" (ptr) : "memory");
+    return ((uint16_t)res);
+  }
+
+  __IAR_FT uint32_t __LDAEX(volatile uint32_t *ptr)
+  {
+    uint32_t res;
+    __ASM volatile ("LDAEX %0, [%1]" : "=r" (res) : "r" (ptr) : "memory");
+    return res;
+  }
+
+  __IAR_FT uint32_t __STLEXB(uint8_t value, volatile uint8_t *ptr)
+  {
+    uint32_t res;
+    __ASM volatile ("STLEXB %0, %2, [%1]" : "=&r" (res) : "r" (ptr), "r" (value) : "memory");
+    return res;
+  }
+
+  __IAR_FT uint32_t __STLEXH(uint16_t value, volatile uint16_t *ptr)
+  {
+    uint32_t res;
+    __ASM volatile ("STLEXH %0, %2, [%1]" : "=&r" (res) : "r" (ptr), "r" (value) : "memory");
+    return res;
+  }
+
+  __IAR_FT uint32_t __STLEX(uint32_t value, volatile uint32_t *ptr)
+  {
+    uint32_t res;
+    __ASM volatile ("STLEX %0, %2, [%1]" : "=&r" (res) : "r" (ptr), "r" (value) : "memory");
+    return res;
+  }
+
+#endif /* __ARM_ARCH_8M_MAIN__ or __ARM_ARCH_8M_BASE__ */
+
+#undef __IAR_FT
+#undef __IAR_M0_FAMILY
+#undef __ICCARM_V8
+
+#pragma diag_default=Pe940
+#pragma diag_default=Pe177
+
+#define __SXTB16_RORn(ARG1, ARG2) __SXTB16(__ROR(ARG1, ARG2))
+
+#define __SXTAB16_RORn(ARG1, ARG2, ARG3) __SXTAB16(ARG1, __ROR(ARG2, ARG3))
+
+#endif /* __CMSIS_ICCARM_M_H__ */

--- a/platform/ext/cmsis/CMSIS/Core/Include/m-profile/cmsis_tiarmclang_m.h
+++ b/platform/ext/cmsis/CMSIS/Core/Include/m-profile/cmsis_tiarmclang_m.h
@@ -1,0 +1,1451 @@
+/*
+ * Copyright (c) 2023-2024 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS-Core(M) Compiler TIARMClang Header File
+ */
+
+#ifndef __CMSIS_TIARMCLANG_M_H
+#define __CMSIS_TIARMCLANG_M_H
+
+#pragma clang system_header   /* treat file as system include file */
+
+#if (__ARM_ACLE >= 200)
+  #include <arm_acle.h>
+#else
+  #error Compiler must support ACLE V2.0
+#endif /* (__ARM_ACLE >= 200) */
+
+/* CMSIS compiler specific defines */
+#ifndef   __ASM
+  #define __ASM                                  __asm
+#endif
+#ifndef   __INLINE
+  #define __INLINE                               __inline
+#endif
+#ifndef   __STATIC_INLINE
+  #define __STATIC_INLINE                        static __inline
+#endif
+#ifndef   __STATIC_FORCEINLINE
+  #define __STATIC_FORCEINLINE                   __attribute__((always_inline)) static __inline
+#endif
+#ifndef   __NO_RETURN
+  #define __NO_RETURN                            __attribute__((__noreturn__))
+#endif
+#ifndef   __USED
+  #define __USED                                 __attribute__((used))
+#endif
+#ifndef   __WEAK
+  #define __WEAK                                 __attribute__((weak))
+#endif
+#ifndef   __PACKED
+  #define __PACKED                               __attribute__((packed, aligned(1)))
+#endif
+#ifndef   __PACKED_STRUCT
+  #define __PACKED_STRUCT                        struct __attribute__((packed, aligned(1)))
+#endif
+#ifndef   __PACKED_UNION
+  #define __PACKED_UNION                         union __attribute__((packed, aligned(1)))
+#endif
+#ifndef   __UNALIGNED_UINT16_WRITE
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wpacked"
+  __PACKED_STRUCT T_UINT16_WRITE { uint16_t v; };
+  #pragma clang diagnostic pop
+  #define __UNALIGNED_UINT16_WRITE(addr, val)    (void)((((struct T_UINT16_WRITE *)(void *)(addr))->v) = (val))
+#endif
+#ifndef   __UNALIGNED_UINT16_READ
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wpacked"
+  __PACKED_STRUCT T_UINT16_READ { uint16_t v; };
+  #pragma clang diagnostic pop
+  #define __UNALIGNED_UINT16_READ(addr)          (((const struct T_UINT16_READ *)(const void *)(addr))->v)
+#endif
+#ifndef   __UNALIGNED_UINT32_WRITE
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wpacked"
+  __PACKED_STRUCT T_UINT32_WRITE { uint32_t v; };
+  #pragma clang diagnostic pop
+  #define __UNALIGNED_UINT32_WRITE(addr, val)    (void)((((struct T_UINT32_WRITE *)(void *)(addr))->v) = (val))
+#endif
+#ifndef   __UNALIGNED_UINT32_READ
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wpacked"
+  __PACKED_STRUCT T_UINT32_READ { uint32_t v; };
+  #pragma clang diagnostic pop
+  #define __UNALIGNED_UINT32_READ(addr)          (((const struct T_UINT32_READ *)(const void *)(addr))->v)
+#endif
+#ifndef   __ALIGNED
+  #define __ALIGNED(x)                           __attribute__((aligned(x)))
+#endif
+#ifndef   __RESTRICT
+  #define __RESTRICT                             __restrict
+#endif
+#ifndef   __COMPILER_BARRIER
+  #define __COMPILER_BARRIER()                   __ASM volatile("":::"memory")
+#endif
+#ifndef __NO_INIT
+  #define __NO_INIT                              __attribute__ ((section (".noinit")))
+#endif
+#ifndef __ALIAS
+  #define __ALIAS(x)                             __attribute__ ((alias(x)))
+#endif
+
+/* #########################  Startup and Lowlevel Init  ######################## */
+#ifndef __PROGRAM_START
+#define __PROGRAM_START           _c_int00
+#endif
+
+#ifndef __INITIAL_SP
+#define __INITIAL_SP              __STACK_END
+#endif
+
+#ifndef __STACK_LIMIT
+#define __STACK_LIMIT             __STACK_SIZE
+#endif
+
+#ifndef __VECTOR_TABLE
+#define __VECTOR_TABLE            __Vectors
+#endif
+
+#ifndef __VECTOR_TABLE_ATTRIBUTE
+#define __VECTOR_TABLE_ATTRIBUTE  __attribute__((used, section(".intvecs")))
+#endif
+
+#if (__ARM_FEATURE_CMSE == 3)
+#ifndef __STACK_SEAL
+#define __STACK_SEAL              Image$$STACKSEAL$$ZI$$Base
+#endif
+
+#ifndef __TZ_STACK_SEAL_SIZE
+#define __TZ_STACK_SEAL_SIZE      8U
+#endif
+
+#ifndef __TZ_STACK_SEAL_VALUE
+#define __TZ_STACK_SEAL_VALUE     0xFEF5EDA5FEF5EDA5ULL
+#endif
+
+
+__STATIC_FORCEINLINE void __TZ_set_STACKSEAL_S (uint32_t* stackTop) {
+  *((uint64_t *)stackTop) = __TZ_STACK_SEAL_VALUE;
+}
+#endif
+
+
+/* ##########################  Core Instruction Access  ######################### */
+/** \defgroup CMSIS_Core_InstructionInterface CMSIS Core Instruction Interface
+  Access to dedicated instructions
+  @{
+*/
+
+/* Define macros for porting to both thumb1 and thumb2.
+ * For thumb1, use low register (r0-r7), specified by constraint "l"
+ * Otherwise, use general registers, specified by constraint "r" */
+#if defined (__thumb__) && !defined (__thumb2__)
+#define __CMSIS_GCC_OUT_REG(r) "=l" (r)
+#define __CMSIS_GCC_RW_REG(r) "+l" (r)
+#define __CMSIS_GCC_USE_REG(r) "l" (r)
+#else
+#define __CMSIS_GCC_OUT_REG(r) "=r" (r)
+#define __CMSIS_GCC_RW_REG(r) "+r" (r)
+#define __CMSIS_GCC_USE_REG(r) "r" (r)
+#endif
+
+/**
+  \brief   No Operation
+  \details No Operation does nothing. This instruction can be used for code alignment purposes.
+ */
+#define __NOP() __nop()
+
+
+/**
+  \brief   Wait For Interrupt
+  \details Wait For Interrupt is a hint instruction that suspends execution until one of a number of events occurs.
+ */
+#define __WFI() __wfi()
+
+
+/**
+  \brief   Wait For Event
+  \details Wait For Event is a hint instruction that permits the processor to enter
+           a low-power state until one of a number of events occurs.
+ */
+#define __WFE() __wfe()
+
+
+/**
+  \brief   Send Event
+  \details Send Event is a hint instruction. It causes an event to be signaled to the CPU.
+ */
+#define __SEV() __sev()
+
+
+/**
+  \brief   Instruction Synchronization Barrier
+  \details Instruction Synchronization Barrier flushes the pipeline in the processor,
+           so that all instructions following the ISB are fetched from cache or memory,
+           after the instruction has been completed.
+ */
+#define __ISB() __isb(0xF)
+
+
+/**
+  \brief   Data Synchronization Barrier
+  \details Acts as a special kind of Data Memory Barrier.
+           It completes when all explicit memory accesses before this instruction complete.
+ */
+#define __DSB() __dsb(0xF)
+
+
+/**
+  \brief   Data Memory Barrier
+  \details Ensures the apparent order of the explicit memory operations before
+           and after the instruction, without ensuring their completion.
+ */
+#define __DMB() __dmb(0xF)
+
+
+/**
+  \brief   Reverse byte order (32 bit)
+  \details Reverses the byte order in unsigned integer value. For example, 0x12345678 becomes 0x78563412.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+#define __REV(value) __rev(value)
+
+
+/**
+  \brief   Reverse byte order (16 bit)
+  \details Reverses the byte order within each halfword of a word. For example, 0x12345678 becomes 0x34127856.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+#define __REV16(value) __rev16(value)
+
+
+/**
+  \brief   Reverse byte order (16 bit)
+  \details Reverses the byte order in a 16-bit value and returns the signed 16-bit result. For example, 0x0080 becomes 0x8000.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+#define __REVSH(value) __revsh(value)
+
+
+/**
+  \brief   Rotate Right in unsigned value (32 bit)
+  \details Rotate Right (immediate) provides the value of the contents of a register rotated by a variable number of bits.
+  \param [in]    op1  Value to rotate
+  \param [in]    op2  Number of Bits to rotate
+  \return               Rotated value
+ */
+#define __ROR(op1, op2) __ror(op1, op2)
+
+
+/**
+  \brief   Breakpoint
+  \details Causes the processor to enter Debug state.
+           Debug tools can use this to investigate system state when the instruction at a particular address is reached.
+  \param [in]    value  is ignored by the processor.
+                 If required, a debugger can use it to store additional information about the breakpoint.
+ */
+#define __BKPT(value)     __ASM volatile ("bkpt "#value)
+
+
+/**
+  \brief   Reverse bit order of value
+  \details Reverses the bit order of the given value.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+#define __RBIT(value)  __rbit(value)
+
+
+/**
+  \brief   Count leading zeros
+  \details Counts the number of leading zeros of a data value.
+  \param [in]  value  Value to count the leading zeros
+  \return             number of leading zeros in value
+ */
+#define __CLZ(value) __clz(value)
+
+
+/* __ARM_FEATURE_SAT is wrong for for Armv8-M Baseline devices */
+#if ((__ARM_FEATURE_SAT    >= 1) && \
+     (__ARM_ARCH_ISA_THUMB >= 2)    )
+/**
+  \brief   Signed Saturate
+  \details Saturates a signed value.
+  \param [in]  value  Value to be saturated
+  \param [in]    sat  Bit position to saturate to (1..32)
+  \return             Saturated value
+ */
+#define __SSAT(value, sat) __ssat(value, sat)
+
+
+/**
+  \brief   Unsigned Saturate
+  \details Saturates an unsigned value.
+  \param [in]  value  Value to be saturated
+  \param [in]    sat  Bit position to saturate to (0..31)
+  \return             Saturated value
+ */
+#define __USAT(value, sat) __usat(value, sat)
+
+#else /* (__ARM_FEATURE_SAT >= 1) */
+/**
+  \brief   Signed Saturate
+  \details Saturates a signed value.
+  \param [in]  value  Value to be saturated
+  \param [in]    sat  Bit position to saturate to (1..32)
+  \return             Saturated value
+ */
+__STATIC_FORCEINLINE int32_t __SSAT(int32_t val, uint32_t sat)
+{
+  if ((sat >= 1U) && (sat <= 32U))
+  {
+    const int32_t max = (int32_t)((1U << (sat - 1U)) - 1U);
+    const int32_t min = -1 - max ;
+    if (val > max)
+    {
+      return (max);
+    }
+    else if (val < min)
+    {
+      return (min);
+    }
+  }
+  return (val);
+}
+
+
+/**
+  \brief   Unsigned Saturate
+  \details Saturates an unsigned value.
+  \param [in]  value  Value to be saturated
+  \param [in]    sat  Bit position to saturate to (0..31)
+  \return             Saturated value
+ */
+__STATIC_FORCEINLINE uint32_t __USAT(int32_t val, uint32_t sat)
+{
+  if (sat <= 31U)
+  {
+    const uint32_t max = ((1U << sat) - 1U);
+    if (val > (int32_t)max)
+    {
+      return (max);
+    }
+    else if (val < 0)
+    {
+      return (0U);
+    }
+  }
+  return ((uint32_t)val);
+}
+#endif /* (__ARM_FEATURE_SAT >= 1) */
+
+
+#if (__ARM_FEATURE_LDREX >= 1)
+/**
+  \brief   Remove the exclusive lock
+  \details Removes the exclusive lock which is created by LDREX.
+ */
+#define __CLREX             __builtin_arm_clrex
+
+
+/**
+  \brief   LDR Exclusive (8 bit)
+  \details Executes a exclusive LDR instruction for 8 bit value.
+  \param [in]    ptr  Pointer to data
+  \return             value of type uint8_t at (*ptr)
+ */
+#define __LDREXB        (uint8_t)__builtin_arm_ldrex
+
+
+/**
+  \brief   STR Exclusive (8 bit)
+  \details Executes a exclusive STR instruction for 8 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+#define __STREXB        (uint32_t)__builtin_arm_strex
+#endif /* (__ARM_FEATURE_LDREX >= 1) */
+
+
+#if (__ARM_FEATURE_LDREX >= 2)
+/**
+  \brief   LDR Exclusive (16 bit)
+  \details Executes a exclusive LDR instruction for 16 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint16_t at (*ptr)
+ */
+#define __LDREXH        (uint16_t)__builtin_arm_ldrex
+
+
+/**
+  \brief   STR Exclusive (16 bit)
+  \details Executes a exclusive STR instruction for 16 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+#define __STREXH        (uint32_t)__builtin_arm_strex
+#endif /* (__ARM_FEATURE_LDREX >= 2) */
+
+
+#if (__ARM_FEATURE_LDREX >= 4)
+/**
+  \brief   LDR Exclusive (32 bit)
+  \details Executes a exclusive LDR instruction for 32 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint32_t at (*ptr)
+ */
+#define __LDREXW        (uint32_t)__builtin_arm_ldrex
+
+
+/**
+  \brief   STR Exclusive (32 bit)
+  \details Executes a exclusive STR instruction for 32 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+#define __STREXW        (uint32_t)__builtin_arm_strex
+#endif /* (__ARM_FEATURE_LDREX >= 4) */
+
+
+#if (__ARM_ARCH_ISA_THUMB >= 2)
+/**
+  \brief   Rotate Right with Extend (32 bit)
+  \details Moves each bit of a bitstring right by one bit.
+           The carry input is shifted in at the left end of the bitstring.
+  \param [in]    value  Value to rotate
+  \return               Rotated value
+ */
+__STATIC_FORCEINLINE uint32_t __RRX(uint32_t value)
+{
+  uint32_t result;
+
+  __ASM volatile ("rrx %0, %1" : "=r" (result) : "r" (value));
+  return (result);
+}
+
+
+/**
+  \brief   LDRT Unprivileged (8 bit)
+  \details Executes a Unprivileged LDRT instruction for 8 bit value.
+  \param [in]    ptr  Pointer to data
+  \return             value of type uint8_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint8_t __LDRBT(volatile uint8_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldrbt %0, %1" : "=r" (result) : "Q" (*ptr) );
+  return ((uint8_t)result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   LDRT Unprivileged (16 bit)
+  \details Executes a Unprivileged LDRT instruction for 16 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint16_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint16_t __LDRHT(volatile uint16_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldrht %0, %1" : "=r" (result) : "Q" (*ptr) );
+  return ((uint16_t)result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   LDRT Unprivileged (32 bit)
+  \details Executes a Unprivileged LDRT instruction for 32 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint32_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint32_t __LDRT(volatile uint32_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldrt %0, %1" : "=r" (result) : "Q" (*ptr) );
+  return (result);
+}
+
+
+/**
+  \brief   STRT Unprivileged (8 bit)
+  \details Executes a Unprivileged STRT instruction for 8 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__STATIC_FORCEINLINE void __STRBT(uint8_t value, volatile uint8_t *ptr)
+{
+  __ASM volatile ("strbt %1, %0" : "=Q" (*ptr) : "r" ((uint32_t)value) );
+}
+
+
+/**
+  \brief   STRT Unprivileged (16 bit)
+  \details Executes a Unprivileged STRT instruction for 16 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__STATIC_FORCEINLINE void __STRHT(uint16_t value, volatile uint16_t *ptr)
+{
+  __ASM volatile ("strht %1, %0" : "=Q" (*ptr) : "r" ((uint32_t)value) );
+}
+
+
+/**
+  \brief   STRT Unprivileged (32 bit)
+  \details Executes a Unprivileged STRT instruction for 32 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__STATIC_FORCEINLINE void __STRT(uint32_t value, volatile uint32_t *ptr)
+{
+  __ASM volatile ("strt %1, %0" : "=Q" (*ptr) : "r" (value) );
+}
+#endif /* (__ARM_ARCH_ISA_THUMB >= 2) */
+
+
+#if (__ARM_ARCH >= 8)
+/**
+  \brief   Load-Acquire (8 bit)
+  \details Executes a LDAB instruction for 8 bit value.
+  \param [in]    ptr  Pointer to data
+  \return             value of type uint8_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint8_t __LDAB(volatile uint8_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldab %0, %1" : "=r" (result) : "Q" (*ptr) : "memory" );
+  return ((uint8_t)result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   Load-Acquire (16 bit)
+  \details Executes a LDAH instruction for 16 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint16_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint16_t __LDAH(volatile uint16_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldah %0, %1" : "=r" (result) : "Q" (*ptr) : "memory" );
+  return ((uint16_t)result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   Load-Acquire (32 bit)
+  \details Executes a LDA instruction for 32 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint32_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint32_t __LDA(volatile uint32_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("lda %0, %1" : "=r" (result) : "Q" (*ptr) : "memory" );
+  return (result);
+}
+
+
+/**
+  \brief   Store-Release (8 bit)
+  \details Executes a STLB instruction for 8 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__STATIC_FORCEINLINE void __STLB(uint8_t value, volatile uint8_t *ptr)
+{
+  __ASM volatile ("stlb %1, %0" : "=Q" (*ptr) : "r" ((uint32_t)value) : "memory" );
+}
+
+
+/**
+  \brief   Store-Release (16 bit)
+  \details Executes a STLH instruction for 16 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__STATIC_FORCEINLINE void __STLH(uint16_t value, volatile uint16_t *ptr)
+{
+  __ASM volatile ("stlh %1, %0" : "=Q" (*ptr) : "r" ((uint32_t)value) : "memory" );
+}
+
+
+/**
+  \brief   Store-Release (32 bit)
+  \details Executes a STL instruction for 32 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__STATIC_FORCEINLINE void __STL(uint32_t value, volatile uint32_t *ptr)
+{
+  __ASM volatile ("stl %1, %0" : "=Q" (*ptr) : "r" ((uint32_t)value) : "memory" );
+}
+
+
+/**
+  \brief   Load-Acquire Exclusive (8 bit)
+  \details Executes a LDAB exclusive instruction for 8 bit value.
+  \param [in]    ptr  Pointer to data
+  \return             value of type uint8_t at (*ptr)
+ */
+#define     __LDAEXB                 (uint8_t)__builtin_arm_ldaex
+
+
+/**
+  \brief   Load-Acquire Exclusive (16 bit)
+  \details Executes a LDAH exclusive instruction for 16 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint16_t at (*ptr)
+ */
+#define     __LDAEXH                 (uint16_t)__builtin_arm_ldaex
+
+
+/**
+  \brief   Load-Acquire Exclusive (32 bit)
+  \details Executes a LDA exclusive instruction for 32 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint32_t at (*ptr)
+ */
+#define     __LDAEX                  (uint32_t)__builtin_arm_ldaex
+
+
+/**
+  \brief   Store-Release Exclusive (8 bit)
+  \details Executes a STLB exclusive instruction for 8 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+#define     __STLEXB                 (uint32_t)__builtin_arm_stlex
+
+
+/**
+  \brief   Store-Release Exclusive (16 bit)
+  \details Executes a STLH exclusive instruction for 16 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+#define     __STLEXH                 (uint32_t)__builtin_arm_stlex
+
+
+/**
+  \brief   Store-Release Exclusive (32 bit)
+  \details Executes a STL exclusive instruction for 32 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+#define     __STLEX                  (uint32_t)__builtin_arm_stlex
+
+#endif /* (__ARM_ARCH >= 8) */
+
+/** @}*/ /* end of group CMSIS_Core_InstructionInterface */
+
+
+/* ###########################  Core Function Access  ########################### */
+/** \ingroup  CMSIS_Core_FunctionInterface
+    \defgroup CMSIS_Core_RegAccFunctions CMSIS Core Register Access Functions
+  @{
+ */
+
+/**
+  \brief   Enable IRQ Interrupts
+  \details Enables IRQ interrupts by clearing special-purpose register PRIMASK.
+           Can only be executed in Privileged modes.
+ */
+#ifndef __ARM_COMPAT_H
+__STATIC_FORCEINLINE void __enable_irq(void)
+{
+  __ASM volatile ("cpsie i" : : : "memory");
+}
+#endif
+
+
+/**
+  \brief   Disable IRQ Interrupts
+  \details Disables IRQ interrupts by setting special-purpose register PRIMASK.
+           Can only be executed in Privileged modes.
+ */
+#ifndef __ARM_COMPAT_H
+__STATIC_FORCEINLINE void __disable_irq(void)
+{
+  __ASM volatile ("cpsid i" : : : "memory");
+}
+#endif
+
+
+/**
+  \brief   Get Control Register
+  \details Returns the content of the Control Register.
+  \return               Control Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_CONTROL(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, control" : "=r" (result) );
+  return (result);
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Control Register (non-secure)
+  \details Returns the content of the non-secure Control Register when in secure mode.
+  \return               non-secure Control Register value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_CONTROL_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, control_ns" : "=r" (result) );
+  return (result);
+}
+#endif
+
+
+/**
+  \brief   Set Control Register
+  \details Writes the given value to the Control Register.
+  \param [in]    control  Control Register value to set
+ */
+__STATIC_FORCEINLINE void __set_CONTROL(uint32_t control)
+{
+  __ASM volatile ("MSR control, %0" : : "r" (control) : "memory");
+  __ISB();
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Set Control Register (non-secure)
+  \details Writes the given value to the non-secure Control Register when in secure state.
+  \param [in]    control  Control Register value to set
+ */
+__STATIC_FORCEINLINE void __TZ_set_CONTROL_NS(uint32_t control)
+{
+  __ASM volatile ("MSR control_ns, %0" : : "r" (control) : "memory");
+  __ISB();
+}
+#endif
+
+
+/**
+  \brief   Get IPSR Register
+  \details Returns the content of the IPSR Register.
+  \return               IPSR Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_IPSR(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, ipsr" : "=r" (result) );
+  return (result);
+}
+
+
+/**
+  \brief   Get APSR Register
+  \details Returns the content of the APSR Register.
+  \return               APSR Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_APSR(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, apsr" : "=r" (result) );
+  return (result);
+}
+
+
+/**
+  \brief   Get xPSR Register
+  \details Returns the content of the xPSR Register.
+  \return               xPSR Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_xPSR(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, xpsr" : "=r" (result) );
+  return (result);
+}
+
+
+/**
+  \brief   Get Process Stack Pointer
+  \details Returns the current value of the Process Stack Pointer (PSP).
+  \return               PSP Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_PSP(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, psp"  : "=r" (result) );
+  return (result);
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Process Stack Pointer (non-secure)
+  \details Returns the current value of the non-secure Process Stack Pointer (PSP) when in secure state.
+  \return               PSP Register value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_PSP_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, psp_ns"  : "=r" (result) );
+  return (result);
+}
+#endif
+
+
+/**
+  \brief   Set Process Stack Pointer
+  \details Assigns the given value to the Process Stack Pointer (PSP).
+  \param [in]    topOfProcStack  Process Stack Pointer value to set
+ */
+__STATIC_FORCEINLINE void __set_PSP(uint32_t topOfProcStack)
+{
+  __ASM volatile ("MSR psp, %0" : : "r" (topOfProcStack) : );
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Set Process Stack Pointer (non-secure)
+  \details Assigns the given value to the non-secure Process Stack Pointer (PSP) when in secure state.
+  \param [in]    topOfProcStack  Process Stack Pointer value to set
+ */
+__STATIC_FORCEINLINE void __TZ_set_PSP_NS(uint32_t topOfProcStack)
+{
+  __ASM volatile ("MSR psp_ns, %0" : : "r" (topOfProcStack) : );
+}
+#endif
+
+
+/**
+  \brief   Get Main Stack Pointer
+  \details Returns the current value of the Main Stack Pointer (MSP).
+  \return               MSP Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_MSP(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, msp" : "=r" (result) );
+  return (result);
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Main Stack Pointer (non-secure)
+  \details Returns the current value of the non-secure Main Stack Pointer (MSP) when in secure state.
+  \return               MSP Register value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_MSP_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, msp_ns" : "=r" (result) );
+  return (result);
+}
+#endif
+
+
+/**
+  \brief   Set Main Stack Pointer
+  \details Assigns the given value to the Main Stack Pointer (MSP).
+  \param [in]    topOfMainStack  Main Stack Pointer value to set
+ */
+__STATIC_FORCEINLINE void __set_MSP(uint32_t topOfMainStack)
+{
+  __ASM volatile ("MSR msp, %0" : : "r" (topOfMainStack) : );
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Set Main Stack Pointer (non-secure)
+  \details Assigns the given value to the non-secure Main Stack Pointer (MSP) when in secure state.
+  \param [in]    topOfMainStack  Main Stack Pointer value to set
+ */
+__STATIC_FORCEINLINE void __TZ_set_MSP_NS(uint32_t topOfMainStack)
+{
+  __ASM volatile ("MSR msp_ns, %0" : : "r" (topOfMainStack) : );
+}
+#endif
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Stack Pointer (non-secure)
+  \details Returns the current value of the non-secure Stack Pointer (SP) when in secure state.
+  \return               SP Register value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_SP_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, sp_ns" : "=r" (result) );
+  return (result);
+}
+
+
+/**
+  \brief   Set Stack Pointer (non-secure)
+  \details Assigns the given value to the non-secure Stack Pointer (SP) when in secure state.
+  \param [in]    topOfStack  Stack Pointer value to set
+ */
+__STATIC_FORCEINLINE void __TZ_set_SP_NS(uint32_t topOfStack)
+{
+  __ASM volatile ("MSR sp_ns, %0" : : "r" (topOfStack) : );
+}
+#endif
+
+
+/**
+  \brief   Get Priority Mask
+  \details Returns the current state of the priority mask bit from the Priority Mask Register.
+  \return               Priority Mask value
+ */
+__STATIC_FORCEINLINE uint32_t __get_PRIMASK(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, primask" : "=r" (result) );
+  return (result);
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Priority Mask (non-secure)
+  \details Returns the current state of the non-secure priority mask bit from the Priority Mask Register when in secure state.
+  \return               Priority Mask value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_PRIMASK_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, primask_ns" : "=r" (result) );
+  return (result);
+}
+#endif
+
+
+/**
+  \brief   Set Priority Mask
+  \details Assigns the given value to the Priority Mask Register.
+  \param [in]    priMask  Priority Mask
+ */
+__STATIC_FORCEINLINE void __set_PRIMASK(uint32_t priMask)
+{
+  __ASM volatile ("MSR primask, %0" : : "r" (priMask) : "memory");
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Set Priority Mask (non-secure)
+  \details Assigns the given value to the non-secure Priority Mask Register when in secure state.
+  \param [in]    priMask  Priority Mask
+ */
+__STATIC_FORCEINLINE void __TZ_set_PRIMASK_NS(uint32_t priMask)
+{
+  __ASM volatile ("MSR primask_ns, %0" : : "r" (priMask) : "memory");
+}
+#endif
+
+
+#if (__ARM_ARCH_ISA_THUMB >= 2)
+/**
+  \brief   Enable FIQ
+  \details Enables FIQ interrupts by clearing special-purpose register FAULTMASK.
+           Can only be executed in Privileged modes.
+ */
+__STATIC_FORCEINLINE void __enable_fault_irq(void)
+{
+  __ASM volatile ("cpsie f" : : : "memory");
+}
+
+
+/**
+  \brief   Disable FIQ
+  \details Disables FIQ interrupts by setting special-purpose register FAULTMASK.
+           Can only be executed in Privileged modes.
+ */
+__STATIC_FORCEINLINE void __disable_fault_irq(void)
+{
+  __ASM volatile ("cpsid f" : : : "memory");
+}
+
+
+/**
+  \brief   Get Base Priority
+  \details Returns the current value of the Base Priority register.
+  \return               Base Priority register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_BASEPRI(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, basepri" : "=r" (result) );
+  return (result);
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Base Priority (non-secure)
+  \details Returns the current value of the non-secure Base Priority register when in secure state.
+  \return               Base Priority register value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_BASEPRI_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, basepri_ns" : "=r" (result) );
+  return (result);
+}
+#endif
+
+
+/**
+  \brief   Set Base Priority
+  \details Assigns the given value to the Base Priority register.
+  \param [in]    basePri  Base Priority value to set
+ */
+__STATIC_FORCEINLINE void __set_BASEPRI(uint32_t basePri)
+{
+  __ASM volatile ("MSR basepri, %0" : : "r" (basePri) : "memory");
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Set Base Priority (non-secure)
+  \details Assigns the given value to the non-secure Base Priority register when in secure state.
+  \param [in]    basePri  Base Priority value to set
+ */
+__STATIC_FORCEINLINE void __TZ_set_BASEPRI_NS(uint32_t basePri)
+{
+  __ASM volatile ("MSR basepri_ns, %0" : : "r" (basePri) : "memory");
+}
+#endif
+
+
+/**
+  \brief   Set Base Priority with condition
+  \details Assigns the given value to the Base Priority register only if BASEPRI masking is disabled,
+           or the new value increases the BASEPRI priority level.
+  \param [in]    basePri  Base Priority value to set
+ */
+__STATIC_FORCEINLINE void __set_BASEPRI_MAX(uint32_t basePri)
+{
+  __ASM volatile ("MSR basepri_max, %0" : : "r" (basePri) : "memory");
+}
+
+
+/**
+  \brief   Get Fault Mask
+  \details Returns the current value of the Fault Mask register.
+  \return               Fault Mask register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_FAULTMASK(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, faultmask" : "=r" (result) );
+  return (result);
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Fault Mask (non-secure)
+  \details Returns the current value of the non-secure Fault Mask register when in secure state.
+  \return               Fault Mask register value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_FAULTMASK_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, faultmask_ns" : "=r" (result) );
+  return (result);
+}
+#endif
+
+
+/**
+  \brief   Set Fault Mask
+  \details Assigns the given value to the Fault Mask register.
+  \param [in]    faultMask  Fault Mask value to set
+ */
+__STATIC_FORCEINLINE void __set_FAULTMASK(uint32_t faultMask)
+{
+  __ASM volatile ("MSR faultmask, %0" : : "r" (faultMask) : "memory");
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Set Fault Mask (non-secure)
+  \details Assigns the given value to the non-secure Fault Mask register when in secure state.
+  \param [in]    faultMask  Fault Mask value to set
+ */
+__STATIC_FORCEINLINE void __TZ_set_FAULTMASK_NS(uint32_t faultMask)
+{
+  __ASM volatile ("MSR faultmask_ns, %0" : : "r" (faultMask) : "memory");
+}
+#endif
+
+#endif /* (__ARM_ARCH_ISA_THUMB >= 2) */
+
+
+#if (__ARM_ARCH >= 8)
+/**
+  \brief   Get Process Stack Pointer Limit
+  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
+  Stack Pointer Limit register hence zero is returned always in non-secure
+  mode.
+
+  \details Returns the current value of the Process Stack Pointer Limit (PSPLIM).
+  \return               PSPLIM Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_PSPLIM(void)
+{
+#if (((__ARM_ARCH_8M_MAIN__   < 1) && \
+      (__ARM_ARCH_8_1M_MAIN__ < 1)    ) && \
+     (__ARM_FEATURE_CMSE < 3)              )
+  /* without main extensions, the non-secure PSPLIM is RAZ/WI */
+  return (0U);
+#else
+  uint32_t result;
+  __ASM volatile ("MRS %0, psplim"  : "=r" (result) );
+  return (result);
+#endif
+}
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Process Stack Pointer Limit (non-secure)
+  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
+  Stack Pointer Limit register hence zero is returned always.
+
+  \details Returns the current value of the non-secure Process Stack Pointer Limit (PSPLIM) when in secure state.
+  \return               PSPLIM Register value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_PSPLIM_NS(void)
+{
+#if ((__ARM_ARCH_8M_MAIN__   < 1) && \
+     (__ARM_ARCH_8_1M_MAIN__ < 1)    )
+  /* without main extensions, the non-secure PSPLIM is RAZ/WI */
+  return (0U);
+#else
+  uint32_t result;
+  __ASM volatile ("MRS %0, psplim_ns"  : "=r" (result) );
+  return (result);
+#endif
+}
+#endif
+
+
+/**
+  \brief   Set Process Stack Pointer Limit
+  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
+  Stack Pointer Limit register hence the write is silently ignored in non-secure
+  mode.
+
+  \details Assigns the given value to the Process Stack Pointer Limit (PSPLIM).
+  \param [in]    ProcStackPtrLimit  Process Stack Pointer Limit value to set
+ */
+__STATIC_FORCEINLINE void __set_PSPLIM(uint32_t ProcStackPtrLimit)
+{
+#if (((__ARM_ARCH_8M_MAIN__   < 1) && \
+      (__ARM_ARCH_8_1M_MAIN__ < 1)    ) && \
+     (__ARM_FEATURE_CMSE < 3)              )
+  /* without main extensions, the non-secure PSPLIM is RAZ/WI */
+  (void)ProcStackPtrLimit;
+#else
+  __ASM volatile ("MSR psplim, %0" : : "r" (ProcStackPtrLimit));
+#endif
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Set Process Stack Pointer (non-secure)
+  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
+  Stack Pointer Limit register hence the write is silently ignored.
+
+  \details Assigns the given value to the non-secure Process Stack Pointer Limit (PSPLIM) when in secure state.
+  \param [in]    ProcStackPtrLimit  Process Stack Pointer Limit value to set
+ */
+__STATIC_FORCEINLINE void __TZ_set_PSPLIM_NS(uint32_t ProcStackPtrLimit)
+{
+#if ((__ARM_ARCH_8M_MAIN__   < 1) && \
+     (__ARM_ARCH_8_1M_MAIN__ < 1)    )
+  /* without main extensions, the non-secure PSPLIM is RAZ/WI */
+  (void)ProcStackPtrLimit;
+#else
+  __ASM volatile ("MSR psplim_ns, %0\n" : : "r" (ProcStackPtrLimit));
+#endif
+}
+#endif
+
+
+/**
+  \brief   Get Main Stack Pointer Limit
+  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
+  Stack Pointer Limit register hence zero is returned always.
+
+  \details Returns the current value of the Main Stack Pointer Limit (MSPLIM).
+  \return               MSPLIM Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_MSPLIM(void)
+{
+#if (((__ARM_ARCH_8M_MAIN__   < 1) && \
+      (__ARM_ARCH_8_1M_MAIN__ < 1)    ) && \
+     (__ARM_FEATURE_CMSE < 3)              )
+  /* without main extensions, the non-secure MSPLIM is RAZ/WI */
+  return (0U);
+#else
+  uint32_t result;
+  __ASM volatile ("MRS %0, msplim" : "=r" (result) );
+  return (result);
+#endif
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Main Stack Pointer Limit (non-secure)
+  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
+  Stack Pointer Limit register hence zero is returned always.
+
+  \details Returns the current value of the non-secure Main Stack Pointer Limit(MSPLIM) when in secure state.
+  \return               MSPLIM Register value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_MSPLIM_NS(void)
+{
+#if ((__ARM_ARCH_8M_MAIN__   < 1) && \
+     (__ARM_ARCH_8_1M_MAIN__ < 1)    )
+  /* without main extensions, the non-secure MSPLIM is RAZ/WI */
+  return (0U);
+#else
+  uint32_t result;
+  __ASM volatile ("MRS %0, msplim_ns" : "=r" (result) );
+  return (result);
+#endif
+}
+#endif
+
+
+/**
+  \brief   Set Main Stack Pointer Limit
+  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
+  Stack Pointer Limit register hence the write is silently ignored.
+
+  \details Assigns the given value to the Main Stack Pointer Limit (MSPLIM).
+  \param [in]    MainStackPtrLimit  Main Stack Pointer Limit value to set
+ */
+__STATIC_FORCEINLINE void __set_MSPLIM(uint32_t MainStackPtrLimit)
+{
+#if (((__ARM_ARCH_8M_MAIN__   < 1) && \
+      (__ARM_ARCH_8_1M_MAIN__ < 1)    ) && \
+     (__ARM_FEATURE_CMSE < 3)              )
+  /* without main extensions, the non-secure MSPLIM is RAZ/WI */
+  (void)MainStackPtrLimit;
+#else
+  __ASM volatile ("MSR msplim, %0" : : "r" (MainStackPtrLimit));
+#endif
+}
+
+
+#if (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Set Main Stack Pointer Limit (non-secure)
+  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
+  Stack Pointer Limit register hence the write is silently ignored.
+
+  \details Assigns the given value to the non-secure Main Stack Pointer Limit (MSPLIM) when in secure state.
+  \param [in]    MainStackPtrLimit  Main Stack Pointer value to set
+ */
+__STATIC_FORCEINLINE void __TZ_set_MSPLIM_NS(uint32_t MainStackPtrLimit)
+{
+#if ((__ARM_ARCH_8M_MAIN__   < 1) && \
+     (__ARM_ARCH_8_1M_MAIN__ < 1)    )
+  /* without main extensions, the non-secure MSPLIM is RAZ/WI */
+  (void)MainStackPtrLimit;
+#else
+  __ASM volatile ("MSR msplim_ns, %0" : : "r" (MainStackPtrLimit));
+#endif
+}
+#endif
+
+#endif /* (__ARM_ARCH >= 8) */
+
+
+/**
+  \brief   Get FPSCR
+  \details Returns the current value of the Floating Point Status/Control register.
+  \return               Floating Point Status/Control register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_FPSCR(void)
+{
+#if (defined(__ARM_FP) && (__ARM_FP >= 1))
+  return (__builtin_arm_get_fpscr());
+#else
+  return (0U);
+#endif
+}
+
+
+/**
+  \brief   Set FPSCR
+  \details Assigns the given value to the Floating Point Status/Control register.
+  \param [in]    fpscr  Floating Point Status/Control value to set
+ */
+__STATIC_FORCEINLINE void __set_FPSCR(uint32_t fpscr)
+{
+#if (defined(__ARM_FP) && (__ARM_FP >= 1))
+  __builtin_arm_set_fpscr(fpscr);
+#else
+  (void)fpscr;
+#endif
+}
+
+
+/** @} end of CMSIS_Core_RegAccFunctions */
+
+
+/* ###################  Compiler specific Intrinsics  ########################### */
+/** \defgroup CMSIS_SIMD_intrinsics CMSIS SIMD Intrinsics
+  Access to dedicated SIMD instructions
+  @{
+*/
+
+#if (__ARM_FEATURE_DSP == 1)
+#define     __SADD8                 __sadd8
+#define     __QADD8                 __qadd8
+#define     __SHADD8                __shadd8
+#define     __UADD8                 __uadd8
+#define     __UQADD8                __uqadd8
+#define     __UHADD8                __uhadd8
+#define     __SSUB8                 __ssub8
+#define     __QSUB8                 __qsub8
+#define     __SHSUB8                __shsub8
+#define     __USUB8                 __usub8
+#define     __UQSUB8                __uqsub8
+#define     __UHSUB8                __uhsub8
+#define     __SADD16                __sadd16
+#define     __QADD16                __qadd16
+#define     __SHADD16               __shadd16
+#define     __UADD16                __uadd16
+#define     __UQADD16               __uqadd16
+#define     __UHADD16               __uhadd16
+#define     __SSUB16                __ssub16
+#define     __QSUB16                __qsub16
+#define     __SHSUB16               __shsub16
+#define     __USUB16                __usub16
+#define     __UQSUB16               __uqsub16
+#define     __UHSUB16               __uhsub16
+#define     __SASX                  __sasx
+#define     __QASX                  __qasx
+#define     __SHASX                 __shasx
+#define     __UASX                  __uasx
+#define     __UQASX                 __uqasx
+#define     __UHASX                 __uhasx
+#define     __SSAX                  __ssax
+#define     __QSAX                  __qsax
+#define     __SHSAX                 __shsax
+#define     __USAX                  __usax
+#define     __UQSAX                 __uqsax
+#define     __UHSAX                 __uhsax
+#define     __USAD8                 __usad8
+#define     __USADA8                __usada8
+#define     __SSAT16                __ssat16
+#define     __USAT16                __usat16
+#define     __UXTB16                __uxtb16
+#define     __UXTAB16               __uxtab16
+#define     __SXTB16                __sxtb16
+#define     __SXTAB16               __sxtab16
+#define     __SMUAD                 __smuad
+#define     __SMUADX                __smuadx
+#define     __SMLAD                 __smlad
+#define     __SMLADX                __smladx
+#define     __SMLALD                __smlald
+#define     __SMLALDX               __smlaldx
+#define     __SMUSD                 __smusd
+#define     __SMUSDX                __smusdx
+#define     __SMLSD                 __smlsd
+#define     __SMLSDX                __smlsdx
+#define     __SMLSLD                __smlsld
+#define     __SMLSLDX               __smlsldx
+#define     __SEL                   __sel
+#define     __QADD                  __qadd
+#define     __QSUB                  __qsub
+
+#define __PKHBT(ARG1,ARG2,ARG3)          ( ((((uint32_t)(ARG1))          ) & 0x0000FFFFUL) |  \
+                                           ((((uint32_t)(ARG2)) << (ARG3)) & 0xFFFF0000UL)  )
+
+#define __PKHTB(ARG1,ARG2,ARG3)          ( ((((uint32_t)(ARG1))          ) & 0xFFFF0000UL) |  \
+                                           ((((uint32_t)(ARG2)) >> (ARG3)) & 0x0000FFFFUL)  )
+
+#define __SXTB16_RORn(ARG1, ARG2)        __SXTB16(__ROR(ARG1, ARG2))
+
+#define __SXTAB16_RORn(ARG1, ARG2, ARG3) __SXTAB16(ARG1, __ROR(ARG2, ARG3))
+
+__STATIC_FORCEINLINE int32_t __SMMLA (int32_t op1, int32_t op2, int32_t op3)
+{
+  int32_t result;
+
+  __ASM volatile ("smmla %0, %1, %2, %3" : "=r" (result): "r"  (op1), "r" (op2), "r" (op3) );
+  return (result);
+}
+
+#endif /* (__ARM_FEATURE_DSP == 1) */
+/** @} end of group CMSIS_SIMD_intrinsics */
+
+
+#endif /* __CMSIS_TIARMCLANG_M_H */

--- a/platform/ext/cmsis/CMSIS/Core/Include/tz_context.h
+++ b/platform/ext/cmsis/CMSIS/Core/Include/tz_context.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2017-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS Core(M) Context Management for Armv8-M TrustZone
+ */
+
+#if   defined ( __ICCARM__ )
+  #pragma system_include         /* treat file as system include file for MISRA check */
+#elif defined (__clang__)
+  #pragma clang system_header   /* treat file as system include file */
+#endif
+
+#ifndef TZ_CONTEXT_H
+#define TZ_CONTEXT_H
+
+#include <stdint.h>
+
+#ifndef TZ_MODULEID_T
+#define TZ_MODULEID_T
+/// \details Data type that identifies secure software modules called by a process.
+typedef uint32_t TZ_ModuleId_t;
+#endif
+
+/// \details TZ Memory ID identifies an allocated memory slot.
+typedef uint32_t TZ_MemoryId_t;
+
+/// Initialize secure context memory system
+/// \return execution status (1: success, 0: error)
+uint32_t TZ_InitContextSystem_S (void);
+
+/// Allocate context memory for calling secure software modules in TrustZone
+/// \param[in]  module   identifies software modules called from non-secure mode
+/// \return value != 0 id TrustZone memory slot identifier
+/// \return value 0    no memory available or internal error
+TZ_MemoryId_t TZ_AllocModuleContext_S (TZ_ModuleId_t module);
+
+/// Free context memory that was previously allocated with \ref TZ_AllocModuleContext_S
+/// \param[in]  id  TrustZone memory slot identifier
+/// \return execution status (1: success, 0: error)
+uint32_t TZ_FreeModuleContext_S (TZ_MemoryId_t id);
+
+/// Load secure context (called on RTOS thread context switch)
+/// \param[in]  id  TrustZone memory slot identifier
+/// \return execution status (1: success, 0: error)
+uint32_t TZ_LoadContext_S (TZ_MemoryId_t id);
+
+/// Store secure context (called on RTOS thread context switch)
+/// \param[in]  id  TrustZone memory slot identifier
+/// \return execution status (1: success, 0: error)
+uint32_t TZ_StoreContext_S (TZ_MemoryId_t id);
+
+#endif  // TZ_CONTEXT_H

--- a/platform/ext/cmsis/CMSIS/Core/Source/irq_ctrl_gic.c
+++ b/platform/ext/cmsis/CMSIS/Core/Source/irq_ctrl_gic.c
@@ -1,0 +1,433 @@
+/**************************************************************************//**
+ * @file     irq_ctrl_gic.c
+ * @brief    Interrupt controller handling implementation for GIC
+ * @version  V1.2.0
+ * @date     30. October 2022
+ ******************************************************************************/
+/*
+ * Copyright (c) 2017-2022 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stddef.h>
+
+#include "RTE_Components.h"
+#include CMSIS_device_header
+
+#include "irq_ctrl.h"
+
+#if defined(__GIC_PRESENT) && (__GIC_PRESENT == 1U)
+
+/// Number of implemented interrupt lines
+#ifndef IRQ_GIC_LINE_COUNT
+#define IRQ_GIC_LINE_COUNT      (1020U)
+#endif
+
+#ifndef IRQ_GIC_EXTERN_IRQ_TABLE
+static IRQHandler_t IRQTable[IRQ_GIC_LINE_COUNT] = { 0U };
+#else
+extern IRQHandler_t IRQTable[IRQ_GIC_LINE_COUNT];
+#endif
+static uint32_t     IRQ_ID0;
+
+/// Initialize interrupt controller.
+__WEAK int32_t IRQ_Initialize (void) {
+  #ifndef IRQ_GIC_EXTERN_IRQ_TABLE
+    uint32_t i;
+
+    for (i = 0U; i < IRQ_GIC_LINE_COUNT; i++) {
+      IRQTable[i] = (IRQHandler_t)NULL;
+    }
+    GIC_Enable();
+  #endif
+  return (0);
+}
+
+
+/// Register interrupt handler.
+__WEAK int32_t IRQ_SetHandler (IRQn_ID_t irqn, IRQHandler_t handler) {
+  int32_t status;
+
+  if ((irqn >= 0) && (irqn < (IRQn_ID_t)IRQ_GIC_LINE_COUNT)) {
+    IRQTable[irqn] = handler;
+    status =  0;
+  } else {
+    status = -1;
+  }
+
+  return (status);
+}
+
+/// The Interrupt Handler.
+__WEAK void IRQ_Handler (void) {
+  IRQn_Type irqn = GIC_AcknowledgePending ();
+  if (irqn < (IRQn_Type)IRQ_GIC_LINE_COUNT) {
+    IRQTable[irqn]();
+  }
+  GIC_EndInterrupt (irqn);
+}
+
+
+/// Get the registered interrupt handler.
+__WEAK IRQHandler_t IRQ_GetHandler (IRQn_ID_t irqn) {
+  IRQHandler_t h;
+
+  // Ignore CPUID field (software generated interrupts)
+  irqn &= 0x3FFU;
+
+  if ((irqn >= 0) && (irqn < (IRQn_ID_t)IRQ_GIC_LINE_COUNT)) {
+    h = IRQTable[irqn];
+  } else {
+    h = (IRQHandler_t)0;
+  }
+
+  return (h);
+}
+
+
+/// Enable interrupt.
+__WEAK int32_t IRQ_Enable (IRQn_ID_t irqn) {
+  int32_t status;
+
+  if ((irqn >= 0) && (irqn < (IRQn_ID_t)IRQ_GIC_LINE_COUNT)) {
+    GIC_EnableIRQ ((IRQn_Type)irqn);
+    status = 0;
+  } else {
+    status = -1;
+  }
+
+  return (status);
+}
+
+
+/// Disable interrupt.
+__WEAK int32_t IRQ_Disable (IRQn_ID_t irqn) {
+  int32_t status;
+
+  if ((irqn >= 0) && (irqn < (IRQn_ID_t)IRQ_GIC_LINE_COUNT)) {
+    GIC_DisableIRQ ((IRQn_Type)irqn);
+    status = 0;
+  } else {
+    status = -1;
+  }
+
+  return (status);
+}
+
+
+/// Get interrupt enable state.
+__WEAK uint32_t IRQ_GetEnableState (IRQn_ID_t irqn) {
+  uint32_t enable;
+
+  if ((irqn >= 0) && (irqn < (IRQn_ID_t)IRQ_GIC_LINE_COUNT)) {
+    enable = GIC_GetEnableIRQ((IRQn_Type)irqn);
+  } else {
+    enable = 0U;
+  }
+
+  return (enable);
+}
+
+
+/// Configure interrupt request mode.
+__WEAK int32_t IRQ_SetMode (IRQn_ID_t irqn, uint32_t mode) {
+  uint32_t val;
+  uint8_t cfg;
+  uint8_t secure;
+  uint8_t cpu;
+  int32_t status = 0;
+
+  if ((irqn >= 0) && (irqn < (IRQn_ID_t)IRQ_GIC_LINE_COUNT)) {
+    // Check triggering mode
+    val = (mode & IRQ_MODE_TRIG_Msk);
+
+    if (val == IRQ_MODE_TRIG_LEVEL) {
+      cfg = 0x00U;
+    } else if (val == IRQ_MODE_TRIG_EDGE) {
+      cfg = 0x02U;
+    } else {
+      cfg = 0x00U;
+      status = -1;
+    }
+
+    val = (mode & IRQ_MODE_MODEL_Msk);
+    if (val == IRQ_MODE_MODEL_1N) {
+      cfg |= 1;   // 1-N model
+    }
+
+    // Check interrupt type
+    val = mode & IRQ_MODE_TYPE_Msk;
+
+    if (val != IRQ_MODE_TYPE_IRQ) {
+      status = -1;
+    }
+
+    // Check interrupt domain
+    val = mode & IRQ_MODE_DOMAIN_Msk;
+
+    if (val == IRQ_MODE_DOMAIN_NONSECURE) {
+      secure = 0U;
+    } else {
+      // Check security extensions support
+      val = GIC_DistributorInfo() & (1UL << 10U);
+
+      if (val != 0U) {
+        // Security extensions are supported
+        secure = 1U;
+      } else {
+        secure = 0U;
+        status = -1;
+      }
+    }
+
+    // Check interrupt CPU targets
+    val = mode & IRQ_MODE_CPU_Msk;
+
+    if (val == IRQ_MODE_CPU_ALL) {
+      cpu = 0xFFU;
+    } else {
+      cpu = (uint8_t)(val >> IRQ_MODE_CPU_Pos);
+    }
+
+    // Apply configuration if no mode error
+    if (status == 0) {
+      GIC_SetConfiguration((IRQn_Type)irqn, cfg);
+      GIC_SetTarget       ((IRQn_Type)irqn, cpu);
+
+      if (secure != 0U) {
+        GIC_SetGroup ((IRQn_Type)irqn, secure);
+      }
+    }
+  }
+
+  return (status);
+}
+
+
+/// Get interrupt mode configuration.
+__WEAK uint32_t IRQ_GetMode (IRQn_ID_t irqn) {
+  uint32_t mode;
+  uint32_t val;
+
+  if ((irqn >= 0) && (irqn < (IRQn_ID_t)IRQ_GIC_LINE_COUNT)) {
+    mode = IRQ_MODE_TYPE_IRQ;
+
+    // Get trigger mode
+    val = GIC_GetConfiguration((IRQn_Type)irqn);
+
+    if ((val & 2U) != 0U) {
+      // Corresponding interrupt is edge triggered
+      mode |= IRQ_MODE_TRIG_EDGE;
+    } else {
+      // Corresponding interrupt is level triggered
+      mode |= IRQ_MODE_TRIG_LEVEL;
+    }
+
+    if (val & 1U) {
+      mode |= IRQ_MODE_MODEL_1N;
+    }
+    // Get interrupt CPU targets
+    mode |= GIC_GetTarget ((IRQn_Type)irqn) << IRQ_MODE_CPU_Pos;
+
+  } else {
+    mode = IRQ_MODE_ERROR;
+  }
+
+  return (mode);
+}
+
+
+/// Get ID number of current interrupt request (IRQ).
+__WEAK IRQn_ID_t IRQ_GetActiveIRQ (void) {
+  IRQn_ID_t irqn;
+  uint32_t prio;
+
+  /* Dummy read to avoid GIC 390 errata 801120 */
+  GIC_GetHighPendingIRQ();
+
+  irqn = GIC_AcknowledgePending();
+
+  __DSB();
+
+  /* Workaround GIC 390 errata 733075 (GIC-390_Errata_Notice_v6.pdf, 09-Jul-2014)  */
+  /* The following workaround code is for a single-core system.  It would be       */
+  /* different in a multi-core system.                                             */
+  /* If the ID is 0 or 0x3FE or 0x3FF, then the GIC CPU interface may be locked-up */
+  /* so unlock it, otherwise service the interrupt as normal.                      */
+  /* Special IDs 1020=0x3FC and 1021=0x3FD are reserved values in GICv1 and GICv2  */
+  /* so will not occur here.                                                       */
+
+  if ((irqn == 0) || (irqn >= 0x3FE)) {
+    /* Unlock the CPU interface with a dummy write to Interrupt Priority Register */
+    prio = GIC_GetPriority((IRQn_Type)0);
+    GIC_SetPriority ((IRQn_Type)0, prio);
+
+    __DSB();
+
+    if ((irqn == 0U) && ((GIC_GetIRQStatus ((IRQn_Type)irqn) & 1U) != 0U) && (IRQ_ID0 == 0U)) {
+      /* If the ID is 0, is active and has not been seen before */
+      IRQ_ID0 = 1U;
+    }
+    /* End of Workaround GIC 390 errata 733075 */
+  }
+
+  return (irqn);
+}
+
+
+/// Get ID number of current fast interrupt request (FIQ).
+__WEAK IRQn_ID_t IRQ_GetActiveFIQ (void) {
+  return ((IRQn_ID_t)-1);
+}
+
+
+/// Signal end of interrupt processing.
+__WEAK int32_t IRQ_EndOfInterrupt (IRQn_ID_t irqn) {
+  int32_t status;
+  IRQn_Type irq = (IRQn_Type)irqn;
+
+  irqn &= 0x3FFU;
+
+  if ((irqn >= 0) && (irqn < (IRQn_ID_t)IRQ_GIC_LINE_COUNT)) {
+    GIC_EndInterrupt (irq);
+
+    if (irqn == 0) {
+      IRQ_ID0 = 0U;
+    }
+
+    status = 0;
+  } else {
+    status = -1;
+  }
+
+  return (status);
+}
+
+
+/// Set interrupt pending flag.
+__WEAK int32_t IRQ_SetPending (IRQn_ID_t irqn) {
+  int32_t status;
+
+  if ((irqn >= 0) && (irqn < (IRQn_ID_t)IRQ_GIC_LINE_COUNT)) {
+    GIC_SetPendingIRQ ((IRQn_Type)irqn);
+    status = 0;
+  } else {
+    status = -1;
+  }
+
+  return (status);
+}
+
+/// Get interrupt pending flag.
+__WEAK uint32_t IRQ_GetPending (IRQn_ID_t irqn) {
+  uint32_t pending;
+
+  if ((irqn >= 16) && (irqn < (IRQn_ID_t)IRQ_GIC_LINE_COUNT)) {
+    pending = GIC_GetPendingIRQ ((IRQn_Type)irqn);
+  } else {
+    pending = 0U;
+  }
+
+  return (pending & 1U);
+}
+
+
+/// Clear interrupt pending flag.
+__WEAK int32_t IRQ_ClearPending (IRQn_ID_t irqn) {
+  int32_t status;
+
+  if ((irqn >= 16) && (irqn < (IRQn_ID_t)IRQ_GIC_LINE_COUNT)) {
+    GIC_ClearPendingIRQ ((IRQn_Type)irqn);
+    status = 0;
+  } else {
+    status = -1;
+  }
+
+  return (status);
+}
+
+
+/// Set interrupt priority value.
+__WEAK int32_t IRQ_SetPriority (IRQn_ID_t irqn, uint32_t priority) {
+  int32_t status;
+
+  if ((irqn >= 0) && (irqn < (IRQn_ID_t)IRQ_GIC_LINE_COUNT)) {
+    GIC_SetPriority ((IRQn_Type)irqn, priority);
+    status = 0;
+  } else {
+    status = -1;
+  }
+
+  return (status);
+}
+
+
+/// Get interrupt priority.
+__WEAK uint32_t IRQ_GetPriority (IRQn_ID_t irqn) {
+  uint32_t priority;
+
+  if ((irqn >= 0) && (irqn < (IRQn_ID_t)IRQ_GIC_LINE_COUNT)) {
+    priority = GIC_GetPriority ((IRQn_Type)irqn);
+  } else {
+    priority = IRQ_PRIORITY_ERROR;
+  }
+
+  return (priority);
+}
+
+
+/// Set priority masking threshold.
+__WEAK int32_t IRQ_SetPriorityMask (uint32_t priority) {
+  GIC_SetInterfacePriorityMask (priority);
+  return (0);
+}
+
+
+/// Get priority masking threshold
+__WEAK uint32_t IRQ_GetPriorityMask (void) {
+  return GIC_GetInterfacePriorityMask();
+}
+
+
+/// Set priority grouping field split point
+__WEAK int32_t IRQ_SetPriorityGroupBits (uint32_t bits) {
+  int32_t status;
+
+  if (bits == IRQ_PRIORITY_Msk) {
+    bits = 7U;
+  }
+
+  if (bits < 8U) {
+    GIC_SetBinaryPoint (7U - bits);
+    status = 0;
+  } else {
+    status = -1;
+  }
+
+  return (status);
+}
+
+
+/// Get priority grouping field split point
+__WEAK uint32_t IRQ_GetPriorityGroupBits (void) {
+  uint32_t bp;
+
+  bp = GIC_GetBinaryPoint() & 0x07U;
+
+  return (7U - bp);
+}
+
+#endif

--- a/platform/ext/cmsis/CMSIS/Core/Template/ARMv8-M/main_s.c
+++ b/platform/ext/cmsis/CMSIS/Core/Template/ARMv8-M/main_s.c
@@ -1,0 +1,58 @@
+/******************************************************************************
+ * @file     main_s.c
+ * @brief    Code template for secure main function
+ * @version  V1.1.1
+ * @date     10. January 2018
+ ******************************************************************************/
+/*
+ * Copyright (c) 2013-2018 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Use CMSE intrinsics */
+#include <arm_cmse.h>
+ 
+#include "RTE_Components.h"
+#include CMSIS_device_header
+ 
+/* TZ_START_NS: Start address of non-secure application */
+#ifndef TZ_START_NS
+#define TZ_START_NS (0x200000U)
+#endif
+ 
+/* typedef for non-secure callback functions */
+typedef void (*funcptr_void) (void) __attribute__((cmse_nonsecure_call));
+ 
+/* Secure main() */
+int main(void) {
+  funcptr_void NonSecure_ResetHandler;
+ 
+  /* Add user setup code for secure part here*/
+ 
+  /* Set non-secure main stack (MSP_NS) */
+  __TZ_set_MSP_NS(*((uint32_t *)(TZ_START_NS)));
+ 
+  /* Get non-secure reset handler */
+  NonSecure_ResetHandler = (funcptr_void)(*((uint32_t *)((TZ_START_NS) + 4U)));
+ 
+  /* Start non-secure state software application */
+  NonSecure_ResetHandler();
+ 
+  /* Non-secure software does not return, this code is not executed */
+  while (1) {
+    __NOP();
+  }
+}

--- a/platform/ext/cmsis/CMSIS/Core/Template/ARMv8-M/tz_context.c
+++ b/platform/ext/cmsis/CMSIS/Core/Template/ARMv8-M/tz_context.c
@@ -1,0 +1,200 @@
+/******************************************************************************
+ * @file     tz_context.c
+ * @brief    Context Management for Armv8-M TrustZone - Sample implementation
+ * @version  V1.1.1
+ * @date     10. January 2018
+ ******************************************************************************/
+/*
+ * Copyright (c) 2016-2018 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "RTE_Components.h"
+#include CMSIS_device_header
+#include "tz_context.h"
+
+/// Number of process slots (threads may call secure library code)
+#ifndef TZ_PROCESS_STACK_SLOTS
+#define TZ_PROCESS_STACK_SLOTS     8U
+#endif
+
+/// Stack size of the secure library code
+#ifndef TZ_PROCESS_STACK_SIZE
+#define TZ_PROCESS_STACK_SIZE      256U
+#endif
+
+typedef struct {
+  uint32_t sp_top;      // stack space top
+  uint32_t sp_limit;    // stack space limit
+  uint32_t sp;          // current stack pointer
+} stack_info_t;
+
+static stack_info_t ProcessStackInfo  [TZ_PROCESS_STACK_SLOTS];
+static uint64_t     ProcessStackMemory[TZ_PROCESS_STACK_SLOTS][TZ_PROCESS_STACK_SIZE/8U];
+static uint32_t     ProcessStackFreeSlot = 0xFFFFFFFFU;
+
+
+/// Initialize secure context memory system
+/// \return execution status (1: success, 0: error)
+__attribute__((cmse_nonsecure_entry))
+uint32_t TZ_InitContextSystem_S (void) {
+  uint32_t n;
+
+  if (__get_IPSR() == 0U) {
+    return 0U;  // Thread Mode
+  }
+
+  for (n = 0U; n < TZ_PROCESS_STACK_SLOTS; n++) {
+    ProcessStackInfo[n].sp = 0U;
+    ProcessStackInfo[n].sp_limit = (uint32_t)&ProcessStackMemory[n];
+    ProcessStackInfo[n].sp_top   = (uint32_t)&ProcessStackMemory[n] + TZ_PROCESS_STACK_SIZE;
+    *((uint32_t *)ProcessStackMemory[n]) = n + 1U;
+  }
+  *((uint32_t *)ProcessStackMemory[--n]) = 0xFFFFFFFFU;
+
+  ProcessStackFreeSlot = 0U;
+
+  // Default process stack pointer and stack limit
+  __set_PSPLIM((uint32_t)ProcessStackMemory);
+  __set_PSP   ((uint32_t)ProcessStackMemory);
+
+  // Privileged Thread Mode using PSP
+  __set_CONTROL(0x02U);
+
+  return 1U;    // Success
+}
+
+
+/// Allocate context memory for calling secure software modules in TrustZone
+/// \param[in]  module   identifies software modules called from non-secure mode
+/// \return value != 0 id TrustZone memory slot identifier
+/// \return value 0    no memory available or internal error
+__attribute__((cmse_nonsecure_entry))
+TZ_MemoryId_t TZ_AllocModuleContext_S (TZ_ModuleId_t module) {
+  uint32_t slot;
+
+  (void)module; // Ignore (fixed Stack size)
+
+  if (__get_IPSR() == 0U) {
+    return 0U;  // Thread Mode
+  }
+
+  if (ProcessStackFreeSlot == 0xFFFFFFFFU) {
+    return 0U;  // No slot available
+  }
+
+  slot = ProcessStackFreeSlot;
+  ProcessStackFreeSlot = *((uint32_t *)ProcessStackMemory[slot]);
+
+  ProcessStackInfo[slot].sp = ProcessStackInfo[slot].sp_top;
+
+  return (slot + 1U);
+}
+
+
+/// Free context memory that was previously allocated with \ref TZ_AllocModuleContext_S
+/// \param[in]  id  TrustZone memory slot identifier
+/// \return execution status (1: success, 0: error)
+__attribute__((cmse_nonsecure_entry))
+uint32_t TZ_FreeModuleContext_S (TZ_MemoryId_t id) {
+  uint32_t slot;
+
+  if (__get_IPSR() == 0U) {
+    return 0U;  // Thread Mode
+  }
+
+  if ((id == 0U) || (id > TZ_PROCESS_STACK_SLOTS)) {
+    return 0U;  // Invalid ID
+  }
+
+  slot = id - 1U;
+
+  if (ProcessStackInfo[slot].sp == 0U) {
+    return 0U;  // Inactive slot
+  }
+  ProcessStackInfo[slot].sp = 0U;
+
+  *((uint32_t *)ProcessStackMemory[slot]) = ProcessStackFreeSlot;
+  ProcessStackFreeSlot = slot;
+
+  return 1U;    // Success
+}
+
+
+/// Load secure context (called on RTOS thread context switch)
+/// \param[in]  id  TrustZone memory slot identifier
+/// \return execution status (1: success, 0: error)
+__attribute__((cmse_nonsecure_entry))
+uint32_t TZ_LoadContext_S (TZ_MemoryId_t id) {
+  uint32_t slot;
+
+  if ((__get_IPSR() == 0U) || ((__get_CONTROL() & 2U) == 0U)) {
+    return 0U;  // Thread Mode or using Main Stack for threads
+  }
+
+  if ((id == 0U) || (id > TZ_PROCESS_STACK_SLOTS)) {
+    return 0U;  // Invalid ID
+  }
+
+  slot = id - 1U;
+
+  if (ProcessStackInfo[slot].sp == 0U) {
+    return 0U;  // Inactive slot
+  }
+
+  // Setup process stack pointer and stack limit
+  __set_PSPLIM(ProcessStackInfo[slot].sp_limit);
+  __set_PSP   (ProcessStackInfo[slot].sp);
+
+  return 1U;    // Success
+}
+
+
+/// Store secure context (called on RTOS thread context switch)
+/// \param[in]  id  TrustZone memory slot identifier
+/// \return execution status (1: success, 0: error)
+__attribute__((cmse_nonsecure_entry))
+uint32_t TZ_StoreContext_S (TZ_MemoryId_t id) {
+  uint32_t slot;
+  uint32_t sp;
+
+  if ((__get_IPSR() == 0U) || ((__get_CONTROL() & 2U) == 0U)) {
+    return 0U;  // Thread Mode or using Main Stack for threads
+  }
+
+  if ((id == 0U) || (id > TZ_PROCESS_STACK_SLOTS)) {
+    return 0U;  // Invalid ID
+  }
+
+  slot = id - 1U;
+
+  if (ProcessStackInfo[slot].sp == 0U) {
+    return 0U;  // Inactive slot
+  }
+
+  sp = __get_PSP();
+  if ((sp < ProcessStackInfo[slot].sp_limit) ||
+      (sp > ProcessStackInfo[slot].sp_top)) {
+    return 0U;  // SP out of range
+  }
+  ProcessStackInfo[slot].sp = sp;
+
+  // Default process stack pointer and stack limit
+  __set_PSPLIM((uint32_t)ProcessStackMemory);
+  __set_PSP   ((uint32_t)ProcessStackMemory);
+
+  return 1U;    // Success
+}

--- a/platform/ext/cmsis/CMSIS/Core/Template/Device_A/Config/Device_ac6.sct
+++ b/platform/ext/cmsis/CMSIS/Core/Template/Device_A/Config/Device_ac6.sct
@@ -1,0 +1,75 @@
+#! armcc -E
+;**************************************************
+; Copyright (c) 2017 ARM Ltd.  All rights reserved.
+;**************************************************
+
+; Scatter-file for Cortex-A
+
+; This scatter-file places application code, data, stack and heap at suitable addresses in the memory map.
+
+#include "mem_<Device>.h"
+
+SDRAM __ROM_BASE __ROM_SIZE       ; load region size_region
+{
+  VECTORS __ROM_BASE __ROM_SIZE ; load address = execution address
+  {
+      * (RESET, +FIRST)         ; Vector table and other startup code
+      * (InRoot$$Sections)      ; All (library) code that must be in a root region
+      * (+RO-CODE)              ; Application RO code (.text)
+      * (+RO-DATA)              ; Application RO data (.constdata)
+  }
+
+  RW_DATA __RAM_BASE __RW_DATA_SIZE
+  { * (+RW) }                   ; Application RW data (.data)
+
+  ZI_DATA (__RAM_BASE+
+           __RW_DATA_SIZE) __ZI_DATA_SIZE
+  { * (+ZI) }                   ; Application ZI data (.bss)
+ 
+  ARM_LIB_HEAP (__RAM_BASE
+               +__RW_DATA_SIZE
+               +__ZI_DATA_SIZE)    EMPTY __HEAP_SIZE        ; Heap region growing up
+  { }
+  
+  ARM_LIB_STACK (__RAM_BASE
+                +__RAM_SIZE       
+                -__FIQ_STACK_SIZE
+                -__IRQ_STACK_SIZE
+                -__SVC_STACK_SIZE
+                -__ABT_STACK_SIZE
+                -__UND_STACK_SIZE) EMPTY -__STACK_SIZE      ; Stack region growing down
+  { }              
+                
+  UND_STACK     (__RAM_BASE
+                +__RAM_SIZE
+                -__FIQ_STACK_SIZE
+                -__IRQ_STACK_SIZE
+                -__SVC_STACK_SIZE
+                -__ABT_STACK_SIZE) EMPTY -__UND_STACK_SIZE  ; UND mode stack
+  { }
+
+  ABT_STACK     (__RAM_BASE
+                +__RAM_SIZE
+                -__FIQ_STACK_SIZE
+                -__IRQ_STACK_SIZE
+                -__SVC_STACK_SIZE) EMPTY -__ABT_STACK_SIZE  ; ABT mode stack
+  { }
+
+  SVC_STACK     (__RAM_BASE
+                +__RAM_SIZE
+                -__FIQ_STACK_SIZE
+                -__IRQ_STACK_SIZE) EMPTY -__SVC_STACK_SIZE  ; SVC mode stack
+  { }  
+
+  IRQ_STACK     (__RAM_BASE
+                +__RAM_SIZE
+                -__FIQ_STACK_SIZE) EMPTY -__IRQ_STACK_SIZE  ; IRQ mode stack
+  { }  
+
+  FIQ_STACK     (__RAM_BASE
+                +__RAM_SIZE)       EMPTY -__FIQ_STACK_SIZE  ; FIQ mode stack
+  { }                            
+
+  TTB            __TTB_BASE        EMPTY __TTB_SIZE         ; Level-1 Translation Table for MMU
+  { }                                        
+}

--- a/platform/ext/cmsis/CMSIS/Core/Template/Device_A/Config/mem_Device.h
+++ b/platform/ext/cmsis/CMSIS/Core/Template/Device_A/Config/mem_Device.h
@@ -1,0 +1,91 @@
+/**************************************************************************//**
+ * @file     mem_<Device>.h
+ * @brief    CMSIS Cortex-A Memory base and size definitions (used in scatter file)
+ * @version  V1.00
+ * @date     10. January 2018
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2018 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MEM_<Device>_H   /* ToDo: replace '<Device>' with your device name */
+#define MEM_<Device>_H
+
+/*----------------------------------------------------------------------------
+  User Stack & Heap size definition
+ *----------------------------------------------------------------------------*/
+/*
+//-------- <<< Use Configuration Wizard in Context Menu >>> ------------------
+*/
+
+/*--------------------- ROM Configuration ------------------------------------
+//
+// <h> ROM Configuration
+//   <o0> ROM Base Address <0x0-0xFFFFFFFF:8>
+//   <o1> ROM Size (in Bytes) <0x0-0xFFFFFFFF:8>
+// </h>
+ *----------------------------------------------------------------------------*/
+#define __ROM_BASE       0x80000000
+#define __ROM_SIZE       0x00200000
+
+/*--------------------- RAM Configuration -----------------------------------
+// <h> RAM Configuration
+//   <o0> RAM Base Address    <0x0-0xFFFFFFFF:8>
+//   <o1> RAM Total Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//   <o2> RW_DATA Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//   <o3> ZI_DATA Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//   <h> Stack / Heap Configuration
+//     <o4>  Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//     <o5>  Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//     <h> Exceptional Modes
+//       <o6> UND Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//       <o7> ABT Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//       <o8> SVC Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//       <o9> IRQ Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//       <o10> FIQ Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//     </h>
+//   </h>
+// </h>
+ *----------------------------------------------------------------------------*/
+#define __RAM_BASE       0x80200000
+#define __RAM_SIZE       0x00200000
+
+#define __RW_DATA_SIZE   0x00100000
+#define __ZI_DATA_SIZE   0x000F0000
+
+#define __STACK_SIZE     0x00001000
+#define __HEAP_SIZE      0x00008000
+
+#define __UND_STACK_SIZE 0x00000100
+#define __ABT_STACK_SIZE 0x00000100
+#define __SVC_STACK_SIZE 0x00000100
+#define __IRQ_STACK_SIZE 0x00000100
+#define __FIQ_STACK_SIZE 0x00000100
+
+/*----------------------------------------------------------------------------*/
+
+/*--------------------- TTB Configuration ------------------------------------
+//
+// <h> TTB Configuration
+//   <o0> TTB Base Address <0x0-0xFFFFFFFF:8>
+//   <o1> TTB Size (in Bytes) <0x0-0xFFFFFFFF:8>
+// </h>
+ *----------------------------------------------------------------------------*/
+#define __TTB_BASE       0x80500000
+#define __TTB_SIZE       0x00004000
+
+#endif /* MEM_<Device>_H */

--- a/platform/ext/cmsis/CMSIS/Core/Template/Device_A/Include/Device.h
+++ b/platform/ext/cmsis/CMSIS/Core/Template/Device_A/Include/Device.h
@@ -1,0 +1,208 @@
+/**************************************************************************//**
+ * @file     <Device>.h
+ * @brief    CMSIS-Core(A) Device Header File for Device <Device>
+ *
+ * @version  V1.0.1
+ * @date     18. July 2023
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef <Device>_H      /* ToDo: replace '<Device>' with your device name */
+#define <Device>_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* ========================================================================= */
+/* ============           Interrupt Number Definition           ============ */
+/* ========================================================================= */
+
+typedef enum IRQn
+{
+/* ================     Cortex-A Specific Interrupt Numbers  =============== */
+
+  /* Software Generated Interrupts */
+  SGI0_IRQn                          =  0,  /* Software Generated Interrupt  0 */
+  SGI1_IRQn                          =  1,  /* Software Generated Interrupt  1 */
+  SGI2_IRQn                          =  2,  /* Software Generated Interrupt  2 */
+  SGI3_IRQn                          =  3,  /* Software Generated Interrupt  3 */
+  SGI4_IRQn                          =  4,  /* Software Generated Interrupt  4 */
+  SGI5_IRQn                          =  5,  /* Software Generated Interrupt  5 */
+  SGI6_IRQn                          =  6,  /* Software Generated Interrupt  6 */
+  SGI7_IRQn                          =  7,  /* Software Generated Interrupt  7 */
+  SGI8_IRQn                          =  8,  /* Software Generated Interrupt  8 */
+  SGI9_IRQn                          =  9,  /* Software Generated Interrupt  9 */
+  SGI10_IRQn                         = 10,  /* Software Generated Interrupt 10 */
+  SGI11_IRQn                         = 11,  /* Software Generated Interrupt 11 */
+  SGI12_IRQn                         = 12,  /* Software Generated Interrupt 12 */
+  SGI13_IRQn                         = 13,  /* Software Generated Interrupt 13 */
+  SGI14_IRQn                         = 14,  /* Software Generated Interrupt 14 */
+  SGI15_IRQn                         = 15,  /* Software Generated Interrupt 15 */
+
+  /* Private Peripheral Interrupts */
+  VirtualMaintenanceInterrupt_IRQn   = 25,  /* Virtual Maintenance Interrupt */
+  HypervisorTimer_IRQn               = 26,  /* Hypervisor Timer Interrupt */
+  VirtualTimer_IRQn                  = 27,  /* Virtual Timer Interrupt */
+  Legacy_nFIQ_IRQn                   = 28,  /* Legacy nFIQ Interrupt */
+  SecurePhyTimer_IRQn                = 29,  /* Secure Physical Timer Interrupt */
+  NonSecurePhyTimer_IRQn             = 30,  /* Non-Secure Physical Timer Interrupt */
+  Legacy_nIRQ_IRQn                   = 31,  /* Legacy nIRQ Interrupt */
+
+ /* Shared Peripheral Interrupts */
+ /* ToDo: add here your device specific external interrupt numbers */
+  <DeviceInterrupt>_IRQn             =  0,  /* Device Interrupt                                                          */
+} IRQn_Type;
+
+
+/* ========================================================================= */
+/* ============      Processor and Core Peripheral Section      ============ */
+/* ========================================================================= */
+
+/* ================ Start of section using anonymous unions ================ */
+#if   defined (__CC_ARM)
+  #pragma push
+  #pragma anon_unions
+#elif defined (__ICCARM__)
+  #pragma language=extended
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wc11-extensions"
+  #pragma clang diagnostic ignored "-Wreserved-id-macro"
+#elif defined (__GNUC__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TMS470__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TASKING__)
+  #pragma warning 586
+#elif defined (__CSMC__)
+  /* anonymous unions are enabled by default */
+#else
+  #warning Not supported compiler type
+#endif
+
+
+/* --------  Configuration of Core Peripherals  ----------------------------------- */
+/* ToDo: set the defines according your Device */
+/* ToDo: define the correct core revision
+         5U if your device is a CORTEX-A5 device
+         7U if your device is a CORTEX-A7 device
+         9U if your device is a CORTEX-A9 device */
+#define __CORTEX_A                    #U      /* Cortex-A# Core */
+#define __CA_REV                 0x0000U      /* Core revision r0p0 */
+/* ToDo: define the correct core features for the <Device> */
+#define __FPU_PRESENT           1U       /* Set to 1 if FPU is present */
+#define __GIC_PRESENT           1U       /* Set to 1 if GIC is present */
+#define __TIM_PRESENT           1U       /* Set to 1 if TIM is present */
+#define __L2C_PRESENT           1U       /* Set to 1 if L2C is present */
+
+/* ToDo: include the correct core_ca#.h file
+         core_ca5.h if your device is a CORTEX-A5 device
+         core_ca7.h if your device is a CORTEX-A7 device
+         core_ca9.h if your device is a CORTEX-A9 device */
+#include <core_ca#.h>                           /* Processor and core peripherals */
+/* ToDo: include your system_<Device>.h file
+         replace '<Device>' with your device name */
+#include "system_<Device>.h"                    /* System Header */
+
+
+
+/* ========================================================================= */
+/* ============       Device Specific Peripheral Section        ============ */
+/* ========================================================================= */
+
+
+/* ToDo: add here your device specific peripheral access structure typedefs
+         following is an example for a timer */
+
+/* ========================================================================= */
+/* ============                       TMR                       ============ */
+/* ========================================================================= */
+
+typedef struct
+{
+  __IOM uint32_t  TimerLoad;                 /* Offset: 0x004 (R/W) Load Register */
+  __IM  uint32_t  TimerValue;                /* Offset: 0x008 (R/ ) Counter Current Value Register */
+  __IOM uint32_t  TimerControl;              /* Offset: 0x00C (R/W) Control Register */
+  __OM  uint32_t  TimerIntClr;               /* Offset: 0x010 ( /W) Interrupt Clear Register */
+  __IM  uint32_t  TimerRIS;                  /* Offset: 0x014 (R/ ) Raw Interrupt Status Register */
+  __IM  uint32_t  TimerMIS;                  /* Offset: 0x018 (R/ ) Masked Interrupt Status Register */
+  __IM  uint32_t  RESERVED[1];
+  __IOM uint32_t  TimerBGLoad;               /* Offset: 0x020 (R/W) Background Load Register */
+} <DeviceAbbreviation>_TMR_TypeDef;
+
+
+
+/* --------  End of section using anonymous unions and disabling warnings  -------- */
+#if   defined (__CC_ARM)
+  #pragma pop
+#elif defined (__ICCARM__)
+  /* leave anonymous unions enabled */
+#elif (defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
+  #pragma clang diagnostic pop
+#elif defined (__GNUC__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TMS470__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TASKING__)
+  #pragma warning restore
+#elif defined (__CSMC__)
+  /* anonymous unions are enabled by default */
+#else
+  #warning Not supported compiler type
+#endif
+
+
+/* ========================================================================= */
+/* ============     Device Specific Peripheral Address Map      ============ */
+/* ========================================================================= */
+
+
+/* ToDo: add here your device peripherals base addresses
+         following is an example for timer */
+
+/* Peripheral and SRAM base address */
+#define <DeviceAbbreviation>_FLASH_BASE       (0x00000000UL)                              /* (FLASH     ) Base Address */
+#define <DeviceAbbreviation>_SRAM_BASE        (0x20000000UL)                              /* (SRAM      ) Base Address */
+#define <DeviceAbbreviation>_PERIPH_BASE      (0x40000000UL)                              /* (Peripheral) Base Address */
+
+/* Peripheral memory map */
+#define <DeviceAbbreviation>TIM0_BASE         (<DeviceAbbreviation>_PERIPH_BASE)          /* (Timer0    ) Base Address */
+#define <DeviceAbbreviation>TIM1_BASE         (<DeviceAbbreviation>_PERIPH_BASE + 0x0800) /* (Timer1    ) Base Address */
+#define <DeviceAbbreviation>TIM2_BASE         (<DeviceAbbreviation>_PERIPH_BASE + 0x1000) /* (Timer2    ) Base Address */
+
+
+/* ========================================================================= */
+/* ============             Peripheral declaration              ============ */
+/* ========================================================================= */
+
+
+/* ToDo: Add here your device peripherals pointer definitions
+         following is an example for timer */
+
+#define <DeviceAbbreviation>_TIM0        ((<DeviceAbbreviation>_TMR_TypeDef *) <DeviceAbbreviation>TIM0_BASE)
+#define <DeviceAbbreviation>_TIM1        ((<DeviceAbbreviation>_TMR_TypeDef *) <DeviceAbbreviation>TIM0_BASE)
+#define <DeviceAbbreviation>_TIM2        ((<DeviceAbbreviation>_TMR_TypeDef *) <DeviceAbbreviation>TIM0_BASE)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* <Device>_H */

--- a/platform/ext/cmsis/CMSIS/Core/Template/Device_A/Include/system_Device.h
+++ b/platform/ext/cmsis/CMSIS/Core/Template/Device_A/Include/system_Device.h
@@ -1,0 +1,61 @@
+/**************************************************************************//**
+ * @file     system_<Device>.h
+ * @brief    CMSIS Cortex-A Device Peripheral Access Layer
+ * @version  V5.00
+ * @date     10. January 2018
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2018 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SYSTEM_<Device>_H   /* ToDo: replace '<Device>' with your device name */
+#define SYSTEM_<Device>_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+extern uint32_t SystemCoreClock;     /*!< System Clock Frequency (Core Clock)  */
+
+/**
+  \brief Setup the microcontroller system.
+
+   Initialize the System and update the SystemCoreClock variable.
+ */
+extern void SystemInit (void);
+
+/**
+  \brief  Update SystemCoreClock variable.
+
+   Updates the SystemCoreClock with current core Clock retrieved from cpu registers.
+ */
+extern void SystemCoreClockUpdate (void);
+
+/**
+  \brief  Create Translation Table.
+
+   Creates Memory Management Unit Translation Table.
+ */
+extern void MMU_CreateTranslationTable(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SYSTEM_<Device>_H */

--- a/platform/ext/cmsis/CMSIS/Core/Template/Device_A/Source/mmu_Device.c
+++ b/platform/ext/cmsis/CMSIS/Core/Template/Device_A/Source/mmu_Device.c
@@ -1,0 +1,232 @@
+/**************************************************************************//**
+ * @file     system_Device.c
+ * @brief    MMU Configuration
+ *           Device <DeviceAbbreviation>
+ * @version  V1.1.0
+ * @date     23. November 2018
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2018 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Memory map description
+
+   ToDo: add in this file your device memory map description
+         following is an example of a Cortex-A9 Arm FVP device
+
+                                                     Memory Type
+0xFFFFFFFF |--------------------------|             ------------
+           |       FLAG SYNC          |             Device Memory
+0xFFFFF000 |--------------------------|             ------------
+           |         Fault            |                Fault
+0xFFF00000 |--------------------------|             ------------
+           |                          |                Normal
+           |                          |
+           |      Daughterboard       |
+           |         memory           |
+           |                          |
+0x80505000 |--------------------------|             ------------
+           |TTB (L2 Sync Flags   ) 4k |                Normal
+0x80504C00 |--------------------------|             ------------
+           |TTB (L2 Peripherals-B) 16k|                Normal
+0x80504800 |--------------------------|             ------------
+           |TTB (L2 Peripherals-A) 16k|                Normal
+0x80504400 |--------------------------|             ------------
+           |TTB (L2 Priv Periphs)  4k |                Normal
+0x80504000 |--------------------------|             ------------
+           |    TTB (L1 Descriptors)  |                Normal
+0x80500000 |--------------------------|             ------------
+           |           Heap           |                Normal
+           |--------------------------|             ------------
+           |          Stack           |                Normal
+0x80400000 |--------------------------|             ------------
+           |         ZI Data          |                Normal
+0x80300000 |--------------------------|             ------------
+           |         RW Data          |                Normal
+0x80200000 |--------------------------|             ------------
+           |         RO Data          |                Normal
+           |--------------------------|             ------------
+           |         RO Code          |              USH Normal
+0x80000000 |--------------------------|             ------------
+           |      Daughterboard       |                Fault
+           |      HSB AXI buses       |
+0x40000000 |--------------------------|             ------------
+           |      Daughterboard       |                Fault
+           |  test chips peripherals  |
+0x2C002000 |--------------------------|             ------------
+           |     Private Address      |            Device Memory
+0x2C000000 |--------------------------|             ------------
+           |      Daughterboard       |                Fault
+           |  test chips peripherals  |
+0x20000000 |--------------------------|             ------------
+           |       Peripherals        |           Device Memory RW/RO
+           |                          |              & Fault
+0x00000000 |--------------------------|
+*/
+
+// L1 Cache info and restrictions about architecture of the caches (CCSIR register):
+// Write-Through support *not* available
+// Write-Back support available.
+// Read allocation support available.
+// Write allocation support available.
+
+// Note: You should use the Shareable attribute carefully.
+// For cores without coherency logic (such as SCU) marking a region as shareable forces the processor to not cache that region regardless of the inner cache settings.
+// Cortex-A versions of RTX use LDREX/STREX instructions relying on Local monitors. Local monitors will be used only when the region gets cached, regions that are not cached will use the Global Monitor.
+// Some Cortex-A implementations do not include Global Monitors, so wrongly setting the attribute Shareable may cause STREX to fail.
+   
+// Recall: When the Shareable attribute is applied to a memory region that is not Write-Back, Normal memory, data held in this region is treated as Non-cacheable.
+// When SMP bit = 0, Inner WB/WA Cacheable Shareable attributes are treated as Non-cacheable.
+// When SMP bit = 1, Inner WB/WA Cacheable Shareable attributes are treated as Cacheable.
+   
+// Following MMU configuration is expected
+// SCTLR.AFE == 1 (Simplified access permissions model - AP[2:1] define access permissions, AP[0] is an access flag)
+// SCTLR.TRE == 0 (TEX remap disabled, so memory type and attributes are described directly by bits in the descriptor)
+// Domain 0 is always the Client domain
+// Descriptors should place all memory in domain 0
+
+#include "<Device>.h" /* ToDo: replace '<Device>' with your device name */
+
+// L2 table pointers
+//-----------------------------------------------------
+#define PRIVATE_TABLE_L2_BASE_4k       (0x80504000) //Map 4k Private Address space
+#define SYNC_FLAGS_TABLE_L2_BASE_4k    (0x80504C00) //Map 4k Flag synchronization
+#define PERIPHERAL_A_TABLE_L2_BASE_64k (0x80504400) //Map 64k Peripheral #1 
+#define PERIPHERAL_B_TABLE_L2_BASE_64k (0x80504800) //Map 64k Peripheral #2 
+
+//--------------------- PERIPHERALS -------------------
+#define PERIPHERAL_A_FAULT             (0x00000000 + 0x1C000000) 
+#define PERIPHERAL_B_FAULT             (0x00100000 + 0x1C000000) 
+
+//--------------------- SYNC FLAGS --------------------
+#define FLAG_SYNC                       0xFFFFF000
+#define F_SYNC_BASE                     0xFFF00000  //1M aligned
+
+//Import symbols from linker
+extern uint32_t Image$$VECTORS$$Base;
+extern uint32_t Image$$RW_DATA$$Base;
+extern uint32_t Image$$ZI_DATA$$Base;
+extern uint32_t Image$$TTB$$ZI$$Base;
+
+static uint32_t Sect_Normal;        // outer & inner wb/wa, non-shareable, executable, rw, domain 0, base addr 0
+static uint32_t Sect_Normal_Cod;    // outer & inner wb/wa, non-shareable, executable, ro, domain 0, base addr 0
+static uint32_t Sect_Normal_RO;     // as Sect_Normal_Cod, but not executable
+static uint32_t Sect_Normal_RW;     // as Sect_Normal_Cod, but writeable and not executable
+static uint32_t Sect_Device_RO;     // device, non-shareable, non-executable, ro, domain 0, base addr 0
+static uint32_t Sect_Device_RW;     // as Sect_Device_RO, but writeable
+                                       
+/* Define global descriptors */        
+static uint32_t Page_L1_4k  = 0x0;  // generic
+static uint32_t Page_L1_64k = 0x0;  // generic
+static uint32_t Page_4k_Device_RW;  // shared device, not executable, rw, domain 0
+static uint32_t Page_64k_Device_RW; // shared device, not executable, rw, domain 0
+
+void MMU_CreateTranslationTable(void)
+{
+  mmu_region_attributes_Type region;
+
+  // Create 4GB of faulting entries
+  MMU_TTSection (&Image$$TTB$$ZI$$Base, 0, 4096, DESCRIPTOR_FAULT);
+
+  /*
+   * Generate descriptors. Refer to core_ca.h to get information about attributes
+   *
+   */
+  // Create descriptors for Vectors, RO, RW, ZI sections
+  section_normal(Sect_Normal, region);
+  section_normal_cod(Sect_Normal_Cod, region);
+  section_normal_ro(Sect_Normal_RO, region);
+  section_normal_rw(Sect_Normal_RW, region);
+  // Create descriptors for peripherals
+  section_Device_ro(Sect_Device_RO, region);
+  section_Device_rw(Sect_Device_RW, region);
+  // Create descriptors for 64k pages
+  page64k_Device_rw(Page_L1_64k, Page_64k_Device_RW, region);
+  // Create descriptors for 4k pages
+  page4k_Device_rw(Page_L1_4k, Page_4k_Device_RW, region);
+
+  /*
+   *  Define MMU flat-map regions and attributes
+   *
+   */
+  // Define Image
+  MMU_TTSection (&Image$$TTB$$ZI$$Base, (uint32_t)&Image$$VECTORS$$Base     ,    1U, Sect_Normal_Cod);
+  MMU_TTSection (&Image$$TTB$$ZI$$Base, (uint32_t)&Image$$RW_DATA$$Base     ,    1U, Sect_Normal_RW);
+  MMU_TTSection (&Image$$TTB$$ZI$$Base, (uint32_t)&Image$$ZI_DATA$$Base     ,    1U, Sect_Normal_RW);
+
+  // All DRAM executable, RW, cacheable - applications may choose to divide memory into RO executable
+  MMU_TTSection (&Image$$TTB$$ZI$$Base, (uint32_t)&Image$$TTB$$ZI$$Base     , 2043U, Sect_Normal);
+
+  //--------------------- PERIPHERALS -------------------
+  MMU_TTSection (&Image$$TTB$$ZI$$Base, <DeviceAbbreviation>_FLASH_BASE0    ,   64U, Sect_Device_RO);
+  MMU_TTSection (&Image$$TTB$$ZI$$Base, <DeviceAbbreviation>_FLASH_BASE1    ,   64U, Sect_Device_RO);
+  MMU_TTSection (&Image$$TTB$$ZI$$Base, <DeviceAbbreviation>_SRAM_BASE      ,   64U, Sect_Device_RW);
+  MMU_TTSection (&Image$$TTB$$ZI$$Base, <DeviceAbbreviation>_VRAM_BASE      ,   32U, Sect_Device_RW);
+  MMU_TTSection (&Image$$TTB$$ZI$$Base, <DeviceAbbreviation>_ETHERNET_BASE  ,   16U, Sect_Device_RW);
+  MMU_TTSection (&Image$$TTB$$ZI$$Base, <DeviceAbbreviation>_USB_BASE       ,   16U, Sect_Device_RW);
+                                                                                
+  // Create (16 * 64k)=1MB faulting entries to cover peripheral range           
+  MMU_TTPage64k(&Image$$TTB$$ZI$$Base, PERIPHERAL_A_FAULT                   ,   16U, Page_L1_64k, (uint32_t *)PERIPHERAL_A_TABLE_L2_BASE_64k, DESCRIPTOR_FAULT);
+  // Define peripheral range                                                    
+  MMU_TTPage64k(&Image$$TTB$$ZI$$Base, <DeviceAbbreviation>_DAP_BASE        ,    1U, Page_L1_64k, (uint32_t *)PERIPHERAL_A_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+  MMU_TTPage64k(&Image$$TTB$$ZI$$Base, <DeviceAbbreviation>_SYSTEM_REG_BASE ,    1U, Page_L1_64k, (uint32_t *)PERIPHERAL_A_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+  MMU_TTPage64k(&Image$$TTB$$ZI$$Base, <DeviceAbbreviation>_SERIAL_BASE     ,    1U, Page_L1_64k, (uint32_t *)PERIPHERAL_A_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+  MMU_TTPage64k(&Image$$TTB$$ZI$$Base, <DeviceAbbreviation>_AACI_BASE       ,    1U, Page_L1_64k, (uint32_t *)PERIPHERAL_A_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+  MMU_TTPage64k(&Image$$TTB$$ZI$$Base, <DeviceAbbreviation>_MMCI_BASE       ,    1U, Page_L1_64k, (uint32_t *)PERIPHERAL_A_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+  MMU_TTPage64k(&Image$$TTB$$ZI$$Base, <DeviceAbbreviation>_KMI0_BASE       ,    2U, Page_L1_64k, (uint32_t *)PERIPHERAL_A_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+  MMU_TTPage64k(&Image$$TTB$$ZI$$Base, <DeviceAbbreviation>_UART_BASE       ,    4U, Page_L1_64k, (uint32_t *)PERIPHERAL_A_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+  MMU_TTPage64k(&Image$$TTB$$ZI$$Base, <DeviceAbbreviation>_WDT_BASE        ,    1U, Page_L1_64k, (uint32_t *)PERIPHERAL_A_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+                                                                                
+  // Create (16 * 64k)=1MB faulting entries to cover peripheral range           
+  MMU_TTPage64k(&Image$$TTB$$ZI$$Base, PERIPHERAL_B_FAULT                   ,   16U, Page_L1_64k, (uint32_t *)PERIPHERAL_B_TABLE_L2_BASE_64k, DESCRIPTOR_FAULT);
+  // Define peripheral range                                                    
+  MMU_TTPage64k(&Image$$TTB$$ZI$$Base, <DeviceAbbreviation>_TIMER_BASE      ,    2U, Page_L1_64k, (uint32_t *)PERIPHERAL_B_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+  MMU_TTPage64k(&Image$$TTB$$ZI$$Base, <DeviceAbbreviation>_DVI_BASE        ,    1U, Page_L1_64k, (uint32_t *)PERIPHERAL_B_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+  MMU_TTPage64k(&Image$$TTB$$ZI$$Base, <DeviceAbbreviation>_RTC_BASE        ,    1U, Page_L1_64k, (uint32_t *)PERIPHERAL_B_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+  MMU_TTPage64k(&Image$$TTB$$ZI$$Base, <DeviceAbbreviation>_UART4_BASE      ,    1U, Page_L1_64k, (uint32_t *)PERIPHERAL_B_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+  MMU_TTPage64k(&Image$$TTB$$ZI$$Base, <DeviceAbbreviation>_CLCD_BASE       ,    1U, Page_L1_64k, (uint32_t *)PERIPHERAL_B_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+
+  // Create (256 * 4k)=1MB faulting entries to cover private address space. Needs to be marked as Device memory
+  MMU_TTPage4k (&Image$$TTB$$ZI$$Base, __get_CBAR()                         ,  256U,  Page_L1_4k, (uint32_t *)PRIVATE_TABLE_L2_BASE_4k, DESCRIPTOR_FAULT);
+  // Define private address space entry
+  MMU_TTPage4k (&Image$$TTB$$ZI$$Base, __get_CBAR()                         ,    2U,  Page_L1_4k, (uint32_t *)PRIVATE_TABLE_L2_BASE_4k, Page_4k_Device_RW);
+  // Define L2CC entry
+  MMU_TTPage4k (&Image$$TTB$$ZI$$Base, <DeviceAbbreviation>_L2C_BASE        ,    1U,  Page_L1_4k, (uint32_t *)PRIVATE_TABLE_L2_BASE_4k, Page_4k_Device_RW);
+
+  // Create (256 * 4k)=1MB faulting entries to synchronization space (Useful if some non-cacheable DMA agent is present in the SoC)
+  MMU_TTPage4k (&Image$$TTB$$ZI$$Base, F_SYNC_BASE                          ,  256U, Page_L1_4k, (uint32_t *)SYNC_FLAGS_TABLE_L2_BASE_4k, DESCRIPTOR_FAULT);
+  // Define synchronization space entry.                       
+  MMU_TTPage4k (&Image$$TTB$$ZI$$Base, FLAG_SYNC                            ,    1U, Page_L1_4k, (uint32_t *)SYNC_FLAGS_TABLE_L2_BASE_4k, Page_4k_Device_RW);
+
+  /* Set location of level 1 page table
+  ; 31:14 - Translation table base addr (31:14-TTBCR.N, TTBCR.N is 0 out of reset)
+  ; 13:7  - 0x0
+  ; 6     - IRGN[0] 0x1  (Inner WB WA)
+  ; 5     - NOS     0x0  (Non-shared)
+  ; 4:3   - RGN     0x01 (Outer WB WA)
+  ; 2     - IMP     0x0  (Implementation Defined)
+  ; 1     - S       0x0  (Non-shared)
+  ; 0     - IRGN[1] 0x0  (Inner WB WA) */
+  __set_TTBR0(((uint32_t)&Image$$TTB$$ZI$$Base) | 0x48);
+  __ISB();
+
+  /* Set up domain access control register
+  ; We set domain 0 to Client and all other domains to No Access.
+  ; All translation table entries specify domain 0 */
+  __set_DACR(1);
+  __ISB();
+}

--- a/platform/ext/cmsis/CMSIS/Core/Template/Device_A/Source/startup_Device.c
+++ b/platform/ext/cmsis/CMSIS/Core/Template/Device_A/Source/startup_Device.c
@@ -1,0 +1,145 @@
+/******************************************************************************
+ * @file     startup_<Device>.c
+ * @brief    CMSIS Cortex-A Device Startup
+ * @version  V1.00
+ * @date     10. January 2018
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2018 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "<Device>.h" /* ToDo: replace '<Device>' with your device name */
+
+/*----------------------------------------------------------------------------
+  Definitions
+ *----------------------------------------------------------------------------*/
+#define USR_MODE 0x10            // User mode
+#define FIQ_MODE 0x11            // Fast Interrupt Request mode
+#define IRQ_MODE 0x12            // Interrupt Request mode
+#define SVC_MODE 0x13            // Supervisor mode
+#define ABT_MODE 0x17            // Abort mode
+#define UND_MODE 0x1B            // Undefined Instruction mode
+#define SYS_MODE 0x1F            // System mode
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+void Vectors       (void) __attribute__ ((section("RESET")));
+void Reset_Handler (void);
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+void Undef_Handler (void) __attribute__ ((weak, alias("Default_Handler")));
+void SVC_Handler   (void) __attribute__ ((weak, alias("Default_Handler")));
+void PAbt_Handler  (void) __attribute__ ((weak, alias("Default_Handler")));
+void DAbt_Handler  (void) __attribute__ ((weak, alias("Default_Handler")));
+void IRQ_Handler   (void) __attribute__ ((weak, alias("Default_Handler")));
+void FIQ_Handler   (void) __attribute__ ((weak, alias("Default_Handler")));
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector Table
+ *----------------------------------------------------------------------------*/
+__ASM void Vectors(void) {
+  IMPORT Undef_Handler
+  IMPORT SVC_Handler
+  IMPORT PAbt_Handler
+  IMPORT DAbt_Handler
+  IMPORT IRQ_Handler
+  IMPORT FIQ_Handler
+  LDR    PC, =Reset_Handler
+  LDR    PC, =Undef_Handler
+  LDR    PC, =SVC_Handler
+  LDR    PC, =PAbt_Handler
+  LDR    PC, =DAbt_Handler
+  NOP
+  LDR    PC, =IRQ_Handler
+  LDR    PC, =FIQ_Handler
+}
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+__ASM void Reset_Handler(void) {
+
+  // Mask interrupts
+  CPSID   if                           
+
+  // Put any cores other than 0 to sleep
+  MRC     p15, 0, R0, c0, c0, 5       // Read MPIDR
+  ANDS    R0, R0, #3
+goToSleep
+  WFINE
+  BNE     goToSleep
+
+  // Reset SCTLR Settings
+  MRC     p15, 0, R0, c1, c0, 0       // Read CP15 System Control register
+  BIC     R0, R0, #(0x1 << 12)        // Clear I bit 12 to disable I Cache
+  BIC     R0, R0, #(0x1 <<  2)        // Clear C bit  2 to disable D Cache
+  BIC     R0, R0, #0x1                // Clear M bit  0 to disable MMU
+  BIC     R0, R0, #(0x1 << 11)        // Clear Z bit 11 to disable branch prediction
+  BIC     R0, R0, #(0x1 << 13)        // Clear V bit 13 to disable hivecs
+  MCR     p15, 0, R0, c1, c0, 0       // Write value back to CP15 System Control register
+  ISB
+
+  // Configure ACTLR
+  MRC     p15, 0, r0, c1, c0, 1       // Read CP15 Auxiliary Control Register
+  ORR     r0, r0, #(1 <<  1)          // Enable L2 prefetch hint (UNK/WI since r4p1)
+  MCR     p15, 0, r0, c1, c0, 1       // Write CP15 Auxiliary Control Register
+
+  // Set Vector Base Address Register (VBAR) to point to this application's vector table
+  LDR    R0, =Vectors
+  MCR    p15, 0, R0, c12, c0, 0
+
+  // Setup Stack for each exceptional mode
+  IMPORT |Image$$FIQ_STACK$$ZI$$Limit|
+  IMPORT |Image$$IRQ_STACK$$ZI$$Limit|
+  IMPORT |Image$$SVC_STACK$$ZI$$Limit|
+  IMPORT |Image$$ABT_STACK$$ZI$$Limit|
+  IMPORT |Image$$UND_STACK$$ZI$$Limit|
+  IMPORT |Image$$ARM_LIB_STACK$$ZI$$Limit|
+  CPS    #0x11
+  LDR    SP, =|Image$$FIQ_STACK$$ZI$$Limit|
+  CPS    #0x12
+  LDR    SP, =|Image$$IRQ_STACK$$ZI$$Limit|
+  CPS    #0x13
+  LDR    SP, =|Image$$SVC_STACK$$ZI$$Limit|
+  CPS    #0x17
+  LDR    SP, =|Image$$ABT_STACK$$ZI$$Limit|
+  CPS    #0x1B
+  LDR    SP, =|Image$$UND_STACK$$ZI$$Limit|
+  CPS    #0x1F
+  LDR    SP, =|Image$$ARM_LIB_STACK$$ZI$$Limit|
+
+  // Call SystemInit
+  IMPORT SystemInit
+  BL     SystemInit
+
+  // Unmask interrupts
+  CPSIE  if
+
+  // Call __main
+  IMPORT __main
+  BL     __main
+}
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+void Default_Handler(void) {
+  while(1);
+}

--- a/platform/ext/cmsis/CMSIS/Core/Template/Device_A/Source/system_Device.c
+++ b/platform/ext/cmsis/CMSIS/Core/Template/Device_A/Source/system_Device.c
@@ -1,0 +1,111 @@
+/******************************************************************************
+ * @file     system_<Device>.c
+ * @brief    CMSIS Cortex-A Device Peripheral Access Layer 
+ * @version  V1.00
+ * @date     10. January 2018
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2018 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdint.h>
+#include "<Device>.h" /* ToDo: replace '<Device>' with your device name */
+#include "irq_ctrl.h"
+
+/*----------------------------------------------------------------------------
+  Define clocks
+ *----------------------------------------------------------------------------*/
+/* ToDo: add here your necessary defines for device initialization
+         following is an example for different system frequencies */
+#define XTAL            (12000000U)       /* Oscillator frequency             */
+
+#define SYSTEM_CLOCK    (5 * XTAL)
+
+
+/*----------------------------------------------------------------------------
+  System Core Clock Variable
+ *----------------------------------------------------------------------------*/
+/* ToDo: initialize SystemCoreClock with the system core clock frequency value
+         achieved after system intitialization.
+         This means system core clock frequency after call to SystemInit() */
+uint32_t SystemCoreClock = SYSTEM_CLOCK;  /* System Clock Frequency (Core Clock)*/
+
+
+
+/*----------------------------------------------------------------------------
+  Clock functions
+ *----------------------------------------------------------------------------*/
+
+void SystemCoreClockUpdate (void)            /* Get Core Clock Frequency      */
+{
+/* ToDo: add code to calculate the system frequency based upon the current
+         register settings.
+         This function can be used to retrieve the system core clock frequeny
+         after user changed register sittings. */
+  SystemCoreClock = SYSTEM_CLOCK;
+}
+
+
+/*----------------------------------------------------------------------------
+  System Initialization
+ *----------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+/* ToDo: add code to initialize the system
+   Do not use global variables because this function is called before
+   reaching pre-main. RW section may be overwritten afterwards.          */
+  SystemCoreClock = SYSTEM_CLOCK;
+
+  // Invalidate entire Unified TLB
+  __set_TLBIALL(0);
+
+  // Invalidate entire branch predictor array
+  __set_BPIALL(0);
+  __DSB();
+  __ISB();
+
+  //  Invalidate instruction cache and flush branch target cache
+  __set_ICIALLU(0);
+  __DSB();
+  __ISB();
+
+  //  Invalidate data cache
+  L1C_InvalidateDCacheAll();
+  
+  // Create Translation Table
+  MMU_CreateTranslationTable();
+
+  // Enable MMU
+  MMU_Enable();
+
+  // Enable Caches
+  L1C_EnableCaches();
+  L1C_EnableBTAC();
+
+#if (__L2C_PRESENT == 1) 
+  // Enable GIC
+  L2C_Enable();
+#endif
+
+#if ((__FPU_PRESENT == 1) && (__FPU_USED == 1))
+  // Enable FPU
+  __FPU_Enable();
+#endif
+
+  // IRQ Initialize
+  IRQ_Initialize();
+}

--- a/platform/ext/cmsis/CMSIS/Core/Template/Device_M/Config/Device_ac6.sct
+++ b/platform/ext/cmsis/CMSIS/Core/Template/Device_M/Config/Device_ac6.sct
@@ -1,0 +1,119 @@
+#! armclang -E --target=arm-arm-none-eabi -mcpu=<CPU> -xc
+; command above MUST be in first line (no comment above!)
+
+;Note: Add '-mcmse' to first line if your software model is "Secure Mode".
+;      #! armclang -E --target=arm-arm-none-eabi -mcpu=<CPU> -xc -mcmse
+
+
+/*
+;-------- <<< Use Configuration Wizard in Context Menu >>> -------------------
+*/
+
+/*--------------------- Flash Configuration ----------------------------------
+; <h> Flash Configuration
+;   <o0> Flash Base Address <0x0-0xFFFFFFFF:8>
+;   <o1> Flash Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __ROM_BASE      0x00000000
+#define __ROM_SIZE      0x00080000
+
+/*--------------------- Embedded RAM Configuration ---------------------------
+; <h> RAM Configuration
+;   <o0> RAM Base Address    <0x0-0xFFFFFFFF:8>
+;   <o1> RAM Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __RAM_BASE      0x20000000
+#define __RAM_SIZE      0x00040000
+
+/*--------------------- Stack / Heap Configuration ---------------------------
+; <h> Stack / Heap Configuration
+;   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+;   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __STACK_SIZE    0x00000200
+#define __HEAP_SIZE     0x00000C00
+
+/*--------------------- CMSE Veneer Configuration ---------------------------
+; <h> CMSE Veneer Configuration
+;   <o0>  CMSE Veneer Size (in Bytes) <0x0-0xFFFFFFFF:32>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __CMSEVENEER_SIZE    0x200
+
+/*
+;------------- <<< end of configuration section >>> ---------------------------
+*/
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+
+/*----------------------------------------------------------------------------
+  User Stack & Heap boundary definition
+ *----------------------------------------------------------------------------*/
+#define __STACK_TOP    (__RAM_BASE + __RAM_SIZE - __STACKSEAL_SIZE) /* starts at end of RAM - 8 byte stack seal */
+#define __HEAP_BASE    (AlignExpr(+0, 8))                           /* starts after RW_RAM section, 8 byte aligned */
+
+
+/*----------------------------------------------------------------------------
+  Region base & size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __CV_BASE          ( __ROM_BASE + __ROM_SIZE - __CMSEVENEER_SIZE )
+#define __CV_SIZE          ( __CMSEVENEER_SIZE )
+#else
+#define __CV_SIZE          ( 0 )
+#endif
+
+#define __RO_BASE          ( __ROM_BASE )
+#define __RO_SIZE          ( __ROM_SIZE - __CV_SIZE )
+
+#define __RW_BASE          ( __RAM_BASE )
+#define __RW_SIZE          ( __RAM_SIZE - __STACK_SIZE - __HEAP_SIZE )
+
+
+/*----------------------------------------------------------------------------
+  Scatter Region definition
+ *----------------------------------------------------------------------------*/
+LR_ROM __RO_BASE __RO_SIZE  {                       ; load region size_region
+  ER_ROM __RO_BASE __RO_SIZE  {                     ; load address = execution address
+   *.o (RESET, +First)
+   *(InRoot$$Sections)
+   .ANY (+RO)
+   .ANY (+XO)
+  }
+
+  RW_RAM __RW_BASE __RW_SIZE  {                     ; RW data
+   .ANY (+RW +ZI)
+  }
+
+#if __HEAP_SIZE > 0
+  ARM_LIB_HEAP  __HEAP_BASE EMPTY  __HEAP_SIZE  {   ; Reserve empty region for heap
+  }
+#endif
+
+  ARM_LIB_STACK __STACK_TOP EMPTY -__STACK_SIZE {   ; Reserve empty region for stack
+  }
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  STACKSEAL +0 EMPTY __STACKSEAL_SIZE {             ; Reserve empty region for stack seal immediately after stack
+  }
+#endif
+}
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+LR_CMSE_VENEER __CV_BASE ALIGN 32 __CV_SIZE  {      ; own load/execution region for CMSE Veneers
+  ER_CMSE_VENEER __CV_BASE __CV_SIZE  {
+   *(Veneer$$CMSE)
+  }
+}
+#endif

--- a/platform/ext/cmsis/CMSIS/Core/Template/Device_M/Config/Device_gcc.ld
+++ b/platform/ext/cmsis/CMSIS/Core/Template/Device_M/Config/Device_gcc.ld
@@ -1,0 +1,319 @@
+/******************************************************************************
+ * @file     Device_gcc.ld
+ * @brief    GNU Linker Script for Cortex-M based device
+ * @version  V2.3.0
+ * @date     23. June 2023
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ *-------- <<< Use Configuration Wizard in Context Menu >>> -------------------
+ */
+
+/*---------------------- Flash Configuration ----------------------------------
+  <h> Flash Configuration
+    <o0> Flash Base Address <0x0-0xFFFFFFFF:8>
+    <o1> Flash Size (in Bytes) <0x0-0xFFFFFFFF:8>
+  </h>
+  -----------------------------------------------------------------------------*/
+__ROM_BASE = 0x00000000;
+__ROM_SIZE = 0x00040000;
+
+/*--------------------- Embedded RAM Configuration ----------------------------
+  <h> RAM Configuration
+    <o0> RAM Base Address    <0x0-0xFFFFFFFF:8>
+    <o1> RAM Size (in Bytes) <0x0-0xFFFFFFFF:8>
+  </h>
+ -----------------------------------------------------------------------------*/
+__RAM_BASE = 0x20000000;
+__RAM_SIZE = 0x00020000;
+
+/*--------------------- Stack / Heap Configuration ----------------------------
+  <h> Stack / Heap Configuration
+    <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+    <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+  </h>
+  -----------------------------------------------------------------------------*/
+__STACK_SIZE = 0x00000400;
+__HEAP_SIZE  = 0x00000C00;
+
+/*
+ *-------------------- <<< end of configuration section >>> -------------------
+ */
+
+/* ARMv8-M stack sealing:
+   to use ARMv8-M stack sealing set __STACKSEAL_SIZE to 8 otherwise keep 0
+ */
+__STACKSEAL_SIZE = 0;
+
+
+MEMORY
+{
+  FLASH (rx)  : ORIGIN = __ROM_BASE, LENGTH = __ROM_SIZE
+  RAM   (rwx) : ORIGIN = __RAM_BASE, LENGTH = __RAM_SIZE
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __copy_table_start__
+ *   __copy_table_end__
+ *   __zero_table_start__
+ *   __zero_table_end__
+ *   __etext          (deprecated)
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ *   __StackSeal      (only if ARMv8-M stack sealing is used)
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+  .text :
+  {
+    KEEP(*(.vectors))
+    *(.text*)
+
+    KEEP(*(.init))
+    KEEP(*(.fini))
+
+    /* .ctors */
+    *crtbegin.o(.ctors)
+    *crtbegin?.o(.ctors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+    *(SORT(.ctors.*))
+    *(.ctors)
+
+    /* .dtors */
+    *crtbegin.o(.dtors)
+    *crtbegin?.o(.dtors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+    *(SORT(.dtors.*))
+    *(.dtors)
+
+    *(.rodata*)
+
+    KEEP(*(.eh_frame*))
+  } > FLASH
+
+  /*
+   * SG veneers:
+   * All SG veneers are placed in the special output section .gnu.sgstubs. Its start address
+   * must be set, either with the command line option '--section-start' or in a linker script,
+   * to indicate where to place these veneers in memory.
+   */
+/*
+  .gnu.sgstubs :
+  {
+    . = ALIGN(32);
+  } > FLASH
+*/
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > FLASH
+
+  __exidx_start = .;
+  .ARM.exidx :
+  {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+  } > FLASH
+  __exidx_end = .;
+
+  .copy.table :
+  {
+    . = ALIGN(4);
+    __copy_table_start__ = .;
+
+    LONG (LOADADDR(.data))
+    LONG (ADDR(.data))
+    LONG (SIZEOF(.data) / 4)
+
+    /* Add each additional data section here */
+/*
+    LONG (LOADADDR(.data2))
+    LONG (ADDR(.data2))
+    LONG (SIZEOF(.data2) / 4)
+*/
+    __copy_table_end__ = .;
+  } > FLASH
+
+  .zero.table :
+  {
+    . = ALIGN(4);
+    __zero_table_start__ = .;
+
+/*  .bss initialization to zero is already done during C Run-Time Startup.
+    LONG (ADDR(.bss))
+    LONG (SIZEOF(.bss) / 4)
+*/
+
+    /* Add each additional bss section here */
+/*
+    LONG (ADDR(.bss2))
+    LONG (SIZEOF(.bss2) / 4)
+*/
+    __zero_table_end__ = .;
+  } > FLASH
+
+  /*
+   * This __etext variable is kept for backward compatibility with older,
+   * ASM based startup files.
+   */
+  PROVIDE(__etext = LOADADDR(.data));
+
+  .data : ALIGN(4)
+  {
+    __data_start__ = .;
+    *(vtable)
+    *(.data)
+    *(.data.*)
+
+    . = ALIGN(4);
+    /* preinit data */
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP(*(.preinit_array))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+
+    . = ALIGN(4);
+    /* init data */
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP(*(SORT(.init_array.*)))
+    KEEP(*(.init_array))
+    PROVIDE_HIDDEN (__init_array_end = .);
+
+    . = ALIGN(4);
+    /* finit data */
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP(*(SORT(.fini_array.*)))
+    KEEP(*(.fini_array))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    /* All data end */
+    __data_end__ = .;
+
+  } > RAM AT > FLASH
+
+  /*
+   * Secondary data section, optional
+   *
+   * Remember to add each additional data section
+   * to the .copy.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .data2 : ALIGN(4)
+  {
+    . = ALIGN(4);
+    __data2_start__ = .;
+    *(.data2)
+    *(.data2.*)
+    . = ALIGN(4);
+    __data2_end__ = .;
+
+  } > RAM2 AT > FLASH
+*/
+
+  .bss :
+  {
+    . = ALIGN(4);
+    __bss_start__ = .;
+    *(.bss)
+    *(.bss.*)
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+  } > RAM AT > RAM
+
+  /*
+   * Secondary bss section, optional
+   *
+   * Remember to add each additional bss section
+   * to the .zero.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .bss2 :
+  {
+    . = ALIGN(4);
+    __bss2_start__ = .;
+    *(.bss2)
+    *(.bss2.*)
+    . = ALIGN(4);
+    __bss2_end__ = .;
+  } > RAM2 AT > RAM2
+*/
+
+  .heap (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE(end = .);
+    . = . + __HEAP_SIZE;
+    . = ALIGN(8);
+    __HeapLimit = .;
+  } > RAM
+
+  .stack (ORIGIN(RAM) + LENGTH(RAM) - __STACK_SIZE - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackLimit = .;
+    . = . + __STACK_SIZE;
+    . = ALIGN(8);
+    __StackTop = .;
+  } > RAM
+  PROVIDE(__stack = __StackTop);
+
+  /* ARMv8-M stack sealing:
+     to use ARMv8-M stack sealing uncomment '.stackseal' section
+   */
+/*
+  .stackseal (ORIGIN(RAM) + LENGTH(RAM) - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackSeal = .;
+    . = . + 8;
+    . = ALIGN(8);
+  } > RAM
+*/
+
+  /* Check if data + heap + stack exceeds RAM limit */
+  ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/platform/ext/cmsis/CMSIS/Core/Template/Device_M/Config/partition_Device.h
+++ b/platform/ext/cmsis/CMSIS/Core/Template/Device_M/Config/partition_Device.h
@@ -1,0 +1,1264 @@
+/*************************************************************************//**
+ * @file     partition_<Device>.h
+ * @brief    CMSIS-Core(M) Device Initial Setup for Secure/Non-Secure Zones for
+ *           Device <Device>
+ * @version  V1.0.0
+ * @date     20. January 2021
+ *****************************************************************************/
+/*
+ * Copyright (c) 2009-2021 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ToDo: rename this file from 'partition_Device.h' to 'partition_<Device>.c according to your device naming */
+
+#ifndef PARTITION_<Device>_H      /* ToDo: Replace '<Device>' with your device name */
+#define PARTITION_<Device>_H
+
+/*
+//-------- <<< Use Configuration Wizard in Context Menu >>> -----------------
+*/
+
+/*
+// <e>Initialize Security Attribution Unit (SAU) CTRL register
+*/
+#define SAU_INIT_CTRL          1
+
+/*
+//   <q> Enable SAU
+//   <i> Value for SAU->CTRL register bit ENABLE
+*/
+#define SAU_INIT_CTRL_ENABLE   1
+
+/*
+//   <o> When SAU is disabled
+//     <0=> All Memory is Secure
+//     <1=> All Memory is Non-Secure
+//   <i> Value for SAU->CTRL register bit ALLNS
+//   <i> When all Memory is Non-Secure (ALLNS is 1), IDAU can override memory map configuration.
+*/
+#define SAU_INIT_CTRL_ALLNS  0
+
+/*
+// </e>
+*/
+
+/*
+// <h>Initialize Security Attribution Unit (SAU) Address Regions
+// <i>SAU configuration specifies regions to be one of:
+// <i> - Secure and Non-Secure Callable
+// <i> - Non-Secure
+// <i>Note: All memory regions not configured by SAU are Secure
+*/
+#define SAU_REGIONS_MAX   8                 /* Max. number of SAU regions */
+
+/*
+//   <e>Initialize SAU Region 0
+//   <i> Setup SAU Region 0 memory attributes
+*/
+#define SAU_INIT_REGION0    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START0     0x00000000      /* start address of SAU region 0 */
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END0       0x001FFFFF      /* end address of SAU region 0 */
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC0       1
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 1
+//   <i> Setup SAU Region 1 memory attributes
+*/
+#define SAU_INIT_REGION1    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START1     0x00200000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END1       0x003FFFFF
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC1       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 2
+//   <i> Setup SAU Region 2 memory attributes
+*/
+#define SAU_INIT_REGION2    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START2     0x20200000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END2       0x203FFFFF
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC2       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 3
+//   <i> Setup SAU Region 3 memory attributes
+*/
+#define SAU_INIT_REGION3    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START3     0x40000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END3       0x40040000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC3       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 4
+//   <i> Setup SAU Region 4 memory attributes
+*/
+#define SAU_INIT_REGION4    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START4     0x00000000      /* start address of SAU region 4 */
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END4       0x00000000      /* end address of SAU region 4 */
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC4       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 5
+//   <i> Setup SAU Region 5 memory attributes
+*/
+#define SAU_INIT_REGION5    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START5     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END5       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC5       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 6
+//   <i> Setup SAU Region 6 memory attributes
+*/
+#define SAU_INIT_REGION6    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START6     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END6       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC6       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 7
+//   <i> Setup SAU Region 7 memory attributes
+*/
+#define SAU_INIT_REGION7    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START7     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END7       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC7       0
+/*
+//   </e>
+*/
+
+/*
+// </h>
+*/
+
+/*
+// <e>Setup behaviour of Sleep and Exception Handling
+*/
+#define SCB_CSR_AIRCR_INIT  1
+
+/*
+//   <o> Deep Sleep can be enabled by
+//     <0=>Secure and Non-Secure state
+//     <1=>Secure state only
+//   <i> Value for SCB->CSR register bit DEEPSLEEPS
+*/
+#define SCB_CSR_DEEPSLEEPS_VAL  1
+
+/*
+//   <o>System reset request accessible from
+//     <0=> Secure and Non-Secure state
+//     <1=> Secure state only
+//   <i> Value for SCB->AIRCR register bit SYSRESETREQS
+*/
+#define SCB_AIRCR_SYSRESETREQS_VAL  1
+
+/*
+//   <o>Priority of Non-Secure exceptions is
+//     <0=> Not altered
+//     <1=> Lowered to 0x80-0xFF
+//   <i> Value for SCB->AIRCR register bit PRIS
+*/
+#define SCB_AIRCR_PRIS_VAL      1
+
+/*
+//   <o>BusFault, HardFault, and NMI target
+//     <0=> Secure state
+//     <1=> Non-Secure state
+//   <i> Value for SCB->AIRCR register bit BFHFNMINS
+*/
+#define SCB_AIRCR_BFHFNMINS_VAL 0
+
+/*
+// </e>
+*/
+
+/*
+// <e>Setup behaviour of Floating Point and Vector Unit (FPU/MVE)
+*/
+#define TZ_FPU_NS_USAGE 1
+
+/*
+// <o>Floating Point and Vector Unit usage
+//     <0=> Secure state only
+//     <3=> Secure and Non-Secure state
+//   <i> Value for SCB->NSACR register bits CP10, CP11
+*/
+#define SCB_NSACR_CP10_11_VAL       3
+
+/*
+// <o>Treat floating-point registers as Secure
+//     <0=> Disabled
+//     <1=> Enabled
+//   <i> Value for FPU->FPCCR register bit TS
+*/
+#define FPU_FPCCR_TS_VAL            0
+
+/*
+// <o>Clear on return (CLRONRET) accessibility
+//     <0=> Secure and Non-Secure state
+//     <1=> Secure state only
+//   <i> Value for FPU->FPCCR register bit CLRONRETS
+*/
+#define FPU_FPCCR_CLRONRETS_VAL     0
+
+/*
+// <o>Clear floating-point caller saved registers on exception return
+//     <0=> Disabled
+//     <1=> Enabled
+//   <i> Value for FPU->FPCCR register bit CLRONRET
+*/
+#define FPU_FPCCR_CLRONRET_VAL      1
+
+/*
+// </e>
+*/
+
+/*
+// <h>Setup Interrupt Target
+*/
+
+/*
+//   <e>Initialize ITNS 0 (Interrupts 0..31)
+*/
+#define NVIC_INIT_ITNS0    1
+
+/*
+// Interrupts 0..31
+//   <o.0>  Interrupt 0   <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 1   <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 2   <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 3   <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 4   <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 5   <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 6   <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 7   <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 8   <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 9   <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 10  <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 11  <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 12  <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 13  <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 14  <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 15  <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 16  <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 17  <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 18  <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 19  <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 20  <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 21  <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 22  <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 23  <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 24  <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 25  <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 26  <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 27  <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 28  <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 29  <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 30  <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 31  <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS0_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 1 (Interrupts 32..63)
+*/
+#define NVIC_INIT_ITNS1    1
+
+/*
+// Interrupts 32..63
+//   <o.0>  Interrupt 32  <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 33  <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 34  <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 35  <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 36  <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 37  <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 38  <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 39  <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 40  <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 41  <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 42  <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 43  <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 44  <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 45  <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 46  <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 47  <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 48  <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 49  <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 50  <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 51  <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 52  <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 53  <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 54  <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 55  <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 56  <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 57  <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 58  <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 59  <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 60  <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 61  <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 62  <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 63  <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS1_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 2 (Interrupts 64..95)
+*/
+#define NVIC_INIT_ITNS2    0
+
+/*
+// Interrupts 64..95
+//   <o.0>  Interrupt 64  <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 65  <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 66  <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 67  <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 68  <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 69  <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 70  <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 71  <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 72  <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 73  <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 74  <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 75  <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 76  <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 77  <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 78  <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 79  <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 80  <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 81  <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 82  <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 83  <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 84  <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 85  <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 86  <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 87  <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 88  <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 89  <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 90  <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 91  <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 92  <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 93  <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 94  <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 95  <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS2_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 3 (Interrupts 96..127)
+*/
+#define NVIC_INIT_ITNS3    0
+
+/*
+// Interrupts 96..127
+//   <o.0>  Interrupt 96  <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 97  <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 98  <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 99  <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 100 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 101 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 102 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 103 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 104 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 105 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 106 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 107 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 108 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 109 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 110 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 111 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 112 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 113 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 114 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 115 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 116 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 117 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 118 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 119 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 120 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 121 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 122 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 123 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 124 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 125 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 126 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 127 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS3_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 4 (Interrupts 128..159)
+*/
+#define NVIC_INIT_ITNS4    0
+
+/*
+// Interrupts 128..159
+//   <o.0>  Interrupt 128 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 129 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 130 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 131 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 132 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 133 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 134 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 135 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 136 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 137 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 138 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 139 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 140 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 141 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 142 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 143 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 144 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 145 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 146 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 147 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 148 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 149 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 150 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 151 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 152 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 153 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 154 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 155 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 156 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 157 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 158 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 159 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS4_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 5 (Interrupts 160..191)
+*/
+#define NVIC_INIT_ITNS5    0
+
+/*
+// Interrupts 160..191
+//   <o.0>  Interrupt 160 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 161 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 162 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 163 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 164 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 165 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 166 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 167 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 168 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 169 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 170 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 171 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 172 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 173 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 174 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 175 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 176 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 177 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 178 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 179 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 180 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 181 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 182 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 183 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 184 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 185 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 186 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 187 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 188 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 189 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 190 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 191 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS5_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 6 (Interrupts 192..223)
+*/
+#define NVIC_INIT_ITNS6    0
+
+/*
+// Interrupts 192..223
+//   <o.0>  Interrupt 192 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 193 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 194 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 195 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 196 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 197 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 198 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 199 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 200 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 201 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 202 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 203 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 204 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 205 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 206 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 207 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 208 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 209 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 210 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 211 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 212 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 213 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 214 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 215 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 216 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 217 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 218 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 219 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 220 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 221 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 222 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 223 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS6_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 7 (Interrupts 224..255)
+*/
+#define NVIC_INIT_ITNS7    0
+
+/*
+// Interrupts 224..255
+//   <o.0>  Interrupt 224 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 225 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 226 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 227 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 228 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 229 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 230 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 231 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 232 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 233 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 234 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 235 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 236 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 237 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 238 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 239 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 240 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 241 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 242 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 243 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 244 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 245 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 246 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 247 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 248 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 249 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 250 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 251 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 252 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 253 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 254 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 255 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS7_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 8 (Interrupts 256..287)
+*/
+#define NVIC_INIT_ITNS8    0
+
+/*
+// Interrupts 256..287
+//   <o.0>  Interrupt 256 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 257 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 258 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 259 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 260 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 261 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 262 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 263 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 264 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 265 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 266 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 267 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 268 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 269 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 270 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 271 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 272 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 273 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 274 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 275 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 276 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 277 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 278 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 279 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 280 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 281 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 282 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 283 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 284 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 285 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 286 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 287 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS8_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 9 (Interrupts 288..319)
+*/
+#define NVIC_INIT_ITNS9    0
+
+/*
+// Interrupts 288..319
+//   <o.0>  Interrupt 288 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 289 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 290 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 291 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 292 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 293 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 294 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 295 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 296 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 297 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 298 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 299 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 300 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 301 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 302 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 303 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 304 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 305 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 306 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 307 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 308 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 309 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 310 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 311 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 312 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 313 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 314 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 315 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 316 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 317 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 318 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 319 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS9_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 10 (Interrupts 320..351)
+*/
+#define NVIC_INIT_ITNS10   0
+
+/*
+// Interrupts 320..351
+//   <o.0>  Interrupt 320 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 321 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 322 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 323 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 324 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 325 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 326 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 327 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 328 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 329 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 330 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 331 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 332 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 333 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 334 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 335 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 336 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 337 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 338 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 339 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 340 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 341 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 342 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 343 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 344 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 345 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 346 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 347 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 348 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 349 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 350 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 351 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS10_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 11 (Interrupts 352..383)
+*/
+#define NVIC_INIT_ITNS11   0
+
+/*
+// Interrupts 352..383
+//   <o.0>  Interrupt 352 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 353 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 354 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 355 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 356 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 357 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 358 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 359 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 360 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 361 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 362 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 363 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 364 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 365 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 366 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 367 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 368 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 369 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 370 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 371 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 372 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 373 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 374 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 375 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 376 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 377 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 378 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 379 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 380 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 381 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 382 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 383 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS11_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 12 (Interrupts 384..415)
+*/
+#define NVIC_INIT_ITNS12   0
+
+/*
+// Interrupts 384..415
+//   <o.0>  Interrupt 384 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 385 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 386 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 387 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 388 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 389 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 390 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 391 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 392 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 393 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 394 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 395 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 396 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 397 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 398 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 399 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 400 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 401 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 402 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 403 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 404 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 405 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 406 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 407 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 408 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 409 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 410 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 411 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 412 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 413 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 414 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 415 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS12_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 13 (Interrupts 416..447)
+*/
+#define NVIC_INIT_ITNS13   0
+
+/*
+// Interrupts 416..447
+//   <o.0>  Interrupt 416 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 417 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 418 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 419 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 420 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 421 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 422 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 423 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 424 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 425 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 426 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 427 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 428 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 429 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 430 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 431 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 432 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 433 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 434 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 435 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 436 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 437 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 438 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 439 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 440 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 441 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 442 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 443 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 444 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 445 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 446 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 447 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS13_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 14 (Interrupts 448..479)
+*/
+#define NVIC_INIT_ITNS14   0
+
+/*
+// Interrupts 448..479
+//   <o.0>  Interrupt 448 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 449 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 450 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 451 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 452 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 453 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 454 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 455 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 456 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 457 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 458 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 459 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 460 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 461 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 462 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 463 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 464 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 465 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 466 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 467 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 468 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 469 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 470 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 471 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 472 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 473 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 474 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 475 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 476 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 477 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 478 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 479 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS14_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 15 (Interrupts 480..511)
+*/
+#define NVIC_INIT_ITNS15   0
+
+/*
+// Interrupts 480..511
+//   <o.0>  Interrupt 480 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 481 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 482 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 483 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 484 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 485 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 486 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 487 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 488 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 489 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 490 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 491 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 492 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 493 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 494 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 495 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 496 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 497 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 498 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 499 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 500 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 501 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 502 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 503 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 504 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 505 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 506 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 507 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 508 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 509 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 510 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 511 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS15_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+// </h>
+*/
+
+
+
+/*
+    max 128 SAU regions.
+    SAU regions are defined in partition.h
+ */
+
+#define SAU_INIT_REGION(n) \
+    SAU->RNR  =  (n                                     & SAU_RNR_REGION_Msk); \
+    SAU->RBAR =  (SAU_INIT_START##n                     & SAU_RBAR_BADDR_Msk); \
+    SAU->RLAR =  (SAU_INIT_END##n                       & SAU_RLAR_LADDR_Msk) | \
+                ((SAU_INIT_NSC##n << SAU_RLAR_NSC_Pos)  & SAU_RLAR_NSC_Msk)   | 1U
+
+/**
+  \brief   Setup a SAU Region
+  \details Writes the region information contained in SAU_Region to the
+           registers SAU_RNR, SAU_RBAR, and SAU_RLAR
+ */
+__STATIC_INLINE void TZ_SAU_Setup (void)
+{
+
+#if defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U)
+
+  #if defined (SAU_INIT_REGION0) && (SAU_INIT_REGION0 == 1U)
+    SAU_INIT_REGION(0);
+  #endif
+
+  #if defined (SAU_INIT_REGION1) && (SAU_INIT_REGION1 == 1U)
+    SAU_INIT_REGION(1);
+  #endif
+
+  #if defined (SAU_INIT_REGION2) && (SAU_INIT_REGION2 == 1U)
+    SAU_INIT_REGION(2);
+  #endif
+
+  #if defined (SAU_INIT_REGION3) && (SAU_INIT_REGION3 == 1U)
+    SAU_INIT_REGION(3);
+  #endif
+
+  #if defined (SAU_INIT_REGION4) && (SAU_INIT_REGION4 == 1U)
+    SAU_INIT_REGION(4);
+  #endif
+
+  #if defined (SAU_INIT_REGION5) && (SAU_INIT_REGION5 == 1U)
+    SAU_INIT_REGION(5);
+  #endif
+
+  #if defined (SAU_INIT_REGION6) && (SAU_INIT_REGION6 == 1U)
+    SAU_INIT_REGION(6);
+  #endif
+
+  #if defined (SAU_INIT_REGION7) && (SAU_INIT_REGION7 == 1U)
+    SAU_INIT_REGION(7);
+  #endif
+
+  /* repeat this for all possible SAU regions */
+
+#endif /* defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U) */
+
+
+  #if defined (SAU_INIT_CTRL) && (SAU_INIT_CTRL == 1U)
+    SAU->CTRL = ((SAU_INIT_CTRL_ENABLE << SAU_CTRL_ENABLE_Pos) & SAU_CTRL_ENABLE_Msk) |
+                ((SAU_INIT_CTRL_ALLNS  << SAU_CTRL_ALLNS_Pos)  & SAU_CTRL_ALLNS_Msk)   ;
+  #endif
+
+  #if defined (SCB_CSR_AIRCR_INIT) && (SCB_CSR_AIRCR_INIT == 1U)
+    SCB->SCR   = (SCB->SCR   & ~(SCB_SCR_SLEEPDEEPS_Msk    )) |
+                   ((SCB_CSR_DEEPSLEEPS_VAL     << SCB_SCR_SLEEPDEEPS_Pos)     & SCB_SCR_SLEEPDEEPS_Msk);
+
+    SCB->AIRCR = (SCB->AIRCR & ~(SCB_AIRCR_VECTKEY_Msk   | SCB_AIRCR_SYSRESETREQS_Msk |
+                                 SCB_AIRCR_BFHFNMINS_Msk | SCB_AIRCR_PRIS_Msk          ))                    |
+                   ((0x05FAU                    << SCB_AIRCR_VECTKEY_Pos)      & SCB_AIRCR_VECTKEY_Msk)      |
+                   ((SCB_AIRCR_SYSRESETREQS_VAL << SCB_AIRCR_SYSRESETREQS_Pos) & SCB_AIRCR_SYSRESETREQS_Msk) |
+                   ((SCB_AIRCR_PRIS_VAL         << SCB_AIRCR_PRIS_Pos)         & SCB_AIRCR_PRIS_Msk)         |
+                   ((SCB_AIRCR_BFHFNMINS_VAL    << SCB_AIRCR_BFHFNMINS_Pos)    & SCB_AIRCR_BFHFNMINS_Msk);
+  #endif /* defined (SCB_CSR_AIRCR_INIT) && (SCB_CSR_AIRCR_INIT == 1U) */
+
+  #if (((defined (__FPU_USED) && (__FPU_USED == 1U))              || \
+        (defined (__ARM_FEATURE_MVE) && (__ARM_FEATURE_MVE > 0))) && \
+       (defined (TZ_FPU_NS_USAGE) && (TZ_FPU_NS_USAGE == 1U)))
+
+    SCB->NSACR = (SCB->NSACR & ~(SCB_NSACR_CP10_Msk | SCB_NSACR_CP11_Msk)) |
+                   ((SCB_NSACR_CP10_11_VAL << SCB_NSACR_CP10_Pos) & (SCB_NSACR_CP10_Msk | SCB_NSACR_CP11_Msk));
+
+    FPU->FPCCR = (FPU->FPCCR & ~(FPU_FPCCR_TS_Msk | FPU_FPCCR_CLRONRETS_Msk | FPU_FPCCR_CLRONRET_Msk)) |
+                   ((FPU_FPCCR_TS_VAL        << FPU_FPCCR_TS_Pos       ) & FPU_FPCCR_TS_Msk       ) |
+                   ((FPU_FPCCR_CLRONRETS_VAL << FPU_FPCCR_CLRONRETS_Pos) & FPU_FPCCR_CLRONRETS_Msk) |
+                   ((FPU_FPCCR_CLRONRET_VAL  << FPU_FPCCR_CLRONRET_Pos ) & FPU_FPCCR_CLRONRET_Msk );
+  #endif
+
+  #if defined (NVIC_INIT_ITNS0) && (NVIC_INIT_ITNS0 == 1U)
+    NVIC->ITNS[0] = NVIC_INIT_ITNS0_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS1) && (NVIC_INIT_ITNS1 == 1U)
+    NVIC->ITNS[1] = NVIC_INIT_ITNS1_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS2) && (NVIC_INIT_ITNS2 == 1U)
+    NVIC->ITNS[2] = NVIC_INIT_ITNS2_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS3) && (NVIC_INIT_ITNS3 == 1U)
+    NVIC->ITNS[3] = NVIC_INIT_ITNS3_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS4) && (NVIC_INIT_ITNS4 == 1U)
+    NVIC->ITNS[4] = NVIC_INIT_ITNS4_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS5) && (NVIC_INIT_ITNS5 == 1U)
+    NVIC->ITNS[5] = NVIC_INIT_ITNS5_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS6) && (NVIC_INIT_ITNS6 == 1U)
+    NVIC->ITNS[6] = NVIC_INIT_ITNS6_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS7) && (NVIC_INIT_ITNS7 == 1U)
+    NVIC->ITNS[7] = NVIC_INIT_ITNS7_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS8) && (NVIC_INIT_ITNS8 == 1U)
+    NVIC->ITNS[8] = NVIC_INIT_ITNS8_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS9) && (NVIC_INIT_ITNS9 == 1U)
+    NVIC->ITNS[9] = NVIC_INIT_ITNS9_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS10) && (NVIC_INIT_ITNS10 == 1U)
+    NVIC->ITNS[10] = NVIC_INIT_ITNS10_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS11) && (NVIC_INIT_ITNS11 == 1U)
+    NVIC->ITNS[11] = NVIC_INIT_ITNS11_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS12) && (NVIC_INIT_ITNS12 == 1U)
+    NVIC->ITNS[12] = NVIC_INIT_ITNS12_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS13) && (NVIC_INIT_ITNS13 == 1U)
+    NVIC->ITNS[13] = NVIC_INIT_ITNS13_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS14) && (NVIC_INIT_ITNS14 == 1U)
+    NVIC->ITNS[14] = NVIC_INIT_ITNS14_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS15) && (NVIC_INIT_ITNS15 == 1U)
+    NVIC->ITNS[15] = NVIC_INIT_ITNS15_VAL;
+  #endif
+
+  /* repeat this for all possible ITNS elements */
+
+}
+
+#endif  /* PARTITION_<Device>_H */

--- a/platform/ext/cmsis/CMSIS/Core/Template/Device_M/Include/Device.h
+++ b/platform/ext/cmsis/CMSIS/Core/Template/Device_M/Include/Device.h
@@ -1,0 +1,232 @@
+/**************************************************************************//**
+ * @file     <Device>.h
+ * @brief    CMSIS-Core(M) Device Header File for Device <Device>
+ *
+ * @version  V1.0.0
+ * @date     18. July 2023
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ToDo: rename this file from Device.h to '<Device>.h according to your device name */
+
+#ifndef <Device>_H      /* ToDo: replace '<Device>' with your device name */
+#define <Device>_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* ========================================================================= */
+/* ============           Interrupt Number Definition           ============ */
+/* ========================================================================= */
+
+typedef enum IRQn
+{
+/* ================     Cortex-M Core Exception Numbers     ================ */
+
+/* ToDo: add Cortex exception numbers according the used Cortex-Core */
+  Reset_IRQn             = -15,  /*  1 Reset Vector
+                                       invoked on Power up and warm reset */
+  NonMaskableInt_IRQn    = -14,  /*  2 Non maskable Interrupt
+                                       cannot be stopped or preempted */
+  HardFault_IRQn         = -13,  /*  3 Hard Fault
+                                       all classes of Fault */
+  MemoryManagement_IRQn  = -12,  /*  4 Memory Management
+                                       MPU mismatch, including Access Violation and No Match */
+  BusFault_IRQn          = -11,  /*  5 Bus Fault
+                                       Pre-Fetch-, Memory Access, other address/memory Fault */
+  UsageFault_IRQn        = -10,  /*  6 Usage Fault
+                                       i.e. Undef Instruction, Illegal State Transition */
+  SecureFault_IRQn       =  -9,  /*  7 Secure Fault Interrupt */
+  SVCall_IRQn            =  -5,  /* 11 System Service Call via SVC instruction */
+  DebugMonitor_IRQn      =  -4,  /* 12 Debug Monitor */
+  PendSV_IRQn            =  -2,  /* 14 Pendable request for system service */
+  SysTick_IRQn           =  -1,  /* 15 System Tick Timer */
+
+/* ================        <Device> Interrupt Numbers       ================ */
+/* ToDo: Add here your device specific interrupt numbers
+         according the interrupt handlers defined in startup_Device.s
+         eg.: Interrupt for Timer#1       TIM1_IRQHandler   ->   TIM1_IRQn */
+  <DeviceInterrupt first>_IRQn = 0,    /* first Device Interrupt*/
+  ...
+  <DeviceInterrupt last>_IRQn  = n     /* last Device Interrupt */
+} IRQn_Type;
+
+
+/* ========================================================================= */
+/* ============      Processor and Core Peripheral Section      ============ */
+/* ========================================================================= */
+
+/* ================ Start of section using anonymous unions ================ */
+#if   defined (__CC_ARM)
+  #pragma push
+  #pragma anon_unions
+#elif defined (__ICCARM__)
+  #pragma language=extended
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wc11-extensions"
+  #pragma clang diagnostic ignored "-Wreserved-id-macro"
+#elif defined (__GNUC__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TMS470__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TASKING__)
+  #pragma warning 586
+#elif defined (__CSMC__)
+  /* anonymous unions are enabled by default */
+#else
+  #warning Not supported compiler type
+#endif
+
+
+/* --------  Configuration of Core Peripherals  ----------------------------------- */
+/* ToDo: set the defines according your Device */
+/* ToDo: define the correct core revision
+         valid CMSIS core revision macro names are:
+           __CM0_REV, __CM0PLUS_REV, __CM1_REV, __CM3_REV, __CM4_REV, __CM7_REV
+           __CM23_REV, __CM33_REV, __CM35P_REV, __CM55_REV
+           __SC000_REV, __SC300_REV */
+#define __CM#_REV               0x0201U  /* Core Revision r2p1 */
+/* ToDo: define the correct core features for the <Device> */
+#define __Vendor_SysTickConfig  0U       /* Set to 1 if different SysTick Config is used */
+#define __NVIC_PRIO_BITS        3U       /* Number of Bits used for Priority Levels */
+#define __VTOR_PRESENT          1U       /* Set to 1 if VTOR is present */
+#define __MPU_PRESENT           1U       /* Set to 1 if MPU is present */
+#define __FPU_PRESENT           0U       /* Set to 1 if FPU is present */
+#define __FPU_DP                0U       /* Set to 1 if FPU is double precision FPU (default is single precision FPU) */
+#define __DSP_PRESENT           1U       /* Set to 1 if DSP extension are present */
+#define __SAUREGION_PRESENT     1U       /* Set to 1 if SAU regions are present */
+#define __PMU_PRESENT           1U       /* Set to 1 if PMU is present */
+#define __PMU_NUM_EVENTCNT      8U       /* Set number of PMU Event Counters */
+#define __ICACHE_PRESENT        0U       /* Set to 1 if I-Cache is present */
+#define __DCACHE_PRESENT        0U       /* Set to 1 if D-Cache is present */
+#define __DTCM_PRESENT          0U       /* Set to 1 if DTCM is present */
+
+
+/* ToDo: include the CMSIS core header file according your device.
+         valid CMSIS core header files are:
+           core_cm0.h, core_cm0plus.h, core_cm1.h, core_cm3.h, core_cm4.h, core_cm7.h
+           core_cm23.h, core_cm33.h, core_cm35p.h, core_cm55.h
+           core_sc000.h, core_sc300.h */
+#include <core_cm#.h>                           /* Processor and core peripherals */
+/* ToDo: include your system_<Device>.h file
+         replace '<Device>' with your device name */
+#include "system_<Device>.h"                    /* System Header */
+
+
+
+/* ========================================================================= */
+/* ============       Device Specific Peripheral Section        ============ */
+/* ========================================================================= */
+
+
+/* ToDo: add here your device specific peripheral access structure typedefs
+         including bit definitions for Pos/Msk macros
+         following is an example for a timer */
+
+/* ========================================================================= */
+/* ============                       TMR                       ============ */
+/* ========================================================================= */
+
+typedef struct
+{
+  __IOM uint32_t  LOAD;                 /* Offset: 0x000 (R/W) Load Register */
+  __IM  uint32_t  VALUE;                /* Offset: 0x004 (R/ ) Value Register */
+  __IOM uint32_t  CONTROL;              /* Offset: 0x008 (R/W) Control Register */
+  __OM  uint32_t  INTCLR;               /* Offset: 0x00C ( /W) Clear Interrupt Register */
+  __IM  uint32_t  RIS;                  /* Offset: 0x010 (R/ ) Raw Interrupt Status Register */
+  __IM  uint32_t  MIS;                  /* Offset: 0x014 (R/ ) Interrupt Status Register */
+  __IOM uint32_t  BGLOAD;               /* Offset: 0x018 (R/W) Background Load Register */
+} <DeviceAbbreviation>_TMR_TypeDef;
+
+/* <DeviceAbbreviation>_TMR LOAD Register Definitions */
+#define <DeviceAbbreviation>_TMR_LOAD_Pos              0
+#define <DeviceAbbreviation>_TMR_LOAD_Msk             (0xFFFFFFFFUL /*<< <DeviceAbbreviation>_TMR_LOAD_Pos*/)
+
+/* <DeviceAbbreviation>_TMR VALUE Register Definitions */
+#define <DeviceAbbreviation>_TMR_VALUE_Pos             0
+#define <DeviceAbbreviation>_TMR_VALUE_Msk            (0xFFFFFFFFUL /*<< <DeviceAbbreviation>_TMR_VALUE_Pos*/)
+
+/* <DeviceAbbreviation>_TMR CONTROL Register Definitions */
+#define <DeviceAbbreviation>_TMR_CONTROL_SIZE_Pos      1
+#define <DeviceAbbreviation>_TMR_CONTROL_SIZE_Msk     (1UL << <DeviceAbbreviation>_TMR_CONTROL_SIZE_Pos)
+
+#define <DeviceAbbreviation>_TMR_CONTROL_ONESHOT_Pos   0
+#define <DeviceAbbreviation>_TMR_CONTROL_ONESHOT_Msk  (1UL /*<< <DeviceAbbreviation>_TMR_CONTROL_ONESHOT_Pos*/)
+
+
+
+/* --------  End of section using anonymous unions and disabling warnings  -------- */
+#if   defined (__CC_ARM)
+  #pragma pop
+#elif defined (__ICCARM__)
+  /* leave anonymous unions enabled */
+#elif (defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
+  #pragma clang diagnostic pop
+#elif defined (__GNUC__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TMS470__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TASKING__)
+  #pragma warning restore
+#elif defined (__CSMC__)
+  /* anonymous unions are enabled by default */
+#else
+  #warning Not supported compiler type
+#endif
+
+
+/* ========================================================================= */
+/* ============     Device Specific Peripheral Address Map      ============ */
+/* ========================================================================= */
+
+
+/* ToDo: add here your device peripherals base addresses
+         following is an example for timer */
+
+/* Peripheral and SRAM base address */
+#define <DeviceAbbreviation>_FLASH_BASE       (0x00000000UL)                              /* (FLASH     ) Base Address */
+#define <DeviceAbbreviation>_SRAM_BASE        (0x20000000UL)                              /* (SRAM      ) Base Address */
+#define <DeviceAbbreviation>_PERIPH_BASE      (0x40000000UL)                              /* (Peripheral) Base Address */
+
+/* Peripheral memory map */
+#define <DeviceAbbreviation>TIM0_BASE         (<DeviceAbbreviation>_PERIPH_BASE)          /* (Timer0    ) Base Address */
+#define <DeviceAbbreviation>TIM1_BASE         (<DeviceAbbreviation>_PERIPH_BASE + 0x0800) /* (Timer1    ) Base Address */
+#define <DeviceAbbreviation>TIM2_BASE         (<DeviceAbbreviation>_PERIPH_BASE + 0x1000) /* (Timer2    ) Base Address */
+
+
+/* ========================================================================= */
+/* ============             Peripheral declaration              ============ */
+/* ========================================================================= */
+
+
+/* ToDo: Add here your device peripherals pointer definitions
+         following is an example for timer */
+
+#define <DeviceAbbreviation>_TIM0        ((<DeviceAbbreviation>_TMR_TypeDef *) <DeviceAbbreviation>TIM0_BASE)
+#define <DeviceAbbreviation>_TIM1        ((<DeviceAbbreviation>_TMR_TypeDef *) <DeviceAbbreviation>TIM0_BASE)
+#define <DeviceAbbreviation>_TIM2        ((<DeviceAbbreviation>_TMR_TypeDef *) <DeviceAbbreviation>TIM0_BASE)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* <Device>_H */

--- a/platform/ext/cmsis/CMSIS/Core/Template/Device_M/Include/system_Device.h
+++ b/platform/ext/cmsis/CMSIS/Core/Template/Device_M/Include/system_Device.h
@@ -1,0 +1,66 @@
+/*************************************************************************//**
+ * @file     system_<Device>.h
+ * @brief    CMSIS-Core(M) Device Peripheral Access Layer Header File for
+ *           Device <Device>
+ * @version  V1.0.1
+ * @date     11. July 2022
+ *****************************************************************************/
+/*
+ * Copyright (c) 2009-2022 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+/* ToDo: rename this file from 'system_Device.h' to 'system_<Device>.h according to your device naming */
+
+#ifndef SYSTEM_<Device>_H   /* ToDo: replace '<Device>' with your device name */
+#define SYSTEM_<Device>_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+/**
+  \brief Exception / Interrupt Handler Function Prototype
+*/
+typedef void(*VECTOR_TABLE_Type)(void);
+
+/**
+  \brief System Clock Frequency (Core Clock)
+*/
+extern uint32_t SystemCoreClock;
+
+/**
+  \brief Setup the microcontroller system.
+
+   Initialize the System and update the SystemCoreClock variable.
+ */
+extern void SystemInit (void);
+
+
+/**
+  \brief  Update SystemCoreClock variable.
+
+   Updates the SystemCoreClock with current core Clock retrieved from cpu registers.
+ */
+extern void SystemCoreClockUpdate (void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SYSTEM_<Device>_H */

--- a/platform/ext/cmsis/CMSIS/Core/Template/Device_M/Source/startup_Device.c
+++ b/platform/ext/cmsis/CMSIS/Core/Template/Device_M/Source/startup_Device.c
@@ -1,0 +1,154 @@
+/******************************************************************************
+ * @file     startup_<Device>.c
+ * @brief    CMSIS-Core(M) Device Startup File for
+ *           Device <Device>
+ * @version  V1.0.0
+ * @date     20. January 2021
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2021 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ToDo: rename this file from 'startup_Device.c' to 'startup_<Device>.c according to your device naming */
+
+
+#include "<Device>.h"
+
+/*---------------------------------------------------------------------------
+  External References
+ *---------------------------------------------------------------------------*/
+extern uint32_t __INITIAL_SP;
+extern uint32_t __STACK_LIMIT;
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+extern uint32_t __STACK_SEAL;
+#endif
+
+extern __NO_RETURN void __PROGRAM_START(void);
+
+/*---------------------------------------------------------------------------
+  Internal References
+ *---------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler  (void);
+__NO_RETURN void Default_Handler(void);
+
+/* ToDo: Add Cortex exception handler according the used Cortex-Core */
+/*---------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *---------------------------------------------------------------------------*/
+/* Exceptions */
+void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void HardFault_Handler      (void) __attribute__ ((weak));
+void MemManage_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
+void BusFault_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void UsageFault_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void SecureFault_Handler    (void) __attribute__ ((weak, alias("Default_Handler")));
+void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void DebugMon_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+
+/* ToDo: Add your device specific interrupt handler */
+void <DeviceInterrupt first>_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+...
+void <DeviceInterrupt last>_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
+
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+/* ToDo: Add Cortex exception vectors according the used Cortex-Core */
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[<Device vector table entries>];
+       const VECTOR_TABLE_Type __VECTOR_TABLE[<Device vector table entries>] __VECTOR_TABLE_ATTRIBUTE = {
+  (VECTOR_TABLE_Type)(&__INITIAL_SP),  /*     Initial Stack Pointer */
+  Reset_Handler,                       /*     Reset Handler */
+  NMI_Handler,                         /* -14 NMI Handler */
+  HardFault_Handler,                   /* -13 Hard Fault Handler */
+  MemManage_Handler,                   /* -12 MPU Fault Handler */
+  BusFault_Handler,                    /* -11 Bus Fault Handler */
+  UsageFault_Handler,                  /* -10 Usage Fault Handler */
+  SecureFault_Handler,                 /*  -9 Secure Fault Handler */
+  0,                                   /*     Reserved */
+  0,                                   /*     Reserved */
+  0,                                   /*     Reserved */
+  SVC_Handler,                         /*  -5 SVCall Handler */
+  DebugMon_Handler,                    /*  -4 Debug Monitor Handler */
+  0,                                   /*     Reserved */
+  PendSV_Handler,                      /*  -2 PendSV Handler */
+  SysTick_Handler,                     /*  -1 SysTick Handler */
+
+/* ToDo: Add your device specific interrupt vectors */
+  /* Interrupts */
+  <DeviceInterrupt first>_Handler,     /* first Device Interrupt */
+  ...
+  <DeviceInterrupt last>_Handler       /* last Device Interrupt */
+};
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
+
+/*---------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *---------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler(void)
+{
+  __set_PSP((uint32_t)(&__INITIAL_SP));
+
+/* ToDo: Initialize stack limit register for Armv8-M Main Extension based processors*/
+  __set_MSPLIM((uint32_t)(&__STACK_LIMIT));
+  __set_PSPLIM((uint32_t)(&__STACK_LIMIT));
+
+/* ToDo: Add stack sealing for Armv8-M based processors */
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  __TZ_set_STACKSEAL_S((uint32_t *)(&__STACK_SEAL));
+#endif
+
+  SystemInit();                    /* CMSIS System Initialization */
+  __PROGRAM_START();               /* Enter PreMain (C library entry point) */
+}
+
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wmissing-noreturn"
+#endif
+
+/*---------------------------------------------------------------------------
+  Hard Fault Handler
+ *---------------------------------------------------------------------------*/
+void HardFault_Handler(void)
+{
+  while(1);
+}
+
+/*---------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *---------------------------------------------------------------------------*/
+void Default_Handler(void)
+{
+  while(1);
+}
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic pop
+#endif

--- a/platform/ext/cmsis/CMSIS/Core/Template/Device_M/Source/system_Device.c
+++ b/platform/ext/cmsis/CMSIS/Core/Template/Device_M/Source/system_Device.c
@@ -1,0 +1,102 @@
+/*************************************************************************//**
+ * @file     system_<Device>.c
+ * @brief    CMSIS-Core(M) Device Peripheral Access Layer Source File for
+ *           Device <Device>
+ * @version  V1.0.0
+ * @date     20. January 2021
+ *****************************************************************************/
+/*
+ * Copyright (c) 2009-2021 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ToDo: rename this file from 'system_Device.c' to 'system_<Device>.c according to your device naming */
+
+#include <stdint.h>
+#include "<Device>.h"
+
+/* ToDo: Include partition header file if TZ is used */
+#if defined (__ARM_FEATURE_CMSE) &&  (__ARM_FEATURE_CMSE == 3U)
+  #include "partition_<Device>.h"
+#endif
+
+
+/*---------------------------------------------------------------------------
+  Define clocks
+ *---------------------------------------------------------------------------*/
+/* ToDo: Add here your necessary defines for device initialization
+         following is an example for different system frequencies */
+#define XTAL            (12000000U)       /* Oscillator frequency */
+
+#define SYSTEM_CLOCK    (5 * XTAL)
+
+
+/*---------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *---------------------------------------------------------------------------*/
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[496];
+
+
+/*---------------------------------------------------------------------------
+  System Core Clock Variable
+ *---------------------------------------------------------------------------*/
+/* ToDo: Initialize SystemCoreClock with the system core clock frequency value
+         achieved after system intitialization.
+         This means system core clock frequency after call to SystemInit() */
+uint32_t SystemCoreClock = SYSTEM_CLOCK;  /* System Clock Frequency (Core Clock)*/
+
+
+/*---------------------------------------------------------------------------
+  System Core Clock function
+ *---------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)
+{
+/* ToDo: Add code to calculate the system frequency based upon the current
+         register settings.
+         This function can be used to retrieve the system core clock frequeny
+         after user changed register sittings. */
+  SystemCoreClock = SYSTEM_CLOCK;
+}
+
+
+/*---------------------------------------------------------------------------
+  System initialization function
+ *---------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+/* ToDo: Add code to initialize the system.
+         Do not use global variables because this function is called before
+         reaching pre-main. RW section maybe overwritten afterwards. */
+
+/* ToDo: Initialize VTOR if available */
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t)(&__VECTOR_TABLE[0]);
+#endif
+
+/* ToDo: Enable co-processor if it is used */
+#if (defined (__FPU_USED) && (__FPU_USED == 1U)) || \
+    (defined (__ARM_FEATURE_MVE) && (__ARM_FEATURE_MVE > 0U))
+  SCB->CPACR |= ((3U << 10U*2U) |           /* enable CP10 Full Access */
+                 (3U << 11U*2U)  );         /* enable CP11 Full Access */
+#endif
+
+/* ToDo: Initialize SAU if TZ is used */
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  TZ_SAU_Setup();
+#endif
+
+  SystemCoreClock = SYSTEM_CLOCK;
+}

--- a/platform/ext/cmsis/CMSIS/Core/Test/README.md
+++ b/platform/ext/cmsis/CMSIS/Core/Test/README.md
@@ -1,0 +1,178 @@
+# CMSIS-Core Unit Tests
+
+This folder contains a unit test suite that validates CMSIS-Core implementation.
+It uses test tools from LLVM, namely LIT and FileCheck, to validate consistency across compilers and devices.
+
+Consult the manual of [FileCheck - Flexible pattern matching file verifier](https://llvm.org/docs/CommandGuide/FileCheck.html)
+for details.
+
+## Folder structure
+
+```txt
+    📂 Test
+    ┣ 📂 src                       Test source files
+    ┣ 📂 build.py                  Build wrapper
+    ┣ 📂 lit.cfg.py                LIT test suite configuration
+    ┣ 📂 requirements.txt          Python dependencies required for build.py script
+    ┗ 📂 vcpkg-configuration.json  vcpkg configuration to create virtual environment required for running these tests
+```
+
+## Test matrix
+
+Currently, the following build configurations are provided:
+
+1. Compiler
+   - Arm Compiler 6 (AC6)
+   - GNU Compiler (GCC)
+   - LLVM/Clang (Clang)
+2. Devices
+   - Cortex-M0
+   - Cortex-M0+
+   - Cortex-M3
+   - Cortex-M4
+     - w/o FPU
+     - with FPU
+   - Cortex-M7
+     - w/o FPU
+     - with SP FPU
+     - with DP FPU
+   - Cortex-M23
+     - w/o security extensions (TrustZone)
+     - in secure mode
+     - in non-secure mode
+   - Cortex-M33 (with FPU and DSP extensions)
+     - w/o security extensions (TrustZone)
+     - in secure mode
+     - in non-secure mode
+   - Cortex-M35P (with FPU and DSP extensions)
+     - w/o security extensions (TrustZone)
+     - in secure mode
+     - in non-secure mode
+   - Cortex-M55 (with FPU and DSP extensions)
+     - in secure mode
+     - in non-secure mode
+   - Cortex-M85 (with FPU and DSP extensions)
+     - in secure mode
+     - in non-secure mode
+   - Cortex-A5
+     - w/o NEON extensions
+     - w NEON extensions
+   - Cortex-A7
+     - w/o NEON extensions
+     - w NEON extensions
+   - Cortex-A9
+     - w/o NEON extensions
+     - w NEON extensions
+3. Optimization Levels
+   - none
+   - balanced
+   - size
+   - speed
+
+## Prerequisites
+
+The following tools are required to build and run the CoreValidation tests:
+
+- [CMSIS-Toolbox 2.1.0](https://artifacts.keil.arm.com/cmsis-toolbox/2.1.0/)*
+- [CMake 3.25.2](https://cmake.org/download/)*
+- [Ninja 1.10.2](https://github.com/ninja-build/ninja/releases)*
+- [Arm Compiler 6.20](https://artifacts.keil.arm.com/arm-compiler/6.20/21/)*
+- [GCC Compiler 13.2.1](https://artifacts.keil.arm.com/arm-none-eabi-gcc/13.2.1/)*
+- [Clang Compiler 17.0.1](https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/releases/tag/release-17.0.1)*
+- [Arm Virtual Hardware for Cortex-M based on FastModels 11.22.39](https://artifacts.keil.arm.com/avh/11.22.39/)*
+- [Python 3.9](https://www.python.org/downloads/)
+- [LLVM FileCheck](https://github.com/llvm/llvm-project/releases/)
+  - Ubuntu package `llvm-<version>-tools`
+  - MacOS Homebrew formula `llvm`
+
+The executables need to be present on the `PATH`.
+For tools distributed via vcpkg (*) this can be achieved automatically:
+
+```bash
+ ./CMSIS/Core/Test $ vcpkg activate
+```
+
+Install the Python packages required by `build.py`:
+
+```bash
+ ./CMSIS/Core/Test $ pip install -r requirements.txt
+```
+
+## Execute LIT tests
+
+To build and run the CoreValidation tests for one or more configurations use the following command line.
+Select the `<compiler>`, `<device>`, and `<optimize>` level to execute `lit` for.
+
+```bash
+ ./CMSIS/Core/Test $ ./build.py -c <compiler> -d <device> -o <optimize> [lit]
+```
+
+For example, to execute the LIT tests using GCC for Cortex-M3 with no optimization, run:
+
+```bash
+ ./CMSIS/Core/Test $ ./build.py -c GCC -d CM3 -o none lit
+[GCC][Cortex-M3][none](lit:run_lit) /opt/homebrew/bin/lit --xunit-xml-output lit.xml -D toolchain=GCC -D device=CM3 -D optimize=none src
+[GCC][Cortex-M3][none](lit:run_lit) -- Testing: 49 tests, 10 workers --
+ :
+[GCC][Cortex-M3][none](lit:run_lit) /opt/homebrew/bin/lit succeeded with exit code 0
+
+Matrix Summary
+==============
+
+compiler    device     optimize    lit
+----------  ---------  ----------  -----
+GCC         Cortex-M3  none        33/33
+```
+
+The summary lists the amount of test cases executed and passed.
+
+## Analyse failing test cases
+
+In case of failing test cases, one can run a single test case with verbose output like this:
+
+```bash
+ ./CMSIS/Core/Test $ lit -D toolchain=GCC -D device=CM3 -D optimize=none -a src/apsr.c
+-- Testing: 1 tests, 1 workers --
+PASS: CMSIS-Core :: src/apsr.c (1 of 1)
+Script:
+--
+: 'RUN: at line 2';   arm-none-eabi-gcc -mcpu=cortex-m3 -mfloat-abi=soft -O1 -I ../Include -D CORE_HEADER=\"core_cm3.h\" -c -D __CM3_REV=0x0000U -D __MPU_PRESENT=1U -D __VTOR_PRESENT=1U -D __NVIC_PRIO_BITS=3U -D __Vendor_SysTickConfig=0U -o ./src/Output/apsr.c.o ./src/apsr.c; llvm-objdump --mcpu=cortex-m3 -d ./src/Output/apsr.c.o | FileCheck --allow-unused-prefixes --check-prefixes CHECK,CHECK-THUMB ./src/apsr.c
+--
+Exit Code: 0
+ :
+********************
+
+Testing Time: 0.10s
+  Passed: 1
+```
+
+The output reveales wich commands are chained and their error output if any.
+
+Failing FileCheck requires in detail analysis of the `// CHECK` annotations in the test source file
+against the `llvm-objdump` output of the test compilation.
+
+Investigating the disassembly can be done like
+
+```bash
+ ./CMSIS/Core/Test $ llvm-objdump --mcpu=cortex-m3 -d ./src/Output/apsr.c.o
+
+./src/Output/apsr.c.o:  file format elf32-littlearm
+
+Disassembly of section .text:
+
+00000000 <get_apsr>:
+       0: b082          sub     sp, #0x8
+       2: f3ef 8300     mrs     r3, apsr
+       6: 9301          str     r3, [sp, #0x4]
+       8: b002          add     sp, #0x8
+       a: 4770          bx      lr
+```
+
+This output is expected to match the test case
+
+```c
+    // CHECK: mrs {{r[0-9]+}}, apsr
+    volatile uint32_t result = __get_APSR();
+```
+
+I.e., the test case expects the `mrs {{r[0-9]+}}, apsr` instruction, additional whitespace is ignored.

--- a/platform/ext/cmsis/CMSIS/Core/Test/build.py
+++ b/platform/ext/cmsis/CMSIS/Core/Test/build.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import logging
+
+from datetime import datetime
+from enum import Enum
+
+from matrix_runner import main, matrix_axis, matrix_action, matrix_command, matrix_filter, \
+    FileReport, JUnitReport
+
+
+@matrix_axis("device", "d", "Device(s) to be considered.")
+class DeviceAxis(Enum):
+    CM0 = ('Cortex-M0', 'CM0')
+    CM0plus = ('Cortex-M0plus', 'CM0plus')
+    CM3 = ('Cortex-M3', 'CM3')
+    CM4 = ('Cortex-M4', 'CM4')
+    CM4FP = ('Cortex-M4FP', 'CM4FP')
+    CM7 = ('Cortex-M7', 'CM7')
+    CM7SP = ('Cortex-M7SP', 'CM7SP')
+    CM7DP = ('Cortex-M7DP', 'CM7DP')
+    CM23 = ('Cortex-M23', 'CM23')
+    CM23S = ('Cortex-M23S', 'CM23S')
+    CM23NS = ('Cortex-M23NS', 'CM23NS')
+    CM33 = ('Cortex-M33', 'CM33')
+    CM33S = ('Cortex-M33S', 'CM33S')
+    CM33NS = ('Cortex-M33NS', 'CM33NS')
+    CM35P = ('Cortex-M35P', 'CM35P')
+    CM35PS = ('Cortex-M35PS', 'CM35PS')
+    CM35PNS = ('Cortex-M35PNS', 'CM35PNS')
+    CM55 = ('Cortex-M55', 'CM55')
+    CM55S = ('Cortex-M55S', 'CM55S')
+    CM55NS = ('Cortex-M55NS', 'CM55NS')
+    CM85 = ('Cortex-M85', 'CM85')
+    CM85S = ('Cortex-M85S', 'CM85S')
+    CM85NS = ('Cortex-M85NS', 'CM85NS')
+    CA5 = ('Cortex-A5', 'CA5')
+    CA7 = ('Cortex-A7', 'CA7')
+    CA9 = ('Cortex-A9', 'CA9')
+    CA5NEON = ('Cortex-A5neon', 'CA5neon')
+    CA7NEON = ('Cortex-A7neon', 'CA7neon')
+    CA9NEON = ('Cortex-A9neon', 'CA9neon')
+
+
+@matrix_axis("compiler", "c", "Compiler(s) to be considered.")
+class CompilerAxis(Enum):
+    AC6 = ('AC6')
+    GCC = ('GCC')
+    IAR = ('IAR')
+    CLANG = ('Clang')
+
+
+@matrix_axis("optimize", "o", "Optimization level(s) to be considered.")
+class OptimizationAxis(Enum):
+    NONE = ('none')
+    BALANCED = ('balanced')
+    SPEED = ('speed')
+    SIZE = ('size')
+
+
+def timestamp():
+    return datetime.now().strftime('%Y%m%d%H%M%S')
+
+
+@matrix_action
+def lit(config, results):
+    """Run tests for the selected configurations using llvm's lit."""
+    yield run_lit(config.compiler[0], config.device[1], config.optimize[0])
+    results[0].test_report.write(f"lit-{config.compiler[0]}-{config.optimize[0]}-{config.device[1]}-{timestamp()}.xunit")
+
+
+def timestamp():
+    return datetime.now().strftime('%Y%m%d%H%M%S')
+
+
+@matrix_command(test_report=FileReport(f"lit.xml") | JUnitReport())
+def run_lit(toolchain, device, optimize):
+    return ["lit", "--xunit-xml-output", f"lit.xml", "-D", f"toolchain={toolchain}", "-D", f"device={device}", "-D", f"optimize={optimize}", "src" ]
+
+
+@matrix_filter
+def filter_iar(config):
+    return config.compiler == CompilerAxis.IAR
+
+
+if __name__ == "__main__":
+    main()

--- a/platform/ext/cmsis/CMSIS/Core/Test/lit.cfg.py
+++ b/platform/ext/cmsis/CMSIS/Core/Test/lit.cfg.py
@@ -1,0 +1,806 @@
+# -*- Python -*-
+
+import os
+
+import lit.formats
+import lit.util
+
+DEVICES = {
+    'CM0': {
+        'arch': 'thumbv6m',
+        'triple': 'thumbv6m',
+        'abi': 'eabi',
+        'mcpu': 'cortex-m0',
+        'mfpu': 'none',
+        'mpu': False,
+        'features': ['thumbv6m'],
+        'header': 'core_cm0.h',
+        'defines': {
+            '__CM0_REV': '0x0000U',
+            '__NVIC_PRIO_BITS': '2U',
+            '__Vendor_SysTickConfig': '0U'
+        }
+    },
+    'CM0plus': {
+        'arch': 'thumbv6m',
+        'triple': 'thumbv6m',
+        'abi': 'eabi',
+        'mcpu': 'cortex-m0plus',
+        'mfpu': 'none',
+        'mpu': True,
+        'features': ['thumbv6m'],
+        'header': 'core_cm0plus.h',
+        'defines': {
+            '__CM0PLUS_REV': '0x0000U',
+            '__MPU_PRESENT': '1U',
+            '__VTOR_PRESENT': '1U',
+            '__NVIC_PRIO_BITS': '2U',
+            '__Vendor_SysTickConfig': '0U'
+        }
+    },
+    'CM3': {
+        'arch': 'thumbv7m',
+        'triple': 'thumbv7-m',
+        'abi': 'eabi',
+        'mcpu': 'cortex-m3',
+        'mfpu': 'none',
+        'mpu': True,
+        'features': ['thumbv6m', 'thumbv7m', 'thumb-2', 'sat', 'ldrex', 'clz'],
+        'header': 'core_cm3.h',
+        'defines': {
+            '__CM3_REV': '0x0000U',
+            '__MPU_PRESENT': '1U',
+            '__VTOR_PRESENT': '1U',
+            '__NVIC_PRIO_BITS': '3U',
+            '__Vendor_SysTickConfig': '0U'
+        }
+    },
+    'CM4': {
+        'arch': 'thumbv7em',
+        'triple': 'thumbv7-em',
+        'abi': 'eabi',
+        'mcpu': 'cortex-m4',
+        'mfpu': 'none',
+        'mpu': True,
+        'features': ['thumbv6m', 'thumbv7m', 'dsp', 'thumb-2', 'sat', 'ldrex', 'clz'],
+        'header': 'core_cm4.h',
+        'defines': {
+            '__CM4_REV': '0x0000U',
+            '__FPU_PRESENT': '0U',
+            '__MPU_PRESENT': '1U',
+            '__VTOR_PRESENT': '1U',
+            '__NVIC_PRIO_BITS': '3U',
+            '__Vendor_SysTickConfig': '0U'
+        }
+    },
+    'CM4FP': {
+        'arch': 'thumbv7em',
+        'triple': 'thumbv7-em',
+        'abi': 'eabihf',
+        'mcpu': 'cortex-m4',
+        'mfpu': 'fpv4-sp-d16',
+        'mpu': True,
+        'features': ['thumbv6m', 'thumbv7m', 'dsp', 'thumb-2', 'sat', 'ldrex', 'clz'],
+        'header': 'core_cm4.h',
+        'defines': {
+            '__CM4_REV': '0x0000U',
+            '__FPU_PRESENT': '1U',
+            '__MPU_PRESENT': '1U',
+            '__VTOR_PRESENT': '1U',
+            '__NVIC_PRIO_BITS': '3U',
+            '__Vendor_SysTickConfig': '0U'
+        }
+    },
+    'CM7': {
+        'arch': 'thumbv7em',
+        'triple': 'thumbv7-em',
+        'abi': 'eabi',
+        'mcpu': 'cortex-m7',
+        'mfpu': 'none',
+        'mpu': True,
+        'features': ['thumbv6m', 'thumbv7m', 'dsp', 'thumb-2', 'sat', 'ldrex', 'clz'],
+        'header': 'core_cm7.h',
+        'defines': {
+            '__CM7_REV': '0x0000U',
+            '__FPU_PRESENT': '0U',
+            '__MPU_PRESENT': '1U',
+            '__ICACHE_PRESENT': '1U',
+            '__DCACHE_PRESENT': '1U',
+            '__DTCM_PRESENT': '1U',
+            '__VTOR_PRESENT': '1U',
+            '__NVIC_PRIO_BITS': '3U',
+            '__Vendor_SysTickConfig': '0U'
+        }
+    },
+    'CM7SP': {
+        'arch': 'thumbv7em',
+        'triple': 'thumbv7-em',
+        'abi': 'eabi',
+        'mcpu': 'cortex-m7',
+        'mfpu': 'fpv4-sp-d16',
+        'mpu': True,
+        'features': ['thumbv6m', 'thumbv7m', 'dsp', 'thumb-2', 'sat', 'ldrex', 'clz'],
+        'header': 'core_cm7.h',
+        'defines': {
+            '__CM7_REV': '0x0000U',
+            '__FPU_PRESENT': '1U',
+            '__MPU_PRESENT': '1U',
+            '__ICACHE_PRESENT': '1U',
+            '__DCACHE_PRESENT': '1U',
+            '__DTCM_PRESENT': '1U',
+            '__VTOR_PRESENT': '1U',
+            '__NVIC_PRIO_BITS': '3U',
+            '__Vendor_SysTickConfig': '0U'
+        }
+    },
+    'CM7DP': {
+        'arch': 'thumbv7em',
+        'triple': 'thumbv7-em',
+        'abi': 'eabihf',
+        'mcpu': 'cortex-m7',
+        'mfpu': 'fpv5-d16',
+        'mpu': True,
+        'features': ['thumbv6m', 'thumbv7m', 'dsp', 'thumb-2', 'sat', 'ldrex', 'clz'],
+        'header': 'core_cm7.h',
+        'defines': {
+            '__CM7_REV': '0x0000U',
+            '__FPU_PRESENT': '1U',
+            '__MPU_PRESENT': '1U',
+            '__ICACHE_PRESENT': '1U',
+            '__DCACHE_PRESENT': '1U',
+            '__DTCM_PRESENT': '1U',
+            '__VTOR_PRESENT': '1U',
+            '__NVIC_PRIO_BITS': '3U',
+            '__Vendor_SysTickConfig': '0U'
+        }
+    },
+    'CM23': {
+        'arch': 'thumbv8m.base',
+        'triple': 'thumbv8m',
+        'abi': 'eabi',
+        'mcpu': 'cortex-m23',
+        'mfpu': 'none',
+        'mpu': True,
+        'features': ['thumbv6m', 'thumbv7m', 'thumbv8m.base', 'ldrex'],
+        'header': 'core_cm23.h',
+        'defines': {
+            '__CM23_REV': '0x0000U',
+            '__FPU_PRESENT': '0U',
+            '__MPU_PRESENT': '1U',
+            '__SAUREGION_PRESENT': '8U',
+            '__VTOR_PRESENT': '1U',
+            '__NVIC_PRIO_BITS': '3U',
+            '__Vendor_SysTickConfig': '0U'
+        }
+    },
+    'CM23S': {
+        'arch': 'thumbv8m.base',
+        'triple': 'thumbv8m',
+        'abi': 'eabi',
+        'mcpu': 'cortex-m23',
+        'mfpu': 'none',
+        'mpu': True,
+        'features': ['thumbv6m', 'thumbv7m', 'thumbv8m.base', 'ldrex'],
+        'header': 'core_cm23.h',
+        'defines': {
+            '__CM23_REV': '0x0000U',
+            '__FPU_PRESENT': '0U',
+            '__MPU_PRESENT': '1U',
+            '__SAUREGION_PRESENT': '8U',
+            '__VTOR_PRESENT': '1U',
+            '__NVIC_PRIO_BITS': '3U',
+            '__Vendor_SysTickConfig': '0U'
+        }
+    },
+    'CM23NS': {
+        'arch': 'thumbv8m.base',
+        'triple': 'thumbv8m',
+        'abi': 'eabi',
+        'mcpu': 'cortex-m23',
+        'mfpu': 'none',
+        'mpu': True,
+        'features': ['thumbv6m', 'thumbv7m', 'thumbv8m.base', 'ldrex'],
+        'header': 'core_cm23.h',
+        'defines': {
+            '__CM23_REV': '0x0000U',
+            '__FPU_PRESENT': '0U',
+            '__MPU_PRESENT': '1U',
+            '__SAUREGION_PRESENT': '8U',
+            '__VTOR_PRESENT': '1U',
+            '__NVIC_PRIO_BITS': '3U',
+            '__Vendor_SysTickConfig': '0U'
+        }
+    },
+    'CM33': {
+        'arch': 'thumbv8m.main',
+        'triple': 'thumbv8m',
+        'abi': 'eabihf',
+        'mcpu': 'cortex-m33',
+        'mfpu': 'fpv5-d16',
+        'mpu': True,
+        'features': ['thumbv6m', 'thumbv7m', 'dsp', 'thumbv8m.base', 'thumbv8m.main', 'thumb-2', 'sat', 'ldrex', 'clz'],
+        'header': 'core_cm33.h',
+        'defines': {
+            '__CM33_REV': '0x0000U',
+            '__FPU_PRESENT': '1U',
+            '__MPU_PRESENT': '1U',
+            '__SAUREGION_PRESENT': '8U',
+            '__VTOR_PRESENT': '1U',
+            '__NVIC_PRIO_BITS': '3U',
+            '__Vendor_SysTickConfig': '0U'
+        }
+    },
+    'CM33S': {
+        'arch': 'thumbv8m.main',
+        'triple': 'thumbv8m',
+        'abi': 'eabihf',
+        'mcpu': 'cortex-m33',
+        'mfpu': 'fpv5-d16',
+        'mpu': True,
+        'features': ['thumbv6m', 'thumbv7m', 'dsp', 'thumbv8m.base', 'thumbv8m.main', 'thumb-2', 'sat', 'ldrex', 'clz'],
+        'header': 'core_cm33.h',
+        'defines': {
+            '__CM33_REV': '0x0000U',
+            '__FPU_PRESENT': '1U',
+            '__MPU_PRESENT': '1U',
+            '__SAUREGION_PRESENT': '8U',
+            '__VTOR_PRESENT': '1U',
+            '__NVIC_PRIO_BITS': '3U',
+            '__Vendor_SysTickConfig': '0U'
+        }
+    },
+    'CM33NS': {
+        'arch': 'thumbv8m.main',
+        'triple': 'thumbv8m',
+        'abi': 'eabihf',
+        'mcpu': 'cortex-m33',
+        'mfpu': 'fpv5-d16',
+        'mpu': True,
+        'features': ['thumbv6m', 'thumbv7m', 'dsp', 'thumbv8m.base', 'thumbv8m.main', 'thumb-2', 'sat', 'ldrex', 'clz'],
+        'header': 'core_cm33.h',
+        'defines': {
+            '__CM33_REV': '0x0000U',
+            '__FPU_PRESENT': '1U',
+            '__MPU_PRESENT': '1U',
+            '__SAUREGION_PRESENT': '8U',
+            '__VTOR_PRESENT': '1U',
+            '__NVIC_PRIO_BITS': '3U',
+            '__Vendor_SysTickConfig': '0U'
+        }
+    },
+    'CM35P': {
+        'arch': 'thumbv8m.main',
+        'triple': 'thumbv8m',
+        'abi': 'eabihf',
+        'mcpu': 'cortex-m35p',
+        'mfpu': 'fpv5-d16',
+        'mpu': True,
+        'features': ['thumbv6m', 'thumbv7m', 'dsp', 'thumbv8m.base', 'thumbv8m.main', 'thumb-2', 'sat', 'ldrex', 'clz'],
+        'header': 'core_cm35p.h',
+        'defines': {
+            '__CM35P_REV': '0x0000U',
+            '__FPU_PRESENT': '1U',
+            '__MPU_PRESENT': '1U',
+            '__SAUREGION_PRESENT': '8U',
+            '__VTOR_PRESENT': '1U',
+            '__NVIC_PRIO_BITS': '3U',
+            '__Vendor_SysTickConfig': '0U'
+        }
+    },
+    'CM35PS': {
+        'arch': 'thumbv8m.main',
+        'triple': 'thumbv8m',
+        'abi': 'eabihf',
+        'mcpu': 'cortex-m35p',
+        'mfpu': 'fpv5-d16',
+        'mpu': True,
+        'features': ['thumbv6m', 'thumbv7m', 'dsp', 'thumbv8m.base', 'thumbv8m.main', 'thumb-2', 'sat', 'ldrex', 'clz'],
+        'header': 'core_cm35p.h',
+        'defines': {
+            '__CM35P_REV': '0x0000U',
+            '__FPU_PRESENT': '1U',
+            '__MPU_PRESENT': '1U',
+            '__SAUREGION_PRESENT': '8U',
+            '__VTOR_PRESENT': '1U',
+            '__NVIC_PRIO_BITS': '3U',
+            '__Vendor_SysTickConfig': '0U'
+        }
+    },
+    'CM35PNS': {
+        'arch': 'thumbv8m.main',
+        'triple': 'thumbv8m',
+        'abi': 'eabihf',
+        'mcpu': 'cortex-m35p',
+        'mfpu': 'fpv5-d16',
+        'mpu': True,
+        'features': ['thumbv6m', 'thumbv7m', 'dsp', 'thumbv8m.base', 'thumbv8m.main', 'thumb-2', 'sat', 'ldrex', 'clz'],
+        'header': 'core_cm35p.h',
+        'defines': {
+            '__CM35P_REV': '0x0000U',
+            '__FPU_PRESENT': '1U',
+            '__MPU_PRESENT': '1U',
+            '__SAUREGION_PRESENT': '8U',
+            '__VTOR_PRESENT': '1U',
+            '__NVIC_PRIO_BITS': '3U',
+            '__Vendor_SysTickConfig': '0U'
+        }
+    },
+    'CM55': {
+        'arch': 'thumbv8.1m.main',
+        'triple': 'thumbv8m',
+        'abi': 'eabihf',
+        'mcpu': 'cortex-m55',
+        'mfpu': 'fpv5-d16',
+        'mpu': True,
+        'features': ['thumbv6m', 'thumbv7m', 'dsp', 'thumbv8m.base', 'thumbv8m.main', 'thumbv8.1m.main', 'thumb-2', 'sat', 'ldrex', 'clz'],
+        'header': 'core_cm55.h',
+        'defines': {
+            '__CM55_REV': '0x0000U',
+            '__FPU_PRESENT': '1U',
+            '__FPU_DP': '1U',
+            '__MPU_PRESENT': '1U',
+            '__ICACHE_PRESENT': '1U',
+            '__DCACHE_PRESENT': '1U',
+            '__SAUREGION_PRESENT': '8U',
+            '__DSP_PRESENT': '1U',
+            '__VTOR_PRESENT': '1U',
+            '__PMU_PRESENT': '1U',
+            '__PMU_NUM_EVENTCNT': '8U',
+            '__DSP_PRESENT': '1U',
+            '__NVIC_PRIO_BITS': '3U',
+            '__Vendor_SysTickConfig': '0U'
+        }
+    },
+    'CM55S': {
+        'arch': 'thumbv8.1m.main',
+        'triple': 'thumbv8m',
+        'abi': 'eabihf',
+        'mcpu': 'cortex-m55',
+        'mfpu': 'fpv5-d16',
+        'mpu': True,
+        'features': ['thumbv6m', 'thumbv7m', 'dsp', 'thumbv8m.base', 'thumbv8m.main', 'thumbv8.1m.main', 'thumb-2', 'sat', 'ldrex', 'clz'],
+        'header': 'core_cm55.h',
+        'defines': {
+            '__CM55_REV': '0x0000U',
+            '__FPU_PRESENT': '1U',
+            '__FPU_DP': '1U',
+            '__MPU_PRESENT': '1U',
+            '__ICACHE_PRESENT': '1U',
+            '__DCACHE_PRESENT': '1U',
+            '__SAUREGION_PRESENT': '8U',
+            '__DSP_PRESENT': '1U',
+            '__VTOR_PRESENT': '1U',
+            '__PMU_PRESENT': '1U',
+            '__PMU_NUM_EVENTCNT': '8U',
+            '__DSP_PRESENT': '1U',
+            '__NVIC_PRIO_BITS': '3U',
+            '__Vendor_SysTickConfig': '0U'
+        }
+    },
+    'CM55NS': {
+        'arch': 'thumbv8.1m.main',
+        'triple': 'thumbv8m',
+        'abi': 'eabihf',
+        'mcpu': 'cortex-m55',
+        'mfpu': 'fpv5-d16',
+        'mpu': True,
+        'features': ['thumbv6m', 'thumbv7m', 'dsp', 'thumbv8m.base', 'thumbv8m.main', 'thumbv8.1m.main', 'thumb-2', 'sat', 'ldrex', 'clz'],
+        'header': 'core_cm55.h',
+        'defines': {
+            '__CM55_REV': '0x0000U',
+            '__FPU_PRESENT': '1U',
+            '__FPU_DP': '1U',
+            '__MPU_PRESENT': '1U',
+            '__ICACHE_PRESENT': '1U',
+            '__DCACHE_PRESENT': '1U',
+            '__SAUREGION_PRESENT': '8U',
+            '__DSP_PRESENT': '1U',
+            '__VTOR_PRESENT': '1U',
+            '__PMU_PRESENT': '1U',
+            '__PMU_NUM_EVENTCNT': '8U',
+            '__DSP_PRESENT': '1U',
+            '__NVIC_PRIO_BITS': '3U',
+            '__Vendor_SysTickConfig': '0U'
+        }
+    },
+    'CM85': {
+        'arch': 'thumbv8.1m.main',
+        'triple': 'thumbv8m',
+        'abi': 'eabihf',
+        'mcpu': 'cortex-m85',
+        'mfpu': 'fpv5-d16',
+        'mpu': True,
+        'features': ['thumbv6m', 'thumbv7m', 'dsp', 'thumbv8m.base', 'thumbv8m.main', 'thumbv8.1m.main', 'thumb-2', 'sat', 'ldrex', 'clz'],
+        'header': 'core_cm85.h',
+        'defines': {
+            '__CM85_REV': '0x0000U',
+            '__FPU_PRESENT': '1U',
+            '__FPU_DP': '1U',
+            '__MPU_PRESENT': '1U',
+            '__ICACHE_PRESENT': '1U',
+            '__DCACHE_PRESENT': '1U',
+            '__SAUREGION_PRESENT': '8U',
+            '__DSP_PRESENT': '1U',
+            '__VTOR_PRESENT': '1U',
+            '__PMU_PRESENT': '1U',
+            '__PMU_NUM_EVENTCNT': '8U',
+            '__DSP_PRESENT': '1U',
+            '__NVIC_PRIO_BITS': '3U',
+            '__Vendor_SysTickConfig': '0U'
+        }
+    },
+    'CM85S': {
+        'arch': 'thumbv8.1m.main',
+        'triple': 'thumbv8m',
+        'abi': 'eabihf',
+        'mcpu': 'cortex-m85',
+        'mfpu': 'fpv5-d16',
+        'mpu': True,
+        'features': ['thumbv6m', 'thumbv7m', 'dsp', 'thumbv8m.base', 'thumbv8m.main', 'thumbv8.1m.main', 'thumb-2', 'sat', 'ldrex', 'clz'],
+        'header': 'core_cm85.h',
+        'defines': {
+            '__CM85_REV': '0x0000U',
+            '__FPU_PRESENT': '1U',
+            '__FPU_DP': '1U',
+            '__MPU_PRESENT': '1U',
+            '__ICACHE_PRESENT': '1U',
+            '__DCACHE_PRESENT': '1U',
+            '__SAUREGION_PRESENT': '8U',
+            '__DSP_PRESENT': '1U',
+            '__VTOR_PRESENT': '1U',
+            '__PMU_PRESENT': '1U',
+            '__PMU_NUM_EVENTCNT': '8U',
+            '__DSP_PRESENT': '1U',
+            '__NVIC_PRIO_BITS': '3U',
+            '__Vendor_SysTickConfig': '0U'
+        }
+    },
+    'CM85NS': {
+        'arch': 'thumbv8.1m.main',
+        'triple': 'thumbv8m',
+        'abi': 'eabihf',
+        'mcpu': 'cortex-m85',
+        'mfpu': 'fpv5-d16',
+        'mpu': True,
+        'features': ['thumbv6m', 'thumbv7m', 'dsp', 'thumbv8m.base', 'thumbv8m.main', 'thumbv8.1m.main', 'thumb-2', 'sat', 'ldrex', 'clz'],
+        'header': 'core_cm85.h',
+        'defines': {
+            '__CM85_REV': '0x0000U',
+            '__FPU_PRESENT': '1U',
+            '__FPU_DP': '1U',
+            '__MPU_PRESENT': '1U',
+            '__ICACHE_PRESENT': '1U',
+            '__DCACHE_PRESENT': '1U',
+            '__SAUREGION_PRESENT': '8U',
+            '__DSP_PRESENT': '1U',
+            '__VTOR_PRESENT': '1U',
+            '__PMU_PRESENT': '1U',
+            '__PMU_NUM_EVENTCNT': '8U',
+            '__DSP_PRESENT': '1U',
+            '__NVIC_PRIO_BITS': '3U',
+            '__Vendor_SysTickConfig': '0U'
+        }
+    },
+    'CA5': {
+        'arch': 'armv7a',
+        'triple': 'armv7-a',
+        'abi': 'eabi',
+        'mcpu': 'cortex-a5',
+        'mfpu': 'none',
+        'mpu': True,
+        'features': ['armv7a', 'thumb-2', 'sat', 'clz'],
+        'header': 'core_ca.h',
+        'defines': {
+            '__CORTEX_A': '7',
+            '__CA_REV': '0x0000U',
+            '__FPU_PRESENT': '0U',
+            '__GIC_PRESENT': '1U',
+            '__TIM_PRESENT': '1U',
+            '__L2C_PRESENT': '1U',
+            'GIC_DISTRIBUTOR_BASE': '0x2C001000UL',
+            'GIC_INTERFACE_BASE': '0x2C000100UL',
+            'TIMER_BASE': '0x2C000600UL',
+            'L2C_310_BASE': '0x2C0F0000UL',
+            'IRQn_Type': 'int'
+        }
+    },
+    'CA5neon': {
+        'arch': 'armv7a',
+        'triple': 'armv7-a',
+        'abi': 'eabihf',
+        'mcpu': 'cortex-a5',
+        'mfpu': 'neon-vfpv4',
+        'mpu': True,
+        'features': ['armv7a', 'thumb-2', 'sat', 'dsp', 'clz'],
+        'header': 'core_ca.h',
+        'defines': {
+            '__CORTEX_A': '7',
+            '__CA_REV': '0x0000U',
+            '__FPU_PRESENT': '1U',
+            '__GIC_PRESENT': '1U',
+            '__TIM_PRESENT': '1U',
+            '__L2C_PRESENT': '1U',
+            'GIC_DISTRIBUTOR_BASE': '0x2C001000UL',
+            'GIC_INTERFACE_BASE': '0x2C000100UL',
+            'TIMER_BASE': '0x2C000600UL',
+            'L2C_310_BASE': '0x2C0F0000UL',
+            'IRQn_Type': 'int'
+        }
+    },
+    'CA7': {
+        'arch': 'armv7a',
+        'triple': 'armv7-a',
+        'abi': 'eabi',
+        'mcpu': 'cortex-a7',
+        'mfpu': 'none',
+        'mpu': True,
+        'features': ['armv7a', 'thumb-2', 'sat', 'clz'],
+        'header': 'core_ca.h',
+        'defines': {
+            '__CORTEX_A': '7',
+            '__CA_REV': '0x0000U',
+            '__FPU_PRESENT': '0U',
+            '__GIC_PRESENT': '1U',
+            '__TIM_PRESENT': '1U',
+            '__L2C_PRESENT': '1U',
+            'GIC_DISTRIBUTOR_BASE': '0x2C001000UL',
+            'GIC_INTERFACE_BASE': '0x2C000100UL',
+            'TIMER_BASE': '0x2C000600UL',
+            'L2C_310_BASE': '0x2C0F0000UL',
+            'IRQn_Type': 'int'
+        }
+    },
+    'CA7neon': {
+        'arch': 'armv7a',
+        'triple': 'armv7-a',
+        'abi': 'eabihf',
+        'mcpu': 'cortex-a7',
+        'mfpu': 'neon-vfpv4',
+        'mpu': True,
+        'features': ['armv7a', 'thumb-2', 'sat', 'dsp', 'clz'],
+        'header': 'core_ca.h',
+        'defines': {
+            '__CORTEX_A': '7',
+            '__CA_REV': '0x0000U',
+            '__FPU_PRESENT': '1U',
+            '__GIC_PRESENT': '1U',
+            '__TIM_PRESENT': '1U',
+            '__L2C_PRESENT': '1U',
+            'GIC_DISTRIBUTOR_BASE': '0x2C001000UL',
+            'GIC_INTERFACE_BASE': '0x2C000100UL',
+            'TIMER_BASE': '0x2C000600UL',
+            'L2C_310_BASE': '0x2C0F0000UL',
+            'IRQn_Type': 'int'
+        }
+    },
+    'CA9': {
+        'arch': 'armv7a',
+        'triple': 'armv7-a',
+        'abi': 'eabi',
+        'mcpu': 'cortex-a9',
+        'mfpu': 'none',
+        'mpu': True,
+        'features': ['armv7a', 'thumb-2', 'sat', 'clz'],
+        'header': 'core_ca.h',
+        'defines': {
+            '__CORTEX_A': '7',
+            '__CA_REV': '0x0000U',
+            '__FPU_PRESENT': '0U',
+            '__GIC_PRESENT': '1U',
+            '__TIM_PRESENT': '1U',
+            '__L2C_PRESENT': '1U',
+            'GIC_DISTRIBUTOR_BASE': '0x2C001000UL',
+            'GIC_INTERFACE_BASE': '0x2C000100UL',
+            'TIMER_BASE': '0x2C000600UL',
+            'L2C_310_BASE': '0x2C0F0000UL',
+            'IRQn_Type': 'int'
+        }
+    },
+    'CA9neon': {
+        'arch': 'armv7a',
+        'triple': 'armv7-a',
+        'abi': 'eabihf',
+        'mcpu': 'cortex-a9',
+        'mfpu': 'neon-vfpv3',
+        'mpu': True,
+        'features': ['armv7a', 'thumb-2', 'sat', 'dsp', 'ldrex', 'clz'],
+        'header': 'core_ca.h',
+        'defines': {
+            '__CORTEX_A': '7',
+            '__CA_REV': '0x0000U',
+            '__FPU_PRESENT': '1U',
+            '__GIC_PRESENT': '1U',
+            '__TIM_PRESENT': '1U',
+            '__L2C_PRESENT': '1U',
+            'GIC_DISTRIBUTOR_BASE': '0x2C001000UL',
+            'GIC_INTERFACE_BASE': '0x2C000100UL',
+            'TIMER_BASE': '0x2C000600UL',
+            'L2C_310_BASE': '0x2C0F0000UL',
+            'IRQn_Type': 'int'
+        }
+    }
+}
+
+# Configuration file for the 'lit' test runner.
+
+# name: The name of this test suite.
+config.name = "CMSIS-Core"
+
+# testFormat: The test format to use to interpret tests.
+#
+# For now we require '&&' between commands, until they get globally killed and
+# the test runner updated.
+config.test_format = lit.formats.ShTest()
+
+# suffixes: A list of file extensions to treat as test files.
+config.suffixes = [
+    ".c"
+]
+
+# test_source_root: The root path where tests are located.
+config.test_source_root = os.path.dirname(__file__)
+
+
+# clang_path = get_toolchain_from_env('CLANG')
+
+toolchain = lit_config.params.get("toolchain", "AC6")
+device = lit_config.params.get("device", "ARMCM3")
+optimize = lit_config.params.get("optimize", "none")
+
+class Toolchain:
+    def __init__(self, toolchain, device, optimize):
+        self._toolchain = toolchain
+        self.device = device
+        self.optimize = optimize
+
+    def get_root_from_env(self):
+        keys = sorted((k for k in os.environ.keys() if k.startswith(f'{self._toolchain}_TOOLCHAIN_')), reverse=True)
+        if not keys:
+            print(f"Toolchain '{self._toolchain}' not registered!")
+            return None
+        return os.environ.get(keys[0])
+
+    def get_root(self):
+        return self.get_root_from_env()
+
+
+class Toolchain_AC6(Toolchain):
+    OPTIMIZE = {
+        'none': '-O1',
+        'balanced': '-O3',
+        'speed': '-Os',
+        'size': '-Oz'
+    }
+
+    def __init__(self, **args):
+        super().__init__('AC6', **args)
+
+    def get_cc(self):
+        return os.path.join(self.get_root(), 'armclang')
+
+    def get_ccflags(self):
+        ccflags = [
+            '--target=arm-arm-none-eabi', f'-mcpu={DEVICES[self.device]["mcpu"]}', f'-mfpu={DEVICES[self.device]["mfpu"]}', 
+            self.OPTIMIZE[self.optimize], '-I', os.path.abspath('../Include'), '-c', '-D', f'CORE_HEADER=\\"{DEVICES[device]["header"]}\\"']
+        if device.endswith('S') and not device.endswith('NS'):
+            ccflags += ["-mcmse"]
+        ccflags += list(sum([('-D', f'{define}={value}') for (define, value) in DEVICES[self.device]['defines'].items()], ()))
+        return ccflags
+
+
+class Toolchain_GCC(Toolchain):
+    OPTIMIZE = {
+        'none': '-O1',
+        'balanced': '-O3',
+        'speed': '-Os',
+        'size': '-Oz'
+    }
+
+    def __init__(self, **args):
+        super().__init__('GCC', **args)
+
+    def get_cc(self):
+        return os.path.join(self.get_root(), 'arm-none-eabi-gcc')
+
+    def get_ccflags(self):
+        floatabi='soft'
+        if DEVICES[self.device]["mfpu"] != 'none':
+            floatabi='hard'
+        ccflags = [
+            f'-mcpu={DEVICES[self.device]["mcpu"]}', f'-mfloat-abi={floatabi}', 
+            self.OPTIMIZE[self.optimize], '-I', os.path.abspath('../Include'), 
+            '-D', f'CORE_HEADER=\\"{DEVICES[device]["header"]}\\"', '-c']
+        if DEVICES[self.device]["mfpu"] != "none":
+            ccflags += [f'-mfpu={DEVICES[self.device]["mfpu"]}']
+        if device.endswith('S') and not device.endswith('NS'):
+            ccflags += ["-mcmse"]
+        ccflags += list(sum([('-D', f'{define}={value}') for (define, value) in DEVICES[self.device]['defines'].items()], ()))
+        return ccflags
+
+class Toolchain_Clang(Toolchain):
+    TARGET = {
+        'CM0': 'thumbv6m-none-unknown-eabi',
+        'CM0plus': 'thumbv6m-none-unknown-eabi',
+        'CM3': 'thumbv7m-none-unknown-eabi',
+        'CM4': 'thumbv7em-none-unknown-eabi',
+        'CM4FP': 'thumbv7em-none-unknown-eabihf',
+        'CM7': 'thumbv7em-none-unknown-eabi',
+        'CM7SP': 'thumbv7em-none-unknown-eabihf',
+        'CM7DP': 'thumbv7em-none-unknown-eabihf',
+        'CM23': 'thumbv8m.base-none-unknown-eabi',
+        'CM23S': 'thumbv8m.base-none-unknown-eabi',
+        'CM23NS': 'thumbv8m.base-none-unknown-eabi',
+        'CM33': 'thumbv8m.main-none-unknown-eabihf',
+        'CM33S': 'thumbv8m.main-none-unknown-eabihf',
+        'CM33NS': 'thumbv8m.main-none-unknown-eabihf',
+        'CM35P': 'thumbv8m.main-none-unknown-eabihf',
+        'CM35PS': 'thumbv8m.main-none-unknown-eabihf',
+        'CM35PNS': 'thumbv8m.main-none-unknown-eabihf',
+        'CM55': 'thumbv8.1m.main-none-unknown-eabihf',
+        'CM55S': 'thumbv8.1m.main-none-unknown-eabihf',
+        'CM55NS': 'thumbv8.1m.main-none-unknown-eabihf',
+        'CM85': 'thumbv8.1m.main-none-unknown-eabihf',
+        'CM85S': 'thumbv8.1m.main-none-unknown-eabihf',
+        'CM85NS': 'thumbv8.1m.main-none-unknown-eabihf',
+        'CA5': 'armv7-none-unknown-eabi',
+        'CA5neon': 'armv7-none-unknown-eabihf',
+        'CA7': 'armv7-none-unknown-eabi',
+        'CA7neon': 'armv7-none-unknown-eabihf',
+        'CA9': 'armv7-none-unknown-eabi',
+        'CA9neon': 'armv7-none-unknown-eabihf'
+    }
+    OPTIMIZE = {
+        'none': '-O1',
+        'balanced': '-O3',
+        'speed': '-Os',
+        'size': '-Oz'
+    }
+    def __init__(self, **args):
+        super().__init__('CLANG', **args)
+
+    def get_cc(self):
+        return os.path.join(self.get_root(), 'clang')
+
+    def get_ccflags(self):
+        ccflags = [
+            f'--target={self.TARGET[self.device]}', self.OPTIMIZE[self.optimize], 
+            f'-mcpu={DEVICES[self.device]["mcpu"]}', f'-mfpu={DEVICES[self.device]["mfpu"]}', 
+            '-I', os.path.abspath('../Include'), '-c', '-D', f'CORE_HEADER=\\"{DEVICES[device]["header"]}\\"']
+        if device.endswith('S') and not device.endswith('NS'):
+            ccflags += ["-mcmse"]
+        ccflags += list(sum([('-D', f'{define}={value}') for (define, value) in DEVICES[self.device]['defines'].items()], ()))
+
+        return ccflags
+    
+tc = None
+if toolchain == 'AC6':
+    tc = Toolchain_AC6(device=device, optimize=optimize)
+elif toolchain == 'GCC':
+    tc = Toolchain_GCC(device=device, optimize=optimize)
+elif toolchain == 'Clang':
+    tc = Toolchain_Clang(device=device, optimize=optimize)
+
+prefixes = ['CHECK']
+if device.endswith('NS'):
+    prefixes += ['CHECK-NS']
+elif device.endswith('S'):
+    prefixes += ['CHECK-S']
+if DEVICES[device]['arch'].startswith('thumb'):
+    prefixes += ['CHECK-THUMB']       
+elif DEVICES[device]['arch'].startswith('arm'):
+    prefixes += ['CHECK-ARM']
+
+if DEVICES[device]["mfpu"] != 'none':
+    config.available_features.add('fpu')
+for feature in DEVICES[device]['features']:
+    config.available_features.add(feature)
+
+objdump = os.path.join(Toolchain("CLANG", "none", "none").get_root(), 'llvm-objdump')
+config.substitutions.append(("llvm-objdump", objdump))
+
+config.substitutions.append(("%ccout%", "-o"))
+config.substitutions.append(("%cc%", tc.get_cc()))
+config.substitutions.append(("%ccflags%", ' '.join(tc.get_ccflags())))
+config.substitutions.append(("%prefixes%", ','.join(prefixes)))
+config.substitutions.append(("%triple%", DEVICES[device]['triple']))
+config.substitutions.append(("%mcpu%", DEVICES[device]['mcpu']))

--- a/platform/ext/cmsis/CMSIS/Core/Test/requirements.txt
+++ b/platform/ext/cmsis/CMSIS/Core/Test/requirements.txt
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+#
+# Python requirements for build.py script
+#
+python-matrix-runner~=1.0
+lit~=17.0

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/apsr.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/apsr.c
@@ -1,0 +1,11 @@
+// REQUIRES: thumbv6m
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+void get_apsr() {
+    // CHECK-LABEL: <get_apsr>:
+    // CHECK: mrs {{r[0-9]+}}, apsr
+    volatile uint32_t result = __get_APSR();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/basepri.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/basepri.c
@@ -1,0 +1,43 @@
+// REQUIRES: thumb-2, thumbv7m
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+void get_basepri() {
+    // CHECK-LABEL: <get_basepri>:
+    // CHECK: mrs {{r[0-9]+}}, basepri
+    volatile uint32_t result = __get_BASEPRI();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void get_basepri_ns() {
+    // CHECK-LABEL: <get_basepri_ns>:
+#if __ARM_FEATURE_CMSE == 3
+    // CHECK-S: mrs {{r[0-9]+}}, basepri_ns
+    volatile uint32_t result = __TZ_get_BASEPRI_NS();
+#endif
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_basepri() {
+    // CHECK-LABEL: <set_basepri>:
+    // CHECK: msr basepri, {{r[0-9]+}}
+    __set_BASEPRI(0x0815u);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_basepri_ns() {
+    // CHECK-LABEL: <set_basepri_ns>:
+#if __ARM_FEATURE_CMSE == 3
+    // CHECK-S: msr basepri_ns, {{r[0-9]+}}
+     __TZ_set_BASEPRI_NS(0x0815u);
+#endif
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_basepri_max() {
+    // CHECK-LABEL: <set_basepri_max>:
+    // CHECK: msr basepri_max, {{r[0-9]+}}
+    __set_BASEPRI_MAX(0x0815u);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/bkpt.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/bkpt.c
@@ -1,0 +1,10 @@
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+void bkpt() {
+    // CHECK-LABEL: <bkpt>:
+    // CHECK: bkpt {{#0x15|#21}}
+    __BKPT(0x15);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/clrex.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/clrex.c
@@ -1,0 +1,12 @@
+// REQUIRES: ldrex
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+void clrex() {
+    // CHECK-LABEL: <clrex>:
+    // CHECK: clrex
+    __CLREX();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/clz.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/clz.c
@@ -1,0 +1,14 @@
+// REQUIRES: clz
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+static volatile uint32_t a = 10u;
+
+void clz() {
+    // CHECK-LABEL: <clz>:
+    // CHECK: clz {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t c = __CLZ(a);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/control.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/control.c
@@ -1,0 +1,39 @@
+// REQUIRES: thumbv6m
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+void get_control() {
+    // CHECK-LABEL: <get_control>:
+    // CHECK: mrs {{r[0-9]+}}, control
+    volatile uint32_t result = __get_CONTROL();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void get_control_ns() {
+    // CHECK-LABEL: <get_control_ns>:
+#if __ARM_FEATURE_CMSE == 3
+    // CHECK-S: mrs {{r[0-9]+}}, control_ns
+    volatile uint32_t result = __TZ_get_CONTROL_NS();
+#endif
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+volatile uint32_t v32 = 0x4711u;
+
+void set_control() {
+    // CHECK-LABEL: <set_control>:
+    // CHECK: msr control, {{r[0-9]+}}
+    __set_CONTROL(v32);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_control_ns() {
+    // CHECK-LABEL: <set_control_ns>:
+#if __ARM_FEATURE_CMSE == 3
+    // CHECK-S: msr control_ns, {{r[0-9]+}}
+    __TZ_set_CONTROL_NS(v32);
+#endif
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/cp15.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/cp15.c
@@ -1,0 +1,293 @@
+// REQUIRES: armv7a
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+static volatile uint32_t u32;
+
+void get_actlr() {
+    // CHECK-LABEL: <get_actlr>:
+    // CHECK: mrc p15, #0x0, {{r[0-9]+}}, c1, c0, #0x1
+    volatile uint32_t result = __get_ACTLR();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_actlr() {
+    // CHECK-LABEL: <set_actlr>:
+    // CHECK: mcr p15, #0x0, {{r[0-9]+}}, c1, c0, #0x1
+    __set_ACTLR(u32);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void get_cpacr() {
+    // CHECK-LABEL: <get_cpacr>:
+    // CHECK: mrc p15, #0x0, {{r[0-9]+}}, c1, c0, #0x2
+    volatile uint32_t result = __get_CPACR();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_cpacr() {
+    // CHECK-LABEL: <set_cpacr>:
+    // CHECK: mcr p15, #0x0, {{r[0-9]+}}, c1, c0, #0x2
+    __set_CPACR(u32);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void get_dfsr() {
+    // CHECK-LABEL: <get_dfsr>:
+    // CHECK: mrc p15, #0x0, {{r[0-9]+}}, c5, c0, #0x0
+    volatile uint32_t result = __get_DFSR();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_dfsr() {
+    // CHECK-LABEL: <set_dfsr>:
+    // CHECK: mcr p15, #0x0, {{r[0-9]+}}, c5, c0, #0x0
+    __set_DFSR(u32);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void get_ifsr() {
+    // CHECK-LABEL: <get_ifsr>:
+    // CHECK: mrc p15, #0x0, {{r[0-9]+}}, c5, c0, #0x1
+    volatile uint32_t result = __get_IFSR();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_ifsr() {
+    // CHECK-LABEL: <set_ifsr>:
+    // CHECK: mcr p15, #0x0, {{r[0-9]+}}, c5, c0, #0x1
+    __set_IFSR(u32);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void get_isr() {
+    // CHECK-LABEL: <get_isr>:
+    // CHECK: mrc p15, #0x0, {{r[0-9]+}}, c12, c1, #0x0
+    volatile uint32_t result = __get_ISR();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void get_cbar() {
+    // CHECK-LABEL: <get_cbar>:
+    // CHECK: mrc p15, #0x4, {{r[0-9]+}}, c15, c0, #0x0
+    volatile uint32_t result = __get_CBAR();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void get_ttbr0() {
+    // CHECK-LABEL: <get_ttbr0>:
+    // CHECK: mrc p15, #0x0, {{r[0-9]+}}, c2, c0, #0x0
+    volatile uint32_t result = __get_TTBR0();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_ttbr0() {
+    // CHECK-LABEL: <set_ttbr0>:
+    // CHECK: mcr p15, #0x0, {{r[0-9]+}}, c2, c0, #0x0
+    __set_TTBR0(u32);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void get_dacr() {
+    // CHECK-LABEL: <get_dacr>:
+    // CHECK: mrc p15, #0x0, {{r[0-9]+}}, c3, c0, #0x0
+    volatile uint32_t result = __get_DACR();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_dacr() {
+    // CHECK-LABEL: <set_dacr>:
+    // CHECK: mcr p15, #0x0, {{r[0-9]+}}, c3, c0, #0x0
+    __set_DACR(u32);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void get_sctlr() {
+    // CHECK-LABEL: <get_sctlr>:
+    // CHECK: mrc p15, #0x0, {{r[0-9]+}}, c1, c0, #0x0
+    volatile uint32_t result = __get_SCTLR();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_sctlr() {
+    // CHECK-LABEL: <set_sctlr>:
+    // CHECK: mcr p15, #0x0, {{r[0-9]+}}, c1, c0, #0x0
+    __set_SCTLR(u32);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void get_mpidr() {
+    // CHECK-LABEL: <get_mpidr>:
+    // CHECK: mrc p15, #0x0, {{r[0-9]+}}, c0, c0, #0x5
+    volatile uint32_t result = __get_MPIDR();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void get_vbar() {
+    // CHECK-LABEL: <get_vbar>:
+    // CHECK: mrc p15, #0x0, {{r[0-9]+}}, c12, c0, #0x0
+    volatile uint32_t result = __get_VBAR();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_vbar() {
+    // CHECK-LABEL: <set_vbar>:
+    // CHECK: mcr p15, #0x0, {{r[0-9]+}}, c12, c0, #0x0
+    __set_VBAR(u32);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void get_mvbar() {
+    // CHECK-LABEL: <get_mvbar>:
+    // CHECK: mrc p15, #0x0, {{r[0-9]+}}, c12, c0, #0x1
+    volatile uint32_t result = __get_MVBAR();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_mvbar() {
+    // CHECK-LABEL: <set_mvbar>:
+    // CHECK: mcr p15, #0x0, {{r[0-9]+}}, c12, c0, #0x1
+    __set_MVBAR(u32);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void get_cntfrq() {
+    // CHECK-LABEL: <get_cntfrq>:
+    // CHECK: mrc p15, #0x0, {{r[0-9]+}}, c14, c0, #0x0
+    volatile uint32_t result = __get_CNTFRQ();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_cntfrq() {
+    // CHECK-LABEL: <set_cntfrq>:
+    // CHECK: mcr p15, #0x0, {{r[0-9]+}}, c14, c0, #0x0
+    __set_CNTFRQ(u32);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void get_cntp_tval() {
+    // CHECK-LABEL: <get_cntp_tval>:
+    // CHECK: mrc p15, #0x0, {{r[0-9]+}}, c14, c2, #0x0
+    volatile uint32_t result = __get_CNTP_TVAL();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_cntp_tval() {
+    // CHECK-LABEL: <set_cntp_tval>:
+    // CHECK: mcr p15, #0x0, {{r[0-9]+}}, c14, c2, #0x0
+    __set_CNTP_TVAL(u32);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void get_cntp_ctl() {
+    // CHECK-LABEL: <get_cntp_ctl>:
+    // CHECK: mrc p15, #0x0, {{r[0-9]+}}, c14, c2, #0x1
+    volatile uint32_t result = __get_CNTP_CTL();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_cntp_ctl() {
+    // CHECK-LABEL: <set_cntp_ctl>:
+    // CHECK: mcr p15, #0x0, {{r[0-9]+}}, c14, c2, #0x1
+    __set_CNTP_CTL(u32);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_tlbiall() {
+    // CHECK-LABEL: <set_tlbiall>:
+    // CHECK: mcr p15, #0x0, {{r[0-9]+}}, c8, c7, #0x0
+    __set_TLBIALL(u32);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_bpiall() {
+    // CHECK-LABEL: <set_bpiall>:
+    // CHECK: mcr p15, #0x0, {{r[0-9]+}}, c7, c5, #0x6
+    __set_BPIALL(u32);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_iciallu() {
+    // CHECK-LABEL: <set_iciallu>:
+    // CHECK: mcr p15, #0x0, {{r[0-9]+}}, c7, c5, #0x0
+    __set_ICIALLU(u32);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_icimvac() {
+    // CHECK-LABEL: <set_icimvac>:
+    // CHECK: mcr p15, #0x0, {{r[0-9]+}}, c7, c5, #0x1
+    __set_ICIMVAC(u32);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_dccmvac() {
+    // CHECK-LABEL: <set_dccmvac>:
+    // CHECK: mcr p15, #0x0, {{r[0-9]+}}, c7, c10, #0x1
+    __set_DCCMVAC(u32);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_dcimvac() {
+    // CHECK-LABEL: <set_dcimvac>:
+    // CHECK: mcr p15, #0x0, {{r[0-9]+}}, c7, c6, #0x1
+    __set_DCIMVAC(u32);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_dccimvac() {
+    // CHECK-LABEL: <set_dccimvac>:
+    // CHECK: mcr p15, #0x0, {{r[0-9]+}}, c7, c14, #0x1
+    __set_DCCIMVAC(u32);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void get_csselr() {
+    // CHECK-LABEL: <get_csselr>:
+    // CHECK: mrc p15, #0x2, {{r[0-9]+}}, c0, c0, #0x0
+    volatile uint32_t result = __get_CSSELR();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_csselr() {
+    // CHECK-LABEL: <set_csselr>:
+    // CHECK: mcr p15, #0x2, {{r[0-9]+}}, c0, c0, #0x0
+    __set_CSSELR(u32);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void get_ccsidr() {
+    // CHECK-LABEL: <get_ccsidr>:
+    // CHECK: mrc p15, #0x1, {{r[0-9]+}}, c0, c0, #0x0
+    volatile uint32_t result = __get_CCSIDR();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void get_clidr() {
+    // CHECK-LABEL: <get_clidr>:
+    // CHECK: mrc p15, #0x1, {{r[0-9]+}}, c0, c0, #0x1
+    volatile uint32_t result = __get_CLIDR();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_dcisw() {
+    // CHECK-LABEL: <set_dcisw>:
+    // CHECK: mcr p15, #0x0, {{r[0-9]+}}, c7, c6, #0x2
+    __set_DCISW(u32);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_dccsw() {
+    // CHECK-LABEL: <set_dccsw>:
+    // CHECK: mcr p15, #0x0, {{r[0-9]+}}, c7, c10, #0x2
+    __set_DCCSW(u32);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_dccisw() {
+    // CHECK-LABEL: <set_dccisw>:
+    // CHECK: mcr p15, #0x0, {{r[0-9]+}}, c7, c14, #0x2
+    __set_DCCISW(u32);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/cpsr.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/cpsr.c
@@ -1,0 +1,35 @@
+// REQUIRES: armv7a
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+static volatile uint32_t u32;
+
+void get_cpsr() {
+    // CHECK-LABEL: <get_cpsr>:
+    // CHECK: mrs {{r[0-9]+}}, apsr
+    volatile uint32_t result = __get_CPSR();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_cpsr() {
+    // CHECK-LABEL: <set_cpsr>:
+    // CHECK: msr CPSR_fc, {{r[0-9]+}}
+    __set_CPSR(u32);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void get_mode() {
+    // CHECK-LABEL: <get_mode>:
+    // CHECK: mrs [[REG:r[0-9]+]], apsr
+    // CHECK: and [[REG]], [[REG]], #{{31|0x1f}}
+    volatile uint32_t result = __get_mode();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_mode() {
+    // CHECK-LABEL: <set_mode>:
+    // CHECK: msr CPSR_c, {{r[0-9]+}}
+    __set_mode(u32);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/dmb.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/dmb.c
@@ -1,0 +1,11 @@
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+void dmb() {
+    // CHECK-LABEL: <dmb>:
+    // CHECK: dmb sy
+    __DMB();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/dsb.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/dsb.c
@@ -1,0 +1,11 @@
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+void dsb() {
+    // CHECK-LABEL: <dsb>:
+    // CHECK: dsb sy
+    __DSB();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/fault_irq.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/fault_irq.c
@@ -1,0 +1,18 @@
+// REQUIRES: thumb-2
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+void enable_fault_irq() {
+    // CHECK-LABEL: <enable_fault_irq>:
+    // CHECK: cpsie f
+    __enable_fault_irq();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void disable_fault_irq() {
+    // CHECK-LABEL: <disable_fault_irq>:
+    // CHECK: cpsid f
+    __disable_fault_irq();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/faultmask.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/faultmask.c
@@ -1,0 +1,36 @@
+// REQUIRES: thumb-2, thumbv7m
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+void get_faultmask() {
+    // CHECK-LABEL: <get_faultmask>:
+    // CHECK: mrs {{r[0-9]+}}, faultmask
+    volatile uint32_t result = __get_FAULTMASK();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void get_faultmask_ns() {
+    // CHECK-LABEL: <get_faultmask_ns>:
+#if __ARM_FEATURE_CMSE == 3
+    // CHECK-S: mrs {{r[0-9]+}}, faultmask_ns
+    volatile uint32_t result = __TZ_get_FAULTMASK_NS();
+#endif
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_faultmask() {
+    // CHECK-LABEL: <set_faultmask>:
+    // CHECK: msr faultmask, {{r[0-9]+}}
+    __set_FAULTMASK(0x0815u);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_faultmask_ns() {
+    // CHECK-LABEL: <set_faultmask_ns>:
+#if __ARM_FEATURE_CMSE == 3
+    // CHECK-S: msr faultmask_ns, {{r[0-9]+}}
+     __TZ_set_FAULTMASK_NS(0x0815u);
+#endif
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/fpexc.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/fpexc.c
@@ -1,0 +1,20 @@
+// REQUIRES: armv7a, fpu
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+static volatile uint32_t u32;
+
+void get_fpexc() {
+    // CHECK-LABEL: <get_fpexc>:
+    // CHECK: vmrs {{r[0-9]+}}, fpexc
+    volatile uint32_t result = __get_FPEXC();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_fpexc() {
+    // CHECK-LABEL: <set_fpexc>:
+    // CHECK: vmsr fpexc, {{r[0-9]+}}
+    __set_FPEXC(u32);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/fpexc_nofp.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/fpexc_nofp.c
@@ -1,0 +1,22 @@
+// REQUIRES: armv7a
+// UNSUPPORTED: fpu
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+static volatile uint32_t u32;
+
+void get_fpexc() {
+    // CHECK-LABEL: <get_fpexc>:
+    // CHECK-NOT: vmrs
+    // CHECK: mov {{r[0-9]+}}, #0
+    volatile uint32_t result = __get_FPEXC();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_fpexc() {
+    // CHECK-LABEL: <set_fpexc>:
+    // CHECK-NOT: vmsr
+    __set_FPEXC(u32);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/fpscr.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/fpscr.c
@@ -1,0 +1,20 @@
+// REQUIRES: fpu
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+void get_fpscr() {
+    // CHECK-LABEL: <get_fpscr>:
+    // CHECK: vmrs {{r[0-9]+}}, fpscr
+    volatile uint32_t result = __get_FPSCR();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+volatile uint32_t v32 = 0x4711u;
+
+void set_fpscr() {
+    // CHECK-LABEL: <set_fpscr>:
+    // CHECK: vmsr fpscr, {{r[0-9]+}}
+    __set_FPSCR(v32);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/fpscr_nofp.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/fpscr_nofp.c
@@ -1,0 +1,21 @@
+// UNSUPPORTED: fpu
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+void get_fpscr() {
+    // CHECK-LABEL: <get_fpscr>:
+    // CHECK-NOT: vmrs {{r[0-9]+}}, fpscr
+    // CHECK: mov{{s?}} {{r[0-9]+}}, #0
+    volatile uint32_t result = __get_FPSCR();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+volatile uint32_t v32 = 0x4711u;
+
+void set_fpscr() {
+    // CHECK-LABEL: <set_fpscr>:
+    // CHECK-NOT: vmsr fpscr, {{r[0-9]+}}
+    __set_FPSCR(v32);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/ipsr.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/ipsr.c
@@ -1,0 +1,12 @@
+
+// REQUIRES: thumbv6m
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+void get_ipsr() {
+    // CHECK-LABEL: <get_ipsr>:
+    // CHECK: mrs {{r[0-9]+}}, ipsr
+    volatile uint32_t result = __get_IPSR();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/irq.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/irq.c
@@ -1,0 +1,17 @@
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+void enable_irq() {
+    // CHECK-LABEL: <enable_irq>:
+    // CHECK: cpsie i
+    __enable_irq();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void disable_irq() {
+    // CHECK-LABEL: <disable_irq>:
+    // CHECK: cpsid i
+    __disable_irq();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/isb.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/isb.c
@@ -1,0 +1,11 @@
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+void isb() {
+    // CHECK-LABEL: <isb>:
+    // CHECK: isb sy
+    __ISB();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/lda.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/lda.c
@@ -1,0 +1,29 @@
+// REQUIRES: armv8m
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+static volatile uint8_t v8 = 0x7u;
+static volatile uint16_t v16 = 0x7u;
+static volatile uint32_t v32 = 0x7u;
+
+void ldab() {
+    // CHECK-LABEL: <ldab>:
+    // CHECK: ldab {{r[0-9]+}}, [{{r[0-9]+}}]
+    volatile uint8_t result = __LDAB(&v8);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void ldah() {
+    // CHECK-LABEL: <ldah>:
+    // CHECK: ldah {{r[0-9]+}}, [{{r[0-9]+}}]
+    volatile uint16_t result = __LDAH(&v16);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void lda() {
+    // CHECK-LABEL: <lda>:
+    // CHECK: lda {{r[0-9]+}}, [{{r[0-9]+}}]
+    volatile uint32_t result = __LDA(&v32);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/ldaex.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/ldaex.c
@@ -1,0 +1,29 @@
+// REQUIRES: armv8m
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+static volatile uint8_t v8 = 0x7u;
+static volatile uint16_t v16 = 0x7u;
+static volatile uint32_t v32 = 0x7u;
+
+void ldaexb() {
+    // CHECK-LABEL: <ldaexb>:
+    // CHECK: ldaexb {{r[0-9]+}}, [{{r[0-9]+}}]
+    volatile uint8_t result = __LDAEXB(&v8);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void ldaexh() {
+    // CHECK-LABEL: <ldaexh>:
+    // CHECK: ldaexh {{r[0-9]+}}, [{{r[0-9]+}}]
+    volatile uint16_t result = __LDAEXH(&v16);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void ldaex() {
+    // CHECK-LABEL: <ldaex>:
+    // CHECK: ldaex {{r[0-9]+}}, [{{r[0-9]+}}]
+    volatile uint32_t result = __LDAEX(&v32);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/ldrex.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/ldrex.c
@@ -1,0 +1,29 @@
+// REQUIRES: ldrex
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+static volatile uint8_t v8 = 0x7u;
+static volatile uint16_t v16 = 0x7u;
+static volatile uint32_t v32 = 0x7u;
+
+void ldrexb() {
+    // CHECK-LABEL: <ldrexb>:
+    // CHECK: ldrexb {{r[0-9]+}}, [{{r[0-9]+}}]
+    volatile uint8_t result = __LDREXB(&v8);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void ldrexh() {
+    // CHECK-LABEL: <ldrexh>:
+    // CHECK: ldrexh {{r[0-9]+}}, [{{r[0-9]+}}]
+    volatile uint16_t result = __LDREXH(&v16);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void ldrexw() {
+    // CHECK-LABEL: <ldrexw>:
+    // CHECK: ldrex {{r[0-9]+}}, [{{r[0-9]+}}]
+    volatile uint32_t result = __LDREXW(&v32);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/ldrt.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/ldrt.c
@@ -1,0 +1,30 @@
+
+// REQUIRES: thumb-2
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+static volatile uint8_t v8 = 0x7u;
+static volatile uint16_t v16 = 0x7u;
+static volatile uint32_t v32 = 0x7u;
+
+void ldrbt() {
+    // CHECK-LABEL: <ldrbt>:
+    // CHECK: ldrbt {{r[0-9]+}}, [{{r[0-9]+}}]
+    volatile uint8_t result = __LDRBT(&v8);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void ldrht() {
+    // CHECK-LABEL: <ldrht>:
+    // CHECK: ldrht {{r[0-9]+}}, [{{r[0-9]+}}]
+    volatile uint16_t result = __LDRHT(&v16);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void ldrt() {
+    // CHECK-LABEL: <ldrt>:
+    // CHECK: ldrt {{r[0-9]+}}, [{{r[0-9]+}}]
+    volatile uint32_t result = __LDRT(&v32);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/msp.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/msp.c
@@ -1,0 +1,36 @@
+// REQUIRES: thumbv6m
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+void get_msp() {
+    // CHECK-LABEL: <get_msp>:
+    // CHECK: mrs {{r[0-9]+}}, msp
+    volatile uint32_t result = __get_MSP();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void get_msp_ns() {
+    // CHECK-LABEL: <get_msp_ns>:
+#if __ARM_FEATURE_CMSE == 3
+    // CHECK-S: mrs {{r[0-9]+}}, msp_ns
+    volatile uint32_t result = __TZ_get_MSP_NS();
+#endif
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_msp() {
+    // CHECK-LABEL: <set_msp>:
+    // CHECK: msr msp, {{r[0-9]+}}
+    __set_MSP(0x0815u);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_msp_ns() {
+    // CHECK-LABEL: <set_msp_ns>:
+#if __ARM_FEATURE_CMSE == 3
+    // CHECK-S: msr msp_ns, {{r[0-9]+}}
+     __TZ_set_MSP_NS(0x0815u);
+#endif
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/msplim.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/msplim.c
@@ -1,0 +1,36 @@
+// REQUIRES: thumbv8m.main
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+void get_msplim() {
+    // CHECK-LABEL: <get_msplim>:
+    // CHECK: mrs {{r[0-9]+}}, msplim
+    volatile uint32_t result = __get_MSPLIM();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void get_msplim_ns() {
+    // CHECK-LABEL: <get_msplim_ns>:
+#if __ARM_FEATURE_CMSE == 3
+    // CHECK-S: mrs {{r[0-9]+}}, msplim_ns
+    volatile uint32_t result = __TZ_get_MSPLIM_NS();
+#endif
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_msplim() {
+    // CHECK-LABEL: <set_msplim>:
+    // CHECK: msr msplim, {{r[0-9]+}}
+    __set_MSPLIM(0x0815u);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_msplim_ns() {
+    // CHECK-LABEL: <set_msplim_ns>:
+#if __ARM_FEATURE_CMSE == 3
+    // CHECK-S: msr msplim_ns, {{r[0-9]+}}
+     __TZ_set_MSPLIM_NS(0x0815u);
+#endif
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/nop.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/nop.c
@@ -1,0 +1,10 @@
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+void nop() {
+    // CHECK-LABEL: <nop>:
+    // CHECK: {{(nop|mov r8, r8)}}
+    __NOP();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/noreturn.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/noreturn.c
@@ -1,0 +1,15 @@
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+__NO_RETURN
+static void func() {
+    while(1);
+}
+
+void noreturn() {
+    // CHECK-LABEL: <noreturn>:
+    // CHECK: b 0x0 <noreturn>
+    func();
+    // CHECK-NOT: bx lr
+}

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/primask.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/primask.c
@@ -1,0 +1,36 @@
+// REQUIRES: thumbv6m
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+void get_primask() {
+    // CHECK-LABEL: <get_primask>:
+    // CHECK: mrs {{r[0-9]+}}, primask
+    volatile uint32_t result = __get_PRIMASK();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void get_primask_ns() {
+    // CHECK-LABEL: <get_primask_ns>:
+#if __ARM_FEATURE_CMSE == 3
+    // CHECK-S: mrs {{r[0-9]+}}, primask_ns
+    volatile uint32_t result = __TZ_get_PRIMASK_NS();
+#endif
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_primask() {
+    // CHECK-LABEL: <set_primask>:
+    // CHECK: msr primask, {{r[0-9]+}}
+    __set_PRIMASK(0x0815u);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_primask_ns() {
+    // CHECK-LABEL: <set_primask_ns>:
+#if __ARM_FEATURE_CMSE == 3
+    // CHECK-S: msr primask_ns, {{r[0-9]+}}
+     __TZ_set_PRIMASK_NS(0x0815u);
+#endif
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/psp.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/psp.c
@@ -1,0 +1,36 @@
+// REQUIRES: thumbv6m
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+void get_psp() {
+    // CHECK-LABEL: <get_psp>:
+    // CHECK: mrs {{r[0-9]+}}, psp
+    volatile uint32_t result = __get_PSP();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void get_psp_ns() {
+    // CHECK-LABEL: <get_psp_ns>:
+#if __ARM_FEATURE_CMSE == 3
+    // CHECK-S: mrs {{r[0-9]+}}, psp_ns
+    volatile uint32_t result = __TZ_get_PSP_NS();
+#endif
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_psp() {
+    // CHECK-LABEL: <set_psp>:
+    // CHECK: msr psp, {{r[0-9]+}}
+    __set_PSP(0x0815u);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_psp_ns() {
+    // CHECK-LABEL: <set_psp_ns>:
+#if __ARM_FEATURE_CMSE == 3
+    // CHECK-S: msr psp_ns, {{r[0-9]+}}
+     __TZ_set_PSP_NS(0x0815u);
+#endif
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/psplim.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/psplim.c
@@ -1,0 +1,36 @@
+// REQUIRES: thumbv8m.main
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+void get_psplim() {
+    // CHECK-LABEL: <get_psplim>:
+    // CHECK: mrs {{r[0-9]+}}, psplim
+    volatile uint32_t result = __get_PSPLIM();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void get_psplim_ns() {
+    // CHECK-LABEL: <get_psplim_ns>:
+#if __ARM_FEATURE_CMSE == 3
+    // CHECK-S: mrs {{r[0-9]+}}, psplim_ns
+    volatile uint32_t result = __TZ_get_PSPLIM_NS();
+#endif
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_psplim() {
+    // CHECK-LABEL: <set_psplim>:
+    // CHECK: msr psplim, {{r[0-9]+}}
+    __set_PSPLIM(0x0815u);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_psplim_ns() {
+    // CHECK-LABEL: <set_psplim_ns>:
+#if __ARM_FEATURE_CMSE == 3
+    // CHECK-S: msr psplim_ns, {{r[0-9]+}}
+     __TZ_set_PSPLIM_NS(0x0815u);
+#endif
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/psplim_baseline.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/psplim_baseline.c
@@ -1,0 +1,39 @@
+// REQUIRES: thumbv8m.base
+// UNSUPPORTED: thumbv8m.main
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+void get_psplim() {
+    // CHECK-LABEL: <get_psplim>:
+    // CHECK-S: mrs {{r[0-9]+}}, psplim
+    // CHECK-NS-NOT: mrs {{r[0-9]+}}, psplim
+    volatile uint32_t result = __get_PSPLIM();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void get_psplim_ns() {
+    // CHECK-LABEL: <get_psplim_ns>:
+#if __ARM_FEATURE_CMSE == 3
+    // CHECK-S-NOT: mrs {{r[0-9]+}}, psplim_ns
+    volatile uint32_t result = __TZ_get_PSPLIM_NS();
+#endif
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_psplim() {
+    // CHECK-LABEL: <set_psplim>:
+    // CHECK-S: msr psplim, {{r[0-9]+}}
+    // CHECK-NS-NOT: msr psplim, {{r[0-9]+}}
+    __set_PSPLIM(0x0815u);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_psplim_ns() {
+    // CHECK-LABEL: <set_psplim_ns>:
+#if __ARM_FEATURE_CMSE == 3
+    // CHECK-S-NOT: msr psplim_ns, {{r[0-9]+}}
+     __TZ_set_PSPLIM_NS(0x0815u);
+#endif
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/rbit.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/rbit.c
@@ -1,0 +1,14 @@
+// REQUIRES: thumb-2
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+static volatile uint32_t a = 10u;
+
+void rbit() {
+    // CHECK-LABEL: <rbit>:
+    // CHECK: rbit {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t c = __RBIT(a);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/rev.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/rev.c
@@ -1,0 +1,13 @@
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+static volatile uint32_t a = 10u;
+
+void rev() {
+    // CHECK-LABEL: <rev>:
+    // CHECK: rev {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t c = __REV(a);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/rev16.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/rev16.c
@@ -1,0 +1,13 @@
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+static volatile uint32_t a = 10u;
+
+void rev16() {
+    // CHECK-LABEL: <rev16>:
+    // CHECK: rev16 {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t c = __REV16(a);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/revsh.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/revsh.c
@@ -1,0 +1,13 @@
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+static volatile uint32_t a = 10u;
+
+void revsh() {
+    // CHECK-LABEL: <revsh>:
+    // CHECK: revsh {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t c = __REVSH(a);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/ror.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/ror.c
@@ -1,0 +1,15 @@
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+static volatile uint32_t a = 10u;
+static volatile uint32_t b = 2u;
+
+void ror() {
+    // CHECK-LABEL: <ror>:
+    // CHECK-THUMB: ror{{s|.w}} {{r[0-9]+}}, {{r[0-9]+}}
+    // CHECK-ARM: ror {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t c = __ROR(a, b);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/rrx.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/rrx.c
@@ -1,0 +1,13 @@
+// REQUIRES: thumb-2
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+static volatile uint32_t a = 10u;
+
+void rrx() {
+    // CHECK-LABEL: <rrx>:
+    // CHECK: rrx {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t c = __RRX(a);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/sat.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/sat.c
@@ -1,0 +1,26 @@
+// REQUIRES: sat
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+static volatile uint32_t s32 = 10;
+static volatile uint32_t u32 = 10U;
+
+void ssat() {
+    // CHECK-LABEL: <ssat>:
+    // CHECK: ssat {{r[0-9]+}}, #0x2, {{r[0-9]+}}
+    volatile uint32_t c = __SSAT(s32, 2u);
+    // CHECK: ssat {{r[0-9]+}}, #0x5, {{r[0-9]+}}
+    volatile uint32_t d = __SSAT(s32, 5u);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void usat() {
+    // CHECK-LABEL: <usat>:
+    // CHECK: usat {{r[0-9]+}}, #0x2, {{r[0-9]+}}
+    volatile uint32_t c = __USAT(u32, 2u);
+    // CHECK: usat {{r[0-9]+}}, #0x5, {{r[0-9]+}}
+    volatile uint32_t d = __USAT(u32, 5u);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/sev.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/sev.c
@@ -1,0 +1,11 @@
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+void sev() {
+    // CHECK-LABEL: <sev>:
+    // CHECK: sev
+    __SEV();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/simd.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/simd.c
@@ -1,0 +1,530 @@
+// REQUIRES: dsp
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+volatile static int32_t s32_1 = 0x47;
+volatile static int32_t s32_2 = 0x11;
+volatile static int32_t s32_3 = 0x15;
+volatile static uint8_t u8 = 5u;
+
+/* ADD8 */
+
+void sadd8() {
+    // CHECK-LABEL: <sadd8>:
+    // CHECK: sadd8 {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __SADD8(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void qadd8() {
+    // CHECK-LABEL: <qadd8>:
+    // CHECK: qadd8 {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __QADD8(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void shadd8() {
+    // CHECK-LABEL: <shadd8>:
+    // CHECK: shadd8 {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __SHADD8(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void uadd8() {
+    // CHECK-LABEL: <uadd8>:
+    // CHECK: uadd8 {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __UADD8(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void uqadd8() {
+    // CHECK-LABEL: <uqadd8>:
+    // CHECK: uqadd8 {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __UQADD8(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void uhadd8() {
+    // CHECK-LABEL: <uhadd8>:
+    // CHECK: uhadd8 {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __UHADD8(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+/* SUB8 */
+
+void ssub8() {
+    // CHECK-LABEL: <ssub8>:
+    // CHECK: ssub8 {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __SSUB8(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void qsub8() {
+    // CHECK-LABEL: <qsub8>:
+    // CHECK: qsub8 {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __QSUB8(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void shsub8() {
+    // CHECK-LABEL: <shsub8>:
+    // CHECK: shsub8 {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __SHSUB8(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void usub8() {
+    // CHECK-LABEL: <usub8>:
+    // CHECK: usub8 {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __USUB8(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void uqsub8() {
+    // CHECK-LABEL: <uqsub8>:
+    // CHECK: uqsub8 {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __UQSUB8(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void uhsub8() {
+    // CHECK-LABEL: <uhsub8>:
+    // CHECK: uhsub8 {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __UHSUB8(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+/* ADD16 */
+
+void sadd16() {
+    // CHECK-LABEL: <sadd16>:
+    // CHECK: sadd16 {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __SADD16(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void qadd16() {
+    // CHECK-LABEL: <qadd16>:
+    // CHECK: qadd16 {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __QADD16(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void shadd16() {
+    // CHECK-LABEL: <shadd16>:
+    // CHECK: shadd16 {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __SHADD16(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void uadd16() {
+    // CHECK-LABEL: <uadd16>:
+    // CHECK: uadd16 {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __UADD16(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void uqadd16() {
+    // CHECK-LABEL: <uqadd16>:
+    // CHECK: uqadd16 {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __UQADD16(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void uhadd16() {
+    // CHECK-LABEL: <uhadd16>:
+    // CHECK: uhadd16 {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __UHADD16(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+/* SUB16 */
+
+void ssub16() {
+    // CHECK-LABEL: <ssub16>:
+    // CHECK: ssub16 {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __SSUB16(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void qsub16() {
+    // CHECK-LABEL: <qsub16>:
+    // CHECK: qsub16 {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __QSUB16(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void shsub16() {
+    // CHECK-LABEL: <shsub16>:
+    // CHECK: shsub16 {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __SHSUB16(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void usub16() {
+    // CHECK-LABEL: <usub16>:
+    // CHECK: usub16 {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __USUB16(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void uqsub16() {
+    // CHECK-LABEL: <uqsub16>:
+    // CHECK: uqsub16 {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __UQSUB16(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void uhsub16() {
+    // CHECK-LABEL: <uhsub16>:
+    // CHECK: uhsub16 {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __UHSUB16(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+/* ASX */
+
+void sasx() {
+    // CHECK-LABEL: <sasx>:
+    // CHECK: sasx {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __SASX(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void qasx() {
+    // CHECK-LABEL: <qasx>:
+    // CHECK: qasx {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __QASX(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void shasx() {
+    // CHECK-LABEL: <shasx>:
+    // CHECK: shasx {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __SHASX(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void uasx() {
+    // CHECK-LABEL: <uasx>:
+    // CHECK: uasx {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __UASX(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void uqasx() {
+    // CHECK-LABEL: <uqasx>:
+    // CHECK: uqasx {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __UQASX(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void uhasx() {
+    // CHECK-LABEL: <uhasx>:
+    // CHECK: uhasx {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __UHASX(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+/* SAX */
+
+void ssax() {
+    // CHECK-LABEL: <ssax>:
+    // CHECK: ssax {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __SSAX(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void qsax() {
+    // CHECK-LABEL: <qsax>:
+    // CHECK: qsax {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __QSAX(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void shsax() {
+    // CHECK-LABEL: <shsax>:
+    // CHECK: shsax {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __SHSAX(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void usax() {
+    // CHECK-LABEL: <usax>:
+    // CHECK: usax {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __USAX(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void uqsax() {
+    // CHECK-LABEL: <uqsax>:
+    // CHECK: uqsax {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __UQSAX(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void uhsax() {
+    // CHECK-LABEL: <uhsax>:
+    // CHECK: uhsax {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __UHSAX(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+/* SAT */
+
+void usad8() {
+    // CHECK-LABEL: <usad8>:
+    // CHECK: usad8 {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __USAD8(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void usada8() {
+    // CHECK-LABEL: <usada8>:
+    // CHECK: usada8 {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __USADA8(s32_1, s32_2, s32_3);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void ssat16() {
+    // CHECK-LABEL: <ssat16>:
+    // CHECK: ssat16 {{r[0-9]+}}, #0x5, {{r[0-9]+}}
+    volatile uint32_t result = __SSAT16(s32_1, 0x05);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void usat16() {
+    // CHECK-LABEL: <usat16>:
+    // CHECK: usat16 {{r[0-9]+}}, #0x5, {{r[0-9]+}}
+    volatile uint32_t result = __USAT16(s32_1, 0x05);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void uxtb16() {
+    // CHECK-LABEL: <uxtb16>:
+    // CHECK: uxtb16 {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __UXTB16(s32_1);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void uxtab16() {
+    // CHECK-LABEL: <uxtab16>:
+    // CHECK: uxtab16 {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __UXTAB16(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void sxtb16() {
+    // CHECK-LABEL: <sxtb16>:
+    // CHECK: sxtb16 {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __SXTB16(s32_1);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void sxtab16() {
+    // CHECK-LABEL: <sxtab16>:
+    // CHECK: sxtab16 {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __SXTAB16(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+/* MUL */
+
+void smuad() {
+    // CHECK-LABEL: <smuad>:
+    // CHECK: smuad {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __SMUAD(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void smuadx() {
+    // CHECK-LABEL: <smuadx>:
+    // CHECK: smuadx {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __SMUADX(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void smlad() {
+    // CHECK-LABEL: <smlad>:
+    // CHECK: smlad {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __SMLAD(s32_1, s32_2, s32_3);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void smladx() {
+    // CHECK-LABEL: <smladx>:
+    // CHECK: smladx {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __SMLADX(s32_1, s32_2, s32_3);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void smlald() {
+    // CHECK-LABEL: <smlald>:
+    // CHECK: smlald {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __SMLALD(s32_1, s32_2, s32_3);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void smlaldx() {
+    // CHECK-LABEL: <smlaldx>:
+    // CHECK: smlaldx {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __SMLALDX(s32_1, s32_2, s32_3);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void smusd() {
+    // CHECK-LABEL: <smusd>:
+    // CHECK: smusd {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __SMUSD(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void smusdx() {
+    // CHECK-LABEL: <smusdx>:
+    // CHECK: smusdx {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __SMUSDX(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void smlsd() {
+    // CHECK-LABEL: <smlsd>:
+    // CHECK: smlsd {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __SMLSD(s32_1, s32_2, s32_3);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void smlsdx() {
+    // CHECK-LABEL: <smlsdx>:
+    // CHECK: smlsdx {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __SMLSDX(s32_1, s32_2, s32_3);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void smlsld() {
+    // CHECK-LABEL: <smlsld>:
+    // CHECK: smlsld {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __SMLSLD(s32_1, s32_2, s32_3);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void smlsldx() {
+    // CHECK-LABEL: <smlsldx>:
+    // CHECK: smlsldx {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __SMLSLDX(s32_1, s32_2, s32_3);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void sel() {
+    // CHECK-LABEL: <sel>:
+    // CHECK: sel {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __SEL(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void qadd() {
+    // CHECK-LABEL: <qadd>:
+    // CHECK: qadd {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __QADD(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void qsub() {
+    // CHECK-LABEL: <qsub>:
+    // CHECK: qsub {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile uint32_t result = __QSUB(s32_1, s32_2);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void pkhbt0() {
+    // CHECK-LABEL: <pkhbt0>:
+    // CHECK: {{pkhtb|pkhbt}} {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    // CHECK-NOT: , lsl
+    // CHECK-NOT: , asr
+    volatile uint32_t result = __PKHBT(s32_1, s32_2, 0);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void pkhbt() {
+    // CHECK-LABEL: <pkhbt>:
+    // CHECK: pkhbt {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}, lsl #11
+    volatile uint32_t result = __PKHBT(s32_1, s32_2, 11);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void pkhtb0() {
+    // CHECK-LABEL: <pkhtb0>:
+    // CHECK: {{pkhtb|pkhbt}} {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    // CHECK-NOT: , lsl
+    // CHECK-NOT: , asr
+    volatile uint32_t result = __PKHTB(s32_1, s32_2, 0);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void pkhtb() {
+    // CHECK-LABEL: <pkhtb>:
+    // CHECK: pkhtb {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}, asr #11
+    volatile uint32_t result = __PKHTB(s32_1, s32_2, 11);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void sxtb16_ror() {    
+    // CHECK-LABEL: <sxtb16_ror>:
+    // CHECK: sxtb16 {{r[0-9]+}}, {{r[0-9]+}}, ror #8
+    volatile uint32_t result = __SXTB16_RORn(s32_1, 8);
+
+    // CHECK: sxtb16 {{r[0-9]+}}, {{r[0-9]+}}, ror #16
+    result = __SXTB16_RORn(s32_1, 16);
+
+    // CHECK: sxtb16 {{r[0-9]+}}, {{r[0-9]+}}, ror #24
+    result = __SXTB16_RORn(s32_1, 24);
+
+    // CHECK-THUMB: ror.w [[REG:r[0-9]+]], {{r[0-9]+}}, {{#5|#0x5}}
+    // CHECK-ARM: ror [[REG:r[0-9]+]], {{r[0-9]+}}, {{#5|#0x5}}
+    // CHECK: sxtb16 {{r[0-9]+}}, [[REG]]
+    // CHECK-NOT: , ror
+    result = __SXTB16_RORn(s32_1, 5);
+
+    // CHECK-THUMB: ror{{.w|ne|s}} {{r[0-9]+}}, {{r[0-9]+}}
+    // CHECK-ARM: ror{{(ne)?}} {{r[0-9]+}}, {{r[0-9]+}}
+    // CHECK: sxtb16 {{r[0-9]+}}, {{r[0-9]+}}
+    // CHECK-NOT: , ror
+    result = __SXTB16_RORn(s32_1, u8);
+
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void sxtab16_ror() {
+    // CHECK-LABEL: <sxtab16_ror>:
+
+    // CHECK: sxtab16 {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}, ror #8
+    volatile uint32_t result = __SXTAB16_RORn(s32_1, s32_2, 8);
+
+    // CHECK: sxtab16 {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}, ror #16
+    result = __SXTAB16_RORn(s32_1, s32_2, 16);
+
+    // CHECK: sxtab16 {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}, ror #24
+    result = __SXTAB16_RORn(s32_1, s32_2, 24);
+
+    // CHECK-THUMB: ror.w [[REG:r[0-9]+]], {{r[0-9]+}}, {{#5|#0x5}}
+    // CHECK-ARM: ror [[REG:r[0-9]+]], {{r[0-9]+}}, {{#5|#0x5}}
+    // CHECK: sxtab16 {{r[0-9]+}}, {{r[0-9]+}}, [[REG]]
+    // CHECK-NOT: , ror
+    result = __SXTAB16_RORn(s32_1, s32_2, 5);
+
+    // CHECK-THUMB: ror{{.w|ne|s}} {{r[0-9]+}}, {{r[0-9]+}}
+    // CHECK-ARM: ror{{(ne)?}} {{r[0-9]+}}, {{r[0-9]+}}
+    // CHECK: sxtab16 {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    // CHECK-NOT: , ror
+    result = __SXTAB16_RORn(s32_1, s32_2, u8);
+
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void smmla() {
+    // CHECK-LABEL: <smmla>:
+    // CHECK: smmla {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}, {{r[0-9]+}}
+    volatile int32_t result = __SMMLA(s32_1, s32_2, s32_3);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/sp.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/sp.c
@@ -1,0 +1,40 @@
+// REQUIRES: armv7a
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+static volatile uint32_t u32;
+
+void get_sp() {
+    // CHECK-LABEL: <get_sp>:
+    // CHECK: mov {{r[0-9]+}}, sp
+    volatile uint32_t result = __get_SP();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_sp() {
+    // CHECK-LABEL: <set_sp>:
+    // CHECK: mov sp, {{r[0-9]+}}
+    __set_SP(u32);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void get_sp_usr() {
+    // CHECK-LABEL: <get_sp_usr>:
+    // CHECK: mrs [[REG:r[0-9]+]], apsr
+    // CHECK: cps #{{31|0x1f}}
+    // CHECK: mov {{r[0-9]+}}, sp
+    // CHECK: msr CPSR_{{f?}}c, [[REG]]
+    volatile uint32_t result = __get_SP_usr();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_sp_usr() {
+    // CHECK-LABEL: <set_sp_usr>:
+    // CHECK: mrs [[REG:r[0-9]+]], apsr
+    // CHECK: cps #{{31|0x1f}}
+    // CHECK: mov sp, {{r[0-9]+}}
+    // CHECK: msr CPSR_{{f?}}c, [[REG]]
+    __set_SP_usr(u32);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/sp_ns.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/sp_ns.c
@@ -1,0 +1,22 @@
+// REQUIRES: thumbv8m.base
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+void get_sp_ns() {
+    // CHECK-LABEL: <get_sp_ns>:
+#if __ARM_FEATURE_CMSE == 3
+    // CHECK-S: mrs {{r[0-9]+}}, sp_ns
+    volatile uint32_t result = __TZ_get_SP_NS();
+#endif
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void set_sp_ns() {
+    // CHECK-LABEL: <set_sp_ns>:
+#if __ARM_FEATURE_CMSE == 3
+    // CHECK-S: msr sp_ns, {{r[0-9]+}}
+     __TZ_set_SP_NS(0x0815u);
+#endif
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/stl.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/stl.c
@@ -1,0 +1,29 @@
+// REQUIRES: armv8m
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+static volatile uint8_t v8;
+static volatile uint16_t v16;
+static volatile uint32_t v32;
+
+void stlb() {
+    // CHECK-LABEL: <stlb>:
+    // CHECK: stlb {{r[0-9]+}}, [{{r[0-9]+}}]
+    __STLB(0x7u, &v8);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void stlh() {
+    // CHECK-LABEL: <stlh>:
+    // CHECK: stlh {{r[0-9]+}}, [{{r[0-9]+}}]
+    __STLH(0x7u, &v16);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void stl() {
+    // CHECK-LABEL: <stl>:
+    // CHECK: stl {{r[0-9]+}}, [{{r[0-9]+}}]
+    __STL(0x7u, &v32);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/stlex.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/stlex.c
@@ -1,0 +1,29 @@
+// REQUIRES: armv8m
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+static volatile uint8_t v8;
+static volatile uint16_t v16;
+static volatile uint32_t v32;
+
+void stlexb() {
+    // CHECK-LABEL: <stlexb>:
+    // CHECK: stlexb {{r[0-9]+}}, {{r[0-9]+}}, [{{r[0-9]+}}]
+    volatile uint32_t result = __STLEXB(0x7u, &v8);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void stlexh() {
+    // CHECK-LABEL: <stlexh>:
+    // CHECK: stlexh {{r[0-9]+}}, {{r[0-9]+}}, [{{r[0-9]+}}]
+    volatile uint32_t result = __STLEXH(0x7u, &v16);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void stlex() {
+    // CHECK-LABEL: <stlex>:
+    // CHECK: stlex {{r[0-9]+}}, {{r[0-9]+}}, [{{r[0-9]+}}]
+    volatile uint32_t result = __STLEX(0x7u, &v32);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/strex.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/strex.c
@@ -1,0 +1,29 @@
+// REQUIRES: ldrex
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+static volatile uint8_t v8;
+static volatile uint16_t v16;
+static volatile uint32_t v32;
+
+void strexb() {
+    // CHECK-LABEL: <strexb>:
+    // CHECK: strexb {{r[0-9]+}}, {{r[0-9]+}}, [{{r[0-9]+}}]
+    volatile uint32_t result = __STREXB(0x7u, &v8);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void strexh() {
+    // CHECK-LABEL: <strexh>:
+    // CHECK: strexh {{r[0-9]+}}, {{r[0-9]+}}, [{{r[0-9]+}}]
+    volatile uint32_t result = __STREXH(0x7u, &v16);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void strexw() {
+    // CHECK-LABEL: <strexw>:
+    // CHECK: strex {{r[0-9]+}}, {{r[0-9]+}}, [{{r[0-9]+}}]
+    volatile uint32_t result = __STREXW(0x7u, &v32);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/strt.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/strt.c
@@ -1,0 +1,29 @@
+// REQUIRES: thumb-2
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+static volatile uint8_t v8;
+static volatile uint16_t v16;
+static volatile uint32_t v32;
+
+void strbt() {
+    // CHECK-LABEL: <strbt>:
+    // CHECK: strbt {{r[0-9]+}}, [{{r[0-9]+}}]
+    __STRBT(0x7u, &v8);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void strht() {
+    // CHECK-LABEL: <strht>:
+    // CHECK: strht {{r[0-9]+}}, [{{r[0-9]+}}]
+    __STRHT(0x7u, &v16);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}
+
+void strt() {
+    // CHECK-LABEL: <strt>:
+    // CHECK: strt {{r[0-9]+}}, [{{r[0-9]+}}]
+    __STRT(0x7u, &v32);
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/systick.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/systick.c
@@ -1,0 +1,17 @@
+// REQUIRES: unsupported
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include <stdint.h>
+
+typedef uint32_t IRQn_Type;
+uint32_t SysTick_IRQn;
+
+#include CORE_HEADER
+
+void systick_type_ctrl() {
+    // CHECK-LABEL: <systick_type_ctrl>:
+    // CHECK: mov.w [[REG:r[0-9]+]], #0xe000e000
+    // CHECK: ldr {{r[0-9]+}}, [[[REG]], #0x10]
+    uint32_t ctrl = SysTick->CTRL;
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/wfi.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/wfi.c
@@ -1,0 +1,10 @@
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+void wfi() {
+    // CHECK-LABEL: <wfi>:
+    // CHECK: wfi
+    __WFI();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}

--- a/platform/ext/cmsis/CMSIS/Core/Test/src/xpsr.c
+++ b/platform/ext/cmsis/CMSIS/Core/Test/src/xpsr.c
@@ -1,0 +1,12 @@
+
+// REQUIRES: thumbv6m
+// RUN: %cc% %ccflags% %ccout% %T/%basename_t.o %s; llvm-objdump --mcpu=%mcpu% -d %T/%basename_t.o | FileCheck --allow-unused-prefixes --check-prefixes %prefixes% %s
+
+#include "cmsis_compiler.h"
+
+void get_xpsr() {
+    // CHECK-LABEL: <get_xpsr>:
+    // CHECK: mrs {{r[0-9]+}}, xpsr
+    volatile uint32_t result = __get_xPSR();
+    // CHECK: {{(bx lr)|(pop {.*pc})}}
+}

--- a/platform/ext/cmsis/CMSIS/Core/Test/vcpkg-configuration.json
+++ b/platform/ext/cmsis/CMSIS/Core/Test/vcpkg-configuration.json
@@ -1,0 +1,20 @@
+{
+    "registries": [
+      {
+        "kind": "artifact",
+        "location": "https://aka.ms/vcpkg-ce-default",
+        "name": "microsoft"
+      },
+      {
+        "kind": "artifact",
+        "location": "https://artifacts.keil.arm.com/vcpkg-ce-registry/registry.zip",
+        "name": "arm"
+      }
+    ],
+    "requires": {
+      "arm:compilers/arm/armclang":"^6.20.0",
+      "arm:compilers/arm/arm-none-eabi-gcc": "^13.2.1",
+      "arm:compilers/arm/llvm-embedded": "^17.0.1-0"
+    }
+  }
+  

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Include/CV_Framework.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Include/CV_Framework.h
@@ -1,0 +1,44 @@
+/*-----------------------------------------------------------------------------
+ *      Name:         CV_Framework.h 
+ *      Purpose:      Framework header
+ *----------------------------------------------------------------------------
+ *      Copyright (c) 2017 ARM Limited. All rights reserved.
+ *----------------------------------------------------------------------------*/
+#ifndef __FRAMEWORK_H__
+#define __FRAMEWORK_H__
+
+#include "CV_Typedefs.h"
+#include "CV_Report.h"
+
+/*-----------------------------------------------------------------------------
+ * Test framework global definitions
+ *----------------------------------------------------------------------------*/
+
+/* Test case definition macro                                                 */
+#define TCD(x, y) {x, #x, y}
+
+/* Test case description structure                                            */
+typedef struct __TestCase {
+  void (*TestFunc)(void);             /* Test function                        */
+  const char *TFName;                 /* Test function name string            */
+  BOOL en;                            /* Test function enabled                */
+} TEST_CASE;
+
+/* Test suite description structure                                           */
+typedef struct __TestSuite {
+  const char *FileName;               /* Test module file name                */
+  const char *Date;                   /* Compilation date                     */
+  const char *Time;                   /* Compilation time                     */
+  const char *ReportTitle;            /* Title or name of module under test   */
+  void (*Init)(void);                 /* Init function callback               */
+  
+  uint32_t TCBaseNum;                 /* Base number for test case numbering  */
+  TEST_CASE *TC;                      /* Array of test cases                  */
+  uint32_t NumOfTC;                   /* Number of test cases (sz of TC array)*/
+
+} TEST_SUITE;
+
+/* Defined in user test module                                                */
+extern TEST_SUITE ts;
+
+#endif /* __FRAMEWORK_H__ */

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Include/CV_Report.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Include/CV_Report.h
@@ -1,0 +1,89 @@
+/*-----------------------------------------------------------------------------
+ *      Name:         CV_Report.h 
+ *      Purpose:      Report statistics and layout header
+ *----------------------------------------------------------------------------
+ *      Copyright (c) 2017 ARM Limited. All rights reserved.
+ *----------------------------------------------------------------------------*/
+#ifndef __REPORT_H__
+#define __REPORT_H__
+
+#include "CV_Config.h"
+#include "CV_Typedefs.h"
+
+/*-----------------------------------------------------------------------------
+ * Test report global definitions
+ *----------------------------------------------------------------------------*/
+ 
+#define REP_TC_FAIL 0
+#define REP_TC_WARN 1
+#define REP_TC_PASS 2
+#define REP_TC_NOEX 3
+
+/* Test case result definition */
+typedef enum {
+  PASSED = 0,
+  WARNING,
+  FAILED,
+  NOT_EXECUTED
+} TC_RES;
+
+/* Assertion result info */
+typedef struct {
+  const char    *module;                  /* Module name                        */
+  uint32_t       line;                    /* Assertion line                     */
+} AS_INFO;
+
+/* Test case callback interface definition */
+typedef struct {
+  BOOL (* Result) (TC_RES res);
+  BOOL (* Dbgi)   (TC_RES res, const char *fn, uint32_t ln, char *desc);
+} TC_ITF;
+
+/* Assert interface to the report */
+extern TC_ITF tcitf;
+
+/* Assertion result buffer */
+typedef struct {
+AS_INFO passed[BUFFER_ASSERTIONS];  
+AS_INFO failed[BUFFER_ASSERTIONS];  
+AS_INFO warnings[BUFFER_ASSERTIONS];  
+} AS_T_INFO;
+
+/* Assertion statistics */
+typedef struct {
+  uint32_t passed;           /* Total assertions passed                  */
+  uint32_t failed;           /* Total assertions failed                  */
+  uint32_t warnings;         /* Total assertions warnings                */
+  AS_T_INFO info;            /* Detailed assertion info                  */
+} AS_STAT;
+
+/* Test global statistics */
+typedef struct {
+  uint32_t  tests;           /* Total test cases count                   */
+  uint32_t  executed;        /* Total test cases executed                */
+  uint32_t  passed;          /* Total test cases passed                  */
+  uint32_t  failed;          /* Total test cases failed                  */
+  uint32_t  warnings;        /* Total test cases warnings                */
+  AS_STAT   assertions;      /* Total assertions statistics              */
+} TEST_REPORT;
+
+/* Test report interface */
+typedef struct {
+  BOOL (* Init)     (void);
+  BOOL (* Open)     (const char *title, const char *date, const char *time, const char *fn);
+  BOOL (* Close)    (void);  
+  BOOL (* Open_TC)  (uint32_t num, const char *fn);
+  BOOL (* Close_TC) (void);
+} REPORT_ITF;
+
+/* Test report statistics */
+extern TEST_REPORT  test_report;
+
+/* Test report interface */
+extern REPORT_ITF   ritf;
+
+/* Assertions and test results */
+extern TC_RES __set_result (const char *fn, uint32_t ln, TC_RES res, char* desc);
+extern TC_RES __assert_true (const char *fn, uint32_t ln, uint32_t cond);
+
+#endif /* __REPORT_H__ */

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Include/CV_Typedefs.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Include/CV_Typedefs.h
@@ -1,0 +1,58 @@
+/*-----------------------------------------------------------------------------
+ *      Name:         CV_Typedefs.h
+ *      Purpose:      Test framework filetypes and structures description
+ *----------------------------------------------------------------------------
+ *      Copyright (c) 2017 - 2018 Arm Limited. All rights reserved.
+ *----------------------------------------------------------------------------*/
+#ifndef __TYPEDEFS_H__
+#define __TYPEDEFS_H__
+
+#include <stdint.h>
+#include <stdarg.h>
+#include <string.h>
+#include <stdio.h>
+
+typedef unsigned int    BOOL;
+
+#ifndef __TRUE
+ #define __TRUE         1
+#endif
+#ifndef __FALSE
+ #define __FALSE        0
+#endif
+
+#ifndef ENABLED
+ #define ENABLED        1
+#endif
+#ifndef DISABLED
+ #define DISABLED       0
+#endif
+
+#ifndef NULL
+ #ifdef __cplusplus              // EC++
+  #define NULL          0
+ #else
+  #define NULL          ((void *) 0)
+ #endif
+#endif
+
+#define ARRAY_SIZE(arr) (sizeof(arr)/sizeof((arr)[0]))
+
+#if defined( __GNUC__ ) || defined ( __clang__ )
+static const int PATH_DELIMITER = '/';
+#else
+static const int PATH_DELIMITER = '\\';
+#endif
+
+//lint -emacro(9016,__FILENAME__) allow pointer arithmetic for truncating filename
+//lint -emacro(613,__FILENAME__) null pointer is checked
+#define __FILENAME__ ((strrchr(__FILE__, PATH_DELIMITER) != NULL) ? (strrchr(__FILE__, PATH_DELIMITER) + 1) : __FILE__)
+
+/* Assertions and test results */
+#define SET_RESULT(res, desc) (void)__set_result(__FILENAME__, __LINE__, (res), (desc));
+
+//lint -emacro(9031,ASSERT_TRUE) allow boolean condition as parameter
+//lint -emacro(613,ASSERT_TRUE) null pointer is checked
+#define ASSERT_TRUE(cond) (void)__assert_true (__FILENAME__, __LINE__, (cond) ? 1U : 0U)
+
+#endif /* __TYPEDEFS_H__ */

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Include/cmsis_cv.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Include/cmsis_cv.h
@@ -1,0 +1,132 @@
+/*-----------------------------------------------------------------------------
+ *      Name:         cmsis_cv.h
+ *      Purpose:      cmsis_cv header
+ *----------------------------------------------------------------------------
+ *      Copyright (c) 2017 - 2021 Arm Limited. All rights reserved.
+ *----------------------------------------------------------------------------*/
+#ifndef __CMSIS_CV_H
+#define __CMSIS_CV_H
+
+#include <stdint.h>
+#include "CV_Config.h"
+
+/* Expansion macro used to create CMSIS Driver references */
+#define EXPAND_SYMBOL(name, port) name##port
+#define CREATE_SYMBOL(name, port) EXPAND_SYMBOL(name, port)
+
+// Simulator counter
+#ifndef HW_PRESENT
+extern uint32_t SIM_CYCCNT;
+#endif
+
+// SVC interrupt callback
+extern void (*TST_IRQHandler)(void);
+
+// Test main function
+extern void cmsis_cv (void);
+extern void cmsis_cv_abort (const char *fn, uint32_t ln, char *desc);
+
+// Test cases
+extern void TC_CoreInstr_NOP (void);
+extern void TC_CoreInstr_SEV (void);
+extern void TC_CoreInstr_BKPT (void);
+extern void TC_CoreInstr_ISB (void);
+extern void TC_CoreInstr_DSB (void);
+extern void TC_CoreInstr_DMB (void);
+extern void TC_CoreInstr_WFI (void);
+extern void TC_CoreInstr_WFE (void);
+extern void TC_CoreInstr_REV (void);
+extern void TC_CoreInstr_REV16 (void);
+extern void TC_CoreInstr_REVSH (void);
+extern void TC_CoreInstr_ROR (void);
+extern void TC_CoreInstr_RBIT (void);
+extern void TC_CoreInstr_CLZ (void);
+extern void TC_CoreInstr_SSAT (void);
+extern void TC_CoreInstr_USAT (void);
+extern void TC_CoreInstr_RRX (void);
+extern void TC_CoreInstr_LoadStoreExclusive (void);
+extern void TC_CoreInstr_LoadStoreUnpriv (void);
+extern void TC_CoreInstr_LoadStoreAcquire (void);
+extern void TC_CoreInstr_LoadStoreAcquireExclusive (void);
+extern void TC_CoreInstr_UnalignedUint16 (void);
+extern void TC_CoreInstr_UnalignedUint32 (void);
+
+extern void TC_CoreSimd_SatAddSub (void);
+extern void TC_CoreSimd_ParSat16 (void);
+extern void TC_CoreSimd_PackUnpack (void);
+extern void TC_CoreSimd_ParSel (void);
+extern void TC_CoreSimd_ParAddSub8 (void);
+extern void TC_CoreSimd_AbsDif8 (void);
+extern void TC_CoreSimd_ParAddSub16 (void);
+extern void TC_CoreSimd_ParMul16 (void);
+extern void TC_CoreSimd_Pack16 (void);
+extern void TC_CoreSimd_MulAcc32 (void);
+
+#if defined(__CORTEX_M)
+  extern void TC_CoreFunc_EnDisIRQ (void);
+  extern void TC_CoreFunc_IRQPrio (void);
+  extern void TC_CoreFunc_EncDecIRQPrio (void);
+  extern void TC_CoreFunc_IRQVect (void);
+  extern void TC_CoreFunc_Control (void);
+  extern void TC_CoreFunc_IPSR (void);
+  extern void TC_CoreFunc_APSR (void);
+  extern void TC_CoreFunc_PSP (void);
+  extern void TC_CoreFunc_MSP (void);
+  extern void TC_CoreFunc_PSPLIM (void);
+  extern void TC_CoreFunc_PSPLIM_NS (void);
+  extern void TC_CoreFunc_MSPLIM (void);
+  extern void TC_CoreFunc_MSPLIM_NS (void);
+  extern void TC_CoreFunc_PRIMASK (void);
+  extern void TC_CoreFunc_FAULTMASK (void);
+  extern void TC_CoreFunc_BASEPRI (void);
+  extern void TC_CoreFunc_FPUType (void);
+  extern void TC_CoreFunc_FPSCR (void);
+#elif defined(__CORTEX_A)
+  extern void TC_CoreAFunc_IRQ (void);
+  extern void TC_CoreAFunc_FaultIRQ (void);
+  extern void TC_CoreAFunc_FPSCR (void);
+  extern void TC_CoreAFunc_CPSR (void);
+  extern void TC_CoreAFunc_Mode (void);
+  extern void TC_CoreAFunc_FPEXC (void);
+  extern void TC_CoreAFunc_ACTLR (void);
+  extern void TC_CoreAFunc_CPACR (void);
+  extern void TC_CoreAFunc_DFSR (void);
+  extern void TC_CoreAFunc_IFSR (void);
+  extern void TC_CoreAFunc_ISR (void);
+  extern void TC_CoreAFunc_CBAR (void);
+  extern void TC_CoreAFunc_TTBR0 (void);
+  extern void TC_CoreAFunc_DACR (void);
+  extern void TC_CoreAFunc_SCTLR (void);
+  extern void TC_CoreAFunc_MPIDR (void);
+  extern void TC_CoreAFunc_VBAR (void);
+  extern void TC_CoreAFunc_MVBAR (void);
+  extern void TC_CoreAFunc_FPU_Enable (void);
+#endif
+
+#if defined(__CORTEX_M)
+extern void TC_MPU_SetClear (void);
+extern void TC_MPU_Load (void);
+#endif
+
+#if defined(__CORTEX_A)
+extern void TC_GenTimer_CNTFRQ (void);
+extern void TC_GenTimer_CNTP_TVAL (void);
+extern void TC_GenTimer_CNTP_CTL (void);
+extern void TC_GenTimer_CNTPCT(void);
+extern void TC_GenTimer_CNTP_CVAL(void);
+#endif
+
+#if defined(__CORTEX_M)
+extern void TC_CML1Cache_EnDisableICache(void);
+extern void TC_CML1Cache_EnDisableDCache(void);
+extern void TC_CML1Cache_CleanDCacheByAddrWhileDisabled(void);
+#elif defined(__CORTEX_A)
+extern void TC_CAL1Cache_EnDisable(void);
+extern void TC_CAL1Cache_EnDisableBTAC(void);
+extern void TC_CAL1Cache_log2_up(void);
+extern void TC_CAL1Cache_InvalidateDCacheAll(void);
+extern void TC_CAL1Cache_CleanDCacheAll(void);
+extern void TC_CAL1Cache_CleanInvalidateDCacheAll(void);
+#endif
+
+#endif /* __CMSIS_CV_H */

--- a/platform/ext/cmsis/CMSIS/CoreValidation/LICENSE.txt
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/App/Bootloader_Cortex-M/App.clayer.yml
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/App/Bootloader_Cortex-M/App.clayer.yml
@@ -1,0 +1,11 @@
+layer:
+  type: App
+  description: Validation of CMSIS-Core implementation (Bootloader part)
+
+  # packs:
+  #   - pack: ARM::CMSIS
+
+  groups:
+    - group: Source Files
+      files:
+        - file: ./bootloader.c

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/App/Bootloader_Cortex-M/bootloader.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/App/Bootloader_Cortex-M/bootloader.c
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2013-2016 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ----------------------------------------------------------------------
+ *
+ * $Date:        15. October 2016
+ * $Revision:    1.1.0
+ *
+ * Project:      TrustZone for ARMv8-M
+ * Title:        Code template for secure main function
+ *
+ *---------------------------------------------------------------------------*/
+ 
+#include <stdio.h>
+#include <stdlib.h>
+
+/* Use CMSE intrinsics */
+#include <arm_cmse.h>
+
+#include "RTE_Components.h"
+#include CMSIS_device_header
+ 
+/* TZ_START_NS: Start address of non-secure application */
+#ifndef TZ_START_NS
+#define TZ_START_NS (0x200000U)
+#endif
+
+#if 1
+/* Dummy Non-secure callable (entry) function */
+__attribute__((cmse_nonsecure_entry)) int validationDummy(int x) { 
+  return x; 
+}
+#endif
+ 
+/* typedef for non-secure callback functions */
+typedef void (*funcptr_void) (void) __attribute__((cmse_nonsecure_call));
+
+/* Secure main() */
+int main(void) {
+  funcptr_void NonSecure_ResetHandler;
+ 
+  /* Add user setup code for secure part here*/
+ 
+  /* Set non-secure main stack (MSP_NS) */
+  __TZ_set_MSP_NS(*((uint32_t *)(TZ_START_NS)));
+
+  /* Set Non-Secure state for Interrupt 0
+    (used in Non-Secure TC_CoreInstr_LoadStoreExclusive Test) */
+  NVIC->ITNS[0] |= 1U;
+ 
+  /* Get non-secure reset handler */
+  NonSecure_ResetHandler = (funcptr_void)(*((uint32_t *)((TZ_START_NS) + 4U)));
+ 
+  /* Start non-secure state software application */
+  NonSecure_ResetHandler();
+ 
+  /* Non-secure software does not return, this code is not executed */
+  while (1) {
+    __NOP();
+  }
+}
+
+#if defined(__CORTEX_M)
+__NO_RETURN
+extern void HardFault_Handler(void);
+void HardFault_Handler(void) {
+  printf("Bootloader HardFault!\n");
+  #ifdef __MICROLIB
+  for(;;) {}
+  #else
+  exit(1);
+  #endif
+}
+#endif

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/App/Validation_Cortex-A/App.clayer.yml
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/App/Validation_Cortex-A/App.clayer.yml
@@ -1,0 +1,44 @@
+layer:
+  type: App
+  description: Validation of CMSIS-Core implementation
+
+  # packs:
+  #   - pack: ARM::CMSIS
+
+  define:
+    - PRINT_XML_REPORT: 1
+
+  add-path:
+    - ../../../Include
+    - ../../../Source/ConfigA
+
+  misc:
+    - for-compiler: AC6
+      C-CPP:
+      - -Wno-declaration-after-statement
+      - -Wno-covered-switch-default
+    - for-compiler: GCC
+      C-CPP:
+      - -Wno-declaration-after-statement
+
+  groups:
+    - group: Documentation
+      files:
+        - file: ../../../README.md
+
+    - group: Source Files
+      files:
+        - file: ./main.c
+
+    - group: CMSIS-Core_Validation
+      files:
+        - file: ../../../Source/cmsis_cv.c
+        - file: ../../../Source/CV_CoreAFunc.c
+        - file: ../../../Source/CV_CoreInstr.c
+        - file: ../../../Source/CV_CAL1Cache.c
+#        - file: ../../../Source/ConfigA/mmu.c
+
+    - group: Validation Framework
+      files:
+        - file: ../../../Source/CV_Framework.c
+        - file: ../../../Source/CV_Report.c

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/App/Validation_Cortex-A/main.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/App/Validation_Cortex-A/main.c
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2022 ARM Limited or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "RTE_Components.h"
+#include  CMSIS_device_header
+
+#ifdef RTE_Compiler_EventRecorder
+#include "EventRecorder.h"
+#endif
+
+#include "cmsis_cv.h"
+#include "CV_Report.h"
+
+//lint -e970 allow using int for main
+
+int main (void)
+{
+
+  // System Initialization
+  SystemCoreClockUpdate();
+
+#ifdef RTE_Compiler_EventRecorder
+  // Initialize and start Event Recorder
+  (void)EventRecorderInitialize(EventRecordError, 1U);
+  (void)EventRecorderEnable(EventRecordAll, 0xFEU, 0xFEU);
+#endif
+
+  cmsis_cv();
+
+  #ifdef __MICROLIB
+  for(;;) {}
+  #else
+  exit(0);
+  #endif
+}
+
+#if defined(__CORTEX_A)
+#include "irq_ctrl.h"
+
+#if (defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)) || \
+    (defined ( __GNUC__ ))
+  #define __IRQ __attribute__((interrupt("IRQ")))
+#elif defined ( __CC_ARM )
+  #define __IRQ __irq
+#elif defined ( __ICCARM__ )
+  #define __IRQ __irq __arm
+#else
+  #error "Unsupported compiler!"
+#endif
+
+
+__IRQ
+void IRQ_Handler(void);
+__IRQ
+void IRQ_Handler(void) {
+  const IRQn_ID_t irqn = IRQ_GetActiveIRQ();
+  IRQHandler_t const handler = IRQ_GetHandler(irqn);
+  if (handler != NULL) {
+    __enable_irq();
+    handler();
+    __disable_irq();
+  }
+  IRQ_EndOfInterrupt(irqn);
+}
+
+__IRQ __NO_RETURN
+void Undef_Handler (void);
+__IRQ __NO_RETURN
+void Undef_Handler (void) {
+  cmsis_cv_abort(__FILENAME__, __LINE__, "Undefined Instruction!");
+  exit(0);
+}
+
+__IRQ
+void SVC_Handler   (void);
+__IRQ
+void SVC_Handler   (void) {
+}
+
+__IRQ __NO_RETURN
+void PAbt_Handler  (void);
+__IRQ __NO_RETURN
+void PAbt_Handler  (void) {
+  cmsis_cv_abort(__FILENAME__, __LINE__, "Prefetch Abort!");
+  exit(0);
+}
+
+__IRQ __NO_RETURN
+void DAbt_Handler  (void);
+__IRQ __NO_RETURN
+void DAbt_Handler  (void) {
+  cmsis_cv_abort(__FILENAME__, __LINE__, "Data Abort!");
+  exit(0);
+}
+
+__IRQ
+void FIQ_Handler   (void);
+__IRQ
+void FIQ_Handler   (void) {
+}
+#endif
+
+#if defined(__CORTEX_M)
+__NO_RETURN
+void HardFault_Handler(void);
+__NO_RETURN
+void HardFault_Handler(void) {
+  cmsis_cv_abort(__FILENAME__, __LINE__, "HardFault!");
+  #ifdef __MICROLIB
+  for(;;) {}
+  #else
+  exit(0);
+  #endif
+}
+#endif

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/App/Validation_Cortex-M/App.clayer.yml
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/App/Validation_Cortex-M/App.clayer.yml
@@ -1,0 +1,71 @@
+layer:
+  type: App
+  description: Validation of CMSIS-Core implementation
+
+  # packs:
+  #   - pack: ARM::CMSIS
+
+  define:
+    - PRINT_XML_REPORT: 1
+
+  add-path:
+    - ../../../Include
+    - ../../../Source/Config
+
+  misc:
+    - for-compiler: AC6
+      C-CPP:
+      - -Wno-declaration-after-statement
+      - -Wno-covered-switch-default
+    - for-compiler: GCC
+      C-CPP:
+      - -Wno-declaration-after-statement
+
+  groups:
+    - group: Documentation
+      files:
+        - file: ../../../README.md
+
+    - group: Source Files
+      files:
+        - file: ./main.c
+
+    - group: CMSIS-Core_Validation
+      files:
+        - file: ../../../Source/cmsis_cv.c
+        - file: ../../../Source/CV_CoreFunc.c
+        - file: ../../../Source/CV_CoreInstr.c
+        - file: ../../../Source/CV_CoreSimd.c
+        - file: ../../../Source/CV_CML1Cache.c
+        - file: ../../../Source/CV_MPU_ARMv7.c
+          for-context:
+            - +CM0
+            - +CM0plus
+            - +CM3
+            - +CM4
+            - +CM4FP
+            - +CM7
+            - +CM7SP
+            - +CM7DP
+        - file: ../../../Source/CV_MPU_ARMv8.c
+          for-context:
+            - +CM23
+            - +CM23S
+            - +CM23NS
+            - +CM33
+            - +CM33S
+            - +CM33NS
+            - +CM35P
+            - +CM35PS
+            - +CM35PNS
+            - +CM55
+            - +CM55S
+            - +CM55NS
+            - +CM85
+            - +CM85S
+            - +CM85NS
+
+    - group: Validation Framework
+      files:
+        - file: ../../../Source/CV_Framework.c
+        - file: ../../../Source/CV_Report.c

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/App/Validation_Cortex-M/main.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/App/Validation_Cortex-M/main.c
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2022 ARM Limited or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "RTE_Components.h"
+#include  CMSIS_device_header
+
+#ifdef RTE_Compiler_EventRecorder
+#include "EventRecorder.h"
+#endif
+
+#include "cmsis_cv.h"
+#include "CV_Report.h"
+
+//lint -e970 allow using int for main
+
+
+#if defined (__ARM_FEATURE_CMSE) &&  (__ARM_FEATURE_CMSE == 3U)
+  #include <arm_cmse.h>
+
+  /* Dummy Non-secure callable (entry) function */
+  __attribute__((cmse_nonsecure_entry)) int validationDummy(int x) {
+    return x;
+  }
+#endif
+
+int main (void)
+{
+
+  // System Initialization
+  SystemCoreClockUpdate();
+
+#ifdef RTE_Compiler_EventRecorder
+  // Initialize and start Event Recorder
+  (void)EventRecorderInitialize(EventRecordError, 1U);
+  (void)EventRecorderEnable(EventRecordAll, 0xFEU, 0xFEU);
+#endif
+
+  cmsis_cv();
+
+  #ifdef __MICROLIB
+  for(;;) {}
+  #else
+  exit(0);
+  #endif
+}
+
+#if defined(__CORTEX_A)
+#include "irq_ctrl.h"
+
+#if (defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)) || \
+    (defined ( __GNUC__ ))
+  #define __IRQ __attribute__((interrupt("IRQ")))
+#elif defined ( __CC_ARM )
+  #define __IRQ __irq
+#elif defined ( __ICCARM__ )
+  #define __IRQ __irq __arm
+#else
+  #error "Unsupported compiler!"
+#endif
+
+
+__IRQ
+void IRQ_Handler(void);
+__IRQ
+void IRQ_Handler(void) {
+  const IRQn_ID_t irqn = IRQ_GetActiveIRQ();
+  IRQHandler_t const handler = IRQ_GetHandler(irqn);
+  if (handler != NULL) {
+    __enable_irq();
+    handler();
+    __disable_irq();
+  }
+  IRQ_EndOfInterrupt(irqn);
+}
+
+__IRQ __NO_RETURN
+void Undef_Handler (void);
+__IRQ __NO_RETURN
+void Undef_Handler (void) {
+  cmsis_cv_abort(__FILENAME__, __LINE__, "Undefined Instruction!");
+  exit(0);
+}
+
+__IRQ
+void SVC_Handler   (void);
+__IRQ
+void SVC_Handler   (void) {
+}
+
+__IRQ __NO_RETURN
+void PAbt_Handler  (void);
+__IRQ __NO_RETURN
+void PAbt_Handler  (void) {
+  cmsis_cv_abort(__FILENAME__, __LINE__, "Prefetch Abort!");
+  exit(0);
+}
+
+__IRQ __NO_RETURN
+void DAbt_Handler  (void);
+__IRQ __NO_RETURN
+void DAbt_Handler  (void) {
+  cmsis_cv_abort(__FILENAME__, __LINE__, "Data Abort!");
+  exit(0);
+}
+
+__IRQ
+void FIQ_Handler   (void);
+__IRQ
+void FIQ_Handler   (void) {
+}
+#endif
+
+#if defined(__CORTEX_M)
+__NO_RETURN
+void HardFault_Handler(void);
+__NO_RETURN
+void HardFault_Handler(void) {
+  cmsis_cv_abort(__FILENAME__, __LINE__, "HardFault!");
+  #ifdef __MICROLIB
+  for(;;) {}
+  #else
+  exit(0);
+  #endif
+}
+#endif

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA5/RTE/Device/ARMCA5/ARMCA5_ac6.sct
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA5/RTE/Device/ARMCA5/ARMCA5_ac6.sct
@@ -1,0 +1,65 @@
+
+SDRAM __ROM_BASE __ROM_SIZE       ; load region size_region
+{
+  VECTORS __ROM_BASE __ROM_SIZE ; load address = execution address
+  {
+      * (RESET, +FIRST)         ; Vector table and other startup code
+      * (InRoot$$Sections)      ; All (library) code that must be in a root region
+      * (+RO-CODE)              ; Application RO code (.text)
+      * (+RO-DATA)              ; Application RO data (.constdata)
+  }
+
+  RW_DATA __RAM_BASE __RW_DATA_SIZE
+  { * (+RW) }                   ; Application RW data (.data)
+
+  ZI_DATA (__RAM_BASE+
+           __RW_DATA_SIZE) __ZI_DATA_SIZE
+  { * (+ZI) }                   ; Application ZI data (.bss)
+
+  ARM_LIB_HEAP  (__RAM_BASE
+                +__RW_DATA_SIZE
+                +__ZI_DATA_SIZE)    EMPTY __HEAP_SIZE        ; Heap region growing up
+  { }
+
+  ARM_LIB_STACK (__RAM_BASE
+                +__RAM_SIZE
+                -__FIQ_STACK_SIZE
+                -__IRQ_STACK_SIZE
+                -__SVC_STACK_SIZE
+                -__ABT_STACK_SIZE
+                -__UND_STACK_SIZE) EMPTY -__STACK_SIZE      ; Stack region growing down
+  { }
+
+  UND_STACK     (__RAM_BASE
+                +__RAM_SIZE
+                -__FIQ_STACK_SIZE
+                -__IRQ_STACK_SIZE
+                -__SVC_STACK_SIZE
+                -__ABT_STACK_SIZE) EMPTY -__UND_STACK_SIZE  ; UND mode stack
+  { }
+
+  ABT_STACK     (__RAM_BASE
+                +__RAM_SIZE
+                -__FIQ_STACK_SIZE
+                -__IRQ_STACK_SIZE
+                -__SVC_STACK_SIZE) EMPTY -__ABT_STACK_SIZE  ; ABT mode stack
+  { }
+
+  SVC_STACK     (__RAM_BASE
+                +__RAM_SIZE
+                -__FIQ_STACK_SIZE
+                -__IRQ_STACK_SIZE) EMPTY -__SVC_STACK_SIZE  ; SVC mode stack
+  { }
+
+  IRQ_STACK     (__RAM_BASE
+                +__RAM_SIZE
+                -__FIQ_STACK_SIZE) EMPTY -__IRQ_STACK_SIZE  ; IRQ mode stack
+  { }
+
+  FIQ_STACK     (__RAM_BASE
+                +__RAM_SIZE)       EMPTY -__FIQ_STACK_SIZE  ; FIQ mode stack
+  { }
+
+  TTB            __TTB_BASE        EMPTY __TTB_SIZE         ; Level-1 Translation Table for MMU
+  { }
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA5/RTE/Device/ARMCA5/ARMCA5_clang.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA5/RTE/Device/ARMCA5/ARMCA5_clang.ld
@@ -1,0 +1,368 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2019 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+MEMORY
+{
+  ROM0 (rx)   : ORIGIN = __ROM_BASE, LENGTH = __ROM_SIZE
+  L_TTB (rw)  : ORIGIN = __TTB_BASE, LENGTH = __TTB_SIZE
+  RAM0 (rwx)  : ORIGIN = __RAM_BASE, LENGTH = __RAM_SIZE
+}
+
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+	.init : {
+		KEEP (*(RESET))
+		KEEP (*(.vectors))
+		KEEP (*(.text.init.enter))
+		KEEP (*(.data.init.enter))
+		KEEP (*(SORT_BY_NAME(.init) SORT_BY_NAME(.init.*)))
+	} >ROM0 AT>ROM0 :text
+
+	.text : {
+
+		/* code */
+		*(.text.unlikely .text.unlikely.*)
+		*(.text.startup .text.startup.*)
+		*(.text .text.* .opd .opd.*)
+		*(.gnu.linkonce.t.*)
+		KEEP (*(.fini .fini.*))
+		__text_end = .;
+
+		PROVIDE (__etext = __text_end);
+		PROVIDE (_etext = __text_end);
+		PROVIDE (etext = __text_end);
+
+		/* read-only data */
+		*(.rdata)
+		*(.rodata .rodata.*)
+		*(.gnu.linkonce.r.*)
+
+		*(.srodata.cst16)
+		*(.srodata.cst8)
+		*(.srodata.cst4)
+		*(.srodata.cst2)
+		*(.srodata .srodata.*)
+		*(.data.rel.ro .data.rel.ro.*)
+		*(.got .got.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		/* lists of constructors and destructors */
+		PROVIDE_HIDDEN ( __preinit_array_start = . );
+		KEEP (*(.preinit_array))
+		PROVIDE_HIDDEN ( __preinit_array_end = . );
+
+		PROVIDE_HIDDEN ( __init_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+		KEEP (*(.init_array .ctors))
+		PROVIDE_HIDDEN ( __init_array_end = . );
+
+		PROVIDE_HIDDEN ( __fini_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
+		KEEP (*(.fini_array .dtors))
+		PROVIDE_HIDDEN ( __fini_array_end = . );
+
+	} >ROM0 AT>ROM0 :text
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+	.veneers :
+	{
+		. = ALIGN(32);
+		KEEP(*(.gnu.sgstubs))
+	} > ROM0 AT>ROM0 :text
+#endif
+
+	.toc : {
+		*(.toc .toc.*)
+	} >ROM0 AT>ROM0 :text
+
+	/* additional sections when compiling with C++ exception support */
+	
+	.except_ordered : {
+		*(.gcc_except_table *.gcc_except_table.*)
+		KEEP (*(.eh_frame .eh_frame.*))
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+	} >ROM0 AT>ROM0 :text
+
+	.except_unordered : {
+		. = ALIGN(8);
+
+		PROVIDE(__exidx_start = .);
+		*(.ARM.exidx*)
+		PROVIDE(__exidx_end = .);
+	} >ROM0 AT>ROM0 :text
+
+    .ttb :
+    {
+        Image$$TTB$$ZI$$Base = .;
+        . += __TTB_SIZE;
+        Image$$TTB$$ZI$$Limit = .;
+    } > L_TTB
+
+	/*
+	 * Data values which are preserved across reset
+	 */
+	.preserve (NOLOAD) : {
+		PROVIDE(__preserve_start__ = .);
+		KEEP(*(SORT_BY_NAME(.preserve.*)))
+		KEEP(*(.preserve))
+		PROVIDE(__preserve_end__ = .);
+	} >RAM0 AT>RAM0 :ram
+
+	.data :  {
+		*(.data .data.*)
+		*(.gnu.linkonce.d.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		PROVIDE( __global_pointer$ = . + 0x800 );
+		*(.sdata .sdata.* .sdata2.*)
+		*(.gnu.linkonce.s.*)
+	} >RAM0 AT>ROM0 :ram_init
+	PROVIDE(__data_start = ADDR(.data));
+	PROVIDE(__data_source = LOADADDR(.data));
+
+	/* Thread local initialized data. This gets
+	 * space allocated as it is expected to be placed
+	 * in ram to be used as a template for TLS data blocks
+	 * allocated at runtime. We're slightly abusing that
+	 * by placing the data in flash where it will be copied
+	 * into the allocate ram addresses by the existing
+	 * data initialization code in crt0
+	 */
+	.tdata :  {
+		*(.tdata .tdata.* .gnu.linkonce.td.*)
+		PROVIDE(__data_end = .);
+		PROVIDE(__tdata_end = .);
+	} >RAM0 AT>ROM0 :tls :ram_init
+	PROVIDE( __tls_base = ADDR(.tdata));
+	PROVIDE( __tdata_start = ADDR(.tdata));
+	PROVIDE( __tdata_source = LOADADDR(.tdata) );
+	PROVIDE( __tdata_source_end = LOADADDR(.tdata) + SIZEOF(.tdata) );
+	PROVIDE( __data_source_end = __tdata_source_end );
+	PROVIDE( __tdata_size = SIZEOF(.tdata) );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata),ALIGNOF(.tbss)) );
+
+	PROVIDE( __edata = __data_end );
+	PROVIDE( _edata = __data_end );
+	PROVIDE( edata = __data_end );
+	PROVIDE( __data_size = __data_end - __data_start );
+	PROVIDE( __data_source_size = __data_source_end - __data_source );
+
+	.tbss (NOLOAD) : {
+		*(.tbss .tbss.* .gnu.linkonce.tb.*)
+		*(.tcommon)
+		PROVIDE( __tls_end = . );
+		PROVIDE( __tbss_end = . );
+	} >RAM0 AT>RAM0 :tls :ram
+	PROVIDE( __bss_start = ADDR(.tbss));
+	PROVIDE( __tbss_start = ADDR(.tbss));
+	PROVIDE( __tbss_offset = ADDR(.tbss) - ADDR(.tdata) );
+	PROVIDE( __tbss_size = SIZEOF(.tbss) );
+	PROVIDE( __tls_size = __tls_end - __tls_base );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
+	PROVIDE( __arm32_tls_tcb_offset = MAX(8, __tls_align) );
+	PROVIDE( __arm64_tls_tcb_offset = MAX(16, __tls_align) );
+
+	/*
+	 * The linker special cases .tbss segments which are
+	 * identified as segments which are not loaded and are
+	 * thread_local.
+	 *
+	 * For these segments, the linker does not advance 'dot'
+	 * across them.  We actually need memory allocated for tbss,
+	 * so we create a special segment here just to make room
+	 */
+	/*
+	.tbss_space (NOLOAD) : {
+		. = ADDR(.tbss);
+		. = . + SIZEOF(.tbss);
+	} >RAM0 AT>RAM0 :ram
+	*/
+
+	.bss (NOLOAD) : {
+		*(.sbss*)
+		*(.gnu.linkonce.sb.*)
+		*(.bss .bss.*)
+		*(.gnu.linkonce.b.*)
+		*(COMMON)
+
+		/* Align the heap */
+		. = ALIGN(8);
+		__bss_end = .;
+	} >RAM0 AT>RAM0 :ram
+	PROVIDE( __non_tls_bss_start = ADDR(.bss) );
+	PROVIDE( __end = __bss_end );
+	PROVIDE( _end = __bss_end );
+	PROVIDE( end = __bss_end );
+	PROVIDE( __bss_size = __bss_end - __bss_start );
+
+	/* Make the rest of memory available for heap storage */
+	PROVIDE (__heap_start = __end);
+#ifdef __HEAP_SIZE
+	PROVIDE (__heap_end = __heap_start + __HEAP_SIZE);
+	PROVIDE (__heap_size = __HEAP_SIZE);
+#else
+	PROVIDE (__heap_end = __stack - __STACK_SIZE);
+	PROVIDE (__heap_size = __heap_end - __heap_start);
+#endif
+	.heap (NOLOAD) : {
+		. += __heap_size;
+	} >RAM0 :ram
+
+	/* Define a stack region to make sure it fits in memory */
+	PROVIDE(__stack = ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE);
+	PROVIDE(__stack_limit = __stack - __STACK_SIZE);
+#if __ARM_ARCH_PROFILE == 'A'
+	.stack (__stack_limit - 5*__STACK_SIZE) (NOLOAD) : {
+        Image$$FIQ_STACK$$ZI$$Base = .;
+        . += __STACK_SIZE;
+        Image$$FIQ_STACK$$ZI$$Limit = .;
+
+        Image$$IRQ_STACK$$ZI$$Base = .;
+        . += __STACK_SIZE;
+        Image$$IRQ_STACK$$ZI$$Limit = .;
+
+        Image$$SVC_STACK$$ZI$$Base = .;
+        . += __STACK_SIZE;
+        Image$$SVC_STACK$$ZI$$Limit = .;
+
+        Image$$ABT_STACK$$ZI$$Base = .;
+        . += __STACK_SIZE;
+        Image$$ABT_STACK$$ZI$$Limit = .;
+
+        Image$$UND_STACK$$ZI$$Base = .;
+        . += __STACK_SIZE;
+        Image$$UND_STACK$$ZI$$Limit = .;
+
+        Image$$SYS_STACK$$ZI$$Base = .;
+        . += __STACK_SIZE;
+        Image$$SYS_STACK$$ZI$$Limit = .;
+	} >RAM0 :ram
+#else
+	.stack (__stack_limit) (NOLOAD) : {
+		. += __STACK_SIZE;
+	} >RAM0 :ram
+#endif
+
+#if __STACKSEAL_SIZE > 0
+	PROVIDE(__stack_seal = __stack);
+  	.stackseal (__stack) (NOLOAD) :
+  	{
+    	. += __STACKSEAL_SIZE;
+  	} >RAM0 :ram
+#endif
+
+	/* Throw away C++ exception handling information */
+
+	/*
+
+	/DISCARD/ : {
+		*(.note .note.*)
+		*(.eh_frame .eh_frame.*)
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+		*(.ARM.exidx*)
+	}
+
+	*/
+
+	/* Stabs debugging sections.  */
+	.stab          0 : { *(.stab) }
+	.stabstr       0 : { *(.stabstr) }
+	.stab.excl     0 : { *(.stab.excl) }
+	.stab.exclstr  0 : { *(.stab.exclstr) }
+	.stab.index    0 : { *(.stab.index) }
+	.stab.indexstr 0 : { *(.stab.indexstr) }
+	.comment       0 : { *(.comment) }
+	.gnu.build.attributes : { *(.gnu.build.attributes .gnu.build.attributes.*) }
+	/* DWARF debug sections.
+	   Symbols in the DWARF debugging sections are relative to the beginning
+	   of the section so we begin them at 0.  */
+	/* DWARF 1.  */
+	.debug          0 : { *(.debug) }
+	.line           0 : { *(.line) }
+	/* GNU DWARF 1 extensions.  */
+	.debug_srcinfo  0 : { *(.debug_srcinfo) }
+	.debug_sfnames  0 : { *(.debug_sfnames) }
+	/* DWARF 1.1 and DWARF 2.  */
+	.debug_aranges  0 : { *(.debug_aranges) }
+	.debug_pubnames 0 : { *(.debug_pubnames) }
+	/* DWARF 2.  */
+	.debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+	.debug_abbrev   0 : { *(.debug_abbrev) }
+	.debug_line     0 : { *(.debug_line .debug_line.* .debug_line_end) }
+	.debug_frame    0 : { *(.debug_frame) }
+	.debug_str      0 : { *(.debug_str) }
+	.debug_loc      0 : { *(.debug_loc) }
+	.debug_macinfo  0 : { *(.debug_macinfo) }
+	/* SGI/MIPS DWARF 2 extensions.  */
+	.debug_weaknames 0 : { *(.debug_weaknames) }
+	.debug_funcnames 0 : { *(.debug_funcnames) }
+	.debug_typenames 0 : { *(.debug_typenames) }
+	.debug_varnames  0 : { *(.debug_varnames) }
+	/* DWARF 3.  */
+	.debug_pubtypes 0 : { *(.debug_pubtypes) }
+	.debug_ranges   0 : { *(.debug_ranges) }
+	/* DWARF 5.  */
+	.debug_addr     0 : { *(.debug_addr) }
+	.debug_line_str 0 : { *(.debug_line_str) }
+	.debug_loclists 0 : { *(.debug_loclists) }
+	.debug_macro    0 : { *(.debug_macro) }
+	.debug_names    0 : { *(.debug_names) }
+	.debug_rnglists 0 : { *(.debug_rnglists) }
+	.debug_str_offsets 0 : { *(.debug_str_offsets) }
+	.debug_sup      0 : { *(.debug_sup) }
+	.gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }
+}
+
+/*
+ * Check that sections that are copied from flash to RAM have matching
+ * padding, so that a single memcpy() of __data_size copies the correct bytes.
+ */
+ASSERT( __data_size == __data_source_size,
+	"ERROR: .data/.tdata flash size does not match RAM size");

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA5/RTE/Device/ARMCA5/ARMCA5_gcc.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA5/RTE/Device/ARMCA5/ARMCA5_gcc.ld
@@ -1,0 +1,176 @@
+
+MEMORY
+{
+  ROM (rx)   : ORIGIN = __ROM_BASE, LENGTH = __ROM_SIZE
+  L_TTB (rw) : ORIGIN = __TTB_BASE, LENGTH = __TTB_SIZE
+  RAM (rwx)  : ORIGIN = __RAM_BASE, LENGTH = __RAM_SIZE
+}
+
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+    .text :
+    {
+        Image$$VECTORS$$Base = .;
+        * (RESET)
+        KEEP(*(.isr_vector))
+        Image$$VECTORS$$Limit = .;
+
+        *(SVC_TABLE)
+        *(.text*)
+
+        KEEP(*(.init))
+        KEEP(*(.fini))
+
+        /* .ctors */
+        *crtbegin.o(.ctors)
+        *crtbegin?.o(.ctors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+        *(SORT(.ctors.*))
+        *(.ctors)
+
+        /* .dtors */
+        *crtbegin.o(.dtors)
+        *crtbegin?.o(.dtors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+        *(SORT(.dtors.*))
+        *(.dtors)
+
+        Image$$RO_DATA$$Base = .;
+        *(.rodata*)
+        Image$$RO_DATA$$Limit = .;
+
+        KEEP(*(.eh_frame*))
+    } > ROM
+
+    .ARM.extab :
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > ROM
+
+    __exidx_start = .;
+    .ARM.exidx :
+    {
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    } > ROM
+    __exidx_end = .;
+
+
+    .copy.table :
+    {
+        . = ALIGN(4);
+        __copy_table_start__ = .;
+        LONG (__etext)
+        LONG (__data_start__)
+        LONG (__data_end__ - __data_start__)
+        __copy_table_end__ = .;
+    } > ROM
+
+    .zero.table :
+    {
+        . = ALIGN(4);
+        __zero_table_start__ = .;
+        LONG (__bss_start__)
+        LONG (__bss_end__ - __bss_start__)
+        __zero_table_end__ = .;
+    } > ROM
+
+    __etext = .;
+
+    .ttb :
+    {
+        Image$$TTB$$ZI$$Base = .;
+        . += __TTB_SIZE;
+        Image$$TTB$$ZI$$Limit = .;
+    } > L_TTB
+
+    .data :
+    {
+        Image$$RW_DATA$$Base = .;
+        __data_start__ = .;
+        *(vtable)
+        *(.data*)
+        Image$$RW_DATA$$Limit = .;
+
+        . = ALIGN(4);
+        /* preinit data */
+        PROVIDE (__preinit_array_start = .);
+        KEEP(*(.preinit_array))
+        PROVIDE (__preinit_array_end = .);
+
+        . = ALIGN(4);
+        /* init data */
+        PROVIDE (__init_array_start = .);
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array))
+        PROVIDE (__init_array_end = .);
+
+        . = ALIGN(4);
+        /* finit data */
+        PROVIDE (__fini_array_start = .);
+        KEEP(*(SORT(.fini_array.*)))
+        KEEP(*(.fini_array))
+        PROVIDE (__fini_array_end = .);
+
+        . = ALIGN(4);
+        /* All data end */
+        __data_end__ = .;
+    } > RAM
+
+
+    .bss ALIGN(0x400):
+    {
+        Image$$ZI_DATA$$Base = .;
+        __bss_start__ = .;
+        *(.bss*)
+        *(COMMON)
+        __bss_end__ = .;
+        Image$$ZI_DATA$$Limit = .;
+        __end__ = .;
+        end = __end__;
+    } > RAM AT > RAM
+
+#if defined(__HEAP_SIZE) && (__HEAP_SIZE > 0)
+    .heap (NOLOAD):
+    {
+        . = ALIGN(8);
+        Image$$HEAP$$ZI$$Base = .;
+        . += __HEAP_SIZE;
+        Image$$HEAP$$ZI$$Limit = .;
+        __HeapLimit = .;
+    } > RAM
+#endif
+
+    .stack (NOLOAD):
+    {
+        . = ORIGIN(RAM) + LENGTH(RAM) - __STACK_SIZE - __FIQ_STACK_SIZE - __IRQ_STACK_SIZE - __SVC_STACK_SIZE - __ABT_STACK_SIZE - __UND_STACK_SIZE;
+        . = ALIGN(8);
+
+        __StackTop = .;
+        Image$$SYS_STACK$$ZI$$Base = .;
+        . += __STACK_SIZE;
+        Image$$SYS_STACK$$ZI$$Limit = .;
+        __stack = .;
+
+        Image$$FIQ_STACK$$ZI$$Base = .;
+        . += __FIQ_STACK_SIZE;
+        Image$$FIQ_STACK$$ZI$$Limit = .;
+
+        Image$$IRQ_STACK$$ZI$$Base = .;
+        . += __IRQ_STACK_SIZE;
+        Image$$IRQ_STACK$$ZI$$Limit = .;
+
+        Image$$SVC_STACK$$ZI$$Base = .;
+        . += __SVC_STACK_SIZE;
+        Image$$SVC_STACK$$ZI$$Limit = .;
+
+        Image$$ABT_STACK$$ZI$$Base = .;
+        . += __ABT_STACK_SIZE;
+        Image$$ABT_STACK$$ZI$$Limit = .;
+
+        Image$$UND_STACK$$ZI$$Base = .;
+        . += __UND_STACK_SIZE;
+        Image$$UND_STACK$$ZI$$Limit = .;
+    } > RAM
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA5/RTE/Device/ARMCA5/ARMCA5_iar.icf
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA5/RTE/Device/ARMCA5/ARMCA5_iar.icf
@@ -1,0 +1,67 @@
+
+/*-Memory Regions-*/
+define symbol __ICFEDIT_region_IROM1_start__ = 0x80000000;
+define symbol __ICFEDIT_region_IROM1_end__   = 0x801FFFFF;
+define symbol __ICFEDIT_region_IROM2_start__ = 0x0;
+define symbol __ICFEDIT_region_IROM2_end__   = 0x0;
+define symbol __ICFEDIT_region_EROM1_start__ = 0x0;
+define symbol __ICFEDIT_region_EROM1_end__   = 0x0;
+define symbol __ICFEDIT_region_EROM2_start__ = 0x0;
+define symbol __ICFEDIT_region_EROM2_end__   = 0x0;
+define symbol __ICFEDIT_region_EROM3_start__ = 0x0;
+define symbol __ICFEDIT_region_EROM3_end__   = 0x0;
+define symbol __ICFEDIT_region_IRAM1_start__ = 0x80200000;
+define symbol __ICFEDIT_region_IRAM1_end__   = 0x803FFFFF;
+define symbol __ICFEDIT_region_IRAM2_start__ = 0x0;
+define symbol __ICFEDIT_region_IRAM2_end__   = 0x0;
+define symbol __ICFEDIT_region_ERAM1_start__ = 0x0;
+define symbol __ICFEDIT_region_ERAM1_end__   = 0x0;
+define symbol __ICFEDIT_region_ERAM2_start__ = 0x0;
+define symbol __ICFEDIT_region_ERAM2_end__   = 0x0;
+define symbol __ICFEDIT_region_ERAM3_start__ = 0x0;
+define symbol __ICFEDIT_region_ERAM3_end__   = 0x0;
+define symbol __ICFEDIT_region_TTB_start__   = 0x80500000;
+define symbol __ICFEDIT_region_TTB_end__     = 0x805FFFFF;
+
+/*-Sizes-*/
+define symbol __ICFEDIT_size_cstack__        = 0x1000;
+define symbol __ICFEDIT_size_irqstack__      = 0x100;
+define symbol __ICFEDIT_size_fiqstack__      = 0x100;
+define symbol __ICFEDIT_size_svcstack__      = 0x100;
+define symbol __ICFEDIT_size_abtstack__      = 0x100;
+define symbol __ICFEDIT_size_undstack__      = 0x100;
+define symbol __ICFEDIT_size_heap__          = 0x8000;
+define symbol __ICFEDIT_size_ttb__           = 0x4000;
+
+define memory mem with size = 4G;
+define region IROM_region   =   mem:[from __ICFEDIT_region_IROM1_start__ to __ICFEDIT_region_IROM1_end__]
+                              | mem:[from __ICFEDIT_region_IROM2_start__ to __ICFEDIT_region_IROM2_end__];
+define region IRAM_region   =   mem:[from __ICFEDIT_region_IRAM1_start__ to __ICFEDIT_region_IRAM1_end__]
+                              | mem:[from __ICFEDIT_region_IRAM2_start__ to __ICFEDIT_region_IRAM2_end__];
+define region ERAM_region   =   mem:[from __ICFEDIT_region_ERAM1_start__ to __ICFEDIT_region_ERAM1_end__]
+                              | mem:[from __ICFEDIT_region_ERAM2_start__ to __ICFEDIT_region_ERAM2_end__]
+                              | mem:[from __ICFEDIT_region_ERAM3_start__ to __ICFEDIT_region_ERAM3_end__];
+define region TTB_region    =   mem:[from __ICFEDIT_region_TTB_start__   to __ICFEDIT_region_TTB_end__  ];
+
+define block USR_STACK     with alignment = 8, size = __ICFEDIT_size_cstack__        { };
+define block IRQ_STACK     with alignment = 8, size = __ICFEDIT_size_irqstack__      { };
+define block FIQ_STACK     with alignment = 8, size = __ICFEDIT_size_fiqstack__      { };
+define block SVC_STACK     with alignment = 8, size = __ICFEDIT_size_svcstack__      { };
+define block ABT_STACK     with alignment = 8, size = __ICFEDIT_size_abtstack__      { };
+define block UND_STACK     with alignment = 8, size = __ICFEDIT_size_undstack__      { };
+define block HEAP          with alignment = 8, size = __ICFEDIT_size_heap__          { };
+define block TTB           with alignment = 8, size = __ICFEDIT_size_ttb__           { section TTB };
+
+do not initialize  { section .noinit };
+
+initialize by copy { readwrite };
+if (isdefinedsymbol(__USE_DLIB_PERTHREAD))
+{
+  // Required in a multi-threaded application
+  initialize by copy with packing = none { section __DLIB_PERTHREAD };
+}
+
+place at address mem:__ICFEDIT_region_IROM1_start__ { readonly section RESET };
+place in IROM_region  { readonly };
+place in IRAM_region  { readwrite, block HEAP, block USR_STACK, block IRQ_STACK, block FIQ_STACK, block SVC_STACK, block ABT_STACK, block UND_STACK };
+place in TTB_region   { block TTB };

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA5/RTE/Device/ARMCA5/mem_ARMCA5.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA5/RTE/Device/ARMCA5/mem_ARMCA5.h
@@ -1,0 +1,100 @@
+/**************************************************************************//**
+ * @file     mem_ARMCA5.h
+ * @brief    Memory base and size definitions (used in scatter file)
+ * @version  V1.1.0
+ * @date     15. May 2019
+ *
+ * @note
+ *
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __MEM_ARMCA5_H
+#define __MEM_ARMCA5_H
+
+/*----------------------------------------------------------------------------
+  User Stack & Heap size definition
+ *----------------------------------------------------------------------------*/
+/*
+//-------- <<< Use Configuration Wizard in Context Menu >>> ------------------
+*/
+
+/*--------------------- ROM Configuration ------------------------------------
+//
+// <h> ROM Configuration
+//   <i> For compatibility with MMU config the sections must be multiple of 1MB
+//   <o0> ROM Base Address <0x0-0xFFFFFFFF:0x100000>
+//   <o1> ROM Size (in Bytes) <0x0-0xFFFFFFFF:0x100000>
+// </h>
+ *----------------------------------------------------------------------------*/
+#define __ROM_BASE       0x80000000
+#define __ROM_SIZE       0x00200000
+
+/*--------------------- RAM Configuration -----------------------------------
+// <h> RAM Configuration
+//   <i> For compatibility with MMU config the sections must be multiple of 1MB
+//   <o0> RAM Base Address    <0x0-0xFFFFFFFF:0x100000>
+//   <o1> RAM Total Size (in Bytes) <0x0-0xFFFFFFFF:0x100000>
+//   <h> Data Sections
+//     <o2> RW_DATA Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//     <o3> ZI_DATA Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//   </h>
+//   <h> Stack / Heap Configuration
+//     <o4>  Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//     <o5>  Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//     <h> Exceptional Modes
+//       <o6> UND Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//       <o7> ABT Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//       <o8> SVC Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//       <o9> IRQ Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//       <o10> FIQ Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//     </h>
+//   </h>
+// </h>
+ *----------------------------------------------------------------------------*/
+#define __RAM_BASE       0x80200000
+#define __RAM_SIZE       0x00200000
+
+#define __RW_DATA_SIZE   0x00100000
+#define __ZI_DATA_SIZE   0x000F0000
+
+#define __STACK_SIZE     0x00001000
+#define __HEAP_SIZE      0x00008000
+
+#define __UND_STACK_SIZE 0x00000100
+#define __ABT_STACK_SIZE 0x00000100
+#define __SVC_STACK_SIZE 0x00000100
+#define __IRQ_STACK_SIZE 0x00000100
+#define __FIQ_STACK_SIZE 0x00000100
+
+/*----------------------------------------------------------------------------*/
+
+/*--------------------- TTB Configuration ------------------------------------
+//
+// <h> TTB Configuration
+//   <i> The TLB L1 contains 4096 32-bit entries and must be 16kB aligned
+//   <i> The TLB L2 entries are placed after the L1 in the MMU config
+//   <o0> TTB Base Address <0x0-0xFFFFFFFF:0x4000>
+//   <o1> TTB Size (in Bytes) <0x0-0xFFFFFFFF:8>
+// </h>
+ *----------------------------------------------------------------------------*/
+#define __TTB_BASE       0x80500000
+#define __TTB_SIZE       0x00005000
+
+#endif /* __MEM_ARMCA5_H */

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA5/RTE/Device/ARMCA5/mmu_ARMCA5.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA5/RTE/Device/ARMCA5/mmu_ARMCA5.c
@@ -1,0 +1,232 @@
+/**************************************************************************//**
+ * @file     mmu_ARMCA5.c
+ * @brief    MMU Configuration for ARM Cortex-A5 Device Series
+ * @version  V1.2.0
+ * @date     15. May 2019
+ *
+ * @note
+ *
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Memory map description from: DUI0447G_v2m_p1_trm.pdf 4.2.2 Arm Cortex-A Series memory map
+
+                                                     Memory Type
+0xffffffff |--------------------------|             ------------
+           |       FLAG SYNC          |             Device Memory
+0xfffff000 |--------------------------|             ------------
+           |         Fault            |                Fault
+0xfff00000 |--------------------------|             ------------
+           |                          |                Normal
+           |                          |
+           |      Daughterboard       |
+           |         memory           |
+           |                          |
+0x80505000 |--------------------------|             ------------
+           |TTB (L2 Sync Flags   ) 4k |                Normal
+0x80504C00 |--------------------------|             ------------
+           |TTB (L2 Peripherals-B) 16k|                Normal
+0x80504800 |--------------------------|             ------------
+           |TTB (L2 Peripherals-A) 16k|                Normal
+0x80504400 |--------------------------|             ------------
+           |TTB (L2 Priv Periphs)  4k |                Normal
+0x80504000 |--------------------------|             ------------
+           |    TTB (L1 Descriptors)  |                Normal
+0x80500000 |--------------------------|             ------------
+           |          Stack           |                Normal
+           |--------------------------|             ------------
+           |          Heap            |                Normal
+0x80400000 |--------------------------|             ------------
+           |         ZI Data          |                Normal
+0x80300000 |--------------------------|             ------------
+           |         RW Data          |                Normal
+0x80200000 |--------------------------|             ------------
+           |         RO Data          |                Normal
+           |--------------------------|             ------------
+           |         RO Code          |              USH Normal
+0x80000000 |--------------------------|             ------------
+           |      Daughterboard       |                Fault
+           |      HSB AXI buses       |
+0x40000000 |--------------------------|             ------------
+           |      Daughterboard       |                Fault
+           |  test chips peripherals  |
+0x2c002000 |--------------------------|             ------------
+           |     Private Address      |            Device Memory
+0x2c000000 |--------------------------|             ------------
+           |      Daughterboard       |                Fault
+           |  test chips peripherals  |
+0x20000000 |--------------------------|             ------------
+           |       Peripherals        |           Device Memory RW/RO
+           |                          |              & Fault
+0x00000000 |--------------------------|
+*/
+
+// L1 Cache info and restrictions about architecture of the caches (CCSIR register):
+// Write-Through support *not* available
+// Write-Back support available.
+// Read allocation support available.
+// Write allocation support available.
+
+//Note: You should use the Shareable attribute carefully.
+//For cores without coherency logic (such as SCU) marking a region as shareable forces the processor to not cache that region regardless of the inner cache settings.
+//Cortex-A versions of RTX use LDREX/STREX instructions relying on Local monitors. Local monitors will be used only when the region gets cached, regions that are not cached will use the Global Monitor.
+//Some Cortex-A implementations do not include Global Monitors, so wrongly setting the attribute Shareable may cause STREX to fail.
+
+//Recall: When the Shareable attribute is applied to a memory region that is not Write-Back, Normal memory, data held in this region is treated as Non-cacheable.
+//When SMP bit = 0, Inner WB/WA Cacheable Shareable attributes are treated as Non-cacheable.
+//When SMP bit = 1, Inner WB/WA Cacheable Shareable attributes are treated as Cacheable.
+
+
+//Following MMU configuration is expected
+//SCTLR.AFE == 1 (Simplified access permissions model - AP[2:1] define access permissions, AP[0] is an access flag)
+//SCTLR.TRE == 0 (TEX remap disabled, so memory type and attributes are described directly by bits in the descriptor)
+//Domain 0 is always the Client domain
+//Descriptors should place all memory in domain 0
+
+#include "ARMCA5.h"
+#include "mem_ARMCA5.h"
+
+// TTB base address
+#define TTB_BASE ((uint32_t*)__TTB_BASE)
+
+// L2 table pointers
+//----------------------------------------
+#define TTB_L1_SIZE                    (0x00004000)                        // The L1 translation table divides the full 4GB address space of a 32-bit core
+                                                                           // into 4096 equally sized sections, each of which describes 1MB of virtual memory space.
+                                                                           // The L1 translation table therefore contains 4096 32-bit (word-sized) entries.
+
+#define PRIVATE_TABLE_L2_BASE_4k       (__TTB_BASE + TTB_L1_SIZE)          // Map 4k Private Address space
+#define PERIPHERAL_A_TABLE_L2_BASE_64k (__TTB_BASE + TTB_L1_SIZE + 0x400)  // Map 64k Peripheral #1 0x1C000000 - 0x1C00FFFFF
+#define PERIPHERAL_B_TABLE_L2_BASE_64k (__TTB_BASE + TTB_L1_SIZE + 0x800)  // Map 64k Peripheral #2 0x1C100000 - 0x1C1FFFFFF
+#define SYNC_FLAGS_TABLE_L2_BASE_4k    (__TTB_BASE + TTB_L1_SIZE + 0xC00)  // Map 4k Flag synchronization
+
+//--------------------- PERIPHERALS -------------------
+#define PERIPHERAL_A_FAULT (0x00000000 + 0x1c000000) //0x1C000000-0x1C00FFFF (1M)
+#define PERIPHERAL_B_FAULT (0x00100000 + 0x1c000000) //0x1C100000-0x1C10FFFF (1M)
+
+//--------------------- SYNC FLAGS --------------------
+#define FLAG_SYNC     0xFFFFF000
+#define F_SYNC_BASE   0xFFF00000  //1M aligned
+
+static uint32_t Sect_Normal;     //outer & inner wb/wa, non-shareable, executable, rw, domain 0, base addr 0
+static uint32_t Sect_Normal_Cod; //outer & inner wb/wa, non-shareable, executable, ro, domain 0, base addr 0
+static uint32_t Sect_Normal_RO;  //as Sect_Normal_Cod, but not executable
+static uint32_t Sect_Normal_RW;  //as Sect_Normal_Cod, but writeable and not executable
+static uint32_t Sect_Device_RO;  //device, non-shareable, non-executable, ro, domain 0, base addr 0
+static uint32_t Sect_Device_RW;  //as Sect_Device_RO, but writeable
+
+/* Define global descriptors */
+static uint32_t Page_L1_4k  = 0x0;  //generic
+static uint32_t Page_L1_64k = 0x0;  //generic
+static uint32_t Page_4k_Device_RW;  //Shared device, not executable, rw, domain 0
+static uint32_t Page_64k_Device_RW; //Shared device, not executable, rw, domain 0
+
+void MMU_CreateTranslationTable(void)
+{
+    mmu_region_attributes_Type region;
+
+    //Create 4GB of faulting entries
+    MMU_TTSection (TTB_BASE, 0, 4096, DESCRIPTOR_FAULT);
+
+    /*
+     * Generate descriptors. Refer to core_ca.h to get information about attributes
+     *
+     */
+    //Create descriptors for Vectors, RO, RW, ZI sections
+    section_normal(Sect_Normal, region);
+    section_normal_cod(Sect_Normal_Cod, region);
+    section_normal_ro(Sect_Normal_RO, region);
+    section_normal_rw(Sect_Normal_RW, region);
+    //Create descriptors for peripherals
+    section_device_ro(Sect_Device_RO, region);
+    section_device_rw(Sect_Device_RW, region);
+    //Create descriptors for 64k pages
+    page64k_device_rw(Page_L1_64k, Page_64k_Device_RW, region);
+    //Create descriptors for 4k pages
+    page4k_device_rw(Page_L1_4k, Page_4k_Device_RW, region);
+
+
+    /*
+     *  Define MMU flat-map regions and attributes
+     *
+     */
+
+    //Define Image
+    MMU_TTSection (TTB_BASE, __ROM_BASE, __ROM_SIZE/0x100000, Sect_Normal_Cod); // multiple of 1MB sections
+    MMU_TTSection (TTB_BASE, __RAM_BASE, __RAM_SIZE/0x100000, Sect_Normal_RW);  // multiple of 1MB sections
+
+    //--------------------- PERIPHERALS -------------------
+    MMU_TTSection (TTB_BASE, VE_A5_MP_FLASH_BASE0   , 64, Sect_Device_RO); // 64MB NOR
+    MMU_TTSection (TTB_BASE, VE_A5_MP_FLASH_BASE1   , 64, Sect_Device_RO); // 64MB NOR
+    MMU_TTSection (TTB_BASE, VE_A5_MP_SRAM_BASE     , 32, Sect_Device_RW); // 32MB RAM
+    MMU_TTSection (TTB_BASE, VE_A5_MP_VRAM_BASE     , 32, Sect_Device_RW); // 32MB RAM
+    MMU_TTSection (TTB_BASE, VE_A5_MP_ETHERNET_BASE , 16, Sect_Device_RW);
+    MMU_TTSection (TTB_BASE, VE_A5_MP_USB_BASE      , 16, Sect_Device_RW);
+
+    // Create (16 * 64k)=1MB faulting entries to cover peripheral range 0x1C000000-0x1C00FFFF
+    MMU_TTPage64k(TTB_BASE, PERIPHERAL_A_FAULT      , 16, Page_L1_64k, (uint32_t *)PERIPHERAL_A_TABLE_L2_BASE_64k, DESCRIPTOR_FAULT);
+    // Define peripheral range 0x1C000000-0x1C00FFFF
+    MMU_TTPage64k(TTB_BASE, VE_A5_MP_DAP_BASE       ,  1, Page_L1_64k, (uint32_t *)PERIPHERAL_A_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+    MMU_TTPage64k(TTB_BASE, VE_A5_MP_SYSTEM_REG_BASE,  1, Page_L1_64k, (uint32_t *)PERIPHERAL_A_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+    MMU_TTPage64k(TTB_BASE, VE_A5_MP_SERIAL_BASE    ,  1, Page_L1_64k, (uint32_t *)PERIPHERAL_A_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+    MMU_TTPage64k(TTB_BASE, VE_A5_MP_AACI_BASE      ,  1, Page_L1_64k, (uint32_t *)PERIPHERAL_A_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+    MMU_TTPage64k(TTB_BASE, VE_A5_MP_MMCI_BASE      ,  1, Page_L1_64k, (uint32_t *)PERIPHERAL_A_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+    MMU_TTPage64k(TTB_BASE, VE_A5_MP_KMI0_BASE      ,  2, Page_L1_64k, (uint32_t *)PERIPHERAL_A_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+    MMU_TTPage64k(TTB_BASE, VE_A5_MP_UART_BASE      ,  4, Page_L1_64k, (uint32_t *)PERIPHERAL_A_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+    MMU_TTPage64k(TTB_BASE, VE_A5_MP_WDT_BASE       ,  1, Page_L1_64k, (uint32_t *)PERIPHERAL_A_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+
+    // Create (16 * 64k)=1MB faulting entries to cover peripheral range 0x1C100000-0x1C10FFFF
+    MMU_TTPage64k(TTB_BASE, PERIPHERAL_B_FAULT      , 16, Page_L1_64k, (uint32_t *)PERIPHERAL_B_TABLE_L2_BASE_64k, DESCRIPTOR_FAULT);
+    // Define peripheral range 0x1C100000-0x1C10FFFF
+    MMU_TTPage64k(TTB_BASE, VE_A5_MP_TIMER_BASE     ,  2, Page_L1_64k, (uint32_t *)PERIPHERAL_B_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+    MMU_TTPage64k(TTB_BASE, VE_A5_MP_DVI_BASE       ,  1, Page_L1_64k, (uint32_t *)PERIPHERAL_B_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+    MMU_TTPage64k(TTB_BASE, VE_A5_MP_RTC_BASE       ,  1, Page_L1_64k, (uint32_t *)PERIPHERAL_B_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+    MMU_TTPage64k(TTB_BASE, VE_A5_MP_UART4_BASE     ,  1, Page_L1_64k, (uint32_t *)PERIPHERAL_B_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+    MMU_TTPage64k(TTB_BASE, VE_A5_MP_CLCD_BASE      ,  1, Page_L1_64k, (uint32_t *)PERIPHERAL_B_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+
+    // Create (256 * 4k)=1MB faulting entries to cover private address space. Needs to be marked as Device memory
+    MMU_TTPage4k (TTB_BASE, __get_CBAR()            ,256,  Page_L1_4k, (uint32_t *)PRIVATE_TABLE_L2_BASE_4k, DESCRIPTOR_FAULT);
+    // Define private address space entry.
+    MMU_TTPage4k (TTB_BASE, __get_CBAR()            ,  3,  Page_L1_4k, (uint32_t *)PRIVATE_TABLE_L2_BASE_4k, Page_4k_Device_RW);
+    // Define L2CC entry.  Uncomment if PL310 is present
+    //    MMU_TTPage4k (TTB_BASE, VE_A5_MP_PL310_BASE     ,  1,  Page_L1_4k, (uint32_t *)PRIVATE_TABLE_L2_BASE_4k, Page_4k_Device_RW);
+
+    // Create (256 * 4k)=1MB faulting entries to synchronization space (Useful if some non-cacheable DMA agent is present in the SoC)
+    MMU_TTPage4k (TTB_BASE, F_SYNC_BASE             , 256, Page_L1_4k, (uint32_t *)SYNC_FLAGS_TABLE_L2_BASE_4k, DESCRIPTOR_FAULT);
+    // Define synchronization space entry.
+    MMU_TTPage4k (TTB_BASE, FLAG_SYNC               ,   1, Page_L1_4k, (uint32_t *)SYNC_FLAGS_TABLE_L2_BASE_4k, Page_4k_Device_RW);
+
+    /* Set location of level 1 page table
+    ; 31:14 - Translation table base addr (31:14-TTBCR.N, TTBCR.N is 0 out of reset)
+    ; 13:7  - 0x0
+    ; 6     - IRGN[0] 0x1  (Inner WB WA)
+    ; 5     - NOS     0x0  (Non-shared)
+    ; 4:3   - RGN     0x01 (Outer WB WA)
+    ; 2     - IMP     0x0  (Implementation Defined)
+    ; 1     - S       0x0  (Non-shared)
+    ; 0     - IRGN[1] 0x0  (Inner WB WA) */
+    __set_TTBR0(__TTB_BASE | 0x48);
+    __ISB();
+
+    /* Set up domain access control register
+    ; We set domain 0 to Client and all other domains to No Access.
+    ; All translation table entries specify domain 0 */
+    __set_DACR(1);
+    __ISB();
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA5/RTE/Device/ARMCA5/startup_ARMCA5.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA5/RTE/Device/ARMCA5/startup_ARMCA5.c
@@ -1,0 +1,148 @@
+/******************************************************************************
+ * @file     startup_ARMCA5.c
+ * @brief    CMSIS Device System Source File for Arm Cortex-A5 Device Series
+ * @version  V1.0.1
+ * @date     10. January 2021
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2021 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <ARMCA5.h>
+
+/*----------------------------------------------------------------------------
+  Definitions
+ *----------------------------------------------------------------------------*/
+#define USR_MODE 0x10            // User mode
+#define FIQ_MODE 0x11            // Fast Interrupt Request mode
+#define IRQ_MODE 0x12            // Interrupt Request mode
+#define SVC_MODE 0x13            // Supervisor mode
+#define ABT_MODE 0x17            // Abort mode
+#define UND_MODE 0x1B            // Undefined Instruction mode
+#define SYS_MODE 0x1F            // System mode
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+void Vectors        (void) __attribute__ ((naked, section("RESET")));
+void Reset_Handler  (void) __attribute__ ((naked));
+void Default_Handler(void) __attribute__ ((noreturn));
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+void Undef_Handler (void) __attribute__ ((weak, alias("Default_Handler")));
+void SVC_Handler   (void) __attribute__ ((weak, alias("Default_Handler")));
+void PAbt_Handler  (void) __attribute__ ((weak, alias("Default_Handler")));
+void DAbt_Handler  (void) __attribute__ ((weak, alias("Default_Handler")));
+void IRQ_Handler   (void) __attribute__ ((weak, alias("Default_Handler")));
+void FIQ_Handler   (void) __attribute__ ((weak, alias("Default_Handler")));
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector Table
+ *----------------------------------------------------------------------------*/
+void Vectors(void) {
+  __ASM volatile(
+  "LDR    PC, =Reset_Handler                        \n"
+  "LDR    PC, =Undef_Handler                        \n"
+  "LDR    PC, =SVC_Handler                          \n"
+  "LDR    PC, =PAbt_Handler                         \n"
+  "LDR    PC, =DAbt_Handler                         \n"
+  "NOP                                              \n"
+  "LDR    PC, =IRQ_Handler                          \n"
+  "LDR    PC, =FIQ_Handler                          \n"
+  );
+}
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+void Reset_Handler(void) {
+  __ASM volatile(
+
+  // Mask interrupts
+  "CPSID   if                                      \n"
+
+  // Put any cores other than 0 to sleep
+  "MRC     p15, 0, R0, c0, c0, 5                   \n"  // Read MPIDR
+  "ANDS    R0, R0, #3                              \n"
+  "goToSleep:                                      \n"
+  "WFINE                                           \n"
+  "BNE     goToSleep                               \n"
+
+  // Reset SCTLR Settings
+  "MRC     p15, 0, R0, c1, c0, 0                   \n"  // Read CP15 System Control register
+  "BIC     R0, R0, #(0x1 << 12)                    \n"  // Clear I bit 12 to disable I Cache
+  "BIC     R0, R0, #(0x1 <<  2)                    \n"  // Clear C bit  2 to disable D Cache
+  "BIC     R0, R0, #0x1                            \n"  // Clear M bit  0 to disable MMU
+  "BIC     R0, R0, #(0x1 << 11)                    \n"  // Clear Z bit 11 to disable branch prediction
+  "BIC     R0, R0, #(0x1 << 13)                    \n"  // Clear V bit 13 to disable hivecs
+  "MCR     p15, 0, R0, c1, c0, 0                   \n"  // Write value back to CP15 System Control register
+  "ISB                                             \n"
+
+  // Configure ACTLR
+  "MRC     p15, 0, r0, c1, c0, 1                   \n"  // Read CP15 Auxiliary Control Register
+  "ORR     r0, r0, #(1 <<  1)                      \n"  // Enable L2 prefetch hint (UNK/WI since r4p1)
+  "MCR     p15, 0, r0, c1, c0, 1                   \n"  // Write CP15 Auxiliary Control Register
+
+  // Set Vector Base Address Register (VBAR) to point to this application's vector table
+  "LDR    R0, =Vectors                             \n"
+  "MCR    p15, 0, R0, c12, c0, 0                   \n"
+
+  // Setup Stack for each exceptional mode
+  "CPS    #0x11                                    \n"
+  "LDR    SP, =Image$$FIQ_STACK$$ZI$$Limit         \n"
+  "CPS    #0x12                                    \n"
+  "LDR    SP, =Image$$IRQ_STACK$$ZI$$Limit         \n"
+  "CPS    #0x13                                    \n"
+  "LDR    SP, =Image$$SVC_STACK$$ZI$$Limit         \n"
+  "CPS    #0x17                                    \n"
+  "LDR    SP, =Image$$ABT_STACK$$ZI$$Limit         \n"
+  "CPS    #0x1B                                    \n"
+  "LDR    SP, =Image$$UND_STACK$$ZI$$Limit         \n"
+  "CPS    #0x1F                                    \n"
+#if defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6100100)
+  "LDR    SP, =Image$$ARM_LIB_STACK$$ZI$$Limit     \n"
+#elif defined ( __GNUC__ )
+  "LDR    SP, =Image$$SYS_STACK$$ZI$$Limit         \n"
+#else
+  #error Unknown compiler.
+#endif
+
+  // Call SystemInit
+  "BL     SystemInit                               \n"
+
+  // Unmask interrupts
+  "CPSIE  if                                       \n"
+
+  // Call __main
+#if defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6100100)
+  "BL     __main                                   \n"
+#elif defined ( __GNUC__ )
+  "BL     _start                                   \n"
+#else
+  #error Unknown compiler.
+#endif
+  );
+}
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+void Default_Handler(void) {
+  while(1);
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA5/RTE/Device/ARMCA5/startup_ARMCA5.s
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA5/RTE/Device/ARMCA5/startup_ARMCA5.s
@@ -1,0 +1,140 @@
+/******************************************************************************
+ * @file     startup_ARMCA9.s
+ * @brief    CMSIS Device System Source File for ARM Cortex-A5 Device Series
+ * @version  V1.00
+ * @date     01 Nov 2017
+ *
+ * @note
+ *
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2017 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+  MODULE  ?startup_ARMCA5
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+  PUBLIC  Reset_Handler
+  PUBWEAK Undef_Handler
+  PUBWEAK SVC_Handler
+  PUBWEAK PAbt_Handler
+  PUBWEAK DAbt_Handler
+  PUBWEAK IRQ_Handler
+  PUBWEAK FIQ_Handler
+
+  SECTION SVC_STACK:DATA:NOROOT(3)
+  SECTION IRQ_STACK:DATA:NOROOT(3)
+  SECTION FIQ_STACK:DATA:NOROOT(3)
+  SECTION ABT_STACK:DATA:NOROOT(3)
+  SECTION UND_STACK:DATA:NOROOT(3)
+  SECTION USR_STACK:DATA:NOROOT(3)
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector Table
+ *----------------------------------------------------------------------------*/
+
+  section RESET:CODE:NOROOT(2)
+  PUBLIC  Vectors
+
+Vectors:  
+  LDR    PC, =Reset_Handler
+  LDR    PC, =Undef_Handler
+  LDR    PC, =SVC_Handler
+  LDR    PC, =PAbt_Handler
+  LDR    PC, =DAbt_Handler
+  NOP
+  LDR    PC, =IRQ_Handler
+  LDR    PC, =FIQ_Handler
+
+
+  section .text:CODE:NOROOT(4)
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+  *----------------------------------------------------------------------------*/
+  EXTERN  SystemInit
+  EXTERN  __iar_program_start
+
+Reset_Handler:  
+
+  // Mask interrupts
+  CPSID   if
+
+  // Put any cores other than 0 to sleep
+  MRC     p15, 0, R0, c0, c0, 5
+  ANDS    R0, R0, #3
+goToSleep:
+  WFINE
+  BNE     goToSleep
+
+  // Reset SCTLR Settings
+  MRC     p15, 0, R0, c1, c0, 0 // Read CP15 System Control register
+  BIC     R0, R0, #(0x1 << 12) // Clear I bit 12 to disable I Cache
+  BIC     R0, R0, #(0x1 <<  2) // Clear C bit  2 to disable D Cache
+  BIC     R0, R0, #0x1       // Clear M bit  0 to disable MMU
+  BIC     R0, R0, #(0x1 << 11) // Clear Z bit 11 to disable branch prediction
+  BIC     R0, R0, #(0x1 << 13) // Clear V bit 13 to disable hivecs
+  MCR     p15, 0, R0, c1, c0, 0 // Write value back to CP15 System Control register
+  ISB
+
+  // Configure ACTLR
+  MRC     p15, 0, r0, c1, c0, 1 // Read CP15 Auxiliary Control Register
+  ORR     r0, r0, #(1 <<  1) // Enable L2 prefetch hint (UNK/WI since r4p1)
+  MCR     p15, 0, r0, c1, c0, 1 // Write CP15 Auxiliary Control Register
+
+  // Set Vector Base Address Register (VBAR) to point to this application's vector table
+  LDR    R0, =Vectors
+  MCR    p15, 0, R0, c12, c0, 0
+
+  // Setup Stack for each exception mode
+  CPS    #0x11
+  LDR    SP, =SFE(FIQ_STACK)
+  CPS    #0x12
+  LDR    SP, =SFE(IRQ_STACK)
+  CPS    #0x13
+  LDR    SP, =SFE(SVC_STACK)
+  CPS    #0x17
+  LDR    SP, =SFE(ABT_STACK)
+  CPS    #0x1B
+  LDR    SP, =SFE(UND_STACK)
+  CPS    #0x1F
+  LDR    SP, =SFE(USR_STACK)
+
+  // Call SystemInit
+  BL     SystemInit
+
+  // Unmask interrupts
+  CPSIE  if
+
+  // Call __iar_program_start
+  BL     __iar_program_start
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+Undef_Handler:
+SVC_Handler:
+PAbt_Handler:
+DAbt_Handler:
+IRQ_Handler:
+FIQ_Handler:
+Default_Handler:
+  B .
+
+  END

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA5/RTE/Device/ARMCA5/system_ARMCA5.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA5/RTE/Device/ARMCA5/system_ARMCA5.c
@@ -1,0 +1,93 @@
+/******************************************************************************
+ * @file     system_ARMCA5.c
+ * @brief    CMSIS Device System Source File for Arm Cortex-A5 Device Series
+ * @version  V1.0.1
+ * @date     13. February 2019
+ *
+ * @note
+ *
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "RTE_Components.h"
+#include CMSIS_device_header
+#include "irq_ctrl.h"
+
+#define  SYSTEM_CLOCK  12000000U
+
+/*----------------------------------------------------------------------------
+  System Core Clock Variable
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = SYSTEM_CLOCK;
+
+/*----------------------------------------------------------------------------
+  System Core Clock update function
+ *----------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)
+{
+  SystemCoreClock = SYSTEM_CLOCK;
+}
+
+/*----------------------------------------------------------------------------
+  System Initialization
+ *----------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+/* do not use global variables because this function is called before
+   reaching pre-main. RW section may be overwritten afterwards.          */
+
+  // Invalidate entire Unified TLB
+  __set_TLBIALL(0);
+
+  // Invalidate entire branch predictor array
+  __set_BPIALL(0);
+  __DSB();
+  __ISB();
+
+  //  Invalidate instruction cache and flush branch target cache
+  __set_ICIALLU(0);
+  __DSB();
+  __ISB();
+
+  //  Invalidate data cache
+  L1C_InvalidateDCacheAll();
+
+#if ((__FPU_PRESENT == 1) && (__FPU_USED == 1))
+  // Enable FPU
+  __FPU_Enable();
+#endif
+
+  // Create Translation Table
+  MMU_CreateTranslationTable();
+
+  // Enable MMU
+  MMU_Enable();
+
+  // Enable Caches
+  L1C_EnableCaches();
+  L1C_EnableBTAC();
+
+#if (__L2C_PRESENT == 1) 
+  // Enable GIC
+  L2C_Enable();
+#endif
+
+  // IRQ Initialize
+  IRQ_Initialize();
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA5/RTE/Device/ARMCA5/system_ARMCA5.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA5/RTE/Device/ARMCA5/system_ARMCA5.h
@@ -1,0 +1,65 @@
+/******************************************************************************
+ * @file     system_ARMCA5.h
+ * @brief    CMSIS Device System Header File for Arm Cortex-A5 Device Series
+ * @version  V1.00
+ * @date     10. January 2018
+ *
+ * @note
+ *
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2018 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __SYSTEM_ARMCA5_H
+#define __SYSTEM_ARMCA5_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+extern uint32_t SystemCoreClock;     /*!< System Clock Frequency (Core Clock)  */
+
+/**
+  \brief Setup the microcontroller system.
+
+   Initialize the System and update the SystemCoreClock variable.
+ */
+extern void SystemInit (void);
+
+
+/**
+  \brief  Update SystemCoreClock variable.
+
+   Updates the SystemCoreClock with current core Clock retrieved from cpu registers.
+ */
+extern void SystemCoreClockUpdate (void);
+
+/**
+  \brief  Create Translation Table.
+
+   Creates Memory Management Unit Translation Table.
+ */
+extern void MMU_CreateTranslationTable(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __SYSTEM_ARMCA5_H */

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA5/Target.clayer.yml
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA5/Target.clayer.yml
@@ -1,0 +1,42 @@
+layer:
+  type: Target
+  description: CA5 target components and files
+
+  packs:
+    - pack: ARM::Cortex_DFP
+
+  device: ARMCA5
+
+  components:
+    # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
+    - component: ARM::CMSIS:CORE
+    - component: Device:Startup
+    - component: Device:IRQ Controller:GIC
+
+  misc:
+    - for-compiler: IAR
+      Link: [--config generic_cortex.icf]
+
+  linker:
+    - script: RTE/Device/ARMCA5/ARMCA5_ac6.sct
+      for-compiler:
+        - AC6
+    - script: RTE/Device/ARMCA5/ARMCA5_gcc.ld
+      for-compiler:
+        - GCC
+    - script: RTE/Device/ARMCA5/ARMCA5_iar.icf
+      for-compiler:
+        - IAR
+    - script: RTE/Device/ARMCA5/ARMCA5_clang.ld
+      for-compiler:
+        - CLANG
+    - regions: RTE/Device/ARMCA5/mem_ARMCA5.h
+      for-compiler:
+        - AC6
+        - GCC
+        - CLANG
+
+  groups:
+    - group: VHT/FVP
+      files:
+        - file: ./model_config.txt

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA5/model_config.txt
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA5/model_config.txt
@@ -1,0 +1,21 @@
+# Parameters:
+# instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+#----------------------------------------------------------------------------------------------
+motherboard.vis.disable_visualisation=1               # (bool  , init-time) default = '0'      : Enable/disable visualisation
+cluster.cpu0.vfp-present=1                            # (bool  , init-time) default = '1'      : Set whether the model has VFP support 
+cluster.cpu0.ase-present=0                            # (bool  , init-time) default = '1'      : Set whether model has NEON support
+cluster.cpu0.semihosting-enable=1                     # (bool  , init-time) default = '1'      : Enable semihosting SVC traps. Applications that do not use semihosting must set this parameter to false
+cluster.cpu0.semihosting-hlt-enable=0                 # (bool  , init-time) default = '0'      : Enable semihosting HLT traps. Applications that use HLT semihosting must set this parameter to true and the semihosting-enable parameter to true
+cluster.cpu0.semihosting-ARM_SVC=0x123456             # (int   , init-time) default = '0x123456' : ARM SVC number for semihosting : [0x0..0xFFFFFF]
+cluster.cpu0.semihosting-Thumb_SVC=0xAB               # (int   , init-time) default = '0xAB'   : Thumb SVC number for semihosting : [0x0..0xFF]
+cluster.cpu0.semihosting-ARM_HLT=0xF000               # (int   , init-time) default = '0xF000' : ARM HLT number for semihosting : [0x0..0xFFFF]
+cluster.cpu0.semihosting-Thumb_HLT=0x3C               # (int   , init-time) default = '0x3C'   : Thumb HLT number for semihosting : [0x0..0x3F]
+cluster.cpu0.semihosting-cmd_line=""                  # (string, init-time) default = ''       : Command line available to semihosting SVC calls
+cluster.cpu0.semihosting-heap_base=0x0                # (int   , init-time) default = '0x0'    : Virtual address of heap base : [0x0..0xFFFFFFFF]
+cluster.cpu0.semihosting-heap_limit=0x0               # (int   , init-time) default = '0xFF000000' : Virtual address of top of heap : [0x0..0xFFFFFFFF]
+cluster.cpu0.semihosting-stack_base=0x0               # (int   , init-time) default = '0xFFFF0000' : Virtual address of base of descending stack : [0x0..0xFFFFFFFF]
+cluster.cpu0.semihosting-stack_limit=0x0              # (int   , init-time) default = '0xFF000000' : Virtual address of stack limit : [0x0..0xFFFFFFFF]
+cluster.cpu0.semihosting-cwd=""                       # (string, init-time) default = ''       : Base directory for semihosting file access.
+cluster.dcache-state_modelled=1                       # (bool  , run-time ) default = '0'      : Set whether D-cache has stateful implementation
+cluster.icache-state_modelled=1                       # (bool  , run-time ) default = '0'      : Set whether I-cache has stateful implementation
+#----------------------------------------------------------------------------------------------

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA7/RTE/Device/ARMCA7/ARMCA7.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA7/RTE/Device/ARMCA7/ARMCA7.ld
@@ -1,0 +1,181 @@
+#include "mem_ARMCA7.h" 
+
+MEMORY
+{
+  ROM (rx)   : ORIGIN = __ROM_BASE, LENGTH = __ROM_SIZE
+  L_TTB (rw) : ORIGIN = __TTB_BASE, LENGTH = __TTB_SIZE 
+  RAM (rwx)  : ORIGIN = __RAM_BASE, LENGTH = __RAM_SIZE
+}
+
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+    .text :
+    {
+
+        Image$$VECTORS$$Base = .;
+        * (RESET)
+        KEEP(*(.isr_vector))
+        Image$$VECTORS$$Limit = .;
+
+        *(SVC_TABLE)
+        *(.text*)
+
+        KEEP(*(.init))
+        KEEP(*(.fini))
+
+        /* .ctors */
+        *crtbegin.o(.ctors)
+        *crtbegin?.o(.ctors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+        *(SORT(.ctors.*))
+        *(.ctors)
+
+        /* .dtors */
+        *crtbegin.o(.dtors)
+        *crtbegin?.o(.dtors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+        *(SORT(.dtors.*))
+        *(.dtors)
+
+        Image$$RO_DATA$$Base = .;
+        *(.rodata*)
+        Image$$RO_DATA$$Limit = .;
+
+        KEEP(*(.eh_frame*))
+    } > ROM
+
+    .ARM.extab : 
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > ROM
+
+    __exidx_start = .;
+    .ARM.exidx :
+    {
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    } > ROM
+    __exidx_end = .;
+
+
+    .copy.table :
+    {
+        . = ALIGN(4);
+        __copy_table_start__ = .;
+        LONG (__etext)
+        LONG (__data_start__)
+        LONG (__data_end__ - __data_start__)
+        __copy_table_end__ = .;
+    } > ROM
+
+    .zero.table :
+    {
+        . = ALIGN(4);
+        __zero_table_start__ = .;
+        LONG (__bss_start__)
+        LONG (__bss_end__ - __bss_start__)
+        __zero_table_end__ = .;
+    } > ROM
+
+    __etext = .;
+        
+    .ttb :
+    {
+        Image$$TTB$$ZI$$Base = .;
+        . += __TTB_SIZE;
+        Image$$TTB$$ZI$$Limit = .;
+    } > L_TTB
+
+    .data :
+    {
+        Image$$RW_DATA$$Base = .;
+        __data_start__ = .;
+        *(vtable)
+        *(.data*)
+        Image$$RW_DATA$$Limit = .;
+
+        . = ALIGN(4);
+        /* preinit data */
+        PROVIDE (__preinit_array_start = .);
+        KEEP(*(.preinit_array))
+        PROVIDE (__preinit_array_end = .);
+
+        . = ALIGN(4);
+        /* init data */
+        PROVIDE (__init_array_start = .);
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array))
+        PROVIDE (__init_array_end = .);
+
+
+        . = ALIGN(4);
+        /* finit data */
+        PROVIDE (__fini_array_start = .);
+        KEEP(*(SORT(.fini_array.*)))
+        KEEP(*(.fini_array))
+        PROVIDE (__fini_array_end = .);
+
+        . = ALIGN(4);
+        /* All data end */
+        __data_end__ = .;
+
+    } > RAM
+
+    
+    .bss ALIGN(0x400):
+    {
+        Image$$ZI_DATA$$Base = .;
+        __bss_start__ = .;
+        *(.bss*)
+        *(COMMON)
+        __bss_end__ = .;
+        Image$$ZI_DATA$$Limit = .;
+        __end__ = .;
+        end = __end__;
+    } > RAM AT > RAM
+
+#if defined(__HEAP_SIZE) && (__HEAP_SIZE > 0)    
+    .heap (NOLOAD):
+    {
+        . = ALIGN(8);
+        Image$$HEAP$$ZI$$Base = .;
+        . += __HEAP_SIZE;
+        Image$$HEAP$$ZI$$Limit = .;
+        __HeapLimit = .;
+    } > RAM  
+#endif
+
+    .stack (NOLOAD):
+    {
+        . = ORIGIN(RAM) + LENGTH(RAM) - __STACK_SIZE - __FIQ_STACK_SIZE - __IRQ_STACK_SIZE - __SVC_STACK_SIZE - __ABT_STACK_SIZE - __UND_STACK_SIZE;
+        . = ALIGN(8);
+        
+        __StackTop = .;
+        Image$$SYS_STACK$$ZI$$Base = .;
+        . += __STACK_SIZE;
+        Image$$SYS_STACK$$ZI$$Limit = .;
+        __stack = .;
+
+        Image$$FIQ_STACK$$ZI$$Base = .;
+        . += __FIQ_STACK_SIZE;
+        Image$$FIQ_STACK$$ZI$$Limit = .;
+
+        Image$$IRQ_STACK$$ZI$$Base = .;
+        . += __IRQ_STACK_SIZE;
+        Image$$IRQ_STACK$$ZI$$Limit = .;
+
+        Image$$SVC_STACK$$ZI$$Base = .;
+        . += __SVC_STACK_SIZE;
+        Image$$SVC_STACK$$ZI$$Limit = .;
+
+        Image$$ABT_STACK$$ZI$$Base = .;
+        . += __ABT_STACK_SIZE;
+        Image$$ABT_STACK$$ZI$$Limit = .;
+
+        Image$$UND_STACK$$ZI$$Base = .;
+        . += __UND_STACK_SIZE;
+        Image$$UND_STACK$$ZI$$Limit = .;
+        
+    } > RAM
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA7/RTE/Device/ARMCA7/ARMCA7.sct
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA7/RTE/Device/ARMCA7/ARMCA7.sct
@@ -1,0 +1,77 @@
+#! armclang -E --target=arm-arm-none-eabi -mcpu=cortex-a7 -xc
+;**************************************************
+; Copyright (c) 2017 ARM Ltd.  All rights reserved.
+;**************************************************
+
+; Scatter-file for RTX Example on Versatile Express
+
+; This scatter-file places application code, data, stack and heap at suitable addresses in the memory map.
+
+; This platform has 2GB SDRAM starting at 0x80000000.
+
+#include "mem_ARMCA7.h"
+
+SDRAM __ROM_BASE __ROM_SIZE       ; load region size_region
+{
+  VECTORS __ROM_BASE __ROM_SIZE ; load address = execution address
+  {
+      * (RESET, +FIRST)         ; Vector table and other startup code
+      * (InRoot$$Sections)      ; All (library) code that must be in a root region
+      * (+RO-CODE)              ; Application RO code (.text)
+      * (+RO-DATA)              ; Application RO data (.constdata)
+  }
+  
+  RW_DATA __RAM_BASE __RW_DATA_SIZE
+  { * (+RW) }                   ; Application RW data (.data)
+  
+  ZI_DATA (__RAM_BASE+
+           __RW_DATA_SIZE) __ZI_DATA_SIZE
+  { * (+ZI) }                   ; Application ZI data (.bss)
+  
+  ARM_LIB_HEAP  (__RAM_BASE
+                +__RW_DATA_SIZE
+                +__ZI_DATA_SIZE)    EMPTY __HEAP_SIZE        ; Heap region growing up
+  { }
+    
+  ARM_LIB_STACK (__RAM_BASE
+                +__RAM_SIZE       
+                -__FIQ_STACK_SIZE
+                -__IRQ_STACK_SIZE
+                -__SVC_STACK_SIZE
+                -__ABT_STACK_SIZE
+                -__UND_STACK_SIZE) EMPTY -__STACK_SIZE      ; Stack region growing down
+  { }              
+                
+  UND_STACK     (__RAM_BASE
+                +__RAM_SIZE
+                -__FIQ_STACK_SIZE
+                -__IRQ_STACK_SIZE
+                -__SVC_STACK_SIZE
+                -__ABT_STACK_SIZE) EMPTY -__UND_STACK_SIZE  ; UND mode stack
+  { }
+  
+  ABT_STACK     (__RAM_BASE
+                +__RAM_SIZE
+                -__FIQ_STACK_SIZE
+                -__IRQ_STACK_SIZE
+                -__SVC_STACK_SIZE) EMPTY -__ABT_STACK_SIZE  ; ABT mode stack
+  { }
+  
+  SVC_STACK     (__RAM_BASE
+                +__RAM_SIZE
+                -__FIQ_STACK_SIZE
+                -__IRQ_STACK_SIZE) EMPTY -__SVC_STACK_SIZE  ; SVC mode stack
+  { }  
+  
+  IRQ_STACK     (__RAM_BASE
+                +__RAM_SIZE
+                -__FIQ_STACK_SIZE) EMPTY -__IRQ_STACK_SIZE  ; IRQ mode stack
+  { }  
+  
+  FIQ_STACK     (__RAM_BASE
+                +__RAM_SIZE)       EMPTY -__FIQ_STACK_SIZE  ; FIQ mode stack
+  { }
+  
+  TTB            __TTB_BASE        EMPTY __TTB_SIZE         ; Level-1 Translation Table for MMU
+  { }                                        
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA7/RTE/Device/ARMCA7/ARMCA7_ac6.sct
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA7/RTE/Device/ARMCA7/ARMCA7_ac6.sct
@@ -1,0 +1,65 @@
+
+SDRAM __ROM_BASE __ROM_SIZE       ; load region size_region
+{
+  VECTORS __ROM_BASE __ROM_SIZE ; load address = execution address
+  {
+      * (RESET, +FIRST)         ; Vector table and other startup code
+      * (InRoot$$Sections)      ; All (library) code that must be in a root region
+      * (+RO-CODE)              ; Application RO code (.text)
+      * (+RO-DATA)              ; Application RO data (.constdata)
+  }
+  
+  RW_DATA __RAM_BASE __RW_DATA_SIZE
+  { * (+RW) }                   ; Application RW data (.data)
+  
+  ZI_DATA (__RAM_BASE+
+           __RW_DATA_SIZE) __ZI_DATA_SIZE
+  { * (+ZI) }                   ; Application ZI data (.bss)
+  
+  ARM_LIB_HEAP  (__RAM_BASE
+                +__RW_DATA_SIZE
+                +__ZI_DATA_SIZE)    EMPTY __HEAP_SIZE        ; Heap region growing up
+  { }
+    
+  ARM_LIB_STACK (__RAM_BASE
+                +__RAM_SIZE       
+                -__FIQ_STACK_SIZE
+                -__IRQ_STACK_SIZE
+                -__SVC_STACK_SIZE
+                -__ABT_STACK_SIZE
+                -__UND_STACK_SIZE) EMPTY -__STACK_SIZE      ; Stack region growing down
+  { }              
+                
+  UND_STACK     (__RAM_BASE
+                +__RAM_SIZE
+                -__FIQ_STACK_SIZE
+                -__IRQ_STACK_SIZE
+                -__SVC_STACK_SIZE
+                -__ABT_STACK_SIZE) EMPTY -__UND_STACK_SIZE  ; UND mode stack
+  { }
+  
+  ABT_STACK     (__RAM_BASE
+                +__RAM_SIZE
+                -__FIQ_STACK_SIZE
+                -__IRQ_STACK_SIZE
+                -__SVC_STACK_SIZE) EMPTY -__ABT_STACK_SIZE  ; ABT mode stack
+  { }
+  
+  SVC_STACK     (__RAM_BASE
+                +__RAM_SIZE
+                -__FIQ_STACK_SIZE
+                -__IRQ_STACK_SIZE) EMPTY -__SVC_STACK_SIZE  ; SVC mode stack
+  { }  
+  
+  IRQ_STACK     (__RAM_BASE
+                +__RAM_SIZE
+                -__FIQ_STACK_SIZE) EMPTY -__IRQ_STACK_SIZE  ; IRQ mode stack
+  { }  
+  
+  FIQ_STACK     (__RAM_BASE
+                +__RAM_SIZE)       EMPTY -__FIQ_STACK_SIZE  ; FIQ mode stack
+  { }
+  
+  TTB            __TTB_BASE        EMPTY __TTB_SIZE         ; Level-1 Translation Table for MMU
+  { }                                        
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA7/RTE/Device/ARMCA7/ARMCA7_clang.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA7/RTE/Device/ARMCA7/ARMCA7_clang.ld
@@ -1,0 +1,368 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2019 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+MEMORY
+{
+  ROM0 (rx)   : ORIGIN = __ROM_BASE, LENGTH = __ROM_SIZE
+  L_TTB (rw)  : ORIGIN = __TTB_BASE, LENGTH = __TTB_SIZE
+  RAM0 (rwx)  : ORIGIN = __RAM_BASE, LENGTH = __RAM_SIZE
+}
+
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+	.init : {
+		KEEP (*(RESET))
+		KEEP (*(.vectors))
+		KEEP (*(.text.init.enter))
+		KEEP (*(.data.init.enter))
+		KEEP (*(SORT_BY_NAME(.init) SORT_BY_NAME(.init.*)))
+	} >ROM0 AT>ROM0 :text
+
+	.text : {
+
+		/* code */
+		*(.text.unlikely .text.unlikely.*)
+		*(.text.startup .text.startup.*)
+		*(.text .text.* .opd .opd.*)
+		*(.gnu.linkonce.t.*)
+		KEEP (*(.fini .fini.*))
+		__text_end = .;
+
+		PROVIDE (__etext = __text_end);
+		PROVIDE (_etext = __text_end);
+		PROVIDE (etext = __text_end);
+
+		/* read-only data */
+		*(.rdata)
+		*(.rodata .rodata.*)
+		*(.gnu.linkonce.r.*)
+
+		*(.srodata.cst16)
+		*(.srodata.cst8)
+		*(.srodata.cst4)
+		*(.srodata.cst2)
+		*(.srodata .srodata.*)
+		*(.data.rel.ro .data.rel.ro.*)
+		*(.got .got.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		/* lists of constructors and destructors */
+		PROVIDE_HIDDEN ( __preinit_array_start = . );
+		KEEP (*(.preinit_array))
+		PROVIDE_HIDDEN ( __preinit_array_end = . );
+
+		PROVIDE_HIDDEN ( __init_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+		KEEP (*(.init_array .ctors))
+		PROVIDE_HIDDEN ( __init_array_end = . );
+
+		PROVIDE_HIDDEN ( __fini_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
+		KEEP (*(.fini_array .dtors))
+		PROVIDE_HIDDEN ( __fini_array_end = . );
+
+	} >ROM0 AT>ROM0 :text
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+	.veneers :
+	{
+		. = ALIGN(32);
+		KEEP(*(.gnu.sgstubs))
+	} > ROM0 AT>ROM0 :text
+#endif
+
+	.toc : {
+		*(.toc .toc.*)
+	} >ROM0 AT>ROM0 :text
+
+	/* additional sections when compiling with C++ exception support */
+	
+	.except_ordered : {
+		*(.gcc_except_table *.gcc_except_table.*)
+		KEEP (*(.eh_frame .eh_frame.*))
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+	} >ROM0 AT>ROM0 :text
+
+	.except_unordered : {
+		. = ALIGN(8);
+
+		PROVIDE(__exidx_start = .);
+		*(.ARM.exidx*)
+		PROVIDE(__exidx_end = .);
+	} >ROM0 AT>ROM0 :text
+
+    .ttb :
+    {
+        Image$$TTB$$ZI$$Base = .;
+        . += __TTB_SIZE;
+        Image$$TTB$$ZI$$Limit = .;
+    } > L_TTB
+
+	/*
+	 * Data values which are preserved across reset
+	 */
+	.preserve (NOLOAD) : {
+		PROVIDE(__preserve_start__ = .);
+		KEEP(*(SORT_BY_NAME(.preserve.*)))
+		KEEP(*(.preserve))
+		PROVIDE(__preserve_end__ = .);
+	} >RAM0 AT>RAM0 :ram
+
+	.data :  {
+		*(.data .data.*)
+		*(.gnu.linkonce.d.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		PROVIDE( __global_pointer$ = . + 0x800 );
+		*(.sdata .sdata.* .sdata2.*)
+		*(.gnu.linkonce.s.*)
+	} >RAM0 AT>ROM0 :ram_init
+	PROVIDE(__data_start = ADDR(.data));
+	PROVIDE(__data_source = LOADADDR(.data));
+
+	/* Thread local initialized data. This gets
+	 * space allocated as it is expected to be placed
+	 * in ram to be used as a template for TLS data blocks
+	 * allocated at runtime. We're slightly abusing that
+	 * by placing the data in flash where it will be copied
+	 * into the allocate ram addresses by the existing
+	 * data initialization code in crt0
+	 */
+	.tdata :  {
+		*(.tdata .tdata.* .gnu.linkonce.td.*)
+		PROVIDE(__data_end = .);
+		PROVIDE(__tdata_end = .);
+	} >RAM0 AT>ROM0 :tls :ram_init
+	PROVIDE( __tls_base = ADDR(.tdata));
+	PROVIDE( __tdata_start = ADDR(.tdata));
+	PROVIDE( __tdata_source = LOADADDR(.tdata) );
+	PROVIDE( __tdata_source_end = LOADADDR(.tdata) + SIZEOF(.tdata) );
+	PROVIDE( __data_source_end = __tdata_source_end );
+	PROVIDE( __tdata_size = SIZEOF(.tdata) );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata),ALIGNOF(.tbss)) );
+
+	PROVIDE( __edata = __data_end );
+	PROVIDE( _edata = __data_end );
+	PROVIDE( edata = __data_end );
+	PROVIDE( __data_size = __data_end - __data_start );
+	PROVIDE( __data_source_size = __data_source_end - __data_source );
+
+	.tbss (NOLOAD) : {
+		*(.tbss .tbss.* .gnu.linkonce.tb.*)
+		*(.tcommon)
+		PROVIDE( __tls_end = . );
+		PROVIDE( __tbss_end = . );
+	} >RAM0 AT>RAM0 :tls :ram
+	PROVIDE( __bss_start = ADDR(.tbss));
+	PROVIDE( __tbss_start = ADDR(.tbss));
+	PROVIDE( __tbss_offset = ADDR(.tbss) - ADDR(.tdata) );
+	PROVIDE( __tbss_size = SIZEOF(.tbss) );
+	PROVIDE( __tls_size = __tls_end - __tls_base );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
+	PROVIDE( __arm32_tls_tcb_offset = MAX(8, __tls_align) );
+	PROVIDE( __arm64_tls_tcb_offset = MAX(16, __tls_align) );
+
+	/*
+	 * The linker special cases .tbss segments which are
+	 * identified as segments which are not loaded and are
+	 * thread_local.
+	 *
+	 * For these segments, the linker does not advance 'dot'
+	 * across them.  We actually need memory allocated for tbss,
+	 * so we create a special segment here just to make room
+	 */
+	/*
+	.tbss_space (NOLOAD) : {
+		. = ADDR(.tbss);
+		. = . + SIZEOF(.tbss);
+	} >RAM0 AT>RAM0 :ram
+	*/
+
+	.bss (NOLOAD) : {
+		*(.sbss*)
+		*(.gnu.linkonce.sb.*)
+		*(.bss .bss.*)
+		*(.gnu.linkonce.b.*)
+		*(COMMON)
+
+		/* Align the heap */
+		. = ALIGN(8);
+		__bss_end = .;
+	} >RAM0 AT>RAM0 :ram
+	PROVIDE( __non_tls_bss_start = ADDR(.bss) );
+	PROVIDE( __end = __bss_end );
+	PROVIDE( _end = __bss_end );
+	PROVIDE( end = __bss_end );
+	PROVIDE( __bss_size = __bss_end - __bss_start );
+
+	/* Make the rest of memory available for heap storage */
+	PROVIDE (__heap_start = __end);
+#ifdef __HEAP_SIZE
+	PROVIDE (__heap_end = __heap_start + __HEAP_SIZE);
+	PROVIDE (__heap_size = __HEAP_SIZE);
+#else
+	PROVIDE (__heap_end = __stack - __STACK_SIZE);
+	PROVIDE (__heap_size = __heap_end - __heap_start);
+#endif
+	.heap (NOLOAD) : {
+		. += __heap_size;
+	} >RAM0 :ram
+
+	/* Define a stack region to make sure it fits in memory */
+	PROVIDE(__stack = ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE);
+	PROVIDE(__stack_limit = __stack - __STACK_SIZE);
+#if __ARM_ARCH_PROFILE == 'A'
+	.stack (__stack_limit - 5*__STACK_SIZE) (NOLOAD) : {
+        Image$$FIQ_STACK$$ZI$$Base = .;
+        . += __STACK_SIZE;
+        Image$$FIQ_STACK$$ZI$$Limit = .;
+
+        Image$$IRQ_STACK$$ZI$$Base = .;
+        . += __STACK_SIZE;
+        Image$$IRQ_STACK$$ZI$$Limit = .;
+
+        Image$$SVC_STACK$$ZI$$Base = .;
+        . += __STACK_SIZE;
+        Image$$SVC_STACK$$ZI$$Limit = .;
+
+        Image$$ABT_STACK$$ZI$$Base = .;
+        . += __STACK_SIZE;
+        Image$$ABT_STACK$$ZI$$Limit = .;
+
+        Image$$UND_STACK$$ZI$$Base = .;
+        . += __STACK_SIZE;
+        Image$$UND_STACK$$ZI$$Limit = .;
+
+        Image$$SYS_STACK$$ZI$$Base = .;
+        . += __STACK_SIZE;
+        Image$$SYS_STACK$$ZI$$Limit = .;
+	} >RAM0 :ram
+#else
+	.stack (__stack_limit) (NOLOAD) : {
+		. += __STACK_SIZE;
+	} >RAM0 :ram
+#endif
+
+#if __STACKSEAL_SIZE > 0
+	PROVIDE(__stack_seal = __stack);
+  	.stackseal (__stack) (NOLOAD) :
+  	{
+    	. += __STACKSEAL_SIZE;
+  	} >RAM0 :ram
+#endif
+
+	/* Throw away C++ exception handling information */
+
+	/*
+
+	/DISCARD/ : {
+		*(.note .note.*)
+		*(.eh_frame .eh_frame.*)
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+		*(.ARM.exidx*)
+	}
+
+	*/
+
+	/* Stabs debugging sections.  */
+	.stab          0 : { *(.stab) }
+	.stabstr       0 : { *(.stabstr) }
+	.stab.excl     0 : { *(.stab.excl) }
+	.stab.exclstr  0 : { *(.stab.exclstr) }
+	.stab.index    0 : { *(.stab.index) }
+	.stab.indexstr 0 : { *(.stab.indexstr) }
+	.comment       0 : { *(.comment) }
+	.gnu.build.attributes : { *(.gnu.build.attributes .gnu.build.attributes.*) }
+	/* DWARF debug sections.
+	   Symbols in the DWARF debugging sections are relative to the beginning
+	   of the section so we begin them at 0.  */
+	/* DWARF 1.  */
+	.debug          0 : { *(.debug) }
+	.line           0 : { *(.line) }
+	/* GNU DWARF 1 extensions.  */
+	.debug_srcinfo  0 : { *(.debug_srcinfo) }
+	.debug_sfnames  0 : { *(.debug_sfnames) }
+	/* DWARF 1.1 and DWARF 2.  */
+	.debug_aranges  0 : { *(.debug_aranges) }
+	.debug_pubnames 0 : { *(.debug_pubnames) }
+	/* DWARF 2.  */
+	.debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+	.debug_abbrev   0 : { *(.debug_abbrev) }
+	.debug_line     0 : { *(.debug_line .debug_line.* .debug_line_end) }
+	.debug_frame    0 : { *(.debug_frame) }
+	.debug_str      0 : { *(.debug_str) }
+	.debug_loc      0 : { *(.debug_loc) }
+	.debug_macinfo  0 : { *(.debug_macinfo) }
+	/* SGI/MIPS DWARF 2 extensions.  */
+	.debug_weaknames 0 : { *(.debug_weaknames) }
+	.debug_funcnames 0 : { *(.debug_funcnames) }
+	.debug_typenames 0 : { *(.debug_typenames) }
+	.debug_varnames  0 : { *(.debug_varnames) }
+	/* DWARF 3.  */
+	.debug_pubtypes 0 : { *(.debug_pubtypes) }
+	.debug_ranges   0 : { *(.debug_ranges) }
+	/* DWARF 5.  */
+	.debug_addr     0 : { *(.debug_addr) }
+	.debug_line_str 0 : { *(.debug_line_str) }
+	.debug_loclists 0 : { *(.debug_loclists) }
+	.debug_macro    0 : { *(.debug_macro) }
+	.debug_names    0 : { *(.debug_names) }
+	.debug_rnglists 0 : { *(.debug_rnglists) }
+	.debug_str_offsets 0 : { *(.debug_str_offsets) }
+	.debug_sup      0 : { *(.debug_sup) }
+	.gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }
+}
+
+/*
+ * Check that sections that are copied from flash to RAM have matching
+ * padding, so that a single memcpy() of __data_size copies the correct bytes.
+ */
+ASSERT( __data_size == __data_source_size,
+	"ERROR: .data/.tdata flash size does not match RAM size");

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA7/RTE/Device/ARMCA7/ARMCA7_gcc.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA7/RTE/Device/ARMCA7/ARMCA7_gcc.ld
@@ -1,0 +1,176 @@
+
+MEMORY
+{
+  ROM (rx)   : ORIGIN = __ROM_BASE, LENGTH = __ROM_SIZE
+  L_TTB (rw) : ORIGIN = __TTB_BASE, LENGTH = __TTB_SIZE 
+  RAM (rwx)  : ORIGIN = __RAM_BASE, LENGTH = __RAM_SIZE
+}
+
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+    .text :
+    {
+        Image$$VECTORS$$Base = .;
+        * (RESET)
+        KEEP(*(.isr_vector))
+        Image$$VECTORS$$Limit = .;
+
+        *(SVC_TABLE)
+        *(.text*)
+
+        KEEP(*(.init))
+        KEEP(*(.fini))
+
+        /* .ctors */
+        *crtbegin.o(.ctors)
+        *crtbegin?.o(.ctors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+        *(SORT(.ctors.*))
+        *(.ctors)
+
+        /* .dtors */
+        *crtbegin.o(.dtors)
+        *crtbegin?.o(.dtors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+        *(SORT(.dtors.*))
+        *(.dtors)
+
+        Image$$RO_DATA$$Base = .;
+        *(.rodata*)
+        Image$$RO_DATA$$Limit = .;
+
+        KEEP(*(.eh_frame*))
+    } > ROM
+
+    .ARM.extab : 
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > ROM
+
+    __exidx_start = .;
+    .ARM.exidx :
+    {
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    } > ROM
+    __exidx_end = .;
+
+
+    .copy.table :
+    {
+        . = ALIGN(4);
+        __copy_table_start__ = .;
+        LONG (__etext)
+        LONG (__data_start__)
+        LONG (__data_end__ - __data_start__)
+        __copy_table_end__ = .;
+    } > ROM
+
+    .zero.table :
+    {
+        . = ALIGN(4);
+        __zero_table_start__ = .;
+        LONG (__bss_start__)
+        LONG (__bss_end__ - __bss_start__)
+        __zero_table_end__ = .;
+    } > ROM
+
+    __etext = .;
+        
+    .ttb :
+    {
+        Image$$TTB$$ZI$$Base = .;
+        . += __TTB_SIZE;
+        Image$$TTB$$ZI$$Limit = .;
+    } > L_TTB
+
+    .data :
+    {
+        Image$$RW_DATA$$Base = .;
+        __data_start__ = .;
+        *(vtable)
+        *(.data*)
+        Image$$RW_DATA$$Limit = .;
+
+        . = ALIGN(4);
+        /* preinit data */
+        PROVIDE (__preinit_array_start = .);
+        KEEP(*(.preinit_array))
+        PROVIDE (__preinit_array_end = .);
+
+        . = ALIGN(4);
+        /* init data */
+        PROVIDE (__init_array_start = .);
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array))
+        PROVIDE (__init_array_end = .);
+
+        . = ALIGN(4);
+        /* finit data */
+        PROVIDE (__fini_array_start = .);
+        KEEP(*(SORT(.fini_array.*)))
+        KEEP(*(.fini_array))
+        PROVIDE (__fini_array_end = .);
+
+        . = ALIGN(4);
+        /* All data end */
+        __data_end__ = .;
+    } > RAM
+
+    
+    .bss ALIGN(0x400):
+    {
+        Image$$ZI_DATA$$Base = .;
+        __bss_start__ = .;
+        *(.bss*)
+        *(COMMON)
+        __bss_end__ = .;
+        Image$$ZI_DATA$$Limit = .;
+        __end__ = .;
+        end = __end__;
+    } > RAM AT > RAM
+
+#if defined(__HEAP_SIZE) && (__HEAP_SIZE > 0)    
+    .heap (NOLOAD):
+    {
+        . = ALIGN(8);
+        Image$$HEAP$$ZI$$Base = .;
+        . += __HEAP_SIZE;
+        Image$$HEAP$$ZI$$Limit = .;
+        __HeapLimit = .;
+    } > RAM  
+#endif
+
+    .stack (NOLOAD):
+    {
+        . = ORIGIN(RAM) + LENGTH(RAM) - __STACK_SIZE - __FIQ_STACK_SIZE - __IRQ_STACK_SIZE - __SVC_STACK_SIZE - __ABT_STACK_SIZE - __UND_STACK_SIZE;
+        . = ALIGN(8);
+        
+        __StackTop = .;
+        Image$$SYS_STACK$$ZI$$Base = .;
+        . += __STACK_SIZE;
+        Image$$SYS_STACK$$ZI$$Limit = .;
+        __stack = .;
+
+        Image$$FIQ_STACK$$ZI$$Base = .;
+        . += __FIQ_STACK_SIZE;
+        Image$$FIQ_STACK$$ZI$$Limit = .;
+
+        Image$$IRQ_STACK$$ZI$$Base = .;
+        . += __IRQ_STACK_SIZE;
+        Image$$IRQ_STACK$$ZI$$Limit = .;
+
+        Image$$SVC_STACK$$ZI$$Base = .;
+        . += __SVC_STACK_SIZE;
+        Image$$SVC_STACK$$ZI$$Limit = .;
+
+        Image$$ABT_STACK$$ZI$$Base = .;
+        . += __ABT_STACK_SIZE;
+        Image$$ABT_STACK$$ZI$$Limit = .;
+
+        Image$$UND_STACK$$ZI$$Base = .;
+        . += __UND_STACK_SIZE;
+        Image$$UND_STACK$$ZI$$Limit = .;
+    } > RAM
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA7/RTE/Device/ARMCA7/ARMCA7_iar.icf
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA7/RTE/Device/ARMCA7/ARMCA7_iar.icf
@@ -1,0 +1,67 @@
+
+/*-Memory Regions-*/
+define symbol __ICFEDIT_region_IROM1_start__ = 0x80000000;
+define symbol __ICFEDIT_region_IROM1_end__   = 0x801FFFFF;
+define symbol __ICFEDIT_region_IROM2_start__ = 0x0;
+define symbol __ICFEDIT_region_IROM2_end__   = 0x0;
+define symbol __ICFEDIT_region_EROM1_start__ = 0x0;
+define symbol __ICFEDIT_region_EROM1_end__   = 0x0;
+define symbol __ICFEDIT_region_EROM2_start__ = 0x0;
+define symbol __ICFEDIT_region_EROM2_end__   = 0x0;
+define symbol __ICFEDIT_region_EROM3_start__ = 0x0;
+define symbol __ICFEDIT_region_EROM3_end__   = 0x0;
+define symbol __ICFEDIT_region_IRAM1_start__ = 0x80200000;
+define symbol __ICFEDIT_region_IRAM1_end__   = 0x803FFFFF;
+define symbol __ICFEDIT_region_IRAM2_start__ = 0x0;
+define symbol __ICFEDIT_region_IRAM2_end__   = 0x0;
+define symbol __ICFEDIT_region_ERAM1_start__ = 0x0;
+define symbol __ICFEDIT_region_ERAM1_end__   = 0x0;
+define symbol __ICFEDIT_region_ERAM2_start__ = 0x0;
+define symbol __ICFEDIT_region_ERAM2_end__   = 0x0;
+define symbol __ICFEDIT_region_ERAM3_start__ = 0x0;
+define symbol __ICFEDIT_region_ERAM3_end__   = 0x0;
+define symbol __ICFEDIT_region_TTB_start__   = 0x80500000;
+define symbol __ICFEDIT_region_TTB_end__     = 0x805FFFFF;
+
+/*-Sizes-*/
+define symbol __ICFEDIT_size_cstack__        = 0x1000;
+define symbol __ICFEDIT_size_irqstack__      = 0x100;
+define symbol __ICFEDIT_size_fiqstack__      = 0x100;
+define symbol __ICFEDIT_size_svcstack__      = 0x100;
+define symbol __ICFEDIT_size_abtstack__      = 0x100;
+define symbol __ICFEDIT_size_undstack__      = 0x100;
+define symbol __ICFEDIT_size_heap__          = 0x8000;
+define symbol __ICFEDIT_size_ttb__           = 0x4000;
+
+define memory mem with size = 4G;
+define region IROM_region   =   mem:[from __ICFEDIT_region_IROM1_start__ to __ICFEDIT_region_IROM1_end__]
+                              | mem:[from __ICFEDIT_region_IROM2_start__ to __ICFEDIT_region_IROM2_end__];
+define region IRAM_region   =   mem:[from __ICFEDIT_region_IRAM1_start__ to __ICFEDIT_region_IRAM1_end__]
+                              | mem:[from __ICFEDIT_region_IRAM2_start__ to __ICFEDIT_region_IRAM2_end__];
+define region ERAM_region   =   mem:[from __ICFEDIT_region_ERAM1_start__ to __ICFEDIT_region_ERAM1_end__]
+                              | mem:[from __ICFEDIT_region_ERAM2_start__ to __ICFEDIT_region_ERAM2_end__]
+                              | mem:[from __ICFEDIT_region_ERAM3_start__ to __ICFEDIT_region_ERAM3_end__];
+define region TTB_region    =   mem:[from __ICFEDIT_region_TTB_start__   to __ICFEDIT_region_TTB_end__  ];
+
+define block USR_STACK     with alignment = 8, size = __ICFEDIT_size_cstack__        { };
+define block IRQ_STACK     with alignment = 8, size = __ICFEDIT_size_irqstack__      { };
+define block FIQ_STACK     with alignment = 8, size = __ICFEDIT_size_fiqstack__      { };
+define block SVC_STACK     with alignment = 8, size = __ICFEDIT_size_svcstack__      { };
+define block ABT_STACK     with alignment = 8, size = __ICFEDIT_size_abtstack__      { };
+define block UND_STACK     with alignment = 8, size = __ICFEDIT_size_undstack__      { };
+define block HEAP          with alignment = 8, size = __ICFEDIT_size_heap__          { };
+define block TTB           with alignment = 8, size = __ICFEDIT_size_ttb__           { section TTB };
+
+do not initialize  { section .noinit };
+
+initialize by copy { readwrite };
+if (isdefinedsymbol(__USE_DLIB_PERTHREAD))
+{
+  // Required in a multi-threaded application
+  initialize by copy with packing = none { section __DLIB_PERTHREAD };
+}
+
+place at address mem:__ICFEDIT_region_IROM1_start__ { readonly section RESET };
+place in IROM_region  { readonly };
+place in IRAM_region  { readwrite, block HEAP, block USR_STACK, block IRQ_STACK, block FIQ_STACK, block SVC_STACK, block ABT_STACK, block UND_STACK };
+place in TTB_region   { block TTB };

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA7/RTE/Device/ARMCA7/mem_ARMCA7.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA7/RTE/Device/ARMCA7/mem_ARMCA7.h
@@ -1,0 +1,100 @@
+/**************************************************************************//**
+ * @file     mem_ARMCA7.h
+ * @brief    Memory base and size definitions (used in scatter file)
+ * @version  V1.1.0
+ * @date     15. May 2019
+ *
+ * @note
+ *
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __MEM_ARMCA7_H
+#define __MEM_ARMCA7_H
+
+/*----------------------------------------------------------------------------
+  User Stack & Heap size definition
+ *----------------------------------------------------------------------------*/
+/*
+//-------- <<< Use Configuration Wizard in Context Menu >>> ------------------
+*/
+
+/*--------------------- ROM Configuration ------------------------------------
+//
+// <h> ROM Configuration
+//   <i> For compatibility with MMU config the sections must be multiple of 1MB
+//   <o0> ROM Base Address <0x0-0xFFFFFFFF:0x100000>
+//   <o1> ROM Size (in Bytes) <0x0-0xFFFFFFFF:0x100000>
+// </h>
+ *----------------------------------------------------------------------------*/
+#define __ROM_BASE       0x80000000
+#define __ROM_SIZE       0x00200000
+
+/*--------------------- RAM Configuration -----------------------------------
+// <h> RAM Configuration
+//   <i> For compatibility with MMU config the sections must be multiple of 1MB
+//   <o0> RAM Base Address    <0x0-0xFFFFFFFF:0x100000>
+//   <o1> RAM Total Size (in Bytes) <0x0-0xFFFFFFFF:0x100000>
+//   <h> Data Sections
+//     <o2> RW_DATA Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//     <o3> ZI_DATA Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//   </h>
+//   <h> Stack / Heap Configuration
+//     <o4>  Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//     <o5>  Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//     <h> Exceptional Modes
+//       <o6> UND Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//       <o7> ABT Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//       <o8> SVC Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//       <o9> IRQ Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//       <o10> FIQ Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//     </h>
+//   </h>
+// </h>
+ *----------------------------------------------------------------------------*/
+#define __RAM_BASE       0x80200000
+#define __RAM_SIZE       0x00200000
+
+#define __RW_DATA_SIZE   0x00100000
+#define __ZI_DATA_SIZE   0x000F0000
+
+#define __STACK_SIZE     0x00001000
+#define __HEAP_SIZE      0x00008000
+
+#define __UND_STACK_SIZE 0x00000100
+#define __ABT_STACK_SIZE 0x00000100
+#define __SVC_STACK_SIZE 0x00000100
+#define __IRQ_STACK_SIZE 0x00000100
+#define __FIQ_STACK_SIZE 0x00000100
+
+/*----------------------------------------------------------------------------*/
+
+/*--------------------- TTB Configuration ------------------------------------
+//
+// <h> TTB Configuration
+//   <i> The TLB L1 contains 4096 32-bit entries and must be 16kB aligned
+//   <i> The TLB L2 entries are placed after the L1 in the MMU config
+//   <o0> TTB Base Address <0x0-0xFFFFFFFF:0x4000>
+//   <o1> TTB Size (in Bytes) <0x0-0xFFFFFFFF:8>
+// </h>
+ *----------------------------------------------------------------------------*/
+#define __TTB_BASE       0x80500000
+#define __TTB_SIZE       0x00005000
+
+#endif /* __MEM_ARMCA7_H */

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA7/RTE/Device/ARMCA7/mmu_ARMCA7.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA7/RTE/Device/ARMCA7/mmu_ARMCA7.c
@@ -1,0 +1,232 @@
+/**************************************************************************//**
+ * @file     mmu_ARMCA7.c
+ * @brief    MMU Configuration for Arm Cortex-A7 Device Series
+ * @version  V1.2.0
+ * @date     15. May 2019
+ *
+ * @note
+ *
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Memory map description from: DUI0447G_v2m_p1_trm.pdf 4.2.2 Arm Cortex-A Series memory map
+
+                                                     Memory Type
+0xffffffff |--------------------------|             ------------
+           |       FLAG SYNC          |             Device Memory
+0xfffff000 |--------------------------|             ------------
+           |         Fault            |                Fault
+0xfff00000 |--------------------------|             ------------
+           |                          |                Normal
+           |                          |
+           |      Daughterboard       |
+           |         memory           |
+           |                          |
+0x80505000 |--------------------------|             ------------
+           |TTB (L2 Sync Flags   ) 4k |                Normal
+0x80504C00 |--------------------------|             ------------
+           |TTB (L2 Peripherals-B) 16k|                Normal
+0x80504800 |--------------------------|             ------------
+           |TTB (L2 Peripherals-A) 16k|                Normal
+0x80504400 |--------------------------|             ------------
+           |TTB (L2 Priv Periphs)  4k |                Normal
+0x80504000 |--------------------------|             ------------
+           |    TTB (L1 Descriptors)  |                Normal
+0x80500000 |--------------------------|             ------------
+           |          Stack           |                Normal
+           |--------------------------|             ------------
+           |          Heap            |                Normal
+0x80400000 |--------------------------|             ------------
+           |         ZI Data          |                Normal
+0x80300000 |--------------------------|             ------------
+           |         RW Data          |                Normal
+0x80200000 |--------------------------|             ------------
+           |         RO Data          |                Normal
+           |--------------------------|             ------------
+           |         RO Code          |              USH Normal
+0x80000000 |--------------------------|             ------------
+           |      Daughterboard       |                Fault
+           |      HSB AXI buses       |
+0x40000000 |--------------------------|             ------------
+           |      Daughterboard       |                Fault
+           |  test chips peripherals  |
+0x2c002000 |--------------------------|             ------------
+           |     Private Address      |            Device Memory
+0x2c000000 |--------------------------|             ------------
+           |      Daughterboard       |                Fault
+           |  test chips peripherals  |
+0x20000000 |--------------------------|             ------------
+           |       Peripherals        |           Device Memory RW/RO
+           |                          |              & Fault
+0x00000000 |--------------------------|
+*/
+
+// L1 Cache info and restrictions about architecture of the caches (CCSIR register):
+// Write-Through support *not* available
+// Write-Back support available.
+// Read allocation support available.
+// Write allocation support available.
+
+//Note: You should use the Shareable attribute carefully.
+//For cores without coherency logic (such as SCU) marking a region as shareable forces the processor to not cache that region regardless of the inner cache settings.
+//Cortex-A versions of RTX use LDREX/STREX instructions relying on Local monitors. Local monitors will be used only when the region gets cached, regions that are not cached will use the Global Monitor.
+//Some Cortex-A implementations do not include Global Monitors, so wrongly setting the attribute Shareable may cause STREX to fail.
+
+//Recall: When the Shareable attribute is applied to a memory region that is not Write-Back, Normal memory, data held in this region is treated as Non-cacheable.
+//When SMP bit = 0, Inner WB/WA Cacheable Shareable attributes are treated as Non-cacheable.
+//When SMP bit = 1, Inner WB/WA Cacheable Shareable attributes are treated as Cacheable.
+
+
+//Following MMU configuration is expected
+//SCTLR.AFE == 1 (Simplified access permissions model - AP[2:1] define access permissions, AP[0] is an access flag)
+//SCTLR.TRE == 0 (TEX remap disabled, so memory type and attributes are described directly by bits in the descriptor)
+//Domain 0 is always the Client domain
+//Descriptors should place all memory in domain 0
+
+#include "ARMCA7.h"
+#include "mem_ARMCA7.h"
+
+// TTB base address
+#define TTB_BASE ((uint32_t*)__TTB_BASE)
+
+// L2 table pointers
+//----------------------------------------
+#define TTB_L1_SIZE                    (0x00004000)                        // The L1 translation table divides the full 4GB address space of a 32-bit core
+                                                                           // into 4096 equally sized sections, each of which describes 1MB of virtual memory space.
+                                                                           // The L1 translation table therefore contains 4096 32-bit (word-sized) entries.
+
+#define PRIVATE_TABLE_L2_BASE_4k       (__TTB_BASE + TTB_L1_SIZE)          // Map 4k Private Address space
+#define PERIPHERAL_A_TABLE_L2_BASE_64k (__TTB_BASE + TTB_L1_SIZE + 0x400)  // Map 64k Peripheral #1 0x1C000000 - 0x1C00FFFFF
+#define PERIPHERAL_B_TABLE_L2_BASE_64k (__TTB_BASE + TTB_L1_SIZE + 0x800)  // Map 64k Peripheral #2 0x1C100000 - 0x1C1FFFFFF
+#define SYNC_FLAGS_TABLE_L2_BASE_4k    (__TTB_BASE + TTB_L1_SIZE + 0xC00)  // Map 4k Flag synchronization
+
+//--------------------- PERIPHERALS -------------------
+#define PERIPHERAL_A_FAULT (0x00000000 + 0x1c000000) //0x1C000000-0x1C00FFFF (1M)
+#define PERIPHERAL_B_FAULT (0x00100000 + 0x1c000000) //0x1C100000-0x1C10FFFF (1M)
+
+//--------------------- SYNC FLAGS --------------------
+#define FLAG_SYNC     0xFFFFF000
+#define F_SYNC_BASE   0xFFF00000  //1M aligned
+
+static uint32_t Sect_Normal;     //outer & inner wb/wa, non-shareable, executable, rw, domain 0, base addr 0
+static uint32_t Sect_Normal_Cod; //outer & inner wb/wa, non-shareable, executable, ro, domain 0, base addr 0
+static uint32_t Sect_Normal_RO;  //as Sect_Normal_Cod, but not executable
+static uint32_t Sect_Normal_RW;  //as Sect_Normal_Cod, but writeable and not executable
+static uint32_t Sect_Device_RO;  //device, non-shareable, non-executable, ro, domain 0, base addr 0
+static uint32_t Sect_Device_RW;  //as Sect_Device_RO, but writeable
+
+/* Define global descriptors */
+static uint32_t Page_L1_4k  = 0x0;  //generic
+static uint32_t Page_L1_64k = 0x0;  //generic
+static uint32_t Page_4k_Device_RW;  //Shared device, not executable, rw, domain 0
+static uint32_t Page_64k_Device_RW; //Shared device, not executable, rw, domain 0
+
+void MMU_CreateTranslationTable(void)
+{
+    mmu_region_attributes_Type region;
+
+    //Create 4GB of faulting entries
+    MMU_TTSection (TTB_BASE, 0, 4096, DESCRIPTOR_FAULT);
+
+    /*
+     * Generate descriptors. Refer to core_ca.h to get information about attributes
+     *
+     */
+    //Create descriptors for Vectors, RO, RW, ZI sections
+    section_normal(Sect_Normal, region);
+    section_normal_cod(Sect_Normal_Cod, region);
+    section_normal_ro(Sect_Normal_RO, region);
+    section_normal_rw(Sect_Normal_RW, region);
+    //Create descriptors for peripherals
+    section_device_ro(Sect_Device_RO, region);
+    section_device_rw(Sect_Device_RW, region);
+    //Create descriptors for 64k pages
+    page64k_device_rw(Page_L1_64k, Page_64k_Device_RW, region);
+    //Create descriptors for 4k pages
+    page4k_device_rw(Page_L1_4k, Page_4k_Device_RW, region);
+
+
+    /*
+     *  Define MMU flat-map regions and attributes
+     *
+     */
+
+    //Define Image
+    MMU_TTSection (TTB_BASE, __ROM_BASE, __ROM_SIZE/0x100000, Sect_Normal_Cod); // multiple of 1MB sections
+    MMU_TTSection (TTB_BASE, __RAM_BASE, __RAM_SIZE/0x100000, Sect_Normal_RW);  // multiple of 1MB sections
+
+    //--------------------- PERIPHERALS -------------------
+    MMU_TTSection (TTB_BASE, VE_A7_MP_FLASH_BASE0   , 64, Sect_Device_RO); // 64MB NOR
+    MMU_TTSection (TTB_BASE, VE_A7_MP_FLASH_BASE1   , 64, Sect_Device_RO); // 64MB NOR
+    MMU_TTSection (TTB_BASE, VE_A7_MP_SRAM_BASE     , 32, Sect_Device_RW); // 32MB RAM
+    MMU_TTSection (TTB_BASE, VE_A7_MP_VRAM_BASE     , 32, Sect_Device_RW); // 32MB RAM
+    MMU_TTSection (TTB_BASE, VE_A7_MP_ETHERNET_BASE , 16, Sect_Device_RW);
+    MMU_TTSection (TTB_BASE, VE_A7_MP_USB_BASE      , 16, Sect_Device_RW);
+
+    // Create (16 * 64k)=1MB faulting entries to cover peripheral range 0x1C000000-0x1C00FFFF
+    MMU_TTPage64k(TTB_BASE, PERIPHERAL_A_FAULT      , 16, Page_L1_64k, (uint32_t *)PERIPHERAL_A_TABLE_L2_BASE_64k, DESCRIPTOR_FAULT);
+    // Define peripheral range 0x1C000000-0x1C00FFFF
+    MMU_TTPage64k(TTB_BASE, VE_A7_MP_DAP_BASE       ,  1, Page_L1_64k, (uint32_t *)PERIPHERAL_A_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+    MMU_TTPage64k(TTB_BASE, VE_A7_MP_SYSTEM_REG_BASE,  1, Page_L1_64k, (uint32_t *)PERIPHERAL_A_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+    MMU_TTPage64k(TTB_BASE, VE_A7_MP_SERIAL_BASE    ,  1, Page_L1_64k, (uint32_t *)PERIPHERAL_A_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+    MMU_TTPage64k(TTB_BASE, VE_A7_MP_AACI_BASE      ,  1, Page_L1_64k, (uint32_t *)PERIPHERAL_A_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+    MMU_TTPage64k(TTB_BASE, VE_A7_MP_MMCI_BASE      ,  1, Page_L1_64k, (uint32_t *)PERIPHERAL_A_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+    MMU_TTPage64k(TTB_BASE, VE_A7_MP_KMI0_BASE      ,  2, Page_L1_64k, (uint32_t *)PERIPHERAL_A_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+    MMU_TTPage64k(TTB_BASE, VE_A7_MP_UART_BASE      ,  4, Page_L1_64k, (uint32_t *)PERIPHERAL_A_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+    MMU_TTPage64k(TTB_BASE, VE_A7_MP_WDT_BASE       ,  1, Page_L1_64k, (uint32_t *)PERIPHERAL_A_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+
+    // Create (16 * 64k)=1MB faulting entries to cover peripheral range 0x1C100000-0x1C10FFFF
+    MMU_TTPage64k(TTB_BASE, PERIPHERAL_B_FAULT      , 16, Page_L1_64k, (uint32_t *)PERIPHERAL_B_TABLE_L2_BASE_64k, DESCRIPTOR_FAULT);
+    // Define peripheral range 0x1C100000-0x1C10FFFF
+    MMU_TTPage64k(TTB_BASE, VE_A7_MP_TIMER_BASE     ,  2, Page_L1_64k, (uint32_t *)PERIPHERAL_B_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+    MMU_TTPage64k(TTB_BASE, VE_A7_MP_DVI_BASE       ,  1, Page_L1_64k, (uint32_t *)PERIPHERAL_B_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+    MMU_TTPage64k(TTB_BASE, VE_A7_MP_RTC_BASE       ,  1, Page_L1_64k, (uint32_t *)PERIPHERAL_B_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+    MMU_TTPage64k(TTB_BASE, VE_A7_MP_UART4_BASE     ,  1, Page_L1_64k, (uint32_t *)PERIPHERAL_B_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+    MMU_TTPage64k(TTB_BASE, VE_A7_MP_CLCD_BASE      ,  1, Page_L1_64k, (uint32_t *)PERIPHERAL_B_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+
+    // Create (256 * 4k)=1MB faulting entries to cover private address space. Needs to be marked as Device memory
+    MMU_TTPage4k (TTB_BASE, __get_CBAR()            ,256,  Page_L1_4k, (uint32_t *)PRIVATE_TABLE_L2_BASE_4k, DESCRIPTOR_FAULT);
+    // Define private address space entry.
+    MMU_TTPage4k (TTB_BASE, __get_CBAR()            ,  3,  Page_L1_4k, (uint32_t *)PRIVATE_TABLE_L2_BASE_4k, Page_4k_Device_RW);
+    // Define L2CC entry.  Uncomment if PL310 is present
+    //    MMU_TTPage4k (TTB_BASE, VE_A5_MP_PL310_BASE     ,  1,  Page_L1_4k, (uint32_t *)PRIVATE_TABLE_L2_BASE_4k, Page_4k_Device_RW);
+
+    // Create (256 * 4k)=1MB faulting entries to synchronization space (Useful if some non-cacheable DMA agent is present in the SoC)
+    MMU_TTPage4k (TTB_BASE, F_SYNC_BASE             , 256, Page_L1_4k, (uint32_t *)SYNC_FLAGS_TABLE_L2_BASE_4k, DESCRIPTOR_FAULT);
+    // Define synchronization space entry.
+    MMU_TTPage4k (TTB_BASE, FLAG_SYNC               ,   1, Page_L1_4k, (uint32_t *)SYNC_FLAGS_TABLE_L2_BASE_4k, Page_4k_Device_RW);
+
+    /* Set location of level 1 page table
+    ; 31:14 - Translation table base addr (31:14-TTBCR.N, TTBCR.N is 0 out of reset)
+    ; 13:7  - 0x0
+    ; 6     - IRGN[0] 0x1  (Inner WB WA)
+    ; 5     - NOS     0x0  (Non-shared)
+    ; 4:3   - RGN     0x01 (Outer WB WA)
+    ; 2     - IMP     0x0  (Implementation Defined)
+    ; 1     - S       0x0  (Non-shared)
+    ; 0     - IRGN[1] 0x0  (Inner WB WA) */
+    __set_TTBR0(__TTB_BASE | 0x48);
+    __ISB();
+
+    /* Set up domain access control register
+    ; We set domain 0 to Client and all other domains to No Access.
+    ; All translation table entries specify domain 0 */
+    __set_DACR(1);
+    __ISB();
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA7/RTE/Device/ARMCA7/startup_ARMCA7.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA7/RTE/Device/ARMCA7/startup_ARMCA7.c
@@ -1,0 +1,148 @@
+/******************************************************************************
+ * @file     startup_ARMCA7.c
+ * @brief    CMSIS Device System Source File for Arm Cortex-A7 Device Series
+ * @version  V1.0.1
+ * @date     10. January 2021
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2021 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <ARMCA7.h>
+
+/*----------------------------------------------------------------------------
+  Definitions
+ *----------------------------------------------------------------------------*/
+#define USR_MODE 0x10            // User mode
+#define FIQ_MODE 0x11            // Fast Interrupt Request mode
+#define IRQ_MODE 0x12            // Interrupt Request mode
+#define SVC_MODE 0x13            // Supervisor mode
+#define ABT_MODE 0x17            // Abort mode
+#define UND_MODE 0x1B            // Undefined Instruction mode
+#define SYS_MODE 0x1F            // System mode
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+void Vectors        (void) __attribute__ ((naked, section("RESET")));
+void Reset_Handler  (void) __attribute__ ((naked));
+void Default_Handler(void) __attribute__ ((noreturn));
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+void Undef_Handler (void) __attribute__ ((weak, alias("Default_Handler")));
+void SVC_Handler   (void) __attribute__ ((weak, alias("Default_Handler")));
+void PAbt_Handler  (void) __attribute__ ((weak, alias("Default_Handler")));
+void DAbt_Handler  (void) __attribute__ ((weak, alias("Default_Handler")));
+void IRQ_Handler   (void) __attribute__ ((weak, alias("Default_Handler")));
+void FIQ_Handler   (void) __attribute__ ((weak, alias("Default_Handler")));
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector Table
+ *----------------------------------------------------------------------------*/
+void Vectors(void) {
+  __ASM volatile(
+  "LDR    PC, =Reset_Handler                        \n"
+  "LDR    PC, =Undef_Handler                        \n"
+  "LDR    PC, =SVC_Handler                          \n"
+  "LDR    PC, =PAbt_Handler                         \n"
+  "LDR    PC, =DAbt_Handler                         \n"
+  "NOP                                              \n"
+  "LDR    PC, =IRQ_Handler                          \n"
+  "LDR    PC, =FIQ_Handler                          \n"
+  );
+}
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+void Reset_Handler(void) {
+  __ASM volatile(
+
+  // Mask interrupts
+  "CPSID   if                                      \n"
+
+  // Put any cores other than 0 to sleep
+  "MRC     p15, 0, R0, c0, c0, 5                   \n"  // Read MPIDR
+  "ANDS    R0, R0, #3                              \n"
+  "goToSleep:                                      \n"
+  "WFINE                                           \n"
+  "BNE     goToSleep                               \n"
+
+  // Reset SCTLR Settings
+  "MRC     p15, 0, R0, c1, c0, 0                   \n"  // Read CP15 System Control register
+  "BIC     R0, R0, #(0x1 << 12)                    \n"  // Clear I bit 12 to disable I Cache
+  "BIC     R0, R0, #(0x1 <<  2)                    \n"  // Clear C bit  2 to disable D Cache
+  "BIC     R0, R0, #0x1                            \n"  // Clear M bit  0 to disable MMU
+  "BIC     R0, R0, #(0x1 << 11)                    \n"  // Clear Z bit 11 to disable branch prediction
+  "BIC     R0, R0, #(0x1 << 13)                    \n"  // Clear V bit 13 to disable hivecs
+  "MCR     p15, 0, R0, c1, c0, 0                   \n"  // Write value back to CP15 System Control register
+  "ISB                                             \n"
+
+  // Configure ACTLR
+  "MRC     p15, 0, r0, c1, c0, 1                   \n"  // Read CP15 Auxiliary Control Register
+  "ORR     r0, r0, #(1 <<  1)                      \n"  // Enable L2 prefetch hint (UNK/WI since r4p1)
+  "MCR     p15, 0, r0, c1, c0, 1                   \n"  // Write CP15 Auxiliary Control Register
+
+  // Set Vector Base Address Register (VBAR) to point to this application's vector table
+  "LDR    R0, =Vectors                             \n"
+  "MCR    p15, 0, R0, c12, c0, 0                   \n"
+
+  // Setup Stack for each exceptional mode
+  "CPS    #0x11                                    \n"
+  "LDR    SP, =Image$$FIQ_STACK$$ZI$$Limit         \n"
+  "CPS    #0x12                                    \n"
+  "LDR    SP, =Image$$IRQ_STACK$$ZI$$Limit         \n"
+  "CPS    #0x13                                    \n"
+  "LDR    SP, =Image$$SVC_STACK$$ZI$$Limit         \n"
+  "CPS    #0x17                                    \n"
+  "LDR    SP, =Image$$ABT_STACK$$ZI$$Limit         \n"
+  "CPS    #0x1B                                    \n"
+  "LDR    SP, =Image$$UND_STACK$$ZI$$Limit         \n"
+  "CPS    #0x1F                                    \n"
+#if defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6100100)
+  "LDR    SP, =Image$$ARM_LIB_STACK$$ZI$$Limit     \n"
+#elif defined ( __GNUC__ )
+  "LDR    SP, =Image$$SYS_STACK$$ZI$$Limit         \n"
+#else
+  #error Unknown compiler.
+#endif
+
+  // Call SystemInit
+  "BL     SystemInit                               \n"
+
+  // Unmask interrupts
+  "CPSIE  if                                       \n"
+
+  // Call __main
+#if defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6100100)
+  "BL     __main                                   \n"
+#elif defined ( __GNUC__ )
+  "BL     _start                                   \n"
+#else
+  #error Unknown compiler.
+#endif
+  );
+}
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+void Default_Handler(void) {
+  while(1);
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA7/RTE/Device/ARMCA7/startup_ARMCA7.s
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA7/RTE/Device/ARMCA7/startup_ARMCA7.s
@@ -1,0 +1,140 @@
+/******************************************************************************
+ * @file     startup_ARMCA7.s
+ * @brief    CMSIS Device System Source File for ARM Cortex-A9 Device Series
+ * @version  V1.00
+ * @date     01 Nov 2017
+ *
+ * @note
+ *
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2017 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+  MODULE  ?startup_ARMCA7
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+  PUBLIC  Reset_Handler
+  PUBWEAK Undef_Handler
+  PUBWEAK SVC_Handler
+  PUBWEAK PAbt_Handler
+  PUBWEAK DAbt_Handler
+  PUBWEAK IRQ_Handler
+  PUBWEAK FIQ_Handler
+
+  SECTION SVC_STACK:DATA:NOROOT(3)
+  SECTION IRQ_STACK:DATA:NOROOT(3)
+  SECTION FIQ_STACK:DATA:NOROOT(3)
+  SECTION ABT_STACK:DATA:NOROOT(3)
+  SECTION UND_STACK:DATA:NOROOT(3)
+  SECTION USR_STACK:DATA:NOROOT(3)
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector Table
+ *----------------------------------------------------------------------------*/
+
+  section RESET:CODE:NOROOT(2)
+  PUBLIC  Vectors
+
+Vectors:
+  LDR    PC, =Reset_Handler
+  LDR    PC, =Undef_Handler
+  LDR    PC, =SVC_Handler
+  LDR    PC, =PAbt_Handler
+  LDR    PC, =DAbt_Handler
+  NOP
+  LDR    PC, =IRQ_Handler
+  LDR    PC, =FIQ_Handler
+
+
+  section .text:CODE:NOROOT(4)
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+  *----------------------------------------------------------------------------*/
+  EXTERN  SystemInit
+  EXTERN  __iar_program_start
+
+Reset_Handler:  
+
+  // Mask interrupts
+  CPSID   if
+
+  // Put any cores other than 0 to sleep
+  MRC     p15, 0, R0, c0, c0, 5
+  ANDS    R0, R0, #3
+goToSleep:
+  WFINE
+  BNE     goToSleep
+
+  // Reset SCTLR Settings
+  MRC     p15, 0, R0, c1, c0, 0 // Read CP15 System Control register
+  BIC     R0, R0, #(0x1 << 12) // Clear I bit 12 to disable I Cache
+  BIC     R0, R0, #(0x1 <<  2) // Clear C bit  2 to disable D Cache
+  BIC     R0, R0, #0x1       // Clear M bit  0 to disable MMU
+  BIC     R0, R0, #(0x1 << 11) // Clear Z bit 11 to disable branch prediction
+  BIC     R0, R0, #(0x1 << 13) // Clear V bit 13 to disable hivecs
+  MCR     p15, 0, R0, c1, c0, 0 // Write value back to CP15 System Control register
+  ISB
+
+  // Configure ACTLR
+  MRC     p15, 0, r0, c1, c0, 1 // Read CP15 Auxiliary Control Register
+  ORR     r0, r0, #(1 <<  1) // Enable L2 prefetch hint (UNK/WI since r4p1)
+  MCR     p15, 0, r0, c1, c0, 1 // Write CP15 Auxiliary Control Register
+
+  // Set Vector Base Address Register (VBAR) to point to this application's vector table
+  LDR    R0, =Vectors
+  MCR    p15, 0, R0, c12, c0, 0
+
+  // Setup Stack for each exception mode
+  CPS    #0x11
+  LDR    SP, =SFE(FIQ_STACK)
+  CPS    #0x12
+  LDR    SP, =SFE(IRQ_STACK)
+  CPS    #0x13
+  LDR    SP, =SFE(SVC_STACK)
+  CPS    #0x17
+  LDR    SP, =SFE(ABT_STACK)
+  CPS    #0x1B
+  LDR    SP, =SFE(UND_STACK)
+  CPS    #0x1F
+  LDR    SP, =SFE(USR_STACK)
+
+  // Call SystemInit
+  BL     SystemInit
+
+  // Unmask interrupts
+  CPSIE  if
+
+  // Call __iar_program_start
+  BL     __iar_program_start
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+Undef_Handler:
+SVC_Handler:
+PAbt_Handler:
+DAbt_Handler:
+IRQ_Handler:
+FIQ_Handler:
+Default_Handler:
+  B .
+
+  END

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA7/RTE/Device/ARMCA7/system_ARMCA7.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA7/RTE/Device/ARMCA7/system_ARMCA7.c
@@ -1,0 +1,93 @@
+/******************************************************************************
+ * @file     system_ARMCA7.c
+ * @brief    CMSIS Device System Source File for Arm Cortex-A7 Device Series
+ * @version  V1.0.1
+ * @date     13. February 2019
+ *
+ * @note
+ *
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "RTE_Components.h"
+#include CMSIS_device_header
+#include "irq_ctrl.h"
+
+#define  SYSTEM_CLOCK  12000000U
+
+/*----------------------------------------------------------------------------
+  System Core Clock Variable
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = SYSTEM_CLOCK;
+
+/*----------------------------------------------------------------------------
+  System Core Clock update function
+ *----------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)
+{
+  SystemCoreClock = SYSTEM_CLOCK;
+}
+
+/*----------------------------------------------------------------------------
+  System Initialization
+ *----------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+/* do not use global variables because this function is called before
+   reaching pre-main. RW section may be overwritten afterwards.          */
+
+  // Invalidate entire Unified TLB
+  __set_TLBIALL(0);
+
+  // Invalidate entire branch predictor array
+  __set_BPIALL(0);
+  __DSB();
+  __ISB();
+
+  //  Invalidate instruction cache and flush branch target cache
+  __set_ICIALLU(0);
+  __DSB();
+  __ISB();
+
+  //  Invalidate data cache
+  L1C_InvalidateDCacheAll();
+
+#if ((__FPU_PRESENT == 1) && (__FPU_USED == 1))
+  // Enable FPU
+  __FPU_Enable();
+#endif
+
+  // Create Translation Table
+  MMU_CreateTranslationTable();
+
+  // Enable MMU
+  MMU_Enable();
+
+  // Enable Caches
+  L1C_EnableCaches();
+  L1C_EnableBTAC();
+
+#if (__L2C_PRESENT == 1) 
+  // Enable GIC
+  L2C_Enable();
+#endif
+
+  // IRQ Initialize
+  IRQ_Initialize();
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA7/RTE/Device/ARMCA7/system_ARMCA7.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA7/RTE/Device/ARMCA7/system_ARMCA7.h
@@ -1,0 +1,65 @@
+/******************************************************************************
+ * @file     system_ARMCA7.h
+ * @brief    CMSIS Device System Header File for Arm Cortex-A7 Device Series
+ * @version  V1.00
+ * @date     10. January 2018
+ *
+ * @note
+ *
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2018 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __SYSTEM_ARMCA7_H
+#define __SYSTEM_ARMCA7_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+extern uint32_t SystemCoreClock;     /*!< System Clock Frequency (Core Clock)  */
+
+/**
+  \brief Setup the microcontroller system.
+
+   Initialize the System and update the SystemCoreClock variable.
+ */
+extern void SystemInit (void);
+
+
+/**
+  \brief  Update SystemCoreClock variable.
+
+   Updates the SystemCoreClock with current core Clock retrieved from cpu registers.
+ */
+extern void SystemCoreClockUpdate (void);
+
+/**
+  \brief  Create Translation Table.
+
+   Creates Memory Management Unit Translation Table.
+ */
+extern void MMU_CreateTranslationTable(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __SYSTEM_ARMCA7_H */

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA7/Target.clayer.yml
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA7/Target.clayer.yml
@@ -1,0 +1,42 @@
+layer:
+  type: Target
+  description: CA7 target components and files
+
+  packs:
+    - pack: ARM::Cortex_DFP
+
+  device: ARMCA7
+
+  components:
+    # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
+    - component: ARM::CMSIS:CORE
+    - component: Device:Startup
+    - component: Device:IRQ Controller:GIC
+
+  misc:
+    - for-compiler: IAR
+      Link: [--config generic_cortex.icf]
+
+  linker:
+    - script: RTE/Device/ARMCA7/ARMCA7_ac6.sct
+      for-compiler:
+        - AC6
+    - script: RTE/Device/ARMCA7/ARMCA7_gcc.ld
+      for-compiler:
+        - GCC
+    - script: RTE/Device/ARMCA7/ARMCA7_clang.ld
+      for-compiler:
+        - CLANG
+    - script: RTE/Device/ARMCA7/ARMCA7_iar.icf
+      for-compiler:
+        - IAR
+    - regions: RTE/Device/ARMCA7/mem_ARMCA7.h
+      for-compiler:
+        - AC6
+        - GCC
+        - CLANG
+
+  groups:
+    - group: FVP
+      files:
+        - file: ./model_config.txt

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA7/model_config.txt
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA7/model_config.txt
@@ -1,0 +1,22 @@
+# Parameters:
+# instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+#----------------------------------------------------------------------------------------------
+motherboard.vis.disable_visualisation=1               # (bool  , init-time) default = '0'      : Enable/disable visualisation
+cluster.cpu0.vfp-present=1                            # (bool  , init-time) default = '1'      : Set whether CT model has been built with VFP support
+cluster.cpu0.ase-present=0                            # (bool  , init-time) default = '1'      : Set whether CT model has been built with NEON support
+cluster.cpu0.semihosting-enable=1                     # (bool  , init-time) default = '1'      : Enable semihosting SVC traps. Applications that do not use semihosting must set this parameter to false
+cluster.cpu0.semihosting-hlt-enable=0                 # (bool  , init-time) default = '0'      : Enable semihosting HLT traps. Applications that use HLT semihosting must set this parameter to true and the semihosting-enable parameter to true
+cluster.cpu0.semihosting-ARM_SVC=0x123456             # (int   , init-time) default = '0x123456' : ARM SVC number for semihosting : [0x0..0xFFFFFF]
+cluster.cpu0.semihosting-Thumb_SVC=0xAB               # (int   , init-time) default = '0xAB'   : Thumb SVC number for semihosting : [0x0..0xFF]
+cluster.cpu0.semihosting-ARM_HLT=0xF000               # (int   , init-time) default = '0xF000' : ARM HLT number for semihosting : [0x0..0xFFFF]
+cluster.cpu0.semihosting-Thumb_HLT=0x3C               # (int   , init-time) default = '0x3C'   : Thumb HLT number for semihosting : [0x0..0x3F]
+cluster.cpu0.semihosting-cmd_line=""                  # (string, init-time) default = ''       : Command line available to semihosting SVC calls
+cluster.cpu0.semihosting-heap_base=0x0                # (int   , init-time) default = '0x0'    : Virtual address of heap base : [0x0..0xFFFFFFFF]
+cluster.cpu0.semihosting-heap_limit=0x0               # (int   , init-time) default = '0xFF000000' : Virtual address of top of heap : [0x0..0xFFFFFFFF]
+cluster.cpu0.semihosting-stack_base=0x0               # (int   , init-time) default = '0xFFFF0000' : Virtual address of base of descending stack : [0x0..0xFFFFFFFF]
+cluster.cpu0.semihosting-stack_limit=0x0              # (int   , init-time) default = '0xFF000000' : Virtual address of stack limit : [0x0..0xFFFFFFFF]
+cluster.cpu0.semihosting-cwd=""                       # (string, init-time) default = ''       : Base directory for semihosting file access.
+cluster.l1_icache-state_modelled=1                    # (bool  , run-time ) default = '0'      : Set whether L1 I-cache has stateful implementation
+cluster.l1_dcache-state_modelled=1                    # (bool  , run-time ) default = '0'      : Set whether L1 D-cache has stateful implementation
+cluster.l2_cache-state_modelled=1                     # (bool  , run-time ) default = '0'      : Set whether L2 cache has stateful implementation
+#----------------------------------------------------------------------------------------------

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA9/RTE/Device/ARMCA9/ARMCA9.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA9/RTE/Device/ARMCA9/ARMCA9.ld
@@ -1,0 +1,181 @@
+#include "mem_ARMCA9.h" 
+
+MEMORY
+{
+  ROM (rx)   : ORIGIN = __ROM_BASE, LENGTH = __ROM_SIZE
+  L_TTB (rw) : ORIGIN = __TTB_BASE, LENGTH = __TTB_SIZE 
+  RAM (rwx)  : ORIGIN = __RAM_BASE, LENGTH = __RAM_SIZE
+}
+
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+    .text :
+    {
+
+        Image$$VECTORS$$Base = .;
+        * (RESET)
+        KEEP(*(.isr_vector))
+        Image$$VECTORS$$Limit = .;
+
+        *(SVC_TABLE)
+        *(.text*)
+
+        KEEP(*(.init))
+        KEEP(*(.fini))
+
+        /* .ctors */
+        *crtbegin.o(.ctors)
+        *crtbegin?.o(.ctors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+        *(SORT(.ctors.*))
+        *(.ctors)
+
+        /* .dtors */
+        *crtbegin.o(.dtors)
+        *crtbegin?.o(.dtors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+        *(SORT(.dtors.*))
+        *(.dtors)
+
+        Image$$RO_DATA$$Base = .;
+        *(.rodata*)
+        Image$$RO_DATA$$Limit = .;
+
+        KEEP(*(.eh_frame*))
+    } > ROM
+
+    .ARM.extab : 
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > ROM
+
+    __exidx_start = .;
+    .ARM.exidx :
+    {
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    } > ROM
+    __exidx_end = .;
+
+
+    .copy.table :
+    {
+        . = ALIGN(4);
+        __copy_table_start__ = .;
+        LONG (__etext)
+        LONG (__data_start__)
+        LONG (__data_end__ - __data_start__)
+        __copy_table_end__ = .;
+    } > ROM
+
+    .zero.table :
+    {
+        . = ALIGN(4);
+        __zero_table_start__ = .;
+        LONG (__bss_start__)
+        LONG (__bss_end__ - __bss_start__)
+        __zero_table_end__ = .;
+    } > ROM
+
+    __etext = .;
+        
+    .ttb :
+    {
+        Image$$TTB$$ZI$$Base = .;
+        . += __TTB_SIZE;
+        Image$$TTB$$ZI$$Limit = .;
+    } > L_TTB
+
+    .data :
+    {
+        Image$$RW_DATA$$Base = .;
+        __data_start__ = .;
+        *(vtable)
+        *(.data*)
+        Image$$RW_DATA$$Limit = .;
+
+        . = ALIGN(4);
+        /* preinit data */
+        PROVIDE (__preinit_array_start = .);
+        KEEP(*(.preinit_array))
+        PROVIDE (__preinit_array_end = .);
+
+        . = ALIGN(4);
+        /* init data */
+        PROVIDE (__init_array_start = .);
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array))
+        PROVIDE (__init_array_end = .);
+
+
+        . = ALIGN(4);
+        /* finit data */
+        PROVIDE (__fini_array_start = .);
+        KEEP(*(SORT(.fini_array.*)))
+        KEEP(*(.fini_array))
+        PROVIDE (__fini_array_end = .);
+
+        . = ALIGN(4);
+        /* All data end */
+        __data_end__ = .;
+
+    } > RAM
+
+    
+    .bss ALIGN(0x400):
+    {
+        Image$$ZI_DATA$$Base = .;
+        __bss_start__ = .;
+        *(.bss*)
+        *(COMMON)
+        __bss_end__ = .;
+        Image$$ZI_DATA$$Limit = .;
+        __end__ = .;
+        end = __end__;
+    } > RAM AT > RAM
+
+#if defined(__HEAP_SIZE) && (__HEAP_SIZE > 0)    
+    .heap (NOLOAD):
+    {
+        . = ALIGN(8);
+        Image$$HEAP$$ZI$$Base = .;
+        . += __HEAP_SIZE;
+        Image$$HEAP$$ZI$$Limit = .;
+        __HeapLimit = .;
+    } > RAM  
+#endif
+
+    .stack (NOLOAD):
+    {
+        . = ORIGIN(RAM) + LENGTH(RAM) - __STACK_SIZE - __FIQ_STACK_SIZE - __IRQ_STACK_SIZE - __SVC_STACK_SIZE - __ABT_STACK_SIZE - __UND_STACK_SIZE;
+        . = ALIGN(8);
+        
+        __StackTop = .;
+        Image$$SYS_STACK$$ZI$$Base = .;
+        . += __STACK_SIZE;
+        Image$$SYS_STACK$$ZI$$Limit = .;
+        __stack = .;
+
+        Image$$FIQ_STACK$$ZI$$Base = .;
+        . += __FIQ_STACK_SIZE;
+        Image$$FIQ_STACK$$ZI$$Limit = .;
+
+        Image$$IRQ_STACK$$ZI$$Base = .;
+        . += __IRQ_STACK_SIZE;
+        Image$$IRQ_STACK$$ZI$$Limit = .;
+
+        Image$$SVC_STACK$$ZI$$Base = .;
+        . += __SVC_STACK_SIZE;
+        Image$$SVC_STACK$$ZI$$Limit = .;
+
+        Image$$ABT_STACK$$ZI$$Base = .;
+        . += __ABT_STACK_SIZE;
+        Image$$ABT_STACK$$ZI$$Limit = .;
+
+        Image$$UND_STACK$$ZI$$Base = .;
+        . += __UND_STACK_SIZE;
+        Image$$UND_STACK$$ZI$$Limit = .;
+        
+    } > RAM
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA9/RTE/Device/ARMCA9/ARMCA9.sct
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA9/RTE/Device/ARMCA9/ARMCA9.sct
@@ -1,0 +1,77 @@
+#! armclang -E --target=arm-arm-none-eabi -mcpu=cortex-a9 -xc
+;**************************************************
+; Copyright (c) 2017 ARM Ltd.  All rights reserved.
+;**************************************************
+
+; Scatter-file for RTX Example on Versatile Express
+
+; This scatter-file places application code, data, stack and heap at suitable addresses in the memory map.
+
+; This platform has 2GB SDRAM starting at 0x80000000.
+
+#include "mem_ARMCA9.h"
+
+SDRAM __ROM_BASE __ROM_SIZE       ; load region size_region
+{
+  VECTORS __ROM_BASE __ROM_SIZE ; load address = execution address
+  {
+      * (RESET, +FIRST)         ; Vector table and other startup code
+      * (InRoot$$Sections)      ; All (library) code that must be in a root region
+      * (+RO-CODE)              ; Application RO code (.text)
+      * (+RO-DATA)              ; Application RO data (.constdata)
+  }
+  
+  RW_DATA __RAM_BASE __RW_DATA_SIZE
+  { * (+RW) }                   ; Application RW data (.data)
+  
+  ZI_DATA (__RAM_BASE+
+           __RW_DATA_SIZE) __ZI_DATA_SIZE
+  { * (+ZI) }                   ; Application ZI data (.bss)
+  
+  ARM_LIB_HEAP  (__RAM_BASE
+                +__RW_DATA_SIZE
+                +__ZI_DATA_SIZE)    EMPTY __HEAP_SIZE        ; Heap region growing up
+  { }
+    
+  ARM_LIB_STACK (__RAM_BASE
+                +__RAM_SIZE       
+                -__FIQ_STACK_SIZE
+                -__IRQ_STACK_SIZE
+                -__SVC_STACK_SIZE
+                -__ABT_STACK_SIZE
+                -__UND_STACK_SIZE) EMPTY -__STACK_SIZE      ; Stack region growing down
+  { }              
+                
+  UND_STACK     (__RAM_BASE
+                +__RAM_SIZE
+                -__FIQ_STACK_SIZE
+                -__IRQ_STACK_SIZE
+                -__SVC_STACK_SIZE
+                -__ABT_STACK_SIZE) EMPTY -__UND_STACK_SIZE  ; UND mode stack
+  { }
+  
+  ABT_STACK     (__RAM_BASE
+                +__RAM_SIZE
+                -__FIQ_STACK_SIZE
+                -__IRQ_STACK_SIZE
+                -__SVC_STACK_SIZE) EMPTY -__ABT_STACK_SIZE  ; ABT mode stack
+  { }
+  
+  SVC_STACK     (__RAM_BASE
+                +__RAM_SIZE
+                -__FIQ_STACK_SIZE
+                -__IRQ_STACK_SIZE) EMPTY -__SVC_STACK_SIZE  ; SVC mode stack
+  { }  
+  
+  IRQ_STACK     (__RAM_BASE
+                +__RAM_SIZE
+                -__FIQ_STACK_SIZE) EMPTY -__IRQ_STACK_SIZE  ; IRQ mode stack
+  { }  
+  
+  FIQ_STACK     (__RAM_BASE
+                +__RAM_SIZE)       EMPTY -__FIQ_STACK_SIZE  ; FIQ mode stack
+  { }
+  
+  TTB            __TTB_BASE        EMPTY __TTB_SIZE         ; Level-1 Translation Table for MMU
+  { }                                        
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA9/RTE/Device/ARMCA9/ARMCA9_ac6.sct
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA9/RTE/Device/ARMCA9/ARMCA9_ac6.sct
@@ -1,0 +1,65 @@
+
+SDRAM __ROM_BASE __ROM_SIZE       ; load region size_region
+{
+  VECTORS __ROM_BASE __ROM_SIZE ; load address = execution address
+  {
+      * (RESET, +FIRST)         ; Vector table and other startup code
+      * (InRoot$$Sections)      ; All (library) code that must be in a root region
+      * (+RO-CODE)              ; Application RO code (.text)
+      * (+RO-DATA)              ; Application RO data (.constdata)
+  }
+  
+  RW_DATA __RAM_BASE __RW_DATA_SIZE
+  { * (+RW) }                   ; Application RW data (.data)
+  
+  ZI_DATA (__RAM_BASE+
+           __RW_DATA_SIZE) __ZI_DATA_SIZE
+  { * (+ZI) }                   ; Application ZI data (.bss)
+  
+  ARM_LIB_HEAP  (__RAM_BASE
+                +__RW_DATA_SIZE
+                +__ZI_DATA_SIZE)    EMPTY __HEAP_SIZE        ; Heap region growing up
+  { }
+    
+  ARM_LIB_STACK (__RAM_BASE
+                +__RAM_SIZE       
+                -__FIQ_STACK_SIZE
+                -__IRQ_STACK_SIZE
+                -__SVC_STACK_SIZE
+                -__ABT_STACK_SIZE
+                -__UND_STACK_SIZE) EMPTY -__STACK_SIZE      ; Stack region growing down
+  { }              
+                
+  UND_STACK     (__RAM_BASE
+                +__RAM_SIZE
+                -__FIQ_STACK_SIZE
+                -__IRQ_STACK_SIZE
+                -__SVC_STACK_SIZE
+                -__ABT_STACK_SIZE) EMPTY -__UND_STACK_SIZE  ; UND mode stack
+  { }
+  
+  ABT_STACK     (__RAM_BASE
+                +__RAM_SIZE
+                -__FIQ_STACK_SIZE
+                -__IRQ_STACK_SIZE
+                -__SVC_STACK_SIZE) EMPTY -__ABT_STACK_SIZE  ; ABT mode stack
+  { }
+  
+  SVC_STACK     (__RAM_BASE
+                +__RAM_SIZE
+                -__FIQ_STACK_SIZE
+                -__IRQ_STACK_SIZE) EMPTY -__SVC_STACK_SIZE  ; SVC mode stack
+  { }  
+  
+  IRQ_STACK     (__RAM_BASE
+                +__RAM_SIZE
+                -__FIQ_STACK_SIZE) EMPTY -__IRQ_STACK_SIZE  ; IRQ mode stack
+  { }  
+  
+  FIQ_STACK     (__RAM_BASE
+                +__RAM_SIZE)       EMPTY -__FIQ_STACK_SIZE  ; FIQ mode stack
+  { }
+  
+  TTB            __TTB_BASE        EMPTY __TTB_SIZE         ; Level-1 Translation Table for MMU
+  { }                                        
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA9/RTE/Device/ARMCA9/ARMCA9_clang.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA9/RTE/Device/ARMCA9/ARMCA9_clang.ld
@@ -1,0 +1,368 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2019 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+MEMORY
+{
+  ROM0 (rx)   : ORIGIN = __ROM_BASE, LENGTH = __ROM_SIZE
+  L_TTB (rw)  : ORIGIN = __TTB_BASE, LENGTH = __TTB_SIZE
+  RAM0 (rwx)  : ORIGIN = __RAM_BASE, LENGTH = __RAM_SIZE
+}
+
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+	.init : {
+		KEEP (*(RESET))
+		KEEP (*(.vectors))
+		KEEP (*(.text.init.enter))
+		KEEP (*(.data.init.enter))
+		KEEP (*(SORT_BY_NAME(.init) SORT_BY_NAME(.init.*)))
+	} >ROM0 AT>ROM0 :text
+
+	.text : {
+
+		/* code */
+		*(.text.unlikely .text.unlikely.*)
+		*(.text.startup .text.startup.*)
+		*(.text .text.* .opd .opd.*)
+		*(.gnu.linkonce.t.*)
+		KEEP (*(.fini .fini.*))
+		__text_end = .;
+
+		PROVIDE (__etext = __text_end);
+		PROVIDE (_etext = __text_end);
+		PROVIDE (etext = __text_end);
+
+		/* read-only data */
+		*(.rdata)
+		*(.rodata .rodata.*)
+		*(.gnu.linkonce.r.*)
+
+		*(.srodata.cst16)
+		*(.srodata.cst8)
+		*(.srodata.cst4)
+		*(.srodata.cst2)
+		*(.srodata .srodata.*)
+		*(.data.rel.ro .data.rel.ro.*)
+		*(.got .got.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		/* lists of constructors and destructors */
+		PROVIDE_HIDDEN ( __preinit_array_start = . );
+		KEEP (*(.preinit_array))
+		PROVIDE_HIDDEN ( __preinit_array_end = . );
+
+		PROVIDE_HIDDEN ( __init_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+		KEEP (*(.init_array .ctors))
+		PROVIDE_HIDDEN ( __init_array_end = . );
+
+		PROVIDE_HIDDEN ( __fini_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
+		KEEP (*(.fini_array .dtors))
+		PROVIDE_HIDDEN ( __fini_array_end = . );
+
+	} >ROM0 AT>ROM0 :text
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+	.veneers :
+	{
+		. = ALIGN(32);
+		KEEP(*(.gnu.sgstubs))
+	} > ROM0 AT>ROM0 :text
+#endif
+
+	.toc : {
+		*(.toc .toc.*)
+	} >ROM0 AT>ROM0 :text
+
+	/* additional sections when compiling with C++ exception support */
+	
+	.except_ordered : {
+		*(.gcc_except_table *.gcc_except_table.*)
+		KEEP (*(.eh_frame .eh_frame.*))
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+	} >ROM0 AT>ROM0 :text
+
+	.except_unordered : {
+		. = ALIGN(8);
+
+		PROVIDE(__exidx_start = .);
+		*(.ARM.exidx*)
+		PROVIDE(__exidx_end = .);
+	} >ROM0 AT>ROM0 :text
+
+    .ttb :
+    {
+        Image$$TTB$$ZI$$Base = .;
+        . += __TTB_SIZE;
+        Image$$TTB$$ZI$$Limit = .;
+    } > L_TTB
+
+	/*
+	 * Data values which are preserved across reset
+	 */
+	.preserve (NOLOAD) : {
+		PROVIDE(__preserve_start__ = .);
+		KEEP(*(SORT_BY_NAME(.preserve.*)))
+		KEEP(*(.preserve))
+		PROVIDE(__preserve_end__ = .);
+	} >RAM0 AT>RAM0 :ram
+
+	.data :  {
+		*(.data .data.*)
+		*(.gnu.linkonce.d.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		PROVIDE( __global_pointer$ = . + 0x800 );
+		*(.sdata .sdata.* .sdata2.*)
+		*(.gnu.linkonce.s.*)
+	} >RAM0 AT>ROM0 :ram_init
+	PROVIDE(__data_start = ADDR(.data));
+	PROVIDE(__data_source = LOADADDR(.data));
+
+	/* Thread local initialized data. This gets
+	 * space allocated as it is expected to be placed
+	 * in ram to be used as a template for TLS data blocks
+	 * allocated at runtime. We're slightly abusing that
+	 * by placing the data in flash where it will be copied
+	 * into the allocate ram addresses by the existing
+	 * data initialization code in crt0
+	 */
+	.tdata :  {
+		*(.tdata .tdata.* .gnu.linkonce.td.*)
+		PROVIDE(__data_end = .);
+		PROVIDE(__tdata_end = .);
+	} >RAM0 AT>ROM0 :tls :ram_init
+	PROVIDE( __tls_base = ADDR(.tdata));
+	PROVIDE( __tdata_start = ADDR(.tdata));
+	PROVIDE( __tdata_source = LOADADDR(.tdata) );
+	PROVIDE( __tdata_source_end = LOADADDR(.tdata) + SIZEOF(.tdata) );
+	PROVIDE( __data_source_end = __tdata_source_end );
+	PROVIDE( __tdata_size = SIZEOF(.tdata) );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata),ALIGNOF(.tbss)) );
+
+	PROVIDE( __edata = __data_end );
+	PROVIDE( _edata = __data_end );
+	PROVIDE( edata = __data_end );
+	PROVIDE( __data_size = __data_end - __data_start );
+	PROVIDE( __data_source_size = __data_source_end - __data_source );
+
+	.tbss (NOLOAD) : {
+		*(.tbss .tbss.* .gnu.linkonce.tb.*)
+		*(.tcommon)
+		PROVIDE( __tls_end = . );
+		PROVIDE( __tbss_end = . );
+	} >RAM0 AT>RAM0 :tls :ram
+	PROVIDE( __bss_start = ADDR(.tbss));
+	PROVIDE( __tbss_start = ADDR(.tbss));
+	PROVIDE( __tbss_offset = ADDR(.tbss) - ADDR(.tdata) );
+	PROVIDE( __tbss_size = SIZEOF(.tbss) );
+	PROVIDE( __tls_size = __tls_end - __tls_base );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
+	PROVIDE( __arm32_tls_tcb_offset = MAX(8, __tls_align) );
+	PROVIDE( __arm64_tls_tcb_offset = MAX(16, __tls_align) );
+
+	/*
+	 * The linker special cases .tbss segments which are
+	 * identified as segments which are not loaded and are
+	 * thread_local.
+	 *
+	 * For these segments, the linker does not advance 'dot'
+	 * across them.  We actually need memory allocated for tbss,
+	 * so we create a special segment here just to make room
+	 */
+	/*
+	.tbss_space (NOLOAD) : {
+		. = ADDR(.tbss);
+		. = . + SIZEOF(.tbss);
+	} >RAM0 AT>RAM0 :ram
+	*/
+
+	.bss (NOLOAD) : {
+		*(.sbss*)
+		*(.gnu.linkonce.sb.*)
+		*(.bss .bss.*)
+		*(.gnu.linkonce.b.*)
+		*(COMMON)
+
+		/* Align the heap */
+		. = ALIGN(8);
+		__bss_end = .;
+	} >RAM0 AT>RAM0 :ram
+	PROVIDE( __non_tls_bss_start = ADDR(.bss) );
+	PROVIDE( __end = __bss_end );
+	PROVIDE( _end = __bss_end );
+	PROVIDE( end = __bss_end );
+	PROVIDE( __bss_size = __bss_end - __bss_start );
+
+	/* Make the rest of memory available for heap storage */
+	PROVIDE (__heap_start = __end);
+#ifdef __HEAP_SIZE
+	PROVIDE (__heap_end = __heap_start + __HEAP_SIZE);
+	PROVIDE (__heap_size = __HEAP_SIZE);
+#else
+	PROVIDE (__heap_end = __stack - __STACK_SIZE);
+	PROVIDE (__heap_size = __heap_end - __heap_start);
+#endif
+	.heap (NOLOAD) : {
+		. += __heap_size;
+	} >RAM0 :ram
+
+	/* Define a stack region to make sure it fits in memory */
+	PROVIDE(__stack = ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE);
+	PROVIDE(__stack_limit = __stack - __STACK_SIZE);
+#if __ARM_ARCH_PROFILE == 'A'
+	.stack (__stack_limit - 5*__STACK_SIZE) (NOLOAD) : {
+        Image$$FIQ_STACK$$ZI$$Base = .;
+        . += __STACK_SIZE;
+        Image$$FIQ_STACK$$ZI$$Limit = .;
+
+        Image$$IRQ_STACK$$ZI$$Base = .;
+        . += __STACK_SIZE;
+        Image$$IRQ_STACK$$ZI$$Limit = .;
+
+        Image$$SVC_STACK$$ZI$$Base = .;
+        . += __STACK_SIZE;
+        Image$$SVC_STACK$$ZI$$Limit = .;
+
+        Image$$ABT_STACK$$ZI$$Base = .;
+        . += __STACK_SIZE;
+        Image$$ABT_STACK$$ZI$$Limit = .;
+
+        Image$$UND_STACK$$ZI$$Base = .;
+        . += __STACK_SIZE;
+        Image$$UND_STACK$$ZI$$Limit = .;
+
+        Image$$SYS_STACK$$ZI$$Base = .;
+        . += __STACK_SIZE;
+        Image$$SYS_STACK$$ZI$$Limit = .;
+	} >RAM0 :ram
+#else
+	.stack (__stack_limit) (NOLOAD) : {
+		. += __STACK_SIZE;
+	} >RAM0 :ram
+#endif
+
+#if __STACKSEAL_SIZE > 0
+	PROVIDE(__stack_seal = __stack);
+  	.stackseal (__stack) (NOLOAD) :
+  	{
+    	. += __STACKSEAL_SIZE;
+  	} >RAM0 :ram
+#endif
+
+	/* Throw away C++ exception handling information */
+
+	/*
+
+	/DISCARD/ : {
+		*(.note .note.*)
+		*(.eh_frame .eh_frame.*)
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+		*(.ARM.exidx*)
+	}
+
+	*/
+
+	/* Stabs debugging sections.  */
+	.stab          0 : { *(.stab) }
+	.stabstr       0 : { *(.stabstr) }
+	.stab.excl     0 : { *(.stab.excl) }
+	.stab.exclstr  0 : { *(.stab.exclstr) }
+	.stab.index    0 : { *(.stab.index) }
+	.stab.indexstr 0 : { *(.stab.indexstr) }
+	.comment       0 : { *(.comment) }
+	.gnu.build.attributes : { *(.gnu.build.attributes .gnu.build.attributes.*) }
+	/* DWARF debug sections.
+	   Symbols in the DWARF debugging sections are relative to the beginning
+	   of the section so we begin them at 0.  */
+	/* DWARF 1.  */
+	.debug          0 : { *(.debug) }
+	.line           0 : { *(.line) }
+	/* GNU DWARF 1 extensions.  */
+	.debug_srcinfo  0 : { *(.debug_srcinfo) }
+	.debug_sfnames  0 : { *(.debug_sfnames) }
+	/* DWARF 1.1 and DWARF 2.  */
+	.debug_aranges  0 : { *(.debug_aranges) }
+	.debug_pubnames 0 : { *(.debug_pubnames) }
+	/* DWARF 2.  */
+	.debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+	.debug_abbrev   0 : { *(.debug_abbrev) }
+	.debug_line     0 : { *(.debug_line .debug_line.* .debug_line_end) }
+	.debug_frame    0 : { *(.debug_frame) }
+	.debug_str      0 : { *(.debug_str) }
+	.debug_loc      0 : { *(.debug_loc) }
+	.debug_macinfo  0 : { *(.debug_macinfo) }
+	/* SGI/MIPS DWARF 2 extensions.  */
+	.debug_weaknames 0 : { *(.debug_weaknames) }
+	.debug_funcnames 0 : { *(.debug_funcnames) }
+	.debug_typenames 0 : { *(.debug_typenames) }
+	.debug_varnames  0 : { *(.debug_varnames) }
+	/* DWARF 3.  */
+	.debug_pubtypes 0 : { *(.debug_pubtypes) }
+	.debug_ranges   0 : { *(.debug_ranges) }
+	/* DWARF 5.  */
+	.debug_addr     0 : { *(.debug_addr) }
+	.debug_line_str 0 : { *(.debug_line_str) }
+	.debug_loclists 0 : { *(.debug_loclists) }
+	.debug_macro    0 : { *(.debug_macro) }
+	.debug_names    0 : { *(.debug_names) }
+	.debug_rnglists 0 : { *(.debug_rnglists) }
+	.debug_str_offsets 0 : { *(.debug_str_offsets) }
+	.debug_sup      0 : { *(.debug_sup) }
+	.gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }
+}
+
+/*
+ * Check that sections that are copied from flash to RAM have matching
+ * padding, so that a single memcpy() of __data_size copies the correct bytes.
+ */
+ASSERT( __data_size == __data_source_size,
+	"ERROR: .data/.tdata flash size does not match RAM size");

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA9/RTE/Device/ARMCA9/ARMCA9_gcc.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA9/RTE/Device/ARMCA9/ARMCA9_gcc.ld
@@ -1,0 +1,176 @@
+
+MEMORY
+{
+  ROM (rx)   : ORIGIN = __ROM_BASE, LENGTH = __ROM_SIZE
+  L_TTB (rw) : ORIGIN = __TTB_BASE, LENGTH = __TTB_SIZE 
+  RAM (rwx)  : ORIGIN = __RAM_BASE, LENGTH = __RAM_SIZE
+}
+
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+    .text :
+    {
+        Image$$VECTORS$$Base = .;
+        * (RESET)
+        KEEP(*(.isr_vector))
+        Image$$VECTORS$$Limit = .;
+
+        *(SVC_TABLE)
+        *(.text*)
+
+        KEEP(*(.init))
+        KEEP(*(.fini))
+
+        /* .ctors */
+        *crtbegin.o(.ctors)
+        *crtbegin?.o(.ctors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+        *(SORT(.ctors.*))
+        *(.ctors)
+
+        /* .dtors */
+        *crtbegin.o(.dtors)
+        *crtbegin?.o(.dtors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+        *(SORT(.dtors.*))
+        *(.dtors)
+
+        Image$$RO_DATA$$Base = .;
+        *(.rodata*)
+        Image$$RO_DATA$$Limit = .;
+
+        KEEP(*(.eh_frame*))
+    } > ROM
+
+    .ARM.extab : 
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > ROM
+
+    __exidx_start = .;
+    .ARM.exidx :
+    {
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    } > ROM
+    __exidx_end = .;
+
+
+    .copy.table :
+    {
+        . = ALIGN(4);
+        __copy_table_start__ = .;
+        LONG (__etext)
+        LONG (__data_start__)
+        LONG (__data_end__ - __data_start__)
+        __copy_table_end__ = .;
+    } > ROM
+
+    .zero.table :
+    {
+        . = ALIGN(4);
+        __zero_table_start__ = .;
+        LONG (__bss_start__)
+        LONG (__bss_end__ - __bss_start__)
+        __zero_table_end__ = .;
+    } > ROM
+
+    __etext = .;
+        
+    .ttb :
+    {
+        Image$$TTB$$ZI$$Base = .;
+        . += __TTB_SIZE;
+        Image$$TTB$$ZI$$Limit = .;
+    } > L_TTB
+
+    .data :
+    {
+        Image$$RW_DATA$$Base = .;
+        __data_start__ = .;
+        *(vtable)
+        *(.data*)
+        Image$$RW_DATA$$Limit = .;
+
+        . = ALIGN(4);
+        /* preinit data */
+        PROVIDE (__preinit_array_start = .);
+        KEEP(*(.preinit_array))
+        PROVIDE (__preinit_array_end = .);
+
+        . = ALIGN(4);
+        /* init data */
+        PROVIDE (__init_array_start = .);
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array))
+        PROVIDE (__init_array_end = .);
+
+        . = ALIGN(4);
+        /* finit data */
+        PROVIDE (__fini_array_start = .);
+        KEEP(*(SORT(.fini_array.*)))
+        KEEP(*(.fini_array))
+        PROVIDE (__fini_array_end = .);
+
+        . = ALIGN(4);
+        /* All data end */
+        __data_end__ = .;
+    } > RAM
+
+    
+    .bss ALIGN(0x400):
+    {
+        Image$$ZI_DATA$$Base = .;
+        __bss_start__ = .;
+        *(.bss*)
+        *(COMMON)
+        __bss_end__ = .;
+        Image$$ZI_DATA$$Limit = .;
+        __end__ = .;
+        end = __end__;
+    } > RAM AT > RAM
+
+#if defined(__HEAP_SIZE) && (__HEAP_SIZE > 0)    
+    .heap (NOLOAD):
+    {
+        . = ALIGN(8);
+        Image$$HEAP$$ZI$$Base = .;
+        . += __HEAP_SIZE;
+        Image$$HEAP$$ZI$$Limit = .;
+        __HeapLimit = .;
+    } > RAM  
+#endif
+
+    .stack (NOLOAD):
+    {
+        . = ORIGIN(RAM) + LENGTH(RAM) - __STACK_SIZE - __FIQ_STACK_SIZE - __IRQ_STACK_SIZE - __SVC_STACK_SIZE - __ABT_STACK_SIZE - __UND_STACK_SIZE;
+        . = ALIGN(8);
+        
+        __StackTop = .;
+        Image$$SYS_STACK$$ZI$$Base = .;
+        . += __STACK_SIZE;
+        Image$$SYS_STACK$$ZI$$Limit = .;
+        __stack = .;
+
+        Image$$FIQ_STACK$$ZI$$Base = .;
+        . += __FIQ_STACK_SIZE;
+        Image$$FIQ_STACK$$ZI$$Limit = .;
+
+        Image$$IRQ_STACK$$ZI$$Base = .;
+        . += __IRQ_STACK_SIZE;
+        Image$$IRQ_STACK$$ZI$$Limit = .;
+
+        Image$$SVC_STACK$$ZI$$Base = .;
+        . += __SVC_STACK_SIZE;
+        Image$$SVC_STACK$$ZI$$Limit = .;
+
+        Image$$ABT_STACK$$ZI$$Base = .;
+        . += __ABT_STACK_SIZE;
+        Image$$ABT_STACK$$ZI$$Limit = .;
+
+        Image$$UND_STACK$$ZI$$Base = .;
+        . += __UND_STACK_SIZE;
+        Image$$UND_STACK$$ZI$$Limit = .;
+    } > RAM
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA9/RTE/Device/ARMCA9/ARMCA9_iar.icf
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA9/RTE/Device/ARMCA9/ARMCA9_iar.icf
@@ -1,0 +1,67 @@
+
+/*-Memory Regions-*/
+define symbol __ICFEDIT_region_IROM1_start__ = 0x80000000;
+define symbol __ICFEDIT_region_IROM1_end__   = 0x801FFFFF;
+define symbol __ICFEDIT_region_IROM2_start__ = 0x0;
+define symbol __ICFEDIT_region_IROM2_end__   = 0x0;
+define symbol __ICFEDIT_region_EROM1_start__ = 0x0;
+define symbol __ICFEDIT_region_EROM1_end__   = 0x0;
+define symbol __ICFEDIT_region_EROM2_start__ = 0x0;
+define symbol __ICFEDIT_region_EROM2_end__   = 0x0;
+define symbol __ICFEDIT_region_EROM3_start__ = 0x0;
+define symbol __ICFEDIT_region_EROM3_end__   = 0x0;
+define symbol __ICFEDIT_region_IRAM1_start__ = 0x80200000;
+define symbol __ICFEDIT_region_IRAM1_end__   = 0x803FFFFF;
+define symbol __ICFEDIT_region_IRAM2_start__ = 0x0;
+define symbol __ICFEDIT_region_IRAM2_end__   = 0x0;
+define symbol __ICFEDIT_region_ERAM1_start__ = 0x0;
+define symbol __ICFEDIT_region_ERAM1_end__   = 0x0;
+define symbol __ICFEDIT_region_ERAM2_start__ = 0x0;
+define symbol __ICFEDIT_region_ERAM2_end__   = 0x0;
+define symbol __ICFEDIT_region_ERAM3_start__ = 0x0;
+define symbol __ICFEDIT_region_ERAM3_end__   = 0x0;
+define symbol __ICFEDIT_region_TTB_start__   = 0x80500000;
+define symbol __ICFEDIT_region_TTB_end__     = 0x805FFFFF;
+
+/*-Sizes-*/
+define symbol __ICFEDIT_size_cstack__        = 0x1000;
+define symbol __ICFEDIT_size_irqstack__      = 0x100;
+define symbol __ICFEDIT_size_fiqstack__      = 0x100;
+define symbol __ICFEDIT_size_svcstack__      = 0x100;
+define symbol __ICFEDIT_size_abtstack__      = 0x100;
+define symbol __ICFEDIT_size_undstack__      = 0x100;
+define symbol __ICFEDIT_size_heap__          = 0x8000;
+define symbol __ICFEDIT_size_ttb__           = 0x4000;
+
+define memory mem with size = 4G;
+define region IROM_region   =   mem:[from __ICFEDIT_region_IROM1_start__ to __ICFEDIT_region_IROM1_end__]
+                              | mem:[from __ICFEDIT_region_IROM2_start__ to __ICFEDIT_region_IROM2_end__];
+define region IRAM_region   =   mem:[from __ICFEDIT_region_IRAM1_start__ to __ICFEDIT_region_IRAM1_end__]
+                              | mem:[from __ICFEDIT_region_IRAM2_start__ to __ICFEDIT_region_IRAM2_end__];
+define region ERAM_region   =   mem:[from __ICFEDIT_region_ERAM1_start__ to __ICFEDIT_region_ERAM1_end__]
+                              | mem:[from __ICFEDIT_region_ERAM2_start__ to __ICFEDIT_region_ERAM2_end__]
+                              | mem:[from __ICFEDIT_region_ERAM3_start__ to __ICFEDIT_region_ERAM3_end__];
+define region TTB_region    =   mem:[from __ICFEDIT_region_TTB_start__   to __ICFEDIT_region_TTB_end__  ];
+
+define block USR_STACK     with alignment = 8, size = __ICFEDIT_size_cstack__        { };
+define block IRQ_STACK     with alignment = 8, size = __ICFEDIT_size_irqstack__      { };
+define block FIQ_STACK     with alignment = 8, size = __ICFEDIT_size_fiqstack__      { };
+define block SVC_STACK     with alignment = 8, size = __ICFEDIT_size_svcstack__      { };
+define block ABT_STACK     with alignment = 8, size = __ICFEDIT_size_abtstack__      { };
+define block UND_STACK     with alignment = 8, size = __ICFEDIT_size_undstack__      { };
+define block HEAP          with alignment = 8, size = __ICFEDIT_size_heap__          { };
+define block TTB           with alignment = 8, size = __ICFEDIT_size_ttb__           { section TTB };
+
+do not initialize  { section .noinit };
+
+initialize by copy { readwrite };
+if (isdefinedsymbol(__USE_DLIB_PERTHREAD))
+{
+  // Required in a multi-threaded application
+  initialize by copy with packing = none { section __DLIB_PERTHREAD };
+}
+
+place at address mem:__ICFEDIT_region_IROM1_start__ { readonly section RESET };
+place in IROM_region  { readonly };
+place in IRAM_region  { readwrite, block HEAP, block USR_STACK, block IRQ_STACK, block FIQ_STACK, block SVC_STACK, block ABT_STACK, block UND_STACK };
+place in TTB_region   { block TTB };

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA9/RTE/Device/ARMCA9/mem_ARMCA9.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA9/RTE/Device/ARMCA9/mem_ARMCA9.h
@@ -1,0 +1,100 @@
+/**************************************************************************//**
+ * @file     mem_ARMCA9.h
+ * @brief    Memory base and size definitions (used in scatter file)
+ * @version  V1.1.0
+ * @date     15. May 2019
+ *
+ * @note
+ *
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __MEM_ARMCA9_H
+#define __MEM_ARMCA9_H
+
+/*----------------------------------------------------------------------------
+  User Stack & Heap size definition
+ *----------------------------------------------------------------------------*/
+/*
+//-------- <<< Use Configuration Wizard in Context Menu >>> ------------------
+*/
+
+/*--------------------- ROM Configuration ------------------------------------
+//
+// <h> ROM Configuration
+//   <i> For compatibility with MMU config the sections must be multiple of 1MB
+//   <o0> ROM Base Address <0x0-0xFFFFFFFF:0x100000>
+//   <o1> ROM Size (in Bytes) <0x0-0xFFFFFFFF:0x100000>
+// </h>
+ *----------------------------------------------------------------------------*/
+#define __ROM_BASE       0x80000000
+#define __ROM_SIZE       0x00200000
+
+/*--------------------- RAM Configuration -----------------------------------
+// <h> RAM Configuration
+//   <i> For compatibility with MMU config the sections must be multiple of 1MB
+//   <o0> RAM Base Address    <0x0-0xFFFFFFFF:0x100000>
+//   <o1> RAM Total Size (in Bytes) <0x0-0xFFFFFFFF:0x100000>
+//   <h> Data Sections
+//     <o2> RW_DATA Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//     <o3> ZI_DATA Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//   </h>
+//   <h> Stack / Heap Configuration
+//     <o4>  Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//     <o5>  Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//     <h> Exceptional Modes
+//       <o6> UND Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//       <o7> ABT Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//       <o8> SVC Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//       <o9> IRQ Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//       <o10> FIQ Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//     </h>
+//   </h>
+// </h>
+ *----------------------------------------------------------------------------*/
+#define __RAM_BASE       0x80200000
+#define __RAM_SIZE       0x00200000
+
+#define __RW_DATA_SIZE   0x00100000
+#define __ZI_DATA_SIZE   0x000F0000
+
+#define __STACK_SIZE     0x00001000
+#define __HEAP_SIZE      0x00008000
+
+#define __UND_STACK_SIZE 0x00000100
+#define __ABT_STACK_SIZE 0x00000100
+#define __SVC_STACK_SIZE 0x00000100
+#define __IRQ_STACK_SIZE 0x00000100
+#define __FIQ_STACK_SIZE 0x00000100
+
+/*----------------------------------------------------------------------------*/
+
+/*--------------------- TTB Configuration ------------------------------------
+//
+// <h> TTB Configuration
+//   <i> The TLB L1 contains 4096 32-bit entries and must be 16kB aligned
+//   <i> The TLB L2 entries are placed after the L1 in the MMU config
+//   <o0> TTB Base Address <0x0-0xFFFFFFFF:0x4000>
+//   <o1> TTB Size (in Bytes) <0x0-0xFFFFFFFF:8>
+// </h>
+ *----------------------------------------------------------------------------*/
+#define __TTB_BASE       0x80500000
+#define __TTB_SIZE       0x00005000
+
+#endif /* __MEM_ARMCA9_H */

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA9/RTE/Device/ARMCA9/mmu_ARMCA9.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA9/RTE/Device/ARMCA9/mmu_ARMCA9.c
@@ -1,0 +1,232 @@
+/**************************************************************************//**
+ * @file     mmu_ARMCA9.c
+ * @brief    MMU Configuration for Arm Cortex-A9 Device Series
+ * @version  V1.2.0
+ * @date     15. May 2019
+ *
+ * @note
+ *
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Memory map description from: DUI0447G_v2m_p1_trm.pdf 4.2.2 Arm Cortex-A Series memory map
+
+                                                     Memory Type
+0xffffffff |--------------------------|             ------------
+           |       FLAG SYNC          |             Device Memory
+0xfffff000 |--------------------------|             ------------
+           |         Fault            |                Fault
+0xfff00000 |--------------------------|             ------------
+           |                          |                Normal
+           |                          |
+           |      Daughterboard       |
+           |         memory           |
+           |                          |
+0x80505000 |--------------------------|             ------------
+           |TTB (L2 Sync Flags   ) 4k |                Normal
+0x80504C00 |--------------------------|             ------------
+           |TTB (L2 Peripherals-B) 16k|                Normal
+0x80504800 |--------------------------|             ------------
+           |TTB (L2 Peripherals-A) 16k|                Normal
+0x80504400 |--------------------------|             ------------
+           |TTB (L2 Priv Periphs)  4k |                Normal
+0x80504000 |--------------------------|             ------------
+           |    TTB (L1 Descriptors)  |                Normal
+0x80500000 |--------------------------|             ------------
+           |          Stack           |                Normal
+           |--------------------------|             ------------
+           |          Heap            |                Normal
+0x80400000 |--------------------------|             ------------
+           |         ZI Data          |                Normal
+0x80300000 |--------------------------|             ------------
+           |         RW Data          |                Normal
+0x80200000 |--------------------------|             ------------
+           |         RO Data          |                Normal
+           |--------------------------|             ------------
+           |         RO Code          |              USH Normal
+0x80000000 |--------------------------|             ------------
+           |      Daughterboard       |                Fault
+           |      HSB AXI buses       |
+0x40000000 |--------------------------|             ------------
+           |      Daughterboard       |                Fault
+           |  test chips peripherals  |
+0x2c002000 |--------------------------|             ------------
+           |     Private Address      |            Device Memory
+0x2c000000 |--------------------------|             ------------
+           |      Daughterboard       |                Fault
+           |  test chips peripherals  |
+0x20000000 |--------------------------|             ------------
+           |       Peripherals        |           Device Memory RW/RO
+           |                          |              & Fault
+0x00000000 |--------------------------|
+*/
+
+// L1 Cache info and restrictions about architecture of the caches (CCSIR register):
+// Write-Through support *not* available
+// Write-Back support available.
+// Read allocation support available.
+// Write allocation support available.
+
+//Note: You should use the Shareable attribute carefully.
+//For cores without coherency logic (such as SCU) marking a region as shareable forces the processor to not cache that region regardless of the inner cache settings.
+//Cortex-A versions of RTX use LDREX/STREX instructions relying on Local monitors. Local monitors will be used only when the region gets cached, regions that are not cached will use the Global Monitor.
+//Some Cortex-A implementations do not include Global Monitors, so wrongly setting the attribute Shareable may cause STREX to fail.
+
+//Recall: When the Shareable attribute is applied to a memory region that is not Write-Back, Normal memory, data held in this region is treated as Non-cacheable.
+//When SMP bit = 0, Inner WB/WA Cacheable Shareable attributes are treated as Non-cacheable.
+//When SMP bit = 1, Inner WB/WA Cacheable Shareable attributes are treated as Cacheable.
+
+
+//Following MMU configuration is expected
+//SCTLR.AFE == 1 (Simplified access permissions model - AP[2:1] define access permissions, AP[0] is an access flag)
+//SCTLR.TRE == 0 (TEX remap disabled, so memory type and attributes are described directly by bits in the descriptor)
+//Domain 0 is always the Client domain
+//Descriptors should place all memory in domain 0
+
+#include "ARMCA9.h"
+#include "mem_ARMCA9.h"
+
+// TTB base address
+#define TTB_BASE ((uint32_t*)__TTB_BASE)
+
+// L2 table pointers
+//----------------------------------------
+#define TTB_L1_SIZE                    (0x00004000)                        // The L1 translation table divides the full 4GB address space of a 32-bit core
+                                                                           // into 4096 equally sized sections, each of which describes 1MB of virtual memory space.
+                                                                           // The L1 translation table therefore contains 4096 32-bit (word-sized) entries.
+
+#define PRIVATE_TABLE_L2_BASE_4k       (__TTB_BASE + TTB_L1_SIZE)          // Map 4k Private Address space
+#define PERIPHERAL_A_TABLE_L2_BASE_64k (__TTB_BASE + TTB_L1_SIZE + 0x400)  // Map 64k Peripheral #1 0x1C000000 - 0x1C00FFFFF
+#define PERIPHERAL_B_TABLE_L2_BASE_64k (__TTB_BASE + TTB_L1_SIZE + 0x800)  // Map 64k Peripheral #2 0x1C100000 - 0x1C1FFFFFF
+#define SYNC_FLAGS_TABLE_L2_BASE_4k    (__TTB_BASE + TTB_L1_SIZE + 0xC00)  // Map 4k Flag synchronization
+
+//--------------------- PERIPHERALS -------------------
+#define PERIPHERAL_A_FAULT (0x00000000 + 0x1c000000) //0x1C000000-0x1C00FFFF (1M)
+#define PERIPHERAL_B_FAULT (0x00100000 + 0x1c000000) //0x1C100000-0x1C10FFFF (1M)
+
+//--------------------- SYNC FLAGS --------------------
+#define FLAG_SYNC     0xFFFFF000
+#define F_SYNC_BASE   0xFFF00000  //1M aligned
+
+static uint32_t Sect_Normal;     //outer & inner wb/wa, non-shareable, executable, rw, domain 0, base addr 0
+static uint32_t Sect_Normal_Cod; //outer & inner wb/wa, non-shareable, executable, ro, domain 0, base addr 0
+static uint32_t Sect_Normal_RO;  //as Sect_Normal_Cod, but not executable
+static uint32_t Sect_Normal_RW;  //as Sect_Normal_Cod, but writeable and not executable
+static uint32_t Sect_Device_RO;  //device, non-shareable, non-executable, ro, domain 0, base addr 0
+static uint32_t Sect_Device_RW;  //as Sect_Device_RO, but writeable
+
+/* Define global descriptors */
+static uint32_t Page_L1_4k  = 0x0;  //generic
+static uint32_t Page_L1_64k = 0x0;  //generic
+static uint32_t Page_4k_Device_RW;  //Shared device, not executable, rw, domain 0
+static uint32_t Page_64k_Device_RW; //Shared device, not executable, rw, domain 0
+
+void MMU_CreateTranslationTable(void)
+{
+    mmu_region_attributes_Type region;
+
+    //Create 4GB of faulting entries
+    MMU_TTSection (TTB_BASE, 0, 4096, DESCRIPTOR_FAULT);
+
+    /*
+     * Generate descriptors. Refer to core_ca.h to get information about attributes
+     *
+     */
+    //Create descriptors for Vectors, RO, RW, ZI sections
+    section_normal(Sect_Normal, region);
+    section_normal_cod(Sect_Normal_Cod, region);
+    section_normal_ro(Sect_Normal_RO, region);
+    section_normal_rw(Sect_Normal_RW, region);
+    //Create descriptors for peripherals
+    section_device_ro(Sect_Device_RO, region);
+    section_device_rw(Sect_Device_RW, region);
+    //Create descriptors for 64k pages
+    page64k_device_rw(Page_L1_64k, Page_64k_Device_RW, region);
+    //Create descriptors for 4k pages
+    page4k_device_rw(Page_L1_4k, Page_4k_Device_RW, region);
+
+
+    /*
+     *  Define MMU flat-map regions and attributes
+     *
+     */
+
+    //Define Image
+    MMU_TTSection (TTB_BASE, __ROM_BASE, __ROM_SIZE/0x100000, Sect_Normal_Cod); // multiple of 1MB sections
+    MMU_TTSection (TTB_BASE, __RAM_BASE, __RAM_SIZE/0x100000, Sect_Normal_RW);  // multiple of 1MB sections
+
+    //--------------------- PERIPHERALS -------------------
+    MMU_TTSection (TTB_BASE, VE_A9_MP_FLASH_BASE0   , 64, Sect_Device_RO); // 64MB NOR
+    MMU_TTSection (TTB_BASE, VE_A9_MP_FLASH_BASE1   , 64, Sect_Device_RO); // 64MB NOR
+    MMU_TTSection (TTB_BASE, VE_A9_MP_SRAM_BASE     , 32, Sect_Device_RW); // 32MB RAM
+    MMU_TTSection (TTB_BASE, VE_A9_MP_VRAM_BASE     , 32, Sect_Device_RW); // 32MB RAM
+    MMU_TTSection (TTB_BASE, VE_A9_MP_ETHERNET_BASE , 16, Sect_Device_RW);
+    MMU_TTSection (TTB_BASE, VE_A9_MP_USB_BASE      , 16, Sect_Device_RW);
+
+    // Create (16 * 64k)=1MB faulting entries to cover peripheral range 0x1C000000-0x1C00FFFF
+    MMU_TTPage64k(TTB_BASE, PERIPHERAL_A_FAULT      , 16, Page_L1_64k, (uint32_t *)PERIPHERAL_A_TABLE_L2_BASE_64k, DESCRIPTOR_FAULT);
+    // Define peripheral range 0x1C000000-0x1C00FFFF
+    MMU_TTPage64k(TTB_BASE, VE_A9_MP_DAP_BASE       ,  1, Page_L1_64k, (uint32_t *)PERIPHERAL_A_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+    MMU_TTPage64k(TTB_BASE, VE_A9_MP_SYSTEM_REG_BASE,  1, Page_L1_64k, (uint32_t *)PERIPHERAL_A_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+    MMU_TTPage64k(TTB_BASE, VE_A9_MP_SERIAL_BASE    ,  1, Page_L1_64k, (uint32_t *)PERIPHERAL_A_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+    MMU_TTPage64k(TTB_BASE, VE_A9_MP_AACI_BASE      ,  1, Page_L1_64k, (uint32_t *)PERIPHERAL_A_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+    MMU_TTPage64k(TTB_BASE, VE_A9_MP_MMCI_BASE      ,  1, Page_L1_64k, (uint32_t *)PERIPHERAL_A_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+    MMU_TTPage64k(TTB_BASE, VE_A9_MP_KMI0_BASE      ,  2, Page_L1_64k, (uint32_t *)PERIPHERAL_A_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+    MMU_TTPage64k(TTB_BASE, VE_A9_MP_UART_BASE      ,  4, Page_L1_64k, (uint32_t *)PERIPHERAL_A_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+    MMU_TTPage64k(TTB_BASE, VE_A9_MP_WDT_BASE       ,  1, Page_L1_64k, (uint32_t *)PERIPHERAL_A_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+
+    // Create (16 * 64k)=1MB faulting entries to cover peripheral range 0x1C100000-0x1C10FFFF
+    MMU_TTPage64k(TTB_BASE, PERIPHERAL_B_FAULT      , 16, Page_L1_64k, (uint32_t *)PERIPHERAL_B_TABLE_L2_BASE_64k, DESCRIPTOR_FAULT);
+    // Define peripheral range 0x1C100000-0x1C10FFFF
+    MMU_TTPage64k(TTB_BASE, VE_A9_MP_TIMER_BASE     ,  2, Page_L1_64k, (uint32_t *)PERIPHERAL_B_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+    MMU_TTPage64k(TTB_BASE, VE_A9_MP_DVI_BASE       ,  1, Page_L1_64k, (uint32_t *)PERIPHERAL_B_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+    MMU_TTPage64k(TTB_BASE, VE_A9_MP_RTC_BASE       ,  1, Page_L1_64k, (uint32_t *)PERIPHERAL_B_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+    MMU_TTPage64k(TTB_BASE, VE_A9_MP_UART4_BASE     ,  1, Page_L1_64k, (uint32_t *)PERIPHERAL_B_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+    MMU_TTPage64k(TTB_BASE, VE_A9_MP_CLCD_BASE      ,  1, Page_L1_64k, (uint32_t *)PERIPHERAL_B_TABLE_L2_BASE_64k, Page_64k_Device_RW);
+
+    // Create (256 * 4k)=1MB faulting entries to cover private address space. Needs to be marked as Device memory
+    MMU_TTPage4k (TTB_BASE, __get_CBAR()            ,256,  Page_L1_4k, (uint32_t *)PRIVATE_TABLE_L2_BASE_4k, DESCRIPTOR_FAULT);
+    // Define private address space entry.
+    MMU_TTPage4k (TTB_BASE, __get_CBAR()            ,  2,  Page_L1_4k, (uint32_t *)PRIVATE_TABLE_L2_BASE_4k, Page_4k_Device_RW);
+    // Define L2CC entry.  Uncomment if PL310 is present
+    //    MMU_TTPage4k (TTB_BASE, VE_A5_MP_PL310_BASE     ,  1,  Page_L1_4k, (uint32_t *)PRIVATE_TABLE_L2_BASE_4k, Page_4k_Device_RW);
+
+    // Create (256 * 4k)=1MB faulting entries to synchronization space (Useful if some non-cacheable DMA agent is present in the SoC)
+    MMU_TTPage4k (TTB_BASE, F_SYNC_BASE             , 256, Page_L1_4k, (uint32_t *)SYNC_FLAGS_TABLE_L2_BASE_4k, DESCRIPTOR_FAULT);
+    // Define synchronization space entry.
+    MMU_TTPage4k (TTB_BASE, FLAG_SYNC               ,   1, Page_L1_4k, (uint32_t *)SYNC_FLAGS_TABLE_L2_BASE_4k, Page_4k_Device_RW);
+
+    /* Set location of level 1 page table
+    ; 31:14 - Translation table base addr (31:14-TTBCR.N, TTBCR.N is 0 out of reset)
+    ; 13:7  - 0x0
+    ; 6     - IRGN[0] 0x1  (Inner WB WA)
+    ; 5     - NOS     0x0  (Non-shared)
+    ; 4:3   - RGN     0x01 (Outer WB WA)
+    ; 2     - IMP     0x0  (Implementation Defined)
+    ; 1     - S       0x0  (Non-shared)
+    ; 0     - IRGN[1] 0x0  (Inner WB WA) */
+    __set_TTBR0(__TTB_BASE | 0x48);
+    __ISB();
+
+    /* Set up domain access control register
+    ; We set domain 0 to Client and all other domains to No Access.
+    ; All translation table entries specify domain 0 */
+    __set_DACR(1);
+    __ISB();
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA9/RTE/Device/ARMCA9/startup_ARMCA9.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA9/RTE/Device/ARMCA9/startup_ARMCA9.c
@@ -1,0 +1,148 @@
+/******************************************************************************
+ * @file     startup_ARMCA9.c
+ * @brief    CMSIS Device System Source File for Arm Cortex-A9 Device Series
+ * @version  V1.0.1
+ * @date     10. January 2021
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2021 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <ARMCA9.h>
+
+/*----------------------------------------------------------------------------
+  Definitions
+ *----------------------------------------------------------------------------*/
+#define USR_MODE 0x10            // User mode
+#define FIQ_MODE 0x11            // Fast Interrupt Request mode
+#define IRQ_MODE 0x12            // Interrupt Request mode
+#define SVC_MODE 0x13            // Supervisor mode
+#define ABT_MODE 0x17            // Abort mode
+#define UND_MODE 0x1B            // Undefined Instruction mode
+#define SYS_MODE 0x1F            // System mode
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+void Vectors        (void) __attribute__ ((naked, section("RESET")));
+void Reset_Handler  (void) __attribute__ ((naked));
+void Default_Handler(void) __attribute__ ((noreturn));
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+void Undef_Handler (void) __attribute__ ((weak, alias("Default_Handler")));
+void SVC_Handler   (void) __attribute__ ((weak, alias("Default_Handler")));
+void PAbt_Handler  (void) __attribute__ ((weak, alias("Default_Handler")));
+void DAbt_Handler  (void) __attribute__ ((weak, alias("Default_Handler")));
+void IRQ_Handler   (void) __attribute__ ((weak, alias("Default_Handler")));
+void FIQ_Handler   (void) __attribute__ ((weak, alias("Default_Handler")));
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector Table
+ *----------------------------------------------------------------------------*/
+void Vectors(void) {
+  __ASM volatile(
+  "LDR    PC, =Reset_Handler                        \n"
+  "LDR    PC, =Undef_Handler                        \n"
+  "LDR    PC, =SVC_Handler                          \n"
+  "LDR    PC, =PAbt_Handler                         \n"
+  "LDR    PC, =DAbt_Handler                         \n"
+  "NOP                                              \n"
+  "LDR    PC, =IRQ_Handler                          \n"
+  "LDR    PC, =FIQ_Handler                          \n"
+  );
+}
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+void Reset_Handler(void) {
+  __ASM volatile(
+
+  // Mask interrupts
+  "CPSID   if                                      \n"
+
+  // Put any cores other than 0 to sleep
+  "MRC     p15, 0, R0, c0, c0, 5                   \n"  // Read MPIDR
+  "ANDS    R0, R0, #3                              \n"
+  "goToSleep:                                      \n"
+  "WFINE                                           \n"
+  "BNE     goToSleep                               \n"
+
+  // Reset SCTLR Settings
+  "MRC     p15, 0, R0, c1, c0, 0                   \n"  // Read CP15 System Control register
+  "BIC     R0, R0, #(0x1 << 12)                    \n"  // Clear I bit 12 to disable I Cache
+  "BIC     R0, R0, #(0x1 <<  2)                    \n"  // Clear C bit  2 to disable D Cache
+  "BIC     R0, R0, #0x1                            \n"  // Clear M bit  0 to disable MMU
+  "BIC     R0, R0, #(0x1 << 11)                    \n"  // Clear Z bit 11 to disable branch prediction
+  "BIC     R0, R0, #(0x1 << 13)                    \n"  // Clear V bit 13 to disable hivecs
+  "MCR     p15, 0, R0, c1, c0, 0                   \n"  // Write value back to CP15 System Control register
+  "ISB                                             \n"
+
+  // Configure ACTLR
+  "MRC     p15, 0, r0, c1, c0, 1                   \n"  // Read CP15 Auxiliary Control Register
+  "ORR     r0, r0, #(1 <<  1)                      \n"  // Enable L2 prefetch hint (UNK/WI since r4p1)
+  "MCR     p15, 0, r0, c1, c0, 1                   \n"  // Write CP15 Auxiliary Control Register
+
+  // Set Vector Base Address Register (VBAR) to point to this application's vector table
+  "LDR    R0, =Vectors                             \n"
+  "MCR    p15, 0, R0, c12, c0, 0                   \n"
+
+  // Setup Stack for each exceptional mode
+  "CPS    #0x11                                    \n"
+  "LDR    SP, =Image$$FIQ_STACK$$ZI$$Limit         \n"
+  "CPS    #0x12                                    \n"
+  "LDR    SP, =Image$$IRQ_STACK$$ZI$$Limit         \n"
+  "CPS    #0x13                                    \n"
+  "LDR    SP, =Image$$SVC_STACK$$ZI$$Limit         \n"
+  "CPS    #0x17                                    \n"
+  "LDR    SP, =Image$$ABT_STACK$$ZI$$Limit         \n"
+  "CPS    #0x1B                                    \n"
+  "LDR    SP, =Image$$UND_STACK$$ZI$$Limit         \n"
+  "CPS    #0x1F                                    \n"
+#if defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6100100)
+  "LDR    SP, =Image$$ARM_LIB_STACK$$ZI$$Limit     \n"
+#elif defined ( __GNUC__ )
+  "LDR    SP, =Image$$SYS_STACK$$ZI$$Limit         \n"
+#else
+  #error Unknown compiler.
+#endif
+
+  // Call SystemInit
+  "BL     SystemInit                               \n"
+
+  // Unmask interrupts
+  "CPSIE  if                                       \n"
+
+  // Call __main
+#if defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6100100)
+  "BL     __main                                   \n"
+#elif defined ( __GNUC__ )
+  "BL     _start                                   \n"
+#else
+  #error Unknown compiler.
+#endif
+  );
+}
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+void Default_Handler(void) {
+  while(1);
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA9/RTE/Device/ARMCA9/startup_ARMCA9.s
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA9/RTE/Device/ARMCA9/startup_ARMCA9.s
@@ -1,0 +1,140 @@
+/******************************************************************************
+ * @file     startup_ARMCA9.s
+ * @brief    CMSIS Device System Source File for ARM Cortex-A9 Device Series
+ * @version  V1.00
+ * @date     01 Nov 2017
+ *
+ * @note
+ *
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2017 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+  MODULE  ?startup_ARMCA9
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+  PUBLIC  Reset_Handler
+  PUBWEAK Undef_Handler
+  PUBWEAK SVC_Handler
+  PUBWEAK PAbt_Handler
+  PUBWEAK DAbt_Handler
+  PUBWEAK IRQ_Handler
+  PUBWEAK FIQ_Handler
+
+  SECTION SVC_STACK:DATA:NOROOT(3)
+  SECTION IRQ_STACK:DATA:NOROOT(3)
+  SECTION FIQ_STACK:DATA:NOROOT(3)
+  SECTION ABT_STACK:DATA:NOROOT(3)
+  SECTION UND_STACK:DATA:NOROOT(3)
+  SECTION USR_STACK:DATA:NOROOT(3)
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector Table
+ *----------------------------------------------------------------------------*/
+
+  section RESET:CODE:NOROOT(2)
+  PUBLIC  Vectors
+
+Vectors:
+  LDR    PC, =Reset_Handler
+  LDR    PC, =Undef_Handler
+  LDR    PC, =SVC_Handler
+  LDR    PC, =PAbt_Handler
+  LDR    PC, =DAbt_Handler
+  NOP
+  LDR    PC, =IRQ_Handler
+  LDR    PC, =FIQ_Handler
+
+
+  section .text:CODE:NOROOT(2)
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+  *----------------------------------------------------------------------------*/
+  EXTERN  SystemInit
+  EXTERN  __iar_program_start
+
+Reset_Handler:  
+
+  // Mask interrupts
+  CPSID   if
+
+  // Put any cores other than 0 to sleep
+  MRC     p15, 0, R0, c0, c0, 5
+  ANDS    R0, R0, #3
+goToSleep:
+  WFINE
+  BNE     goToSleep
+
+  // Reset SCTLR Settings
+  MRC     p15, 0, R0, c1, c0, 0 // Read CP15 System Control register
+  BIC     R0, R0, #(0x1 << 12) // Clear I bit 12 to disable I Cache
+  BIC     R0, R0, #(0x1 <<  2) // Clear C bit  2 to disable D Cache
+  BIC     R0, R0, #0x1       // Clear M bit  0 to disable MMU
+  BIC     R0, R0, #(0x1 << 11) // Clear Z bit 11 to disable branch prediction
+  BIC     R0, R0, #(0x1 << 13) // Clear V bit 13 to disable hivecs
+  MCR     p15, 0, R0, c1, c0, 0 // Write value back to CP15 System Control register
+  ISB
+
+  // Configure ACTLR
+  MRC     p15, 0, r0, c1, c0, 1 // Read CP15 Auxiliary Control Register
+  ORR     r0, r0, #(1 <<  1) // Enable L2 prefetch hint (UNK/WI since r4p1)
+  MCR     p15, 0, r0, c1, c0, 1 // Write CP15 Auxiliary Control Register
+
+  // Set Vector Base Address Register (VBAR) to point to this application's vector table
+  LDR    R0, =Vectors
+  MCR    p15, 0, R0, c12, c0, 0
+
+  // Setup Stack for each exception mode
+  CPS    #0x11
+  LDR    SP, =SFE(FIQ_STACK)
+  CPS    #0x12
+  LDR    SP, =SFE(IRQ_STACK)
+  CPS    #0x13
+  LDR    SP, =SFE(SVC_STACK)
+  CPS    #0x17
+  LDR    SP, =SFE(ABT_STACK)
+  CPS    #0x1B
+  LDR    SP, =SFE(UND_STACK)
+  CPS    #0x1F
+  LDR    SP, =SFE(USR_STACK)
+
+  // Call SystemInit
+  BL     SystemInit
+
+  // Unmask interrupts
+  CPSIE  if
+
+  // Call __iar_program_start
+  BL     __iar_program_start
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+Undef_Handler:
+SVC_Handler:
+PAbt_Handler:
+DAbt_Handler:
+IRQ_Handler:
+FIQ_Handler:
+Default_Handler:
+  B .
+
+  END

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA9/RTE/Device/ARMCA9/system_ARMCA9.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA9/RTE/Device/ARMCA9/system_ARMCA9.c
@@ -1,0 +1,93 @@
+/******************************************************************************
+ * @file     system_ARMCA9.c
+ * @brief    CMSIS Device System Source File for Arm Cortex-A9 Device Series
+ * @version  V1.0.1
+ * @date     13. February 2019
+ *
+ * @note
+ *
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "RTE_Components.h"
+#include CMSIS_device_header
+#include "irq_ctrl.h"
+
+#define  SYSTEM_CLOCK  12000000U
+
+/*----------------------------------------------------------------------------
+  System Core Clock Variable
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = SYSTEM_CLOCK;
+
+/*----------------------------------------------------------------------------
+  System Core Clock update function
+ *----------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)
+{
+  SystemCoreClock = SYSTEM_CLOCK;
+}
+
+/*----------------------------------------------------------------------------
+  System Initialization
+ *----------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+/* do not use global variables because this function is called before
+   reaching pre-main. RW section may be overwritten afterwards.          */
+
+  // Invalidate entire Unified TLB
+  __set_TLBIALL(0);
+
+  // Invalidate entire branch predictor array
+  __set_BPIALL(0);
+  __DSB();
+  __ISB();
+
+  //  Invalidate instruction cache and flush branch target cache
+  __set_ICIALLU(0);
+  __DSB();
+  __ISB();
+
+  //  Invalidate data cache
+  L1C_InvalidateDCacheAll();
+
+#if ((__FPU_PRESENT == 1) && (__FPU_USED == 1))
+  // Enable FPU
+  __FPU_Enable();
+#endif
+
+  // Create Translation Table
+  MMU_CreateTranslationTable();
+
+  // Enable MMU
+  MMU_Enable();
+
+  // Enable Caches
+  L1C_EnableCaches();
+  L1C_EnableBTAC();
+
+#if (__L2C_PRESENT == 1) 
+  // Enable GIC
+  L2C_Enable();
+#endif
+
+  // IRQ Initialize
+  IRQ_Initialize();
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA9/RTE/Device/ARMCA9/system_ARMCA9.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA9/RTE/Device/ARMCA9/system_ARMCA9.h
@@ -1,0 +1,65 @@
+/******************************************************************************
+ * @file     system_ARMCA9.h
+ * @brief    CMSIS Device System Header File for Arm Cortex-A9 Device Series
+ * @version  V1.00
+ * @date     10. January 2018
+ *
+ * @note
+ *
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2018 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __SYSTEM_ARMCA9_H
+#define __SYSTEM_ARMCA9_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+extern uint32_t SystemCoreClock;     /*!< System Clock Frequency (Core Clock)  */
+
+/**
+  \brief Setup the microcontroller system.
+
+   Initialize the System and update the SystemCoreClock variable.
+ */
+extern void SystemInit (void);
+
+
+/**
+  \brief  Update SystemCoreClock variable.
+
+   Updates the SystemCoreClock with current core Clock retrieved from cpu registers.
+ */
+extern void SystemCoreClockUpdate (void);
+
+/**
+  \brief  Create Translation Table.
+
+   Creates Memory Management Unit Translation Table.
+ */
+extern void MMU_CreateTranslationTable(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __SYSTEM_ARMCA9_H */

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA9/Target.clayer.yml
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA9/Target.clayer.yml
@@ -1,0 +1,42 @@
+layer:
+  type: Target
+  description: CA9 target components and files
+
+  packs:
+    - pack: ARM::Cortex_DFP
+
+  device: ARMCA9
+
+  components:
+    # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
+    - component: ARM::CMSIS:CORE
+    - component: Device:Startup
+    - component: Device:IRQ Controller:GIC
+
+  misc:
+    - for-compiler: IAR
+      Link: [--config generic_cortex.icf]
+
+  linker:
+    - script: RTE/Device/ARMCA9/ARMCA9_ac6.sct
+      for-compiler:
+        - AC6
+    - script: RTE/Device/ARMCA9/ARMCA9_gcc.ld
+      for-compiler:
+        - GCC
+    - script: RTE/Device/ARMCA9/ARMCA9_clang.ld
+      for-compiler:
+        - CLANG
+    - script: RTE/Device/ARMCA9/ARMCA9_iar.icf
+      for-compiler:
+        - IAR
+    - regions: RTE/Device/ARMCA9/mem_ARMCA9.h
+      for-compiler:
+        - AC6
+        - GCC
+        - CLANG
+
+  groups:
+    - group: FVP
+      files:
+        - file: ./model_config.txt

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA9/model_config.txt
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CA9/model_config.txt
@@ -1,0 +1,21 @@
+# Parameters:
+# instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+#----------------------------------------------------------------------------------------------
+motherboard.vis.disable_visualisation=1               # (bool  , init-time) default = '0'      : Enable/disable visualisation
+cluster.cpu0.vfp-present=1                            # (bool  , init-time) default = '1'      : Set whether the model has VFP support
+cluster.cpu0.ase-present=0                            # (bool  , init-time) default = '1'      : Set whether model has NEON support
+cluster.cpu0.semihosting-enable=1                     # (bool  , init-time) default = '1'      : Enable semihosting SVC traps. Applications that do not use semihosting must set this parameter to false
+cluster.cpu0.semihosting-hlt-enable=0                 # (bool  , init-time) default = '0'      : Enable semihosting HLT traps. Applications that use HLT semihosting must set this parameter to true and the semihosting-enable parameter to true
+cluster.cpu0.semihosting-ARM_SVC=0x123456             # (int   , init-time) default = '0x123456' : ARM SVC number for semihosting : [0x0..0xFFFFFF]
+cluster.cpu0.semihosting-Thumb_SVC=0xAB               # (int   , init-time) default = '0xAB'   : Thumb SVC number for semihosting : [0x0..0xFF]
+cluster.cpu0.semihosting-ARM_HLT=0xF000               # (int   , init-time) default = '0xF000' : ARM HLT number for semihosting : [0x0..0xFFFF]
+cluster.cpu0.semihosting-Thumb_HLT=0x3C               # (int   , init-time) default = '0x3C'   : Thumb HLT number for semihosting : [0x0..0x3F]
+cluster.cpu0.semihosting-cmd_line=""                  # (string, init-time) default = ''       : Command line available to semihosting SVC calls
+cluster.cpu0.semihosting-heap_base=0x0                # (int   , init-time) default = '0x0'    : Virtual address of heap base : [0x0..0xFFFFFFFF]
+cluster.cpu0.semihosting-heap_limit=0x0               # (int   , init-time) default = '0xFF000000' : Virtual address of top of heap : [0x0..0xFFFFFFFF]
+cluster.cpu0.semihosting-stack_base=0x0               # (int   , init-time) default = '0xFFFF0000' : Virtual address of base of descending stack : [0x0..0xFFFFFFFF]
+cluster.cpu0.semihosting-stack_limit=0x0              # (int   , init-time) default = '0xFF000000' : Virtual address of stack limit : [0x0..0xFFFFFFFF]
+cluster.cpu0.semihosting-cwd=""                       # (string, init-time) default = ''       : Base directory for semihosting file access.
+cluster.dcache-state_modelled=1                       # (bool  , run-time ) default = '0'      : Set whether D-cache has stateful implementation
+cluster.icache-state_modelled=1                       # (bool  , run-time ) default = '0'      : Set whether I-cache has stateful implementation
+#----------------------------------------------------------------------------------------------

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM0/RTE/Device/ARMCM0/ac6_linker_script.sct
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM0/RTE/Device/ARMCM0/ac6_linker_script.sct
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE 8
+#else
+#define __STACKSEAL_SIZE 0
+#endif
+
+/*----------------------------------------------------------------------------
+  Scatter File Definitions definition
+ *----------------------------------------------------------------------------*/
+
+LR_ROM0 __ROM0_BASE __ROM0_SIZE  {
+
+  ER_ROM0 __ROM0_BASE __ROM0_SIZE {
+    *.o (RESET, +First)
+    *(InRoot$$Sections)
+    *(+RO +XO)
+  }
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  ER_CMSE_VENEER AlignExpr(+0, 32) (__ROM0_SIZE - AlignExpr(ImageLength(ER_ROM0), 32)) {
+    *(Veneer$$CMSE)
+  }
+#endif
+
+  RW_NOINIT __RAM0_BASE UNINIT (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE) {
+    *(.bss.noinit)
+  }
+
+  RW_RAM0 AlignExpr(+0, 8) (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE - AlignExpr(ImageLength(RW_NOINIT), 8)) {
+    *(+RW +ZI)
+  }
+
+#if __HEAP_SIZE > 0
+  ARM_LIB_HEAP  (AlignExpr(+0, 8)) EMPTY __HEAP_SIZE  {   ; Reserve empty region for heap
+  }
+#endif
+
+  ARM_LIB_STACK (__RAM0_BASE + __RAM0_SIZE - __STACKSEAL_SIZE) EMPTY -__STACK_SIZE {   ; Reserve empty region for stack
+  }
+
+#if __STACKSEAL_SIZE > 0
+  STACKSEAL +0 EMPTY __STACKSEAL_SIZE {             ; Reserve empty region for stack seal immediately after stack
+  }
+#endif
+
+#if __RAM1_SIZE > 0
+  RW_RAM1 __RAM1_BASE __RAM1_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+
+#if __RAM2_SIZE > 0
+  RW_RAM2 __RAM2_BASE __RAM2_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+
+#if __RAM3_SIZE > 0
+  RW_RAM3 __RAM3_BASE __RAM3_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+}
+
+#if __ROM1_SIZE > 0
+LR_ROM1 __ROM1_BASE __ROM1_SIZE  {
+  ER_ROM1 +0 __ROM1_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif
+
+#if __ROM2_SIZE > 0
+LR_ROM2 __ROM2_BASE __ROM2_SIZE  {
+  ER_ROM2 +0 __ROM2_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif
+
+#if __ROM3_SIZE > 0
+LR_ROM3 __ROM3_BASE __ROM3_SIZE  {
+  ER_ROM3 +0 __ROM3_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM0/RTE/Device/ARMCM0/clang_linker_script.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM0/RTE/Device/ARMCM0/clang_linker_script.ld
@@ -1,0 +1,361 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2019 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+/* ----------------------------------------------------------------------------
+  Memory definition
+ *----------------------------------------------------------------------------*/
+MEMORY
+{
+  ROM0  (rx!w)  : ORIGIN = __ROM0_BASE, LENGTH = __ROM0_SIZE
+#if __ROM1_SIZE > 0
+  ROM1  (rx!w)  : ORIGIN = __ROM1_BASE, LENGTH = __ROM1_SIZE
+#endif
+#if __ROM2_SIZE > 0
+  ROM2  (rx!w)  : ORIGIN = __ROM2_BASE, LENGTH = __ROM2_SIZE
+#endif
+#if __ROM3_SIZE > 0
+  ROM3  (rx!w)  : ORIGIN = __ROM3_BASE, LENGTH = __ROM3_SIZE
+#endif
+
+  RAM0  (w!rx) : ORIGIN = __RAM0_BASE, LENGTH = __RAM0_SIZE
+#if __RAM1_SIZE > 0
+  RAM1  (w!rx) : ORIGIN = __RAM1_BASE, LENGTH = __RAM1_SIZE
+#endif
+#if __RAM2_SIZE > 0
+  RAM2  (w!rx) : ORIGIN = __RAM2_BASE, LENGTH = __RAM2_SIZE
+#endif
+#if __RAM3_SIZE > 0
+  RAM3  (w!rx) : ORIGIN = __RAM3_BASE, LENGTH = __RAM3_SIZE
+#endif
+}
+
+ENTRY(Reset_Handler)
+
+PHDRS
+{
+	text PT_LOAD;
+	ram PT_LOAD;
+	ram_init PT_LOAD;
+	tls PT_TLS;
+}
+
+SECTIONS
+{
+	.init : {
+		KEEP (*(.vectors))
+		KEEP (*(.text.init.enter))
+		KEEP (*(.data.init.enter))
+		KEEP (*(SORT_BY_NAME(.init) SORT_BY_NAME(.init.*)))
+	} >ROM0 AT>ROM0 :text
+
+	.text : {
+
+		/* code */
+		*(.text.unlikely .text.unlikely.*)
+		*(.text.startup .text.startup.*)
+		*(.text .text.* .opd .opd.*)
+		*(.gnu.linkonce.t.*)
+		KEEP (*(.fini .fini.*))
+		__text_end = .;
+
+		PROVIDE (__etext = __text_end);
+		PROVIDE (_etext = __text_end);
+		PROVIDE (etext = __text_end);
+
+		/* read-only data */
+		*(.rdata)
+		*(.rodata .rodata.*)
+		*(.gnu.linkonce.r.*)
+
+		*(.srodata.cst16)
+		*(.srodata.cst8)
+		*(.srodata.cst4)
+		*(.srodata.cst2)
+		*(.srodata .srodata.*)
+		*(.data.rel.ro .data.rel.ro.*)
+		*(.got .got.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		/* lists of constructors and destructors */
+		PROVIDE_HIDDEN ( __preinit_array_start = . );
+		KEEP (*(.preinit_array))
+		PROVIDE_HIDDEN ( __preinit_array_end = . );
+
+		PROVIDE_HIDDEN ( __init_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+		KEEP (*(.init_array .ctors))
+		PROVIDE_HIDDEN ( __init_array_end = . );
+
+		PROVIDE_HIDDEN ( __fini_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
+		KEEP (*(.fini_array .dtors))
+		PROVIDE_HIDDEN ( __fini_array_end = . );
+
+	} >ROM0 AT>ROM0 :text
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+	.veneers :
+	{
+		. = ALIGN(32);
+		KEEP(*(.gnu.sgstubs))
+	} > ROM0 AT>ROM0 :text
+#endif
+
+	.toc : {
+		*(.toc .toc.*)
+	} >ROM0 AT>ROM0 :text
+
+	/* additional sections when compiling with C++ exception support */
+	
+	.except_ordered : {
+		*(.gcc_except_table *.gcc_except_table.*)
+		KEEP (*(.eh_frame .eh_frame.*))
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+	} >ROM0 AT>ROM0 :text
+
+	.except_unordered : {
+		. = ALIGN(8);
+
+		PROVIDE(__exidx_start = .);
+		*(.ARM.exidx*)
+		PROVIDE(__exidx_end = .);
+	} >ROM0 AT>ROM0 :text
+	
+
+	/*
+	 * Data values which are preserved across reset
+	 */
+	.preserve (NOLOAD) : {
+		PROVIDE(__preserve_start__ = .);
+		KEEP(*(SORT_BY_NAME(.preserve.*)))
+		KEEP(*(.preserve))
+		PROVIDE(__preserve_end__ = .);
+	} >RAM0 AT>RAM0 :ram
+
+	.data :  {
+		*(.data .data.*)
+		*(.gnu.linkonce.d.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		PROVIDE( __global_pointer$ = . + 0x800 );
+		*(.sdata .sdata.* .sdata2.*)
+		*(.gnu.linkonce.s.*)
+	} >RAM0 AT>ROM0 :ram_init
+	PROVIDE(__data_start = ADDR(.data));
+	PROVIDE(__data_source = LOADADDR(.data));
+
+	/* Thread local initialized data. This gets
+	 * space allocated as it is expected to be placed
+	 * in ram to be used as a template for TLS data blocks
+	 * allocated at runtime. We're slightly abusing that
+	 * by placing the data in flash where it will be copied
+	 * into the allocate ram addresses by the existing
+	 * data initialization code in crt0
+	 */
+	.tdata :  {
+		*(.tdata .tdata.* .gnu.linkonce.td.*)
+		PROVIDE(__data_end = .);
+		PROVIDE(__tdata_end = .);
+	} >RAM0 AT>ROM0 :tls :ram_init
+	PROVIDE( __tls_base = ADDR(.tdata));
+	PROVIDE( __tdata_start = ADDR(.tdata));
+	PROVIDE( __tdata_source = LOADADDR(.tdata) );
+	PROVIDE( __tdata_source_end = LOADADDR(.tdata) + SIZEOF(.tdata) );
+	PROVIDE( __data_source_end = __tdata_source_end );
+	PROVIDE( __tdata_size = SIZEOF(.tdata) );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata),ALIGNOF(.tbss)) );
+
+	PROVIDE( __edata = __data_end );
+	PROVIDE( _edata = __data_end );
+	PROVIDE( edata = __data_end );
+	PROVIDE( __data_size = __data_end - __data_start );
+	PROVIDE( __data_source_size = __data_source_end - __data_source );
+
+	.tbss (NOLOAD) : {
+		*(.tbss .tbss.* .gnu.linkonce.tb.*)
+		*(.tcommon)
+		PROVIDE( __tls_end = . );
+		PROVIDE( __tbss_end = . );
+	} >RAM0 AT>RAM0 :tls :ram
+	PROVIDE( __bss_start = ADDR(.tbss));
+	PROVIDE( __tbss_start = ADDR(.tbss));
+	PROVIDE( __tbss_offset = ADDR(.tbss) - ADDR(.tdata) );
+	PROVIDE( __tbss_size = SIZEOF(.tbss) );
+	PROVIDE( __tls_size = __tls_end - __tls_base );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
+	PROVIDE( __arm32_tls_tcb_offset = MAX(8, __tls_align) );
+	PROVIDE( __arm64_tls_tcb_offset = MAX(16, __tls_align) );
+
+	/*
+	 * The linker special cases .tbss segments which are
+	 * identified as segments which are not loaded and are
+	 * thread_local.
+	 *
+	 * For these segments, the linker does not advance 'dot'
+	 * across them.  We actually need memory allocated for tbss,
+	 * so we create a special segment here just to make room
+	 */
+	/*
+	.tbss_space (NOLOAD) : {
+		. = ADDR(.tbss);
+		. = . + SIZEOF(.tbss);
+	} >RAM0 AT>RAM0 :ram
+	*/
+
+	.bss (NOLOAD) : {
+		*(.sbss*)
+		*(.gnu.linkonce.sb.*)
+		*(.bss .bss.*)
+		*(.gnu.linkonce.b.*)
+		*(COMMON)
+
+		/* Align the heap */
+		. = ALIGN(8);
+		__bss_end = .;
+	} >RAM0 AT>RAM0 :ram
+	PROVIDE( __non_tls_bss_start = ADDR(.bss) );
+	PROVIDE( __end = __bss_end );
+	PROVIDE( _end = __bss_end );
+	PROVIDE( end = __bss_end );
+	PROVIDE( __bss_size = __bss_end - __bss_start );
+
+	/* Make the rest of memory available for heap storage */
+	PROVIDE (__heap_start = __end);
+#ifdef __HEAP_SIZE
+	PROVIDE (__heap_end = __heap_start + __HEAP_SIZE);
+	PROVIDE (__heap_size = __HEAP_SIZE);
+#else
+	PROVIDE (__heap_end = __stack - __STACK_SIZE);
+	PROVIDE (__heap_size = __heap_end - __heap_start);
+#endif
+	.heap (NOLOAD) : {
+		. += __heap_size;
+	} >RAM0 :ram
+
+	/* Define a stack region to make sure it fits in memory */
+	PROVIDE(__stack = ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE);
+	PROVIDE(__stack_limit = __stack - __STACK_SIZE);
+	.stack (__stack_limit) (NOLOAD) : {
+		. += __STACK_SIZE;
+	} >RAM0 :ram
+
+#if __STACKSEAL_SIZE > 0
+	PROVIDE(__stack_seal = __stack);
+  	.stackseal (__stack) (NOLOAD) :
+  	{
+    	. += __STACKSEAL_SIZE;
+  	} >RAM0 :ram
+#endif
+
+	/* Throw away C++ exception handling information */
+
+	/*
+
+	/DISCARD/ : {
+		*(.note .note.*)
+		*(.eh_frame .eh_frame.*)
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+		*(.ARM.exidx*)
+	}
+
+	*/
+
+	/* Stabs debugging sections.  */
+	.stab          0 : { *(.stab) }
+	.stabstr       0 : { *(.stabstr) }
+	.stab.excl     0 : { *(.stab.excl) }
+	.stab.exclstr  0 : { *(.stab.exclstr) }
+	.stab.index    0 : { *(.stab.index) }
+	.stab.indexstr 0 : { *(.stab.indexstr) }
+	.comment       0 : { *(.comment) }
+	.gnu.build.attributes : { *(.gnu.build.attributes .gnu.build.attributes.*) }
+	/* DWARF debug sections.
+	   Symbols in the DWARF debugging sections are relative to the beginning
+	   of the section so we begin them at 0.  */
+	/* DWARF 1.  */
+	.debug          0 : { *(.debug) }
+	.line           0 : { *(.line) }
+	/* GNU DWARF 1 extensions.  */
+	.debug_srcinfo  0 : { *(.debug_srcinfo) }
+	.debug_sfnames  0 : { *(.debug_sfnames) }
+	/* DWARF 1.1 and DWARF 2.  */
+	.debug_aranges  0 : { *(.debug_aranges) }
+	.debug_pubnames 0 : { *(.debug_pubnames) }
+	/* DWARF 2.  */
+	.debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+	.debug_abbrev   0 : { *(.debug_abbrev) }
+	.debug_line     0 : { *(.debug_line .debug_line.* .debug_line_end) }
+	.debug_frame    0 : { *(.debug_frame) }
+	.debug_str      0 : { *(.debug_str) }
+	.debug_loc      0 : { *(.debug_loc) }
+	.debug_macinfo  0 : { *(.debug_macinfo) }
+	/* SGI/MIPS DWARF 2 extensions.  */
+	.debug_weaknames 0 : { *(.debug_weaknames) }
+	.debug_funcnames 0 : { *(.debug_funcnames) }
+	.debug_typenames 0 : { *(.debug_typenames) }
+	.debug_varnames  0 : { *(.debug_varnames) }
+	/* DWARF 3.  */
+	.debug_pubtypes 0 : { *(.debug_pubtypes) }
+	.debug_ranges   0 : { *(.debug_ranges) }
+	/* DWARF 5.  */
+	.debug_addr     0 : { *(.debug_addr) }
+	.debug_line_str 0 : { *(.debug_line_str) }
+	.debug_loclists 0 : { *(.debug_loclists) }
+	.debug_macro    0 : { *(.debug_macro) }
+	.debug_names    0 : { *(.debug_names) }
+	.debug_rnglists 0 : { *(.debug_rnglists) }
+	.debug_str_offsets 0 : { *(.debug_str_offsets) }
+	.debug_sup      0 : { *(.debug_sup) }
+	.gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }
+}
+/*
+ * Check that sections that are copied from flash to RAM have matching
+ * padding, so that a single memcpy() of __data_size copies the correct bytes.
+ */
+ASSERT( __data_size == __data_source_size,
+	"ERROR: .data/.tdata flash size does not match RAM size");

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM0/RTE/Device/ARMCM0/gcc_linker_script.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM0/RTE/Device/ARMCM0/gcc_linker_script.ld
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+/* ----------------------------------------------------------------------------
+  Memory definition
+ *----------------------------------------------------------------------------*/
+MEMORY
+{
+  ROM0  (rx)  : ORIGIN = __ROM0_BASE, LENGTH = __ROM0_SIZE
+#if __ROM1_SIZE > 0
+  ROM1  (rx)  : ORIGIN = __ROM1_BASE, LENGTH = __ROM1_SIZE
+#endif
+#if __ROM2_SIZE > 0
+  ROM2  (rx)  : ORIGIN = __ROM2_BASE, LENGTH = __ROM2_SIZE
+#endif
+#if __ROM3_SIZE > 0
+  ROM3  (rx)  : ORIGIN = __ROM3_BASE, LENGTH = __ROM3_SIZE
+#endif
+
+  RAM0  (rwx) : ORIGIN = __RAM0_BASE, LENGTH = __RAM0_SIZE
+#if __RAM1_SIZE > 0
+  RAM1  (rwx) : ORIGIN = __RAM1_BASE, LENGTH = __RAM1_SIZE
+#endif
+#if __RAM2_SIZE > 0
+  RAM2  (rwx) : ORIGIN = __RAM2_BASE, LENGTH = __RAM2_SIZE
+#endif
+#if __RAM3_SIZE > 0
+  RAM3  (rwx) : ORIGIN = __RAM3_BASE, LENGTH = __RAM3_SIZE
+#endif
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __copy_table_start__
+ *   __copy_table_end__
+ *   __zero_table_start__
+ *   __zero_table_end__
+ *   __etext          (deprecated)
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+  .text :
+  {
+    KEEP(*(.vectors))
+    *(.text*)
+
+    KEEP(*(.init))
+    KEEP(*(.fini))
+
+    /* .ctors */
+    *crtbegin.o(.ctors)
+    *crtbegin?.o(.ctors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+    *(SORT(.ctors.*))
+    *(.ctors)
+
+    /* .dtors */
+    *crtbegin.o(.dtors)
+    *crtbegin?.o(.dtors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+    *(SORT(.dtors.*))
+    *(.dtors)
+
+    *(.rodata*)
+
+    KEEP(*(.eh_frame*))
+  } > ROM0
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  .gnu.sgstubs :
+  {
+    . = ALIGN(32);
+  } > ROM0
+#endif
+
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > ROM0
+
+  __exidx_start = .;
+  .ARM.exidx :
+  {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+  } > ROM0
+  __exidx_end = .;
+
+  .copy.table :
+  {
+    . = ALIGN(4);
+    __copy_table_start__ = .;
+
+    LONG (LOADADDR(.data))
+    LONG (ADDR(.data))
+    LONG (SIZEOF(.data) / 4)
+
+    /* Add each additional data section here */
+/*
+    LONG (LOADADDR(.data2))
+    LONG (ADDR(.data2))
+    LONG (SIZEOF(.data2) / 4)
+*/
+    __copy_table_end__ = .;
+  } > ROM0
+
+  .zero.table :
+  {
+    . = ALIGN(4);
+    __zero_table_start__ = .;
+
+/*  .bss initialization to zero is already done during C Run-Time Startup.
+    LONG (ADDR(.bss))
+    LONG (SIZEOF(.bss) / 4)
+*/
+
+    /* Add each additional bss section here */
+/*
+    LONG (ADDR(.bss2))
+    LONG (SIZEOF(.bss2) / 4)
+*/
+    __zero_table_end__ = .;
+  } > ROM0
+
+  /*
+   * This __etext variable is kept for backward compatibility with older,
+   * ASM based startup files.
+   */
+  PROVIDE(__etext = LOADADDR(.data));
+
+  .data : ALIGN(4)
+  {
+    __data_start__ = .;
+    *(vtable)
+    *(.data)
+    *(.data.*)
+
+    . = ALIGN(4);
+    /* preinit data */
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP(*(.preinit_array))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+
+    . = ALIGN(4);
+    /* init data */
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP(*(SORT(.init_array.*)))
+    KEEP(*(.init_array))
+    PROVIDE_HIDDEN (__init_array_end = .);
+
+    . = ALIGN(4);
+    /* finit data */
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP(*(SORT(.fini_array.*)))
+    KEEP(*(.fini_array))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    /* All data end */
+    __data_end__ = .;
+
+  } > RAM0 AT > ROM0
+
+  /*
+   * Secondary data section, optional
+   *
+   * Remember to add each additional data section
+   * to the .copy.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .data2 : ALIGN(4)
+  {
+    . = ALIGN(4);
+    __data2_start__ = .;
+    *(.data2)
+    *(.data2.*)
+    . = ALIGN(4);
+    __data2_end__ = .;
+
+  } > RAM1 AT > ROM0 
+*/
+
+  .bss :
+  {
+    . = ALIGN(4);
+    __bss_start__ = .;
+    *(.bss)
+    *(.bss.*)
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+  } > RAM0 AT > RAM0
+
+  /*
+   * Secondary bss section, optional
+   *
+   * Remember to add each additional bss section
+   * to the .zero.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .bss2 :
+  {
+    . = ALIGN(4);
+    __bss2_start__ = .;
+    *(.bss2)
+    *(.bss2.*)
+    . = ALIGN(4);
+    __bss2_end__ = .;
+  } > RAM1 AT > RAM1
+*/
+
+  .heap (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE(end = .);
+    . = . + __HEAP_SIZE;
+    . = ALIGN(8);
+    __HeapLimit = .;
+  } > RAM0
+
+  .stack (ORIGIN(RAM0) + LENGTH(RAM0) - __STACK_SIZE - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackLimit = .;
+    . = . + __STACK_SIZE;
+    . = ALIGN(8);
+    __StackTop = .;
+  } > RAM0
+  PROVIDE(__stack = __StackTop);
+
+#if __STACKSEAL_SIZE > 0
+  .stackseal (ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackSeal = .;
+    . = . + 8;
+    . = ALIGN(8);
+  } > RAM0
+#endif
+
+  /* Check if data + heap + stack exceeds RAM limit */
+  ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM0/RTE/Device/ARMCM0/iar_linker_script.icf
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM0/RTE/Device/ARMCM0/iar_linker_script.icf
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+define memory mem with size = 4G;
+
+#if __ROM0_SIZE > 0
+  define region ROM0_region = mem:[from __ROM0_BASE to (__ROM0_BASE+__ROM0_SIZE-1)];
+#else
+  define region ROM0_region = [];
+#endif
+
+#if __ROM1_SIZE > 0
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+#else
+  define region ROM1_region = [];
+#endif
+
+#if __ROM2_SIZE > 0
+  define region ROM2_region = mem:[from __ROM2_BASE to (__ROM2_BASE+__ROM2_SIZE-1)];
+#else
+  define region ROM2_region = [];
+#endif
+
+#if __ROM3_SIZE > 0
+  define region ROM3_region = mem:[from __ROM3_BASE to (__ROM3_BASE+__ROM3_SIZE-1)];
+#else
+  define region ROM3_region = [];
+#endif
+
+define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_region;
+
+#if __RAM0_SIZE > 0
+  define region RAM0_region = mem:[from __RAM0_BASE to (__RAM0_BASE+__RAM0_SIZE-1)];
+#else
+  define region RAM0_region = [];
+#endif
+
+#if __RAM1_SIZE > 0
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+#else
+  define region RAM1_region = [];
+#endif
+
+#if __RAM2_SIZE > 0
+  define region RAM2_region = mem:[from __RAM2_BASE to (__RAM2_BASE+__RAM2_SIZE-1)];
+#else
+  define region RAM2_region = [];
+#endif
+
+#if __RAM3_SIZE > 0
+  define region RAM3_region = mem:[from __RAM3_BASE to (__RAM3_BASE+__RAM3_SIZE-1)];
+#else
+  define region RAM3_region = [];
+#endif
+
+define region RAM_region = RAM0_region | RAM1_region | RAM2_region | RAM3_region;
+
+do not initialize  { section .noinit };
+initialize by copy { readwrite };
+if (isdefinedsymbol(__USE_DLIB_PERTHREAD))
+{
+  // Required in a multi-threaded application
+  initialize by copy with packing = none { section __DLIB_PERTHREAD };
+}
+
+place at address mem:__ROM0_BASE { readonly section .intvec };
+
+if (!isempty(ROM_region))
+{
+  place in ROM_region  { readonly };
+}
+
+if (!isempty(RAM_region))
+{
+  define block CSTACK     with alignment = 8, size = __STACK_SIZE     { };
+  define block PROC_STACK with alignment = 8, size = 0 { };
+  define block HEAP       with alignment = 8, size = __HEAP_SIZE       { };
+  place in RAM_region  { readwrite, block CSTACK, block PROC_STACK, block HEAP };
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM0/RTE/Device/ARMCM0/regions_ARMCM0.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM0/RTE/Device/ARMCM0/regions_ARMCM0.h
@@ -1,0 +1,60 @@
+#ifndef REGIONS_ARMCM0_H
+#define REGIONS_ARMCM0_H
+
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+// <n>Device pack:   ARM::Cortex_DFP@1.0.0-dev16
+// <i>Device pack used to generate this file
+
+// <h>ROM Configuration
+// =======================
+// <h> ROM=<__ROM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x00000000
+#define __ROM0_BASE 0x00000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00040000
+#define __ROM0_SIZE 0x00040000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __ROM0_DEFAULT 1
+//   <q>Startup
+//   <i> Selects region to be used for startup code.
+#define __ROM0_STARTUP 1
+// </h>
+
+// </h>
+
+// <h>RAM Configuration
+// =======================
+// <h> RAM=<__RAM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x20000000
+#define __RAM0_BASE 0x20000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00020000
+#define __RAM0_SIZE 0x00020000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __RAM0_DEFAULT 1
+//   <q>No zero initialize
+//   <i> Excludes region from zero initialization.
+#define __RAM0_NOINIT 0
+// </h>
+
+// </h>
+
+// <h>Stack / Heap Configuration
+//   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+#define __STACK_SIZE 0x00000400
+#define __HEAP_SIZE 0x00000C00
+// </h>
+
+
+#endif /* REGIONS_ARMCM0_H */

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM0/RTE/Device/ARMCM0/startup_ARMCM0.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM0/RTE/Device/ARMCM0/startup_ARMCM0.c
@@ -1,0 +1,146 @@
+/******************************************************************************
+ * @file     startup_ARMCM0.c
+ * @brief    CMSIS-Core(M) Device Startup File for a Cortex-M0 Device
+ * @version  V2.0.3
+ * @date     31. March 2020
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2020 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (ARMCM0)
+  #include "ARMCM0.h"
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  External References
+ *----------------------------------------------------------------------------*/
+extern uint32_t __INITIAL_SP;
+
+extern __NO_RETURN void __PROGRAM_START(void);
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler  (void);
+            void Default_Handler(void);
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+/* Exceptions */
+void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void HardFault_Handler      (void) __attribute__ ((weak));
+void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+
+void Interrupt0_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt1_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt2_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt3_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt4_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt5_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt6_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt7_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt8_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt9_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[48];
+       const VECTOR_TABLE_Type __VECTOR_TABLE[48] __VECTOR_TABLE_ATTRIBUTE = {
+  (VECTOR_TABLE_Type)(&__INITIAL_SP),       /*     Initial Stack Pointer */
+  Reset_Handler,                            /*     Reset Handler */
+  NMI_Handler,                              /* -14 NMI Handler */
+  HardFault_Handler,                        /* -13 Hard Fault Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  SVC_Handler,                              /*  -5 SVCall Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  PendSV_Handler,                           /*  -2 PendSV Handler */
+  SysTick_Handler,                          /*  -1 SysTick Handler */
+
+  /* Interrupts */
+  Interrupt0_Handler,                       /*   0 Interrupt 0 */
+  Interrupt1_Handler,                       /*   1 Interrupt 1 */
+  Interrupt2_Handler,                       /*   2 Interrupt 2 */
+  Interrupt3_Handler,                       /*   3 Interrupt 3 */
+  Interrupt4_Handler,                       /*   4 Interrupt 4 */
+  Interrupt5_Handler,                       /*   5 Interrupt 5 */
+  Interrupt6_Handler,                       /*   6 Interrupt 6 */
+  Interrupt7_Handler,                       /*   7 Interrupt 7 */
+  Interrupt8_Handler,                       /*   8 Interrupt 8 */
+  Interrupt9_Handler                        /*   9 Interrupt 9 */
+                                            /* Interrupts 10..31 are left out */
+};
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler(void)
+{
+  SystemInit();                             /* CMSIS System Initialization */
+  __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
+}
+
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wmissing-noreturn"
+#endif
+
+/*----------------------------------------------------------------------------
+  Hard Fault Handler
+ *----------------------------------------------------------------------------*/
+void HardFault_Handler(void)
+{
+  while(1);
+}
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+void Default_Handler(void)
+{
+  while(1);
+}
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic pop
+#endif
+

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM0/RTE/Device/ARMCM0/system_ARMCM0.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM0/RTE/Device/ARMCM0/system_ARMCM0.c
@@ -1,0 +1,56 @@
+/**************************************************************************//**
+ * @file     system_ARMCM0.c
+ * @brief    CMSIS Device System Source File for
+ *           ARMCM0 Device
+ * @version  V1.0.0
+ * @date     09. July 2018
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2018 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ARMCM0.h"
+
+/*----------------------------------------------------------------------------
+  Define clocks
+ *----------------------------------------------------------------------------*/
+#define  XTAL            (50000000UL)     /* Oscillator frequency */
+
+#define  SYSTEM_CLOCK    (XTAL / 2U)
+
+
+/*----------------------------------------------------------------------------
+  System Core Clock Variable
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = SYSTEM_CLOCK;  /* System Core Clock Frequency */
+
+
+/*----------------------------------------------------------------------------
+  System Core Clock update function
+ *----------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)
+{
+  SystemCoreClock = SYSTEM_CLOCK;
+}
+
+/*----------------------------------------------------------------------------
+  System initialization function
+ *----------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+  SystemCoreClock = SYSTEM_CLOCK;
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM0/RTE/Device/ARMCM0/tiac_arm.cmd
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM0/RTE/Device/ARMCM0/tiac_arm.cmd
@@ -1,0 +1,41 @@
+/****************************************************************************/
+/* tiac_arm.cmd - COMMAND FILE FOR LINKING ARM C PROGRAMS                   */
+/*                                                                          */
+/*   Description: This file is a sample command file that can be used       */
+/*                for linking programs built with the TI Arm Clang          */
+/*                Compiler.   Use it as a guideline; you may want to change */
+/*                the allocation scheme according to the size of your       */
+/*                program and the memory layout of your target system.      */
+/*                                                                          */
+/****************************************************************************/
+-c                                         /* LINK USING C CONVENTIONS      */
+-stack  0x4000                             /* SOFTWARE STACK SIZE           */
+-heap   0x4000                             /* HEAP AREA SIZE                */
+--args 0x1000
+
+/* SPECIFY THE SYSTEM MEMORY MAP */
+MEMORY
+{
+    V_MEM    : org = 0x00000000   len = 0x00001000  /* INT VECTOR */
+    P_MEM    : org = 0x00001000   len = 0x20000000  /* PROGRAM MEMORY (ROM) */
+    D_MEM    : org = 0x20001000   len = 0x20000000  /* DATA MEMORY    (RAM) */
+}
+
+/* SPECIFY THE SECTIONS ALLOCATION INTO MEMORY */
+SECTIONS
+{
+    .intvecs    : {} > 0x0             /* INTERRUPT VECTORS                 */
+    .bss        : {} > D_MEM           /* GLOBAL & STATIC VARS              */
+    .data       : {} > D_MEM
+    .sysmem     : {} > D_MEM           /* DYNAMIC MEMORY ALLOCATION AREA    */
+    .stack      : {} > D_MEM           /* SOFTWARE SYSTEM STACK             */
+
+    .text       : {} > P_MEM           /* CODE                              */
+    .cinit      : {} > P_MEM           /* INITIALIZATION TABLES             */
+    .const      : {} > P_MEM           /* CONSTANT DATA                     */
+    .rodata     : {} > P_MEM, palign(4)
+    .init_array : {} > P_MEM           /* C++ CONSTRUCTOR TABLES            */
+
+
+    .TI.ramfunc : {} load=P_MEM, run=D_MEM, table(BINIT)
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM0/Target.clayer.yml
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM0/Target.clayer.yml
@@ -1,0 +1,32 @@
+layer:
+  type: Target
+  description: CM0 target components and files
+
+  packs:
+    - pack: ARM::Cortex_DFP
+
+  device: ARMCM0
+
+  components:
+    # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
+    - component: ARM::CMSIS:CORE
+    - component: Device:Startup&C Startup
+
+  groups:
+    - group: FVP
+      files:
+        - file: ./model_config.txt
+
+  linker:
+    - for-compiler: AC6
+      script: RTE/Device/$Dname$/ac6_linker_script.sct
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: GCC
+      script: RTE/Device/$Dname$/gcc_linker_script.ld
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: CLANG
+      script: RTE/Device/$Dname$/clang_linker_script.ld
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: IAR
+      script: RTE/Device/$Dname$/iar_linker_script.icf
+      regions: RTE/Device/$Dname$/regions_$Dname$.h

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM0/model_config.txt
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM0/model_config.txt
@@ -1,0 +1,8 @@
+# Parameters:
+# instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+#------------------------------------------------------------------------------
+fvp_mps2.UART0.out_file=-                             # (string, init-time) default = ''       : Output file to hold data written by the UART (use '-' to send all output to stdout)
+fvp_mps2.UART0.shutdown_on_eot=1                      # (bool  , init-time) default = '0'      : Shutdown simulation when a EOT (ASCII 4) char is transmitted (useful for regression tests when semihosting is not available)
+fvp_mps2.UART0.unbuffered_output=1                    # (bool  , init-time) default = '0'      : Unbuffered output
+fvp_mps2.mps2_visualisation.disable-visualisation=1   # (bool  , init-time) default = '0'      : Enable/disable visualisation
+#------------------------------------------------------------------------------

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM0plus/RTE/Device/ARMCM0P/ac6_linker_script.sct
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM0plus/RTE/Device/ARMCM0P/ac6_linker_script.sct
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE 8
+#else
+#define __STACKSEAL_SIZE 0
+#endif
+
+/*----------------------------------------------------------------------------
+  Scatter File Definitions definition
+ *----------------------------------------------------------------------------*/
+
+LR_ROM0 __ROM0_BASE __ROM0_SIZE  {
+
+  ER_ROM0 __ROM0_BASE __ROM0_SIZE {
+    *.o (RESET, +First)
+    *(InRoot$$Sections)
+    *(+RO +XO)
+  }
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  ER_CMSE_VENEER AlignExpr(+0, 32) (__ROM0_SIZE - AlignExpr(ImageLength(ER_ROM0), 32)) {
+    *(Veneer$$CMSE)
+  }
+#endif
+
+  RW_NOINIT __RAM0_BASE UNINIT (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE) {
+    *(.bss.noinit)
+  }
+
+  RW_RAM0 AlignExpr(+0, 8) (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE - AlignExpr(ImageLength(RW_NOINIT), 8)) {
+    *(+RW +ZI)
+  }
+
+#if __HEAP_SIZE > 0
+  ARM_LIB_HEAP  (AlignExpr(+0, 8)) EMPTY __HEAP_SIZE  {   ; Reserve empty region for heap
+  }
+#endif
+
+  ARM_LIB_STACK (__RAM0_BASE + __RAM0_SIZE - __STACKSEAL_SIZE) EMPTY -__STACK_SIZE {   ; Reserve empty region for stack
+  }
+
+#if __STACKSEAL_SIZE > 0
+  STACKSEAL +0 EMPTY __STACKSEAL_SIZE {             ; Reserve empty region for stack seal immediately after stack
+  }
+#endif
+
+#if __RAM1_SIZE > 0
+  RW_RAM1 __RAM1_BASE __RAM1_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+
+#if __RAM2_SIZE > 0
+  RW_RAM2 __RAM2_BASE __RAM2_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+
+#if __RAM3_SIZE > 0
+  RW_RAM3 __RAM3_BASE __RAM3_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+}
+
+#if __ROM1_SIZE > 0
+LR_ROM1 __ROM1_BASE __ROM1_SIZE  {
+  ER_ROM1 +0 __ROM1_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif
+
+#if __ROM2_SIZE > 0
+LR_ROM2 __ROM2_BASE __ROM2_SIZE  {
+  ER_ROM2 +0 __ROM2_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif
+
+#if __ROM3_SIZE > 0
+LR_ROM3 __ROM3_BASE __ROM3_SIZE  {
+  ER_ROM3 +0 __ROM3_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM0plus/RTE/Device/ARMCM0P/clang_linker_script.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM0plus/RTE/Device/ARMCM0P/clang_linker_script.ld
@@ -1,0 +1,361 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2019 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+/* ----------------------------------------------------------------------------
+  Memory definition
+ *----------------------------------------------------------------------------*/
+MEMORY
+{
+  ROM0  (rx!w)  : ORIGIN = __ROM0_BASE, LENGTH = __ROM0_SIZE
+#if __ROM1_SIZE > 0
+  ROM1  (rx!w)  : ORIGIN = __ROM1_BASE, LENGTH = __ROM1_SIZE
+#endif
+#if __ROM2_SIZE > 0
+  ROM2  (rx!w)  : ORIGIN = __ROM2_BASE, LENGTH = __ROM2_SIZE
+#endif
+#if __ROM3_SIZE > 0
+  ROM3  (rx!w)  : ORIGIN = __ROM3_BASE, LENGTH = __ROM3_SIZE
+#endif
+
+  RAM0  (w!rx) : ORIGIN = __RAM0_BASE, LENGTH = __RAM0_SIZE
+#if __RAM1_SIZE > 0
+  RAM1  (w!rx) : ORIGIN = __RAM1_BASE, LENGTH = __RAM1_SIZE
+#endif
+#if __RAM2_SIZE > 0
+  RAM2  (w!rx) : ORIGIN = __RAM2_BASE, LENGTH = __RAM2_SIZE
+#endif
+#if __RAM3_SIZE > 0
+  RAM3  (w!rx) : ORIGIN = __RAM3_BASE, LENGTH = __RAM3_SIZE
+#endif
+}
+
+ENTRY(Reset_Handler)
+
+PHDRS
+{
+	text PT_LOAD;
+	ram PT_LOAD;
+	ram_init PT_LOAD;
+	tls PT_TLS;
+}
+
+SECTIONS
+{
+	.init : {
+		KEEP (*(.vectors))
+		KEEP (*(.text.init.enter))
+		KEEP (*(.data.init.enter))
+		KEEP (*(SORT_BY_NAME(.init) SORT_BY_NAME(.init.*)))
+	} >ROM0 AT>ROM0 :text
+
+	.text : {
+
+		/* code */
+		*(.text.unlikely .text.unlikely.*)
+		*(.text.startup .text.startup.*)
+		*(.text .text.* .opd .opd.*)
+		*(.gnu.linkonce.t.*)
+		KEEP (*(.fini .fini.*))
+		__text_end = .;
+
+		PROVIDE (__etext = __text_end);
+		PROVIDE (_etext = __text_end);
+		PROVIDE (etext = __text_end);
+
+		/* read-only data */
+		*(.rdata)
+		*(.rodata .rodata.*)
+		*(.gnu.linkonce.r.*)
+
+		*(.srodata.cst16)
+		*(.srodata.cst8)
+		*(.srodata.cst4)
+		*(.srodata.cst2)
+		*(.srodata .srodata.*)
+		*(.data.rel.ro .data.rel.ro.*)
+		*(.got .got.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		/* lists of constructors and destructors */
+		PROVIDE_HIDDEN ( __preinit_array_start = . );
+		KEEP (*(.preinit_array))
+		PROVIDE_HIDDEN ( __preinit_array_end = . );
+
+		PROVIDE_HIDDEN ( __init_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+		KEEP (*(.init_array .ctors))
+		PROVIDE_HIDDEN ( __init_array_end = . );
+
+		PROVIDE_HIDDEN ( __fini_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
+		KEEP (*(.fini_array .dtors))
+		PROVIDE_HIDDEN ( __fini_array_end = . );
+
+	} >ROM0 AT>ROM0 :text
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+	.veneers :
+	{
+		. = ALIGN(32);
+		KEEP(*(.gnu.sgstubs))
+	} > ROM0 AT>ROM0 :text
+#endif
+
+	.toc : {
+		*(.toc .toc.*)
+	} >ROM0 AT>ROM0 :text
+
+	/* additional sections when compiling with C++ exception support */
+	
+	.except_ordered : {
+		*(.gcc_except_table *.gcc_except_table.*)
+		KEEP (*(.eh_frame .eh_frame.*))
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+	} >ROM0 AT>ROM0 :text
+
+	.except_unordered : {
+		. = ALIGN(8);
+
+		PROVIDE(__exidx_start = .);
+		*(.ARM.exidx*)
+		PROVIDE(__exidx_end = .);
+	} >ROM0 AT>ROM0 :text
+	
+
+	/*
+	 * Data values which are preserved across reset
+	 */
+	.preserve (NOLOAD) : {
+		PROVIDE(__preserve_start__ = .);
+		KEEP(*(SORT_BY_NAME(.preserve.*)))
+		KEEP(*(.preserve))
+		PROVIDE(__preserve_end__ = .);
+	} >RAM0 AT>RAM0 :ram
+
+	.data :  {
+		*(.data .data.*)
+		*(.gnu.linkonce.d.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		PROVIDE( __global_pointer$ = . + 0x800 );
+		*(.sdata .sdata.* .sdata2.*)
+		*(.gnu.linkonce.s.*)
+	} >RAM0 AT>ROM0 :ram_init
+	PROVIDE(__data_start = ADDR(.data));
+	PROVIDE(__data_source = LOADADDR(.data));
+
+	/* Thread local initialized data. This gets
+	 * space allocated as it is expected to be placed
+	 * in ram to be used as a template for TLS data blocks
+	 * allocated at runtime. We're slightly abusing that
+	 * by placing the data in flash where it will be copied
+	 * into the allocate ram addresses by the existing
+	 * data initialization code in crt0
+	 */
+	.tdata :  {
+		*(.tdata .tdata.* .gnu.linkonce.td.*)
+		PROVIDE(__data_end = .);
+		PROVIDE(__tdata_end = .);
+	} >RAM0 AT>ROM0 :tls :ram_init
+	PROVIDE( __tls_base = ADDR(.tdata));
+	PROVIDE( __tdata_start = ADDR(.tdata));
+	PROVIDE( __tdata_source = LOADADDR(.tdata) );
+	PROVIDE( __tdata_source_end = LOADADDR(.tdata) + SIZEOF(.tdata) );
+	PROVIDE( __data_source_end = __tdata_source_end );
+	PROVIDE( __tdata_size = SIZEOF(.tdata) );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata),ALIGNOF(.tbss)) );
+
+	PROVIDE( __edata = __data_end );
+	PROVIDE( _edata = __data_end );
+	PROVIDE( edata = __data_end );
+	PROVIDE( __data_size = __data_end - __data_start );
+	PROVIDE( __data_source_size = __data_source_end - __data_source );
+
+	.tbss (NOLOAD) : {
+		*(.tbss .tbss.* .gnu.linkonce.tb.*)
+		*(.tcommon)
+		PROVIDE( __tls_end = . );
+		PROVIDE( __tbss_end = . );
+	} >RAM0 AT>RAM0 :tls :ram
+	PROVIDE( __bss_start = ADDR(.tbss));
+	PROVIDE( __tbss_start = ADDR(.tbss));
+	PROVIDE( __tbss_offset = ADDR(.tbss) - ADDR(.tdata) );
+	PROVIDE( __tbss_size = SIZEOF(.tbss) );
+	PROVIDE( __tls_size = __tls_end - __tls_base );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
+	PROVIDE( __arm32_tls_tcb_offset = MAX(8, __tls_align) );
+	PROVIDE( __arm64_tls_tcb_offset = MAX(16, __tls_align) );
+
+	/*
+	 * The linker special cases .tbss segments which are
+	 * identified as segments which are not loaded and are
+	 * thread_local.
+	 *
+	 * For these segments, the linker does not advance 'dot'
+	 * across them.  We actually need memory allocated for tbss,
+	 * so we create a special segment here just to make room
+	 */
+	/*
+	.tbss_space (NOLOAD) : {
+		. = ADDR(.tbss);
+		. = . + SIZEOF(.tbss);
+	} >RAM0 AT>RAM0 :ram
+	*/
+
+	.bss (NOLOAD) : {
+		*(.sbss*)
+		*(.gnu.linkonce.sb.*)
+		*(.bss .bss.*)
+		*(.gnu.linkonce.b.*)
+		*(COMMON)
+
+		/* Align the heap */
+		. = ALIGN(8);
+		__bss_end = .;
+	} >RAM0 AT>RAM0 :ram
+	PROVIDE( __non_tls_bss_start = ADDR(.bss) );
+	PROVIDE( __end = __bss_end );
+	PROVIDE( _end = __bss_end );
+	PROVIDE( end = __bss_end );
+	PROVIDE( __bss_size = __bss_end - __bss_start );
+
+	/* Make the rest of memory available for heap storage */
+	PROVIDE (__heap_start = __end);
+#ifdef __HEAP_SIZE
+	PROVIDE (__heap_end = __heap_start + __HEAP_SIZE);
+	PROVIDE (__heap_size = __HEAP_SIZE);
+#else
+	PROVIDE (__heap_end = __stack - __STACK_SIZE);
+	PROVIDE (__heap_size = __heap_end - __heap_start);
+#endif
+	.heap (NOLOAD) : {
+		. += __heap_size;
+	} >RAM0 :ram
+
+	/* Define a stack region to make sure it fits in memory */
+	PROVIDE(__stack = ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE);
+	PROVIDE(__stack_limit = __stack - __STACK_SIZE);
+	.stack (__stack_limit) (NOLOAD) : {
+		. += __STACK_SIZE;
+	} >RAM0 :ram
+
+#if __STACKSEAL_SIZE > 0
+	PROVIDE(__stack_seal = __stack);
+  	.stackseal (__stack) (NOLOAD) :
+  	{
+    	. += __STACKSEAL_SIZE;
+  	} >RAM0 :ram
+#endif
+
+	/* Throw away C++ exception handling information */
+
+	/*
+
+	/DISCARD/ : {
+		*(.note .note.*)
+		*(.eh_frame .eh_frame.*)
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+		*(.ARM.exidx*)
+	}
+
+	*/
+
+	/* Stabs debugging sections.  */
+	.stab          0 : { *(.stab) }
+	.stabstr       0 : { *(.stabstr) }
+	.stab.excl     0 : { *(.stab.excl) }
+	.stab.exclstr  0 : { *(.stab.exclstr) }
+	.stab.index    0 : { *(.stab.index) }
+	.stab.indexstr 0 : { *(.stab.indexstr) }
+	.comment       0 : { *(.comment) }
+	.gnu.build.attributes : { *(.gnu.build.attributes .gnu.build.attributes.*) }
+	/* DWARF debug sections.
+	   Symbols in the DWARF debugging sections are relative to the beginning
+	   of the section so we begin them at 0.  */
+	/* DWARF 1.  */
+	.debug          0 : { *(.debug) }
+	.line           0 : { *(.line) }
+	/* GNU DWARF 1 extensions.  */
+	.debug_srcinfo  0 : { *(.debug_srcinfo) }
+	.debug_sfnames  0 : { *(.debug_sfnames) }
+	/* DWARF 1.1 and DWARF 2.  */
+	.debug_aranges  0 : { *(.debug_aranges) }
+	.debug_pubnames 0 : { *(.debug_pubnames) }
+	/* DWARF 2.  */
+	.debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+	.debug_abbrev   0 : { *(.debug_abbrev) }
+	.debug_line     0 : { *(.debug_line .debug_line.* .debug_line_end) }
+	.debug_frame    0 : { *(.debug_frame) }
+	.debug_str      0 : { *(.debug_str) }
+	.debug_loc      0 : { *(.debug_loc) }
+	.debug_macinfo  0 : { *(.debug_macinfo) }
+	/* SGI/MIPS DWARF 2 extensions.  */
+	.debug_weaknames 0 : { *(.debug_weaknames) }
+	.debug_funcnames 0 : { *(.debug_funcnames) }
+	.debug_typenames 0 : { *(.debug_typenames) }
+	.debug_varnames  0 : { *(.debug_varnames) }
+	/* DWARF 3.  */
+	.debug_pubtypes 0 : { *(.debug_pubtypes) }
+	.debug_ranges   0 : { *(.debug_ranges) }
+	/* DWARF 5.  */
+	.debug_addr     0 : { *(.debug_addr) }
+	.debug_line_str 0 : { *(.debug_line_str) }
+	.debug_loclists 0 : { *(.debug_loclists) }
+	.debug_macro    0 : { *(.debug_macro) }
+	.debug_names    0 : { *(.debug_names) }
+	.debug_rnglists 0 : { *(.debug_rnglists) }
+	.debug_str_offsets 0 : { *(.debug_str_offsets) }
+	.debug_sup      0 : { *(.debug_sup) }
+	.gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }
+}
+/*
+ * Check that sections that are copied from flash to RAM have matching
+ * padding, so that a single memcpy() of __data_size copies the correct bytes.
+ */
+ASSERT( __data_size == __data_source_size,
+	"ERROR: .data/.tdata flash size does not match RAM size");

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM0plus/RTE/Device/ARMCM0P/gcc_linker_script.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM0plus/RTE/Device/ARMCM0P/gcc_linker_script.ld
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+/* ----------------------------------------------------------------------------
+  Memory definition
+ *----------------------------------------------------------------------------*/
+MEMORY
+{
+  ROM0  (rx)  : ORIGIN = __ROM0_BASE, LENGTH = __ROM0_SIZE
+#if __ROM1_SIZE > 0
+  ROM1  (rx)  : ORIGIN = __ROM1_BASE, LENGTH = __ROM1_SIZE
+#endif
+#if __ROM2_SIZE > 0
+  ROM2  (rx)  : ORIGIN = __ROM2_BASE, LENGTH = __ROM2_SIZE
+#endif
+#if __ROM3_SIZE > 0
+  ROM3  (rx)  : ORIGIN = __ROM3_BASE, LENGTH = __ROM3_SIZE
+#endif
+
+  RAM0  (rwx) : ORIGIN = __RAM0_BASE, LENGTH = __RAM0_SIZE
+#if __RAM1_SIZE > 0
+  RAM1  (rwx) : ORIGIN = __RAM1_BASE, LENGTH = __RAM1_SIZE
+#endif
+#if __RAM2_SIZE > 0
+  RAM2  (rwx) : ORIGIN = __RAM2_BASE, LENGTH = __RAM2_SIZE
+#endif
+#if __RAM3_SIZE > 0
+  RAM3  (rwx) : ORIGIN = __RAM3_BASE, LENGTH = __RAM3_SIZE
+#endif
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __copy_table_start__
+ *   __copy_table_end__
+ *   __zero_table_start__
+ *   __zero_table_end__
+ *   __etext          (deprecated)
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+  .text :
+  {
+    KEEP(*(.vectors))
+    *(.text*)
+
+    KEEP(*(.init))
+    KEEP(*(.fini))
+
+    /* .ctors */
+    *crtbegin.o(.ctors)
+    *crtbegin?.o(.ctors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+    *(SORT(.ctors.*))
+    *(.ctors)
+
+    /* .dtors */
+    *crtbegin.o(.dtors)
+    *crtbegin?.o(.dtors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+    *(SORT(.dtors.*))
+    *(.dtors)
+
+    *(.rodata*)
+
+    KEEP(*(.eh_frame*))
+  } > ROM0
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  .gnu.sgstubs :
+  {
+    . = ALIGN(32);
+  } > ROM0
+#endif
+
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > ROM0
+
+  __exidx_start = .;
+  .ARM.exidx :
+  {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+  } > ROM0
+  __exidx_end = .;
+
+  .copy.table :
+  {
+    . = ALIGN(4);
+    __copy_table_start__ = .;
+
+    LONG (LOADADDR(.data))
+    LONG (ADDR(.data))
+    LONG (SIZEOF(.data) / 4)
+
+    /* Add each additional data section here */
+/*
+    LONG (LOADADDR(.data2))
+    LONG (ADDR(.data2))
+    LONG (SIZEOF(.data2) / 4)
+*/
+    __copy_table_end__ = .;
+  } > ROM0
+
+  .zero.table :
+  {
+    . = ALIGN(4);
+    __zero_table_start__ = .;
+
+/*  .bss initialization to zero is already done during C Run-Time Startup.
+    LONG (ADDR(.bss))
+    LONG (SIZEOF(.bss) / 4)
+*/
+
+    /* Add each additional bss section here */
+/*
+    LONG (ADDR(.bss2))
+    LONG (SIZEOF(.bss2) / 4)
+*/
+    __zero_table_end__ = .;
+  } > ROM0
+
+  /*
+   * This __etext variable is kept for backward compatibility with older,
+   * ASM based startup files.
+   */
+  PROVIDE(__etext = LOADADDR(.data));
+
+  .data : ALIGN(4)
+  {
+    __data_start__ = .;
+    *(vtable)
+    *(.data)
+    *(.data.*)
+
+    . = ALIGN(4);
+    /* preinit data */
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP(*(.preinit_array))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+
+    . = ALIGN(4);
+    /* init data */
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP(*(SORT(.init_array.*)))
+    KEEP(*(.init_array))
+    PROVIDE_HIDDEN (__init_array_end = .);
+
+    . = ALIGN(4);
+    /* finit data */
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP(*(SORT(.fini_array.*)))
+    KEEP(*(.fini_array))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    /* All data end */
+    __data_end__ = .;
+
+  } > RAM0 AT > ROM0
+
+  /*
+   * Secondary data section, optional
+   *
+   * Remember to add each additional data section
+   * to the .copy.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .data2 : ALIGN(4)
+  {
+    . = ALIGN(4);
+    __data2_start__ = .;
+    *(.data2)
+    *(.data2.*)
+    . = ALIGN(4);
+    __data2_end__ = .;
+
+  } > RAM1 AT > ROM0 
+*/
+
+  .bss :
+  {
+    . = ALIGN(4);
+    __bss_start__ = .;
+    *(.bss)
+    *(.bss.*)
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+  } > RAM0 AT > RAM0
+
+  /*
+   * Secondary bss section, optional
+   *
+   * Remember to add each additional bss section
+   * to the .zero.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .bss2 :
+  {
+    . = ALIGN(4);
+    __bss2_start__ = .;
+    *(.bss2)
+    *(.bss2.*)
+    . = ALIGN(4);
+    __bss2_end__ = .;
+  } > RAM1 AT > RAM1
+*/
+
+  .heap (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE(end = .);
+    . = . + __HEAP_SIZE;
+    . = ALIGN(8);
+    __HeapLimit = .;
+  } > RAM0
+
+  .stack (ORIGIN(RAM0) + LENGTH(RAM0) - __STACK_SIZE - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackLimit = .;
+    . = . + __STACK_SIZE;
+    . = ALIGN(8);
+    __StackTop = .;
+  } > RAM0
+  PROVIDE(__stack = __StackTop);
+
+#if __STACKSEAL_SIZE > 0
+  .stackseal (ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackSeal = .;
+    . = . + 8;
+    . = ALIGN(8);
+  } > RAM0
+#endif
+
+  /* Check if data + heap + stack exceeds RAM limit */
+  ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM0plus/RTE/Device/ARMCM0P/iar_linker_script.icf
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM0plus/RTE/Device/ARMCM0P/iar_linker_script.icf
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+define memory mem with size = 4G;
+
+#if __ROM0_SIZE > 0
+  define region ROM0_region = mem:[from __ROM0_BASE to (__ROM0_BASE+__ROM0_SIZE-1)];
+#else
+  define region ROM0_region = [];
+#endif
+
+#if __ROM1_SIZE > 0
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+#else
+  define region ROM1_region = [];
+#endif
+
+#if __ROM2_SIZE > 0
+  define region ROM2_region = mem:[from __ROM2_BASE to (__ROM2_BASE+__ROM2_SIZE-1)];
+#else
+  define region ROM2_region = [];
+#endif
+
+#if __ROM3_SIZE > 0
+  define region ROM3_region = mem:[from __ROM3_BASE to (__ROM3_BASE+__ROM3_SIZE-1)];
+#else
+  define region ROM3_region = [];
+#endif
+
+define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_region;
+
+#if __RAM0_SIZE > 0
+  define region RAM0_region = mem:[from __RAM0_BASE to (__RAM0_BASE+__RAM0_SIZE-1)];
+#else
+  define region RAM0_region = [];
+#endif
+
+#if __RAM1_SIZE > 0
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+#else
+  define region RAM1_region = [];
+#endif
+
+#if __RAM2_SIZE > 0
+  define region RAM2_region = mem:[from __RAM2_BASE to (__RAM2_BASE+__RAM2_SIZE-1)];
+#else
+  define region RAM2_region = [];
+#endif
+
+#if __RAM3_SIZE > 0
+  define region RAM3_region = mem:[from __RAM3_BASE to (__RAM3_BASE+__RAM3_SIZE-1)];
+#else
+  define region RAM3_region = [];
+#endif
+
+define region RAM_region = RAM0_region | RAM1_region | RAM2_region | RAM3_region;
+
+do not initialize  { section .noinit };
+initialize by copy { readwrite };
+if (isdefinedsymbol(__USE_DLIB_PERTHREAD))
+{
+  // Required in a multi-threaded application
+  initialize by copy with packing = none { section __DLIB_PERTHREAD };
+}
+
+place at address mem:__ROM0_BASE { readonly section .intvec };
+
+if (!isempty(ROM_region))
+{
+  place in ROM_region  { readonly };
+}
+
+if (!isempty(RAM_region))
+{
+  define block CSTACK     with alignment = 8, size = __STACK_SIZE     { };
+  define block PROC_STACK with alignment = 8, size = 0 { };
+  define block HEAP       with alignment = 8, size = __HEAP_SIZE       { };
+  place in RAM_region  { readwrite, block CSTACK, block PROC_STACK, block HEAP };
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM0plus/RTE/Device/ARMCM0P/regions_ARMCM0P.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM0plus/RTE/Device/ARMCM0P/regions_ARMCM0P.h
@@ -1,0 +1,60 @@
+#ifndef REGIONS_ARMCM0P_H
+#define REGIONS_ARMCM0P_H
+
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+// <n>Device pack:   ARM::Cortex_DFP@1.0.0-dev16
+// <i>Device pack used to generate this file
+
+// <h>ROM Configuration
+// =======================
+// <h> ROM=<__ROM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x00000000
+#define __ROM0_BASE 0x00000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00040000
+#define __ROM0_SIZE 0x00040000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __ROM0_DEFAULT 1
+//   <q>Startup
+//   <i> Selects region to be used for startup code.
+#define __ROM0_STARTUP 1
+// </h>
+
+// </h>
+
+// <h>RAM Configuration
+// =======================
+// <h> RAM=<__RAM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x20000000
+#define __RAM0_BASE 0x20000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00020000
+#define __RAM0_SIZE 0x00020000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __RAM0_DEFAULT 1
+//   <q>No zero initialize
+//   <i> Excludes region from zero initialization.
+#define __RAM0_NOINIT 0
+// </h>
+
+// </h>
+
+// <h>Stack / Heap Configuration
+//   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+#define __STACK_SIZE 0x00000400
+#define __HEAP_SIZE 0x00000C00
+// </h>
+
+
+#endif /* REGIONS_ARMCM0P_H */

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM0plus/RTE/Device/ARMCM0P/startup_ARMCM0plus.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM0plus/RTE/Device/ARMCM0P/startup_ARMCM0plus.c
@@ -1,0 +1,146 @@
+/******************************************************************************
+ * @file     startup_ARMCM0plus.c
+ * @brief    CMSIS-Core(M) Device Startup File for a Cortex-M0+ Device
+ * @version  V3.0.0
+ * @date     06. April 2023
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (ARMCM0P)
+  #include "ARMCM0plus.h"
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  External References
+ *----------------------------------------------------------------------------*/
+extern uint32_t __INITIAL_SP;
+
+extern __NO_RETURN void __PROGRAM_START(void);
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler  (void);
+            void Default_Handler(void);
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+/* Exceptions */
+void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void HardFault_Handler      (void) __attribute__ ((weak));
+void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+
+void Interrupt0_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt1_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt2_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt3_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt4_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt5_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt6_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt7_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt8_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt9_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[48];
+       const VECTOR_TABLE_Type __VECTOR_TABLE[48] __VECTOR_TABLE_ATTRIBUTE = {
+  (VECTOR_TABLE_Type)(&__INITIAL_SP),       /*     Initial Stack Pointer */
+  Reset_Handler,                            /*     Reset Handler */
+  NMI_Handler,                              /* -14 NMI Handler */
+  HardFault_Handler,                        /* -13 Hard Fault Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  SVC_Handler,                              /*  -5 SVCall Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  PendSV_Handler,                           /*  -2 PendSV Handler */
+  SysTick_Handler,                          /*  -1 SysTick Handler */
+
+  /* Interrupts */
+  Interrupt0_Handler,                       /*   0 Interrupt 0 */
+  Interrupt1_Handler,                       /*   1 Interrupt 1 */
+  Interrupt2_Handler,                       /*   2 Interrupt 2 */
+  Interrupt3_Handler,                       /*   3 Interrupt 3 */
+  Interrupt4_Handler,                       /*   4 Interrupt 4 */
+  Interrupt5_Handler,                       /*   5 Interrupt 5 */
+  Interrupt6_Handler,                       /*   6 Interrupt 6 */
+  Interrupt7_Handler,                       /*   7 Interrupt 7 */
+  Interrupt8_Handler,                       /*   8 Interrupt 8 */
+  Interrupt9_Handler                        /*   9 Interrupt 9 */
+                                            /* Interrupts 10..31 are left out */
+};
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler(void)
+{
+  SystemInit();                             /* CMSIS System Initialization */
+  __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
+}
+
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wmissing-noreturn"
+#endif
+
+/*----------------------------------------------------------------------------
+  Hard Fault Handler
+ *----------------------------------------------------------------------------*/
+void HardFault_Handler(void)
+{
+  while(1);
+}
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+void Default_Handler(void)
+{
+  while(1);
+}
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic pop
+#endif
+

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM0plus/RTE/Device/ARMCM0P/system_ARMCM0plus.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM0plus/RTE/Device/ARMCM0P/system_ARMCM0plus.c
@@ -1,0 +1,69 @@
+/**************************************************************************//**
+ * @file     system_ARMCM0plus.c
+ * @brief    CMSIS Device System Source File for
+ *           ARMCM0plus Device
+ * @version  V2.0.0
+ * @date     06. April 2023
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (ARMCM0P)
+  #include "ARMCM0plus.h"
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  Define clocks
+ *----------------------------------------------------------------------------*/
+#define  XTAL            (50000000UL)     /* Oscillator frequency */
+
+#define  SYSTEM_CLOCK    (XTAL / 2U)
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[48];
+
+/*----------------------------------------------------------------------------
+  System Core Clock Variable
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = SYSTEM_CLOCK;  /* System Core Clock Frequency */
+
+
+/*----------------------------------------------------------------------------
+  System Core Clock update function
+ *----------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)
+{
+  SystemCoreClock = SYSTEM_CLOCK;
+}
+
+/*----------------------------------------------------------------------------
+  System initialization function
+ *----------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t) &(__VECTOR_TABLE[0]);
+#endif
+
+  SystemCoreClock = SYSTEM_CLOCK;
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM0plus/RTE/Device/ARMCM0P/tiac_arm.cmd
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM0plus/RTE/Device/ARMCM0P/tiac_arm.cmd
@@ -1,0 +1,41 @@
+/****************************************************************************/
+/* tiac_arm.cmd - COMMAND FILE FOR LINKING ARM C PROGRAMS                   */
+/*                                                                          */
+/*   Description: This file is a sample command file that can be used       */
+/*                for linking programs built with the TI Arm Clang          */
+/*                Compiler.   Use it as a guideline; you may want to change */
+/*                the allocation scheme according to the size of your       */
+/*                program and the memory layout of your target system.      */
+/*                                                                          */
+/****************************************************************************/
+-c                                         /* LINK USING C CONVENTIONS      */
+-stack  0x4000                             /* SOFTWARE STACK SIZE           */
+-heap   0x4000                             /* HEAP AREA SIZE                */
+--args 0x1000
+
+/* SPECIFY THE SYSTEM MEMORY MAP */
+MEMORY
+{
+    V_MEM    : org = 0x00000000   len = 0x00001000  /* INT VECTOR */
+    P_MEM    : org = 0x00001000   len = 0x20000000  /* PROGRAM MEMORY (ROM) */
+    D_MEM    : org = 0x20001000   len = 0x20000000  /* DATA MEMORY    (RAM) */
+}
+
+/* SPECIFY THE SECTIONS ALLOCATION INTO MEMORY */
+SECTIONS
+{
+    .intvecs    : {} > 0x0             /* INTERRUPT VECTORS                 */
+    .bss        : {} > D_MEM           /* GLOBAL & STATIC VARS              */
+    .data       : {} > D_MEM
+    .sysmem     : {} > D_MEM           /* DYNAMIC MEMORY ALLOCATION AREA    */
+    .stack      : {} > D_MEM           /* SOFTWARE SYSTEM STACK             */
+
+    .text       : {} > P_MEM           /* CODE                              */
+    .cinit      : {} > P_MEM           /* INITIALIZATION TABLES             */
+    .const      : {} > P_MEM           /* CONSTANT DATA                     */
+    .rodata     : {} > P_MEM, palign(4)
+    .init_array : {} > P_MEM           /* C++ CONSTRUCTOR TABLES            */
+
+
+    .TI.ramfunc : {} load=P_MEM, run=D_MEM, table(BINIT)
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM0plus/Target.clayer.yml
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM0plus/Target.clayer.yml
@@ -1,0 +1,32 @@
+layer:
+  type: Target
+  description: CM0+ target components and files
+
+  packs:
+    - pack: ARM::Cortex_DFP
+
+  device: ARMCM0P
+
+  components:
+    # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
+    - component: ARM::CMSIS:CORE
+    - component: Device:Startup&C Startup
+
+  groups:
+    - group: FVP
+      files:
+        - file: ./model_config.txt
+
+  linker:
+    - for-compiler: AC6
+      script: RTE/Device/$Dname$/ac6_linker_script.sct
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: GCC
+      script: RTE/Device/$Dname$/gcc_linker_script.ld
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: CLANG
+      script: RTE/Device/$Dname$/clang_linker_script.ld
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: IAR
+      script: RTE/Device/$Dname$/iar_linker_script.icf
+      regions: RTE/Device/$Dname$/regions_$Dname$.h

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM0plus/model_config.txt
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM0plus/model_config.txt
@@ -1,0 +1,8 @@
+# Parameters:
+# instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+#------------------------------------------------------------------------------
+fvp_mps2.UART0.out_file=-                             # (string, init-time) default = ''       : Output file to hold data written by the UART (use '-' to send all output to stdout)
+fvp_mps2.UART0.shutdown_on_eot=1                      # (bool  , init-time) default = '0'      : Shutdown simulation when a EOT (ASCII 4) char is transmitted (useful for regression tests when semihosting is not available)
+fvp_mps2.UART0.unbuffered_output=1                    # (bool  , init-time) default = '0'      : Unbuffered output
+fvp_mps2.mps2_visualisation.disable-visualisation=1   # (bool  , init-time) default = '0'      : Enable/disable visualisation
+#------------------------------------------------------------------------------

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23/RTE/Device/ARMCM23/ac6_linker_script.sct
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23/RTE/Device/ARMCM23/ac6_linker_script.sct
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE 8
+#else
+#define __STACKSEAL_SIZE 0
+#endif
+
+/*----------------------------------------------------------------------------
+  Scatter File Definitions definition
+ *----------------------------------------------------------------------------*/
+
+LR_ROM0 __ROM0_BASE __ROM0_SIZE  {
+
+  ER_ROM0 __ROM0_BASE __ROM0_SIZE {
+    *.o (RESET, +First)
+    *(InRoot$$Sections)
+    *(+RO +XO)
+  }
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  ER_CMSE_VENEER AlignExpr(+0, 32) (__ROM0_SIZE - AlignExpr(ImageLength(ER_ROM0), 32)) {
+    *(Veneer$$CMSE)
+  }
+#endif
+
+  RW_NOINIT __RAM0_BASE UNINIT (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE) {
+    *(.bss.noinit)
+  }
+
+  RW_RAM0 AlignExpr(+0, 8) (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE - AlignExpr(ImageLength(RW_NOINIT), 8)) {
+    *(+RW +ZI)
+  }
+
+#if __HEAP_SIZE > 0
+  ARM_LIB_HEAP  (AlignExpr(+0, 8)) EMPTY __HEAP_SIZE  {   ; Reserve empty region for heap
+  }
+#endif
+
+  ARM_LIB_STACK (__RAM0_BASE + __RAM0_SIZE - __STACKSEAL_SIZE) EMPTY -__STACK_SIZE {   ; Reserve empty region for stack
+  }
+
+#if __STACKSEAL_SIZE > 0
+  STACKSEAL +0 EMPTY __STACKSEAL_SIZE {             ; Reserve empty region for stack seal immediately after stack
+  }
+#endif
+
+#if __RAM1_SIZE > 0
+  RW_RAM1 __RAM1_BASE __RAM1_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+
+#if __RAM2_SIZE > 0
+  RW_RAM2 __RAM2_BASE __RAM2_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+
+#if __RAM3_SIZE > 0
+  RW_RAM3 __RAM3_BASE __RAM3_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+}
+
+#if __ROM1_SIZE > 0
+LR_ROM1 __ROM1_BASE __ROM1_SIZE  {
+  ER_ROM1 +0 __ROM1_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif
+
+#if __ROM2_SIZE > 0
+LR_ROM2 __ROM2_BASE __ROM2_SIZE  {
+  ER_ROM2 +0 __ROM2_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif
+
+#if __ROM3_SIZE > 0
+LR_ROM3 __ROM3_BASE __ROM3_SIZE  {
+  ER_ROM3 +0 __ROM3_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23/RTE/Device/ARMCM23/clang_linker_script.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23/RTE/Device/ARMCM23/clang_linker_script.ld
@@ -1,0 +1,361 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2019 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+/* ----------------------------------------------------------------------------
+  Memory definition
+ *----------------------------------------------------------------------------*/
+MEMORY
+{
+  ROM0  (rx!w)  : ORIGIN = __ROM0_BASE, LENGTH = __ROM0_SIZE
+#if __ROM1_SIZE > 0
+  ROM1  (rx!w)  : ORIGIN = __ROM1_BASE, LENGTH = __ROM1_SIZE
+#endif
+#if __ROM2_SIZE > 0
+  ROM2  (rx!w)  : ORIGIN = __ROM2_BASE, LENGTH = __ROM2_SIZE
+#endif
+#if __ROM3_SIZE > 0
+  ROM3  (rx!w)  : ORIGIN = __ROM3_BASE, LENGTH = __ROM3_SIZE
+#endif
+
+  RAM0  (w!rx) : ORIGIN = __RAM0_BASE, LENGTH = __RAM0_SIZE
+#if __RAM1_SIZE > 0
+  RAM1  (w!rx) : ORIGIN = __RAM1_BASE, LENGTH = __RAM1_SIZE
+#endif
+#if __RAM2_SIZE > 0
+  RAM2  (w!rx) : ORIGIN = __RAM2_BASE, LENGTH = __RAM2_SIZE
+#endif
+#if __RAM3_SIZE > 0
+  RAM3  (w!rx) : ORIGIN = __RAM3_BASE, LENGTH = __RAM3_SIZE
+#endif
+}
+
+ENTRY(Reset_Handler)
+
+PHDRS
+{
+	text PT_LOAD;
+	ram PT_LOAD;
+	ram_init PT_LOAD;
+	tls PT_TLS;
+}
+
+SECTIONS
+{
+	.init : {
+		KEEP (*(.vectors))
+		KEEP (*(.text.init.enter))
+		KEEP (*(.data.init.enter))
+		KEEP (*(SORT_BY_NAME(.init) SORT_BY_NAME(.init.*)))
+	} >ROM0 AT>ROM0 :text
+
+	.text : {
+
+		/* code */
+		*(.text.unlikely .text.unlikely.*)
+		*(.text.startup .text.startup.*)
+		*(.text .text.* .opd .opd.*)
+		*(.gnu.linkonce.t.*)
+		KEEP (*(.fini .fini.*))
+		__text_end = .;
+
+		PROVIDE (__etext = __text_end);
+		PROVIDE (_etext = __text_end);
+		PROVIDE (etext = __text_end);
+
+		/* read-only data */
+		*(.rdata)
+		*(.rodata .rodata.*)
+		*(.gnu.linkonce.r.*)
+
+		*(.srodata.cst16)
+		*(.srodata.cst8)
+		*(.srodata.cst4)
+		*(.srodata.cst2)
+		*(.srodata .srodata.*)
+		*(.data.rel.ro .data.rel.ro.*)
+		*(.got .got.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		/* lists of constructors and destructors */
+		PROVIDE_HIDDEN ( __preinit_array_start = . );
+		KEEP (*(.preinit_array))
+		PROVIDE_HIDDEN ( __preinit_array_end = . );
+
+		PROVIDE_HIDDEN ( __init_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+		KEEP (*(.init_array .ctors))
+		PROVIDE_HIDDEN ( __init_array_end = . );
+
+		PROVIDE_HIDDEN ( __fini_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
+		KEEP (*(.fini_array .dtors))
+		PROVIDE_HIDDEN ( __fini_array_end = . );
+
+	} >ROM0 AT>ROM0 :text
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+	.veneers :
+	{
+		. = ALIGN(32);
+		KEEP(*(.gnu.sgstubs))
+	} > ROM0 AT>ROM0 :text
+#endif
+
+	.toc : {
+		*(.toc .toc.*)
+	} >ROM0 AT>ROM0 :text
+
+	/* additional sections when compiling with C++ exception support */
+	
+	.except_ordered : {
+		*(.gcc_except_table *.gcc_except_table.*)
+		KEEP (*(.eh_frame .eh_frame.*))
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+	} >ROM0 AT>ROM0 :text
+
+	.except_unordered : {
+		. = ALIGN(8);
+
+		PROVIDE(__exidx_start = .);
+		*(.ARM.exidx*)
+		PROVIDE(__exidx_end = .);
+	} >ROM0 AT>ROM0 :text
+	
+
+	/*
+	 * Data values which are preserved across reset
+	 */
+	.preserve (NOLOAD) : {
+		PROVIDE(__preserve_start__ = .);
+		KEEP(*(SORT_BY_NAME(.preserve.*)))
+		KEEP(*(.preserve))
+		PROVIDE(__preserve_end__ = .);
+	} >RAM0 AT>RAM0 :ram
+
+	.data :  {
+		*(.data .data.*)
+		*(.gnu.linkonce.d.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		PROVIDE( __global_pointer$ = . + 0x800 );
+		*(.sdata .sdata.* .sdata2.*)
+		*(.gnu.linkonce.s.*)
+	} >RAM0 AT>ROM0 :ram_init
+	PROVIDE(__data_start = ADDR(.data));
+	PROVIDE(__data_source = LOADADDR(.data));
+
+	/* Thread local initialized data. This gets
+	 * space allocated as it is expected to be placed
+	 * in ram to be used as a template for TLS data blocks
+	 * allocated at runtime. We're slightly abusing that
+	 * by placing the data in flash where it will be copied
+	 * into the allocate ram addresses by the existing
+	 * data initialization code in crt0
+	 */
+	.tdata :  {
+		*(.tdata .tdata.* .gnu.linkonce.td.*)
+		PROVIDE(__data_end = .);
+		PROVIDE(__tdata_end = .);
+	} >RAM0 AT>ROM0 :tls :ram_init
+	PROVIDE( __tls_base = ADDR(.tdata));
+	PROVIDE( __tdata_start = ADDR(.tdata));
+	PROVIDE( __tdata_source = LOADADDR(.tdata) );
+	PROVIDE( __tdata_source_end = LOADADDR(.tdata) + SIZEOF(.tdata) );
+	PROVIDE( __data_source_end = __tdata_source_end );
+	PROVIDE( __tdata_size = SIZEOF(.tdata) );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata),ALIGNOF(.tbss)) );
+
+	PROVIDE( __edata = __data_end );
+	PROVIDE( _edata = __data_end );
+	PROVIDE( edata = __data_end );
+	PROVIDE( __data_size = __data_end - __data_start );
+	PROVIDE( __data_source_size = __data_source_end - __data_source );
+
+	.tbss (NOLOAD) : {
+		*(.tbss .tbss.* .gnu.linkonce.tb.*)
+		*(.tcommon)
+		PROVIDE( __tls_end = . );
+		PROVIDE( __tbss_end = . );
+	} >RAM0 AT>RAM0 :tls :ram
+	PROVIDE( __bss_start = ADDR(.tbss));
+	PROVIDE( __tbss_start = ADDR(.tbss));
+	PROVIDE( __tbss_offset = ADDR(.tbss) - ADDR(.tdata) );
+	PROVIDE( __tbss_size = SIZEOF(.tbss) );
+	PROVIDE( __tls_size = __tls_end - __tls_base );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
+	PROVIDE( __arm32_tls_tcb_offset = MAX(8, __tls_align) );
+	PROVIDE( __arm64_tls_tcb_offset = MAX(16, __tls_align) );
+
+	/*
+	 * The linker special cases .tbss segments which are
+	 * identified as segments which are not loaded and are
+	 * thread_local.
+	 *
+	 * For these segments, the linker does not advance 'dot'
+	 * across them.  We actually need memory allocated for tbss,
+	 * so we create a special segment here just to make room
+	 */
+	/*
+	.tbss_space (NOLOAD) : {
+		. = ADDR(.tbss);
+		. = . + SIZEOF(.tbss);
+	} >RAM0 AT>RAM0 :ram
+	*/
+
+	.bss (NOLOAD) : {
+		*(.sbss*)
+		*(.gnu.linkonce.sb.*)
+		*(.bss .bss.*)
+		*(.gnu.linkonce.b.*)
+		*(COMMON)
+
+		/* Align the heap */
+		. = ALIGN(8);
+		__bss_end = .;
+	} >RAM0 AT>RAM0 :ram
+	PROVIDE( __non_tls_bss_start = ADDR(.bss) );
+	PROVIDE( __end = __bss_end );
+	PROVIDE( _end = __bss_end );
+	PROVIDE( end = __bss_end );
+	PROVIDE( __bss_size = __bss_end - __bss_start );
+
+	/* Make the rest of memory available for heap storage */
+	PROVIDE (__heap_start = __end);
+#ifdef __HEAP_SIZE
+	PROVIDE (__heap_end = __heap_start + __HEAP_SIZE);
+	PROVIDE (__heap_size = __HEAP_SIZE);
+#else
+	PROVIDE (__heap_end = __stack - __STACK_SIZE);
+	PROVIDE (__heap_size = __heap_end - __heap_start);
+#endif
+	.heap (NOLOAD) : {
+		. += __heap_size;
+	} >RAM0 :ram
+
+	/* Define a stack region to make sure it fits in memory */
+	PROVIDE(__stack = ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE);
+	PROVIDE(__stack_limit = __stack - __STACK_SIZE);
+	.stack (__stack_limit) (NOLOAD) : {
+		. += __STACK_SIZE;
+	} >RAM0 :ram
+
+#if __STACKSEAL_SIZE > 0
+	PROVIDE(__stack_seal = __stack);
+  	.stackseal (__stack) (NOLOAD) :
+  	{
+    	. += __STACKSEAL_SIZE;
+  	} >RAM0 :ram
+#endif
+
+	/* Throw away C++ exception handling information */
+
+	/*
+
+	/DISCARD/ : {
+		*(.note .note.*)
+		*(.eh_frame .eh_frame.*)
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+		*(.ARM.exidx*)
+	}
+
+	*/
+
+	/* Stabs debugging sections.  */
+	.stab          0 : { *(.stab) }
+	.stabstr       0 : { *(.stabstr) }
+	.stab.excl     0 : { *(.stab.excl) }
+	.stab.exclstr  0 : { *(.stab.exclstr) }
+	.stab.index    0 : { *(.stab.index) }
+	.stab.indexstr 0 : { *(.stab.indexstr) }
+	.comment       0 : { *(.comment) }
+	.gnu.build.attributes : { *(.gnu.build.attributes .gnu.build.attributes.*) }
+	/* DWARF debug sections.
+	   Symbols in the DWARF debugging sections are relative to the beginning
+	   of the section so we begin them at 0.  */
+	/* DWARF 1.  */
+	.debug          0 : { *(.debug) }
+	.line           0 : { *(.line) }
+	/* GNU DWARF 1 extensions.  */
+	.debug_srcinfo  0 : { *(.debug_srcinfo) }
+	.debug_sfnames  0 : { *(.debug_sfnames) }
+	/* DWARF 1.1 and DWARF 2.  */
+	.debug_aranges  0 : { *(.debug_aranges) }
+	.debug_pubnames 0 : { *(.debug_pubnames) }
+	/* DWARF 2.  */
+	.debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+	.debug_abbrev   0 : { *(.debug_abbrev) }
+	.debug_line     0 : { *(.debug_line .debug_line.* .debug_line_end) }
+	.debug_frame    0 : { *(.debug_frame) }
+	.debug_str      0 : { *(.debug_str) }
+	.debug_loc      0 : { *(.debug_loc) }
+	.debug_macinfo  0 : { *(.debug_macinfo) }
+	/* SGI/MIPS DWARF 2 extensions.  */
+	.debug_weaknames 0 : { *(.debug_weaknames) }
+	.debug_funcnames 0 : { *(.debug_funcnames) }
+	.debug_typenames 0 : { *(.debug_typenames) }
+	.debug_varnames  0 : { *(.debug_varnames) }
+	/* DWARF 3.  */
+	.debug_pubtypes 0 : { *(.debug_pubtypes) }
+	.debug_ranges   0 : { *(.debug_ranges) }
+	/* DWARF 5.  */
+	.debug_addr     0 : { *(.debug_addr) }
+	.debug_line_str 0 : { *(.debug_line_str) }
+	.debug_loclists 0 : { *(.debug_loclists) }
+	.debug_macro    0 : { *(.debug_macro) }
+	.debug_names    0 : { *(.debug_names) }
+	.debug_rnglists 0 : { *(.debug_rnglists) }
+	.debug_str_offsets 0 : { *(.debug_str_offsets) }
+	.debug_sup      0 : { *(.debug_sup) }
+	.gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }
+}
+/*
+ * Check that sections that are copied from flash to RAM have matching
+ * padding, so that a single memcpy() of __data_size copies the correct bytes.
+ */
+ASSERT( __data_size == __data_source_size,
+	"ERROR: .data/.tdata flash size does not match RAM size");

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23/RTE/Device/ARMCM23/gcc_linker_script.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23/RTE/Device/ARMCM23/gcc_linker_script.ld
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+/* ----------------------------------------------------------------------------
+  Memory definition
+ *----------------------------------------------------------------------------*/
+MEMORY
+{
+  ROM0  (rx)  : ORIGIN = __ROM0_BASE, LENGTH = __ROM0_SIZE
+#if __ROM1_SIZE > 0
+  ROM1  (rx)  : ORIGIN = __ROM1_BASE, LENGTH = __ROM1_SIZE
+#endif
+#if __ROM2_SIZE > 0
+  ROM2  (rx)  : ORIGIN = __ROM2_BASE, LENGTH = __ROM2_SIZE
+#endif
+#if __ROM3_SIZE > 0
+  ROM3  (rx)  : ORIGIN = __ROM3_BASE, LENGTH = __ROM3_SIZE
+#endif
+
+  RAM0  (rwx) : ORIGIN = __RAM0_BASE, LENGTH = __RAM0_SIZE
+#if __RAM1_SIZE > 0
+  RAM1  (rwx) : ORIGIN = __RAM1_BASE, LENGTH = __RAM1_SIZE
+#endif
+#if __RAM2_SIZE > 0
+  RAM2  (rwx) : ORIGIN = __RAM2_BASE, LENGTH = __RAM2_SIZE
+#endif
+#if __RAM3_SIZE > 0
+  RAM3  (rwx) : ORIGIN = __RAM3_BASE, LENGTH = __RAM3_SIZE
+#endif
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __copy_table_start__
+ *   __copy_table_end__
+ *   __zero_table_start__
+ *   __zero_table_end__
+ *   __etext          (deprecated)
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+  .text :
+  {
+    KEEP(*(.vectors))
+    *(.text*)
+
+    KEEP(*(.init))
+    KEEP(*(.fini))
+
+    /* .ctors */
+    *crtbegin.o(.ctors)
+    *crtbegin?.o(.ctors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+    *(SORT(.ctors.*))
+    *(.ctors)
+
+    /* .dtors */
+    *crtbegin.o(.dtors)
+    *crtbegin?.o(.dtors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+    *(SORT(.dtors.*))
+    *(.dtors)
+
+    *(.rodata*)
+
+    KEEP(*(.eh_frame*))
+  } > ROM0
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  .gnu.sgstubs :
+  {
+    . = ALIGN(32);
+  } > ROM0
+#endif
+
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > ROM0
+
+  __exidx_start = .;
+  .ARM.exidx :
+  {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+  } > ROM0
+  __exidx_end = .;
+
+  .copy.table :
+  {
+    . = ALIGN(4);
+    __copy_table_start__ = .;
+
+    LONG (LOADADDR(.data))
+    LONG (ADDR(.data))
+    LONG (SIZEOF(.data) / 4)
+
+    /* Add each additional data section here */
+/*
+    LONG (LOADADDR(.data2))
+    LONG (ADDR(.data2))
+    LONG (SIZEOF(.data2) / 4)
+*/
+    __copy_table_end__ = .;
+  } > ROM0
+
+  .zero.table :
+  {
+    . = ALIGN(4);
+    __zero_table_start__ = .;
+
+/*  .bss initialization to zero is already done during C Run-Time Startup.
+    LONG (ADDR(.bss))
+    LONG (SIZEOF(.bss) / 4)
+*/
+
+    /* Add each additional bss section here */
+/*
+    LONG (ADDR(.bss2))
+    LONG (SIZEOF(.bss2) / 4)
+*/
+    __zero_table_end__ = .;
+  } > ROM0
+
+  /*
+   * This __etext variable is kept for backward compatibility with older,
+   * ASM based startup files.
+   */
+  PROVIDE(__etext = LOADADDR(.data));
+
+  .data : ALIGN(4)
+  {
+    __data_start__ = .;
+    *(vtable)
+    *(.data)
+    *(.data.*)
+
+    . = ALIGN(4);
+    /* preinit data */
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP(*(.preinit_array))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+
+    . = ALIGN(4);
+    /* init data */
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP(*(SORT(.init_array.*)))
+    KEEP(*(.init_array))
+    PROVIDE_HIDDEN (__init_array_end = .);
+
+    . = ALIGN(4);
+    /* finit data */
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP(*(SORT(.fini_array.*)))
+    KEEP(*(.fini_array))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    /* All data end */
+    __data_end__ = .;
+
+  } > RAM0 AT > ROM0
+
+  /*
+   * Secondary data section, optional
+   *
+   * Remember to add each additional data section
+   * to the .copy.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .data2 : ALIGN(4)
+  {
+    . = ALIGN(4);
+    __data2_start__ = .;
+    *(.data2)
+    *(.data2.*)
+    . = ALIGN(4);
+    __data2_end__ = .;
+
+  } > RAM1 AT > ROM0 
+*/
+
+  .bss :
+  {
+    . = ALIGN(4);
+    __bss_start__ = .;
+    *(.bss)
+    *(.bss.*)
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+  } > RAM0 AT > RAM0
+
+  /*
+   * Secondary bss section, optional
+   *
+   * Remember to add each additional bss section
+   * to the .zero.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .bss2 :
+  {
+    . = ALIGN(4);
+    __bss2_start__ = .;
+    *(.bss2)
+    *(.bss2.*)
+    . = ALIGN(4);
+    __bss2_end__ = .;
+  } > RAM1 AT > RAM1
+*/
+
+  .heap (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE(end = .);
+    . = . + __HEAP_SIZE;
+    . = ALIGN(8);
+    __HeapLimit = .;
+  } > RAM0
+
+  .stack (ORIGIN(RAM0) + LENGTH(RAM0) - __STACK_SIZE - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackLimit = .;
+    . = . + __STACK_SIZE;
+    . = ALIGN(8);
+    __StackTop = .;
+  } > RAM0
+  PROVIDE(__stack = __StackTop);
+
+#if __STACKSEAL_SIZE > 0
+  .stackseal (ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackSeal = .;
+    . = . + 8;
+    . = ALIGN(8);
+  } > RAM0
+#endif
+
+  /* Check if data + heap + stack exceeds RAM limit */
+  ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23/RTE/Device/ARMCM23/iar_linker_script.icf
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23/RTE/Device/ARMCM23/iar_linker_script.icf
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+define memory mem with size = 4G;
+
+#if __ROM0_SIZE > 0
+  define region ROM0_region = mem:[from __ROM0_BASE to (__ROM0_BASE+__ROM0_SIZE-1)];
+#else
+  define region ROM0_region = [];
+#endif
+
+#if __ROM1_SIZE > 0
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+#else
+  define region ROM1_region = [];
+#endif
+
+#if __ROM2_SIZE > 0
+  define region ROM2_region = mem:[from __ROM2_BASE to (__ROM2_BASE+__ROM2_SIZE-1)];
+#else
+  define region ROM2_region = [];
+#endif
+
+#if __ROM3_SIZE > 0
+  define region ROM3_region = mem:[from __ROM3_BASE to (__ROM3_BASE+__ROM3_SIZE-1)];
+#else
+  define region ROM3_region = [];
+#endif
+
+define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_region;
+
+#if __RAM0_SIZE > 0
+  define region RAM0_region = mem:[from __RAM0_BASE to (__RAM0_BASE+__RAM0_SIZE-1)];
+#else
+  define region RAM0_region = [];
+#endif
+
+#if __RAM1_SIZE > 0
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+#else
+  define region RAM1_region = [];
+#endif
+
+#if __RAM2_SIZE > 0
+  define region RAM2_region = mem:[from __RAM2_BASE to (__RAM2_BASE+__RAM2_SIZE-1)];
+#else
+  define region RAM2_region = [];
+#endif
+
+#if __RAM3_SIZE > 0
+  define region RAM3_region = mem:[from __RAM3_BASE to (__RAM3_BASE+__RAM3_SIZE-1)];
+#else
+  define region RAM3_region = [];
+#endif
+
+define region RAM_region = RAM0_region | RAM1_region | RAM2_region | RAM3_region;
+
+do not initialize  { section .noinit };
+initialize by copy { readwrite };
+if (isdefinedsymbol(__USE_DLIB_PERTHREAD))
+{
+  // Required in a multi-threaded application
+  initialize by copy with packing = none { section __DLIB_PERTHREAD };
+}
+
+place at address mem:__ROM0_BASE { readonly section .intvec };
+
+if (!isempty(ROM_region))
+{
+  place in ROM_region  { readonly };
+}
+
+if (!isempty(RAM_region))
+{
+  define block CSTACK     with alignment = 8, size = __STACK_SIZE     { };
+  define block PROC_STACK with alignment = 8, size = 0 { };
+  define block HEAP       with alignment = 8, size = __HEAP_SIZE       { };
+  place in RAM_region  { readwrite, block CSTACK, block PROC_STACK, block HEAP };
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23/RTE/Device/ARMCM23/regions_ARMCM23.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23/RTE/Device/ARMCM23/regions_ARMCM23.h
@@ -1,0 +1,94 @@
+#ifndef REGIONS_ARMCM23_H
+#define REGIONS_ARMCM23_H
+
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+// <n>Device pack:   ARM::Cortex_DFP@1.0.0-dev16
+// <i>Device pack used to generate this file
+
+// <h>ROM Configuration
+// =======================
+// <h> ROM_S=<__ROM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x00000000
+#define __ROM0_BASE 0x00000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00200000
+#define __ROM0_SIZE 0x00200000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __ROM0_DEFAULT 1
+//   <q>Startup
+//   <i> Selects region to be used for startup code.
+#define __ROM0_STARTUP 1
+// </h>
+
+// <h> ROM_NS=<__ROM1>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x00200000
+#define __ROM1_BASE 0x00200000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00200000
+#define __ROM1_SIZE 0x00200000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __ROM1_DEFAULT 0
+//   <q>Startup
+//   <i> Selects region to be used for startup code.
+#define __ROM1_STARTUP 0
+// </h>
+
+// </h>
+
+// <h>RAM Configuration
+// =======================
+// <h> RAM_S=<__RAM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x20000000
+#define __RAM0_BASE 0x20000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00020000
+#define __RAM0_SIZE 0x00020000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __RAM0_DEFAULT 1
+//   <q>No zero initialize
+//   <i> Excludes region from zero initialization.
+#define __RAM0_NOINIT 0
+// </h>
+
+// <h> RAM_NS=<__RAM1>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x20200000
+#define __RAM1_BASE 0x20200000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00020000
+#define __RAM1_SIZE 0x00020000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __RAM1_DEFAULT 0
+//   <q>No zero initialize
+//   <i> Excludes region from zero initialization.
+#define __RAM1_NOINIT 0
+// </h>
+
+// </h>
+
+// <h>Stack / Heap Configuration
+//   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+#define __STACK_SIZE 0x00000400
+#define __HEAP_SIZE 0x00000C00
+// </h>
+
+
+#endif /* REGIONS_ARMCM23_H */

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23/RTE/Device/ARMCM23/startup_ARMCM23.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23/RTE/Device/ARMCM23/startup_ARMCM23.c
@@ -1,0 +1,159 @@
+/******************************************************************************
+ * @file     startup_ARMCM23.c
+ * @brief    CMSIS-Core Device Startup File for a Cortex-M23 Device
+ * @version  V3.0.0
+ * @date     06. April 2023
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (ARMCM23)
+  #include "ARMCM23.h"
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  External References
+ *----------------------------------------------------------------------------*/
+extern uint32_t __INITIAL_SP;
+extern uint32_t __STACK_LIMIT;
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+extern uint32_t __STACK_SEAL;
+#endif
+
+extern __NO_RETURN void __PROGRAM_START(void);
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler  (void);
+            void Default_Handler(void);
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+/* Exceptions */
+void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void HardFault_Handler      (void) __attribute__ ((weak));
+void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+
+void Interrupt0_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt1_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt2_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt3_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt4_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt5_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt6_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt7_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt8_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt9_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[240];
+       const VECTOR_TABLE_Type __VECTOR_TABLE[240] __VECTOR_TABLE_ATTRIBUTE = {
+  (VECTOR_TABLE_Type)(&__INITIAL_SP),       /*     Initial Stack Pointer */
+  Reset_Handler,                            /*     Reset Handler */
+  NMI_Handler,                              /* -14 NMI Handler */
+  HardFault_Handler,                        /* -13 Hard Fault Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  SVC_Handler,                              /*  -5 SVCall Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  PendSV_Handler,                           /*  -2 PendSV Handler */
+  SysTick_Handler,                          /*  -1 SysTick Handler */
+
+  /* Interrupts */
+  Interrupt0_Handler,                       /*   0 Interrupt 0 */
+  Interrupt1_Handler,                       /*   1 Interrupt 1 */
+  Interrupt2_Handler,                       /*   2 Interrupt 2 */
+  Interrupt3_Handler,                       /*   3 Interrupt 3 */
+  Interrupt4_Handler,                       /*   4 Interrupt 4 */
+  Interrupt5_Handler,                       /*   5 Interrupt 5 */
+  Interrupt6_Handler,                       /*   6 Interrupt 6 */
+  Interrupt7_Handler,                       /*   7 Interrupt 7 */
+  Interrupt8_Handler,                       /*   8 Interrupt 8 */
+  Interrupt9_Handler                        /*   9 Interrupt 9 */
+                                            /* Interrupts 10 .. 223 are left out */
+};
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler(void)
+{
+  __set_PSP((uint32_t)(&__INITIAL_SP));
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  __set_MSPLIM((uint32_t)(&__STACK_LIMIT));
+  __set_PSPLIM((uint32_t)(&__STACK_LIMIT));
+
+  __TZ_set_STACKSEAL_S((uint32_t *)(&__STACK_SEAL));
+#endif
+
+  SystemInit();                             /* CMSIS System Initialization */
+  __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
+}
+
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wmissing-noreturn"
+#endif
+
+/*----------------------------------------------------------------------------
+  Hard Fault Handler
+ *----------------------------------------------------------------------------*/
+void HardFault_Handler(void)
+{
+  while(1);
+}
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+void Default_Handler(void)
+{
+  while(1);
+}
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic pop
+#endif
+

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23/RTE/Device/ARMCM23/system_ARMCM23.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23/RTE/Device/ARMCM23/system_ARMCM23.c
@@ -1,0 +1,77 @@
+/**************************************************************************//**
+ * @file     system_ARMCM23.c
+ * @brief    CMSIS Device System Source File for
+ *           ARMCM23 Device
+ * @version  V2.0.0
+ * @date     06. April 2023
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (ARMCM23)
+  #include "ARMCM23.h"
+  #if defined (__ARM_FEATURE_CMSE) &&  (__ARM_FEATURE_CMSE == 3U)
+    #include "partition_ARMCM23.h"
+  #endif
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  Define clocks
+ *----------------------------------------------------------------------------*/
+#define  XTAL            (50000000UL)     /* Oscillator frequency */
+
+#define  SYSTEM_CLOCK    (XTAL / 2U)
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[240];
+
+
+/*----------------------------------------------------------------------------
+  System Core Clock Variable
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = SYSTEM_CLOCK;  /* System Core Clock Frequency */
+
+
+/*----------------------------------------------------------------------------
+  System Core Clock update function
+ *----------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)
+{
+  SystemCoreClock = SYSTEM_CLOCK;
+}
+
+/*----------------------------------------------------------------------------
+  System initialization function
+ *----------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t) &(__VECTOR_TABLE[0]);
+#endif
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  TZ_SAU_Setup();
+#endif
+
+  SystemCoreClock = SYSTEM_CLOCK;
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23/Target.clayer.yml
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23/Target.clayer.yml
@@ -1,0 +1,35 @@
+layer:
+  type: Target
+  description: CM23 target components and files
+
+  packs:
+    - pack: ARM::Cortex_DFP
+
+  device: ARMCM23
+
+  processor:
+    trustzone: off
+
+  components:
+    # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
+    - component: ARM::CMSIS:CORE
+    - component: Device:Startup&C Startup
+
+  groups:
+    - group: FVP
+      files:
+        - file: ./model_config.txt
+
+  linker:
+    - for-compiler: AC6
+      script: RTE/Device/$Dname$/ac6_linker_script.sct
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: GCC
+      script: RTE/Device/$Dname$/gcc_linker_script.ld
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: CLANG
+      script: RTE/Device/$Dname$/clang_linker_script.ld
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: IAR
+      script: RTE/Device/$Dname$/iar_linker_script.icf
+      regions: RTE/Device/$Dname$/regions_$Dname$.h

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23/model_config.txt
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23/model_config.txt
@@ -1,0 +1,16 @@
+# Parameters:
+# instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+#----------------------------------------------------------------------------------------------
+fvp_mps2.mps2_visualisation.disable-visualisation=1   # (bool  , init-time) default = '0'      : Enable/disable visualisation
+cpu0.semihosting-enable=1                             # (bool  , init-time) default = '1'      : Enable semihosting SVC traps. Applications that do not use semihosting must set this parameter to false.
+cpu0.semihosting-Thumb_SVC=0xAB                       # (int   , init-time) default = '0xAB'   : T32 SVC number for semihosting : [0x0..0xFF]
+cpu0.semihosting-cmd_line=""                          # (string, init-time) default = ''       : Command line available to semihosting SVC calls
+cpu0.semihosting-heap_base=0x0                        # (int   , init-time) default = '0x0'    : Virtual address of heap base : [0x0..0xFFFFFFFF]
+cpu0.semihosting-heap_limit=0x0                       # (int   , init-time) default = '0x10700000' : Virtual address of top of heap : [0x0..0xFFFFFFFF]
+cpu0.semihosting-stack_base=0x0                       # (int   , init-time) default = '0x10700000' : Virtual address of base of descending stack : [0x0..0xFFFFFFFF]
+cpu0.semihosting-stack_limit=0x0                      # (int   , init-time) default = '0x10800000' : Virtual address of stack limit : [0x0..0xFFFFFFFF]
+cpu0.semihosting-cwd=""                               # (string, init-time) default = ''       : Base directory for semihosting file access.
+idau.NUM_IDAU_REGION=0x0                              # (int   , init-time) default = '0xA'    : 
+cpu0.SECEXT=0                                         # (bool  , init-time) default = '1'      : Whether the ARMv8-M Security Extensions are included
+fvp_mps2.DISABLE_GATING=1                             # (bool  , init-time) default = '0'      : Disable Memory gating logic
+#----------------------------------------------------------------------------------------------

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23NS/RTE/Device/ARMCM23/ac6_linker_script.sct
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23NS/RTE/Device/ARMCM23/ac6_linker_script.sct
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE 8
+#else
+#define __STACKSEAL_SIZE 0
+#endif
+
+/*----------------------------------------------------------------------------
+  Scatter File Definitions definition
+ *----------------------------------------------------------------------------*/
+
+LR_ROM0 __ROM0_BASE __ROM0_SIZE  {
+
+  ER_ROM0 __ROM0_BASE __ROM0_SIZE {
+    *.o (RESET, +First)
+    *(InRoot$$Sections)
+    *(+RO +XO)
+  }
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  ER_CMSE_VENEER AlignExpr(+0, 32) (__ROM0_SIZE - AlignExpr(ImageLength(ER_ROM0), 32)) {
+    *(Veneer$$CMSE)
+  }
+#endif
+
+  RW_NOINIT __RAM0_BASE UNINIT (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE) {
+    *(.bss.noinit)
+  }
+
+  RW_RAM0 AlignExpr(+0, 8) (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE - AlignExpr(ImageLength(RW_NOINIT), 8)) {
+    *(+RW +ZI)
+  }
+
+#if __HEAP_SIZE > 0
+  ARM_LIB_HEAP  (AlignExpr(+0, 8)) EMPTY __HEAP_SIZE  {   ; Reserve empty region for heap
+  }
+#endif
+
+  ARM_LIB_STACK (__RAM0_BASE + __RAM0_SIZE - __STACKSEAL_SIZE) EMPTY -__STACK_SIZE {   ; Reserve empty region for stack
+  }
+
+#if __STACKSEAL_SIZE > 0
+  STACKSEAL +0 EMPTY __STACKSEAL_SIZE {             ; Reserve empty region for stack seal immediately after stack
+  }
+#endif
+
+#if __RAM1_SIZE > 0
+  RW_RAM1 __RAM1_BASE __RAM1_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+
+#if __RAM2_SIZE > 0
+  RW_RAM2 __RAM2_BASE __RAM2_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+
+#if __RAM3_SIZE > 0
+  RW_RAM3 __RAM3_BASE __RAM3_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+}
+
+#if __ROM1_SIZE > 0
+LR_ROM1 __ROM1_BASE __ROM1_SIZE  {
+  ER_ROM1 +0 __ROM1_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif
+
+#if __ROM2_SIZE > 0
+LR_ROM2 __ROM2_BASE __ROM2_SIZE  {
+  ER_ROM2 +0 __ROM2_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif
+
+#if __ROM3_SIZE > 0
+LR_ROM3 __ROM3_BASE __ROM3_SIZE  {
+  ER_ROM3 +0 __ROM3_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23NS/RTE/Device/ARMCM23/clang_linker_script.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23NS/RTE/Device/ARMCM23/clang_linker_script.ld
@@ -1,0 +1,361 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2019 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+/* ----------------------------------------------------------------------------
+  Memory definition
+ *----------------------------------------------------------------------------*/
+MEMORY
+{
+  ROM0  (rx!w)  : ORIGIN = __ROM0_BASE, LENGTH = __ROM0_SIZE
+#if __ROM1_SIZE > 0
+  ROM1  (rx!w)  : ORIGIN = __ROM1_BASE, LENGTH = __ROM1_SIZE
+#endif
+#if __ROM2_SIZE > 0
+  ROM2  (rx!w)  : ORIGIN = __ROM2_BASE, LENGTH = __ROM2_SIZE
+#endif
+#if __ROM3_SIZE > 0
+  ROM3  (rx!w)  : ORIGIN = __ROM3_BASE, LENGTH = __ROM3_SIZE
+#endif
+
+  RAM0  (w!rx) : ORIGIN = __RAM0_BASE, LENGTH = __RAM0_SIZE
+#if __RAM1_SIZE > 0
+  RAM1  (w!rx) : ORIGIN = __RAM1_BASE, LENGTH = __RAM1_SIZE
+#endif
+#if __RAM2_SIZE > 0
+  RAM2  (w!rx) : ORIGIN = __RAM2_BASE, LENGTH = __RAM2_SIZE
+#endif
+#if __RAM3_SIZE > 0
+  RAM3  (w!rx) : ORIGIN = __RAM3_BASE, LENGTH = __RAM3_SIZE
+#endif
+}
+
+ENTRY(Reset_Handler)
+
+PHDRS
+{
+	text PT_LOAD;
+	ram PT_LOAD;
+	ram_init PT_LOAD;
+	tls PT_TLS;
+}
+
+SECTIONS
+{
+	.init : {
+		KEEP (*(.vectors))
+		KEEP (*(.text.init.enter))
+		KEEP (*(.data.init.enter))
+		KEEP (*(SORT_BY_NAME(.init) SORT_BY_NAME(.init.*)))
+	} >ROM0 AT>ROM0 :text
+
+	.text : {
+
+		/* code */
+		*(.text.unlikely .text.unlikely.*)
+		*(.text.startup .text.startup.*)
+		*(.text .text.* .opd .opd.*)
+		*(.gnu.linkonce.t.*)
+		KEEP (*(.fini .fini.*))
+		__text_end = .;
+
+		PROVIDE (__etext = __text_end);
+		PROVIDE (_etext = __text_end);
+		PROVIDE (etext = __text_end);
+
+		/* read-only data */
+		*(.rdata)
+		*(.rodata .rodata.*)
+		*(.gnu.linkonce.r.*)
+
+		*(.srodata.cst16)
+		*(.srodata.cst8)
+		*(.srodata.cst4)
+		*(.srodata.cst2)
+		*(.srodata .srodata.*)
+		*(.data.rel.ro .data.rel.ro.*)
+		*(.got .got.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		/* lists of constructors and destructors */
+		PROVIDE_HIDDEN ( __preinit_array_start = . );
+		KEEP (*(.preinit_array))
+		PROVIDE_HIDDEN ( __preinit_array_end = . );
+
+		PROVIDE_HIDDEN ( __init_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+		KEEP (*(.init_array .ctors))
+		PROVIDE_HIDDEN ( __init_array_end = . );
+
+		PROVIDE_HIDDEN ( __fini_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
+		KEEP (*(.fini_array .dtors))
+		PROVIDE_HIDDEN ( __fini_array_end = . );
+
+	} >ROM0 AT>ROM0 :text
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+	.veneers :
+	{
+		. = ALIGN(32);
+		KEEP(*(.gnu.sgstubs))
+	} > ROM0 AT>ROM0 :text
+#endif
+
+	.toc : {
+		*(.toc .toc.*)
+	} >ROM0 AT>ROM0 :text
+
+	/* additional sections when compiling with C++ exception support */
+	
+	.except_ordered : {
+		*(.gcc_except_table *.gcc_except_table.*)
+		KEEP (*(.eh_frame .eh_frame.*))
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+	} >ROM0 AT>ROM0 :text
+
+	.except_unordered : {
+		. = ALIGN(8);
+
+		PROVIDE(__exidx_start = .);
+		*(.ARM.exidx*)
+		PROVIDE(__exidx_end = .);
+	} >ROM0 AT>ROM0 :text
+	
+
+	/*
+	 * Data values which are preserved across reset
+	 */
+	.preserve (NOLOAD) : {
+		PROVIDE(__preserve_start__ = .);
+		KEEP(*(SORT_BY_NAME(.preserve.*)))
+		KEEP(*(.preserve))
+		PROVIDE(__preserve_end__ = .);
+	} >RAM0 AT>RAM0 :ram
+
+	.data :  {
+		*(.data .data.*)
+		*(.gnu.linkonce.d.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		PROVIDE( __global_pointer$ = . + 0x800 );
+		*(.sdata .sdata.* .sdata2.*)
+		*(.gnu.linkonce.s.*)
+	} >RAM0 AT>ROM0 :ram_init
+	PROVIDE(__data_start = ADDR(.data));
+	PROVIDE(__data_source = LOADADDR(.data));
+
+	/* Thread local initialized data. This gets
+	 * space allocated as it is expected to be placed
+	 * in ram to be used as a template for TLS data blocks
+	 * allocated at runtime. We're slightly abusing that
+	 * by placing the data in flash where it will be copied
+	 * into the allocate ram addresses by the existing
+	 * data initialization code in crt0
+	 */
+	.tdata :  {
+		*(.tdata .tdata.* .gnu.linkonce.td.*)
+		PROVIDE(__data_end = .);
+		PROVIDE(__tdata_end = .);
+	} >RAM0 AT>ROM0 :tls :ram_init
+	PROVIDE( __tls_base = ADDR(.tdata));
+	PROVIDE( __tdata_start = ADDR(.tdata));
+	PROVIDE( __tdata_source = LOADADDR(.tdata) );
+	PROVIDE( __tdata_source_end = LOADADDR(.tdata) + SIZEOF(.tdata) );
+	PROVIDE( __data_source_end = __tdata_source_end );
+	PROVIDE( __tdata_size = SIZEOF(.tdata) );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata),ALIGNOF(.tbss)) );
+
+	PROVIDE( __edata = __data_end );
+	PROVIDE( _edata = __data_end );
+	PROVIDE( edata = __data_end );
+	PROVIDE( __data_size = __data_end - __data_start );
+	PROVIDE( __data_source_size = __data_source_end - __data_source );
+
+	.tbss (NOLOAD) : {
+		*(.tbss .tbss.* .gnu.linkonce.tb.*)
+		*(.tcommon)
+		PROVIDE( __tls_end = . );
+		PROVIDE( __tbss_end = . );
+	} >RAM0 AT>RAM0 :tls :ram
+	PROVIDE( __bss_start = ADDR(.tbss));
+	PROVIDE( __tbss_start = ADDR(.tbss));
+	PROVIDE( __tbss_offset = ADDR(.tbss) - ADDR(.tdata) );
+	PROVIDE( __tbss_size = SIZEOF(.tbss) );
+	PROVIDE( __tls_size = __tls_end - __tls_base );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
+	PROVIDE( __arm32_tls_tcb_offset = MAX(8, __tls_align) );
+	PROVIDE( __arm64_tls_tcb_offset = MAX(16, __tls_align) );
+
+	/*
+	 * The linker special cases .tbss segments which are
+	 * identified as segments which are not loaded and are
+	 * thread_local.
+	 *
+	 * For these segments, the linker does not advance 'dot'
+	 * across them.  We actually need memory allocated for tbss,
+	 * so we create a special segment here just to make room
+	 */
+	/*
+	.tbss_space (NOLOAD) : {
+		. = ADDR(.tbss);
+		. = . + SIZEOF(.tbss);
+	} >RAM0 AT>RAM0 :ram
+	*/
+
+	.bss (NOLOAD) : {
+		*(.sbss*)
+		*(.gnu.linkonce.sb.*)
+		*(.bss .bss.*)
+		*(.gnu.linkonce.b.*)
+		*(COMMON)
+
+		/* Align the heap */
+		. = ALIGN(8);
+		__bss_end = .;
+	} >RAM0 AT>RAM0 :ram
+	PROVIDE( __non_tls_bss_start = ADDR(.bss) );
+	PROVIDE( __end = __bss_end );
+	PROVIDE( _end = __bss_end );
+	PROVIDE( end = __bss_end );
+	PROVIDE( __bss_size = __bss_end - __bss_start );
+
+	/* Make the rest of memory available for heap storage */
+	PROVIDE (__heap_start = __end);
+#ifdef __HEAP_SIZE
+	PROVIDE (__heap_end = __heap_start + __HEAP_SIZE);
+	PROVIDE (__heap_size = __HEAP_SIZE);
+#else
+	PROVIDE (__heap_end = __stack - __STACK_SIZE);
+	PROVIDE (__heap_size = __heap_end - __heap_start);
+#endif
+	.heap (NOLOAD) : {
+		. += __heap_size;
+	} >RAM0 :ram
+
+	/* Define a stack region to make sure it fits in memory */
+	PROVIDE(__stack = ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE);
+	PROVIDE(__stack_limit = __stack - __STACK_SIZE);
+	.stack (__stack_limit) (NOLOAD) : {
+		. += __STACK_SIZE;
+	} >RAM0 :ram
+
+#if __STACKSEAL_SIZE > 0
+	PROVIDE(__stack_seal = __stack);
+  	.stackseal (__stack) (NOLOAD) :
+  	{
+    	. += __STACKSEAL_SIZE;
+  	} >RAM0 :ram
+#endif
+
+	/* Throw away C++ exception handling information */
+
+	/*
+
+	/DISCARD/ : {
+		*(.note .note.*)
+		*(.eh_frame .eh_frame.*)
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+		*(.ARM.exidx*)
+	}
+
+	*/
+
+	/* Stabs debugging sections.  */
+	.stab          0 : { *(.stab) }
+	.stabstr       0 : { *(.stabstr) }
+	.stab.excl     0 : { *(.stab.excl) }
+	.stab.exclstr  0 : { *(.stab.exclstr) }
+	.stab.index    0 : { *(.stab.index) }
+	.stab.indexstr 0 : { *(.stab.indexstr) }
+	.comment       0 : { *(.comment) }
+	.gnu.build.attributes : { *(.gnu.build.attributes .gnu.build.attributes.*) }
+	/* DWARF debug sections.
+	   Symbols in the DWARF debugging sections are relative to the beginning
+	   of the section so we begin them at 0.  */
+	/* DWARF 1.  */
+	.debug          0 : { *(.debug) }
+	.line           0 : { *(.line) }
+	/* GNU DWARF 1 extensions.  */
+	.debug_srcinfo  0 : { *(.debug_srcinfo) }
+	.debug_sfnames  0 : { *(.debug_sfnames) }
+	/* DWARF 1.1 and DWARF 2.  */
+	.debug_aranges  0 : { *(.debug_aranges) }
+	.debug_pubnames 0 : { *(.debug_pubnames) }
+	/* DWARF 2.  */
+	.debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+	.debug_abbrev   0 : { *(.debug_abbrev) }
+	.debug_line     0 : { *(.debug_line .debug_line.* .debug_line_end) }
+	.debug_frame    0 : { *(.debug_frame) }
+	.debug_str      0 : { *(.debug_str) }
+	.debug_loc      0 : { *(.debug_loc) }
+	.debug_macinfo  0 : { *(.debug_macinfo) }
+	/* SGI/MIPS DWARF 2 extensions.  */
+	.debug_weaknames 0 : { *(.debug_weaknames) }
+	.debug_funcnames 0 : { *(.debug_funcnames) }
+	.debug_typenames 0 : { *(.debug_typenames) }
+	.debug_varnames  0 : { *(.debug_varnames) }
+	/* DWARF 3.  */
+	.debug_pubtypes 0 : { *(.debug_pubtypes) }
+	.debug_ranges   0 : { *(.debug_ranges) }
+	/* DWARF 5.  */
+	.debug_addr     0 : { *(.debug_addr) }
+	.debug_line_str 0 : { *(.debug_line_str) }
+	.debug_loclists 0 : { *(.debug_loclists) }
+	.debug_macro    0 : { *(.debug_macro) }
+	.debug_names    0 : { *(.debug_names) }
+	.debug_rnglists 0 : { *(.debug_rnglists) }
+	.debug_str_offsets 0 : { *(.debug_str_offsets) }
+	.debug_sup      0 : { *(.debug_sup) }
+	.gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }
+}
+/*
+ * Check that sections that are copied from flash to RAM have matching
+ * padding, so that a single memcpy() of __data_size copies the correct bytes.
+ */
+ASSERT( __data_size == __data_source_size,
+	"ERROR: .data/.tdata flash size does not match RAM size");

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23NS/RTE/Device/ARMCM23/gcc_linker_script.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23NS/RTE/Device/ARMCM23/gcc_linker_script.ld
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+/* ----------------------------------------------------------------------------
+  Memory definition
+ *----------------------------------------------------------------------------*/
+MEMORY
+{
+  ROM0  (rx)  : ORIGIN = __ROM0_BASE, LENGTH = __ROM0_SIZE
+#if __ROM1_SIZE > 0
+  ROM1  (rx)  : ORIGIN = __ROM1_BASE, LENGTH = __ROM1_SIZE
+#endif
+#if __ROM2_SIZE > 0
+  ROM2  (rx)  : ORIGIN = __ROM2_BASE, LENGTH = __ROM2_SIZE
+#endif
+#if __ROM3_SIZE > 0
+  ROM3  (rx)  : ORIGIN = __ROM3_BASE, LENGTH = __ROM3_SIZE
+#endif
+
+  RAM0  (rwx) : ORIGIN = __RAM0_BASE, LENGTH = __RAM0_SIZE
+#if __RAM1_SIZE > 0
+  RAM1  (rwx) : ORIGIN = __RAM1_BASE, LENGTH = __RAM1_SIZE
+#endif
+#if __RAM2_SIZE > 0
+  RAM2  (rwx) : ORIGIN = __RAM2_BASE, LENGTH = __RAM2_SIZE
+#endif
+#if __RAM3_SIZE > 0
+  RAM3  (rwx) : ORIGIN = __RAM3_BASE, LENGTH = __RAM3_SIZE
+#endif
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __copy_table_start__
+ *   __copy_table_end__
+ *   __zero_table_start__
+ *   __zero_table_end__
+ *   __etext          (deprecated)
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+  .text :
+  {
+    KEEP(*(.vectors))
+    *(.text*)
+
+    KEEP(*(.init))
+    KEEP(*(.fini))
+
+    /* .ctors */
+    *crtbegin.o(.ctors)
+    *crtbegin?.o(.ctors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+    *(SORT(.ctors.*))
+    *(.ctors)
+
+    /* .dtors */
+    *crtbegin.o(.dtors)
+    *crtbegin?.o(.dtors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+    *(SORT(.dtors.*))
+    *(.dtors)
+
+    *(.rodata*)
+
+    KEEP(*(.eh_frame*))
+  } > ROM0
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  .gnu.sgstubs :
+  {
+    . = ALIGN(32);
+  } > ROM0
+#endif
+
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > ROM0
+
+  __exidx_start = .;
+  .ARM.exidx :
+  {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+  } > ROM0
+  __exidx_end = .;
+
+  .copy.table :
+  {
+    . = ALIGN(4);
+    __copy_table_start__ = .;
+
+    LONG (LOADADDR(.data))
+    LONG (ADDR(.data))
+    LONG (SIZEOF(.data) / 4)
+
+    /* Add each additional data section here */
+/*
+    LONG (LOADADDR(.data2))
+    LONG (ADDR(.data2))
+    LONG (SIZEOF(.data2) / 4)
+*/
+    __copy_table_end__ = .;
+  } > ROM0
+
+  .zero.table :
+  {
+    . = ALIGN(4);
+    __zero_table_start__ = .;
+
+/*  .bss initialization to zero is already done during C Run-Time Startup.
+    LONG (ADDR(.bss))
+    LONG (SIZEOF(.bss) / 4)
+*/
+
+    /* Add each additional bss section here */
+/*
+    LONG (ADDR(.bss2))
+    LONG (SIZEOF(.bss2) / 4)
+*/
+    __zero_table_end__ = .;
+  } > ROM0
+
+  /*
+   * This __etext variable is kept for backward compatibility with older,
+   * ASM based startup files.
+   */
+  PROVIDE(__etext = LOADADDR(.data));
+
+  .data : ALIGN(4)
+  {
+    __data_start__ = .;
+    *(vtable)
+    *(.data)
+    *(.data.*)
+
+    . = ALIGN(4);
+    /* preinit data */
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP(*(.preinit_array))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+
+    . = ALIGN(4);
+    /* init data */
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP(*(SORT(.init_array.*)))
+    KEEP(*(.init_array))
+    PROVIDE_HIDDEN (__init_array_end = .);
+
+    . = ALIGN(4);
+    /* finit data */
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP(*(SORT(.fini_array.*)))
+    KEEP(*(.fini_array))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    /* All data end */
+    __data_end__ = .;
+
+  } > RAM0 AT > ROM0
+
+  /*
+   * Secondary data section, optional
+   *
+   * Remember to add each additional data section
+   * to the .copy.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .data2 : ALIGN(4)
+  {
+    . = ALIGN(4);
+    __data2_start__ = .;
+    *(.data2)
+    *(.data2.*)
+    . = ALIGN(4);
+    __data2_end__ = .;
+
+  } > RAM1 AT > ROM0 
+*/
+
+  .bss :
+  {
+    . = ALIGN(4);
+    __bss_start__ = .;
+    *(.bss)
+    *(.bss.*)
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+  } > RAM0 AT > RAM0
+
+  /*
+   * Secondary bss section, optional
+   *
+   * Remember to add each additional bss section
+   * to the .zero.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .bss2 :
+  {
+    . = ALIGN(4);
+    __bss2_start__ = .;
+    *(.bss2)
+    *(.bss2.*)
+    . = ALIGN(4);
+    __bss2_end__ = .;
+  } > RAM1 AT > RAM1
+*/
+
+  .heap (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE(end = .);
+    . = . + __HEAP_SIZE;
+    . = ALIGN(8);
+    __HeapLimit = .;
+  } > RAM0
+
+  .stack (ORIGIN(RAM0) + LENGTH(RAM0) - __STACK_SIZE - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackLimit = .;
+    . = . + __STACK_SIZE;
+    . = ALIGN(8);
+    __StackTop = .;
+  } > RAM0
+  PROVIDE(__stack = __StackTop);
+
+#if __STACKSEAL_SIZE > 0
+  .stackseal (ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackSeal = .;
+    . = . + 8;
+    . = ALIGN(8);
+  } > RAM0
+#endif
+
+  /* Check if data + heap + stack exceeds RAM limit */
+  ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23NS/RTE/Device/ARMCM23/iar_linker_script.icf
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23NS/RTE/Device/ARMCM23/iar_linker_script.icf
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+define memory mem with size = 4G;
+
+#if __ROM0_SIZE > 0
+  define region ROM0_region = mem:[from __ROM0_BASE to (__ROM0_BASE+__ROM0_SIZE-1)];
+#else
+  define region ROM0_region = [];
+#endif
+
+#if __ROM1_SIZE > 0
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+#else
+  define region ROM1_region = [];
+#endif
+
+#if __ROM2_SIZE > 0
+  define region ROM2_region = mem:[from __ROM2_BASE to (__ROM2_BASE+__ROM2_SIZE-1)];
+#else
+  define region ROM2_region = [];
+#endif
+
+#if __ROM3_SIZE > 0
+  define region ROM3_region = mem:[from __ROM3_BASE to (__ROM3_BASE+__ROM3_SIZE-1)];
+#else
+  define region ROM3_region = [];
+#endif
+
+define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_region;
+
+#if __RAM0_SIZE > 0
+  define region RAM0_region = mem:[from __RAM0_BASE to (__RAM0_BASE+__RAM0_SIZE-1)];
+#else
+  define region RAM0_region = [];
+#endif
+
+#if __RAM1_SIZE > 0
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+#else
+  define region RAM1_region = [];
+#endif
+
+#if __RAM2_SIZE > 0
+  define region RAM2_region = mem:[from __RAM2_BASE to (__RAM2_BASE+__RAM2_SIZE-1)];
+#else
+  define region RAM2_region = [];
+#endif
+
+#if __RAM3_SIZE > 0
+  define region RAM3_region = mem:[from __RAM3_BASE to (__RAM3_BASE+__RAM3_SIZE-1)];
+#else
+  define region RAM3_region = [];
+#endif
+
+define region RAM_region = RAM0_region | RAM1_region | RAM2_region | RAM3_region;
+
+do not initialize  { section .noinit };
+initialize by copy { readwrite };
+if (isdefinedsymbol(__USE_DLIB_PERTHREAD))
+{
+  // Required in a multi-threaded application
+  initialize by copy with packing = none { section __DLIB_PERTHREAD };
+}
+
+place at address mem:__ROM0_BASE { readonly section .intvec };
+
+if (!isempty(ROM_region))
+{
+  place in ROM_region  { readonly };
+}
+
+if (!isempty(RAM_region))
+{
+  define block CSTACK     with alignment = 8, size = __STACK_SIZE     { };
+  define block PROC_STACK with alignment = 8, size = 0 { };
+  define block HEAP       with alignment = 8, size = __HEAP_SIZE       { };
+  place in RAM_region  { readwrite, block CSTACK, block PROC_STACK, block HEAP };
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23NS/RTE/Device/ARMCM23/regions_ARMCM23.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23NS/RTE/Device/ARMCM23/regions_ARMCM23.h
@@ -1,0 +1,94 @@
+#ifndef REGIONS_ARMCM23_H
+#define REGIONS_ARMCM23_H
+
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+// <n>Device pack:   ARM::Cortex_DFP@1.0.0-dev16
+// <i>Device pack used to generate this file
+
+// <h>ROM Configuration
+// =======================
+// <h> ROM_S=<__ROM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x00000000
+#define __ROM0_BASE 0x00200000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00200000
+#define __ROM0_SIZE 0x00200000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __ROM0_DEFAULT 1
+//   <q>Startup
+//   <i> Selects region to be used for startup code.
+#define __ROM0_STARTUP 1
+// </h>
+
+// <h> ROM_NS=<__ROM1>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x00200000
+#define __ROM1_BASE 0x00000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00200000
+#define __ROM1_SIZE 0x00200000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __ROM1_DEFAULT 0
+//   <q>Startup
+//   <i> Selects region to be used for startup code.
+#define __ROM1_STARTUP 0
+// </h>
+
+// </h>
+
+// <h>RAM Configuration
+// =======================
+// <h> RAM_S=<__RAM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x20000000
+#define __RAM0_BASE 0x20200000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00020000
+#define __RAM0_SIZE 0x00020000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __RAM0_DEFAULT 1
+//   <q>No zero initialize
+//   <i> Excludes region from zero initialization.
+#define __RAM0_NOINIT 0
+// </h>
+
+// <h> RAM_NS=<__RAM1>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x20200000
+#define __RAM1_BASE 0x20000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00020000
+#define __RAM1_SIZE 0x00020000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __RAM1_DEFAULT 0
+//   <q>No zero initialize
+//   <i> Excludes region from zero initialization.
+#define __RAM1_NOINIT 0
+// </h>
+
+// </h>
+
+// <h>Stack / Heap Configuration
+//   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+#define __STACK_SIZE 0x00000400
+#define __HEAP_SIZE 0x00000C00
+// </h>
+
+
+#endif /* REGIONS_ARMCM23_H */

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23NS/RTE/Device/ARMCM23/startup_ARMCM23.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23NS/RTE/Device/ARMCM23/startup_ARMCM23.c
@@ -1,0 +1,159 @@
+/******************************************************************************
+ * @file     startup_ARMCM23.c
+ * @brief    CMSIS-Core Device Startup File for a Cortex-M23 Device
+ * @version  V3.0.0
+ * @date     06. April 2023
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (ARMCM23)
+  #include "ARMCM23.h"
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  External References
+ *----------------------------------------------------------------------------*/
+extern uint32_t __INITIAL_SP;
+extern uint32_t __STACK_LIMIT;
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+extern uint32_t __STACK_SEAL;
+#endif
+
+extern __NO_RETURN void __PROGRAM_START(void);
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler  (void);
+            void Default_Handler(void);
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+/* Exceptions */
+void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void HardFault_Handler      (void) __attribute__ ((weak));
+void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+
+void Interrupt0_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt1_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt2_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt3_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt4_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt5_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt6_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt7_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt8_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt9_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[240];
+       const VECTOR_TABLE_Type __VECTOR_TABLE[240] __VECTOR_TABLE_ATTRIBUTE = {
+  (VECTOR_TABLE_Type)(&__INITIAL_SP),       /*     Initial Stack Pointer */
+  Reset_Handler,                            /*     Reset Handler */
+  NMI_Handler,                              /* -14 NMI Handler */
+  HardFault_Handler,                        /* -13 Hard Fault Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  SVC_Handler,                              /*  -5 SVCall Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  PendSV_Handler,                           /*  -2 PendSV Handler */
+  SysTick_Handler,                          /*  -1 SysTick Handler */
+
+  /* Interrupts */
+  Interrupt0_Handler,                       /*   0 Interrupt 0 */
+  Interrupt1_Handler,                       /*   1 Interrupt 1 */
+  Interrupt2_Handler,                       /*   2 Interrupt 2 */
+  Interrupt3_Handler,                       /*   3 Interrupt 3 */
+  Interrupt4_Handler,                       /*   4 Interrupt 4 */
+  Interrupt5_Handler,                       /*   5 Interrupt 5 */
+  Interrupt6_Handler,                       /*   6 Interrupt 6 */
+  Interrupt7_Handler,                       /*   7 Interrupt 7 */
+  Interrupt8_Handler,                       /*   8 Interrupt 8 */
+  Interrupt9_Handler                        /*   9 Interrupt 9 */
+                                            /* Interrupts 10 .. 223 are left out */
+};
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler(void)
+{
+  __set_PSP((uint32_t)(&__INITIAL_SP));
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  __set_MSPLIM((uint32_t)(&__STACK_LIMIT));
+  __set_PSPLIM((uint32_t)(&__STACK_LIMIT));
+
+  __TZ_set_STACKSEAL_S((uint32_t *)(&__STACK_SEAL));
+#endif
+
+  SystemInit();                             /* CMSIS System Initialization */
+  __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
+}
+
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wmissing-noreturn"
+#endif
+
+/*----------------------------------------------------------------------------
+  Hard Fault Handler
+ *----------------------------------------------------------------------------*/
+void HardFault_Handler(void)
+{
+  while(1);
+}
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+void Default_Handler(void)
+{
+  while(1);
+}
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic pop
+#endif
+

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23NS/RTE/Device/ARMCM23/system_ARMCM23.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23NS/RTE/Device/ARMCM23/system_ARMCM23.c
@@ -1,0 +1,77 @@
+/**************************************************************************//**
+ * @file     system_ARMCM23.c
+ * @brief    CMSIS Device System Source File for
+ *           ARMCM23 Device
+ * @version  V2.0.0
+ * @date     06. April 2023
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (ARMCM23)
+  #include "ARMCM23.h"
+  #if defined (__ARM_FEATURE_CMSE) &&  (__ARM_FEATURE_CMSE == 3U)
+    #include "partition_ARMCM23.h"
+  #endif
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  Define clocks
+ *----------------------------------------------------------------------------*/
+#define  XTAL            (50000000UL)     /* Oscillator frequency */
+
+#define  SYSTEM_CLOCK    (XTAL / 2U)
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[240];
+
+
+/*----------------------------------------------------------------------------
+  System Core Clock Variable
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = SYSTEM_CLOCK;  /* System Core Clock Frequency */
+
+
+/*----------------------------------------------------------------------------
+  System Core Clock update function
+ *----------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)
+{
+  SystemCoreClock = SYSTEM_CLOCK;
+}
+
+/*----------------------------------------------------------------------------
+  System initialization function
+ *----------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t) &(__VECTOR_TABLE[0]);
+#endif
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  TZ_SAU_Setup();
+#endif
+
+  SystemCoreClock = SYSTEM_CLOCK;
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23NS/Target.clayer.yml
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23NS/Target.clayer.yml
@@ -1,0 +1,35 @@
+layer:
+  type: Target
+  description: CM23NS target components and files
+
+  packs:
+    - pack: ARM::Cortex_DFP
+
+  device: ARMCM23
+
+  processor:
+    trustzone: non-secure
+
+  components:
+    # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
+    - component: ARM::CMSIS:CORE
+    - component: Device:Startup&C Startup
+
+  groups:
+    - group: FVP
+      files:
+        - file: ./model_config.txt
+
+  linker:
+    - for-compiler: AC6
+      script: RTE/Device/$Dname$/ac6_linker_script.sct
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: GCC
+      script: RTE/Device/$Dname$/gcc_linker_script.ld
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: CLANG
+      script: RTE/Device/$Dname$/clang_linker_script.ld
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: IAR
+      script: RTE/Device/$Dname$/iar_linker_script.icf
+      regions: RTE/Device/$Dname$/regions_$Dname$.h

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23NS/model_config.txt
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23NS/model_config.txt
@@ -1,0 +1,16 @@
+# Parameters:
+# instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+#----------------------------------------------------------------------------------------------
+fvp_mps2.mps2_visualisation.disable-visualisation=1   # (bool  , init-time) default = '0'      : Enable/disable visualisation
+cpu0.semihosting-enable=1                             # (bool  , init-time) default = '1'      : Enable semihosting SVC traps. Applications that do not use semihosting must set this parameter to false.
+cpu0.semihosting-Thumb_SVC=0xAB                       # (int   , init-time) default = '0xAB'   : T32 SVC number for semihosting : [0x0..0xFF]
+cpu0.semihosting-cmd_line=""                          # (string, init-time) default = ''       : Command line available to semihosting SVC calls
+cpu0.semihosting-heap_base=0x0                        # (int   , init-time) default = '0x0'    : Virtual address of heap base : [0x0..0xFFFFFFFF]
+cpu0.semihosting-heap_limit=0x0                       # (int   , init-time) default = '0x10700000' : Virtual address of top of heap : [0x0..0xFFFFFFFF]
+cpu0.semihosting-stack_base=0x0                       # (int   , init-time) default = '0x10700000' : Virtual address of base of descending stack : [0x0..0xFFFFFFFF]
+cpu0.semihosting-stack_limit=0x0                      # (int   , init-time) default = '0x10800000' : Virtual address of stack limit : [0x0..0xFFFFFFFF]
+cpu0.semihosting-cwd=""                               # (string, init-time) default = ''       : Base directory for semihosting file access.
+idau.NUM_IDAU_REGION=0x0                              # (int   , init-time) default = '0xA'    : 
+cpu0.SECEXT=1                                         # (bool  , init-time) default = '1'      : Whether the ARMv8-M Security Extensions are included
+fvp_mps2.DISABLE_GATING=1                             # (bool  , init-time) default = '0'      : Disable Memory gating logic
+#----------------------------------------------------------------------------------------------

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23S/RTE/Device/ARMCM23/ARMCM23_ac6.sct
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23S/RTE/Device/ARMCM23/ARMCM23_ac6.sct
@@ -1,0 +1,123 @@
+#! armclang -E --target=arm-arm-none-eabi -mcpu=cortex-m23 -xc
+; command above MUST be in first line (no comment above!)
+
+;Note: Add '-mcmse' to first line if your software model is "Secure Mode".
+;      #! armclang -E --target=arm-arm-none-eabi -mcpu=cortex-m23 -xc -mcmse
+
+
+/*
+;-------- <<< Use Configuration Wizard in Context Menu >>> -------------------
+*/
+
+/*--------------------- Flash Configuration ----------------------------------
+; <h> Flash Configuration
+;   <o0> Flash Base Address <0x0-0xFFFFFFFF:8>
+;   <o1> Flash Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __ROM_BASE      0x00000000
+#define __ROM_SIZE      0x00080000
+
+/*--------------------- Embedded RAM Configuration ---------------------------
+; <h> RAM Configuration
+;   <o0> RAM Base Address    <0x0-0xFFFFFFFF:8>
+;   <o1> RAM Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __RAM_BASE      0x20000000
+#define __RAM_SIZE      0x00040000
+
+/*--------------------- Stack / Heap Configuration ---------------------------
+; <h> Stack / Heap Configuration
+;   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+;   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __STACK_SIZE    0x00000200
+#define __HEAP_SIZE     0x00000C00
+
+/*--------------------- CMSE Veneer Configuration ---------------------------
+; <h> CMSE Veneer Configuration
+;   <o0>  CMSE Veneer Size (in Bytes) <0x0-0xFFFFFFFF:32>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __CMSEVENEER_SIZE    0x200
+
+/*
+;------------- <<< end of configuration section >>> ---------------------------
+*/
+
+
+/*----------------------------------------------------------------------------
+  User Stack & Heap boundary definition
+ *----------------------------------------------------------------------------*/
+#define __STACK_TOP    (__RAM_BASE + __RAM_SIZE - __STACKSEAL_SIZE) /* starts at end of RAM - 8 byte stack seal */
+#define __HEAP_BASE    (AlignExpr(+0, 8))                           /* starts after RW_RAM section, 8 byte aligned */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+
+/*----------------------------------------------------------------------------
+  Region base & size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __CV_BASE          ( __ROM_BASE + __ROM_SIZE - __CMSEVENEER_SIZE )
+#define __CV_SIZE          ( __CMSEVENEER_SIZE )
+#else
+#define __CV_SIZE          ( 0 )
+#endif
+
+#define __RO_BASE          ( __ROM_BASE )
+#define __RO_SIZE          ( __ROM_SIZE - __CV_SIZE )
+
+#define __RW_BASE          ( __RAM_BASE )
+#define __RW_SIZE      (__RAM_SIZE - __STACK_SIZE - __HEAP_SIZE - __STACKSEAL_SIZE )
+
+
+/*----------------------------------------------------------------------------
+  Scatter Region definition
+ *----------------------------------------------------------------------------*/
+LR_ROM __RO_BASE __RO_SIZE  {                       ; load region size_region
+  ER_ROM __RO_BASE __RO_SIZE  {                     ; load address = execution address
+   *.o (RESET, +First)
+   *(InRoot$$Sections)
+   .ANY (+RO)
+   .ANY (+XO)
+  }
+
+  RW_NOINIT __RW_BASE UNINIT __RW_SIZE {
+    *(.bss.noinit)
+  }
+
+  RW_RAM AlignExpr(+0, 8) (__RW_SIZE - AlignExpr(ImageLength(RW_NOINIT), 8)) {
+    *(+RW +ZI)
+  }
+
+#if __HEAP_SIZE > 0
+  ARM_LIB_HEAP  __HEAP_BASE EMPTY  __HEAP_SIZE  {   ; Reserve empty region for heap
+  }
+#endif
+
+  ARM_LIB_STACK __STACK_TOP EMPTY -__STACK_SIZE {   ; Reserve empty region for stack
+  }
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  STACKSEAL +0 EMPTY __STACKSEAL_SIZE {             ; Reserve empty region for stack seal immediately after stack
+  }
+#endif
+}
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+LR_CMSE_VENEER __CV_BASE ALIGN 32 __CV_SIZE  {      ; own load/execution region for CMSE Veneers
+  ER_CMSE_VENEER __CV_BASE __CV_SIZE  {
+   *(Veneer$$CMSE)
+  }
+}
+#endif

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23S/RTE/Device/ARMCM23/ARMCM23_ac6.sct.base@1.1.0
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23S/RTE/Device/ARMCM23/ARMCM23_ac6.sct.base@1.1.0
@@ -1,0 +1,123 @@
+#! armclang -E --target=arm-arm-none-eabi -mcpu=cortex-m23 -xc
+; command above MUST be in first line (no comment above!)
+
+;Note: Add '-mcmse' to first line if your software model is "Secure Mode".
+;      #! armclang -E --target=arm-arm-none-eabi -mcpu=cortex-m23 -xc -mcmse
+
+
+/*
+;-------- <<< Use Configuration Wizard in Context Menu >>> -------------------
+*/
+
+/*--------------------- Flash Configuration ----------------------------------
+; <h> Flash Configuration
+;   <o0> Flash Base Address <0x0-0xFFFFFFFF:8>
+;   <o1> Flash Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __ROM_BASE      0x00000000
+#define __ROM_SIZE      0x00080000
+
+/*--------------------- Embedded RAM Configuration ---------------------------
+; <h> RAM Configuration
+;   <o0> RAM Base Address    <0x0-0xFFFFFFFF:8>
+;   <o1> RAM Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __RAM_BASE      0x20000000
+#define __RAM_SIZE      0x00040000
+
+/*--------------------- Stack / Heap Configuration ---------------------------
+; <h> Stack / Heap Configuration
+;   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+;   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __STACK_SIZE    0x00000200
+#define __HEAP_SIZE     0x00000C00
+
+/*--------------------- CMSE Veneer Configuration ---------------------------
+; <h> CMSE Veneer Configuration
+;   <o0>  CMSE Veneer Size (in Bytes) <0x0-0xFFFFFFFF:32>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __CMSEVENEER_SIZE    0x200
+
+/*
+;------------- <<< end of configuration section >>> ---------------------------
+*/
+
+
+/*----------------------------------------------------------------------------
+  User Stack & Heap boundary definition
+ *----------------------------------------------------------------------------*/
+#define __STACK_TOP    (__RAM_BASE + __RAM_SIZE - __STACKSEAL_SIZE) /* starts at end of RAM - 8 byte stack seal */
+#define __HEAP_BASE    (AlignExpr(+0, 8))                           /* starts after RW_RAM section, 8 byte aligned */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+
+/*----------------------------------------------------------------------------
+  Region base & size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __CV_BASE          ( __ROM_BASE + __ROM_SIZE - __CMSEVENEER_SIZE )
+#define __CV_SIZE          ( __CMSEVENEER_SIZE )
+#else
+#define __CV_SIZE          ( 0 )
+#endif
+
+#define __RO_BASE          ( __ROM_BASE )
+#define __RO_SIZE          ( __ROM_SIZE - __CV_SIZE )
+
+#define __RW_BASE          ( __RAM_BASE )
+#define __RW_SIZE      (__RAM_SIZE - __STACK_SIZE - __HEAP_SIZE - __STACKSEAL_SIZE )
+
+
+/*----------------------------------------------------------------------------
+  Scatter Region definition
+ *----------------------------------------------------------------------------*/
+LR_ROM __RO_BASE __RO_SIZE  {                       ; load region size_region
+  ER_ROM __RO_BASE __RO_SIZE  {                     ; load address = execution address
+   *.o (RESET, +First)
+   *(InRoot$$Sections)
+   .ANY (+RO)
+   .ANY (+XO)
+  }
+
+  RW_NOINIT __RW_BASE UNINIT __RW_SIZE {
+    *(.bss.noinit)
+  }
+
+  RW_RAM AlignExpr(+0, 8) (__RW_SIZE - AlignExpr(ImageLength(RW_NOINIT), 8)) {
+    *(+RW +ZI)
+  }
+
+#if __HEAP_SIZE > 0
+  ARM_LIB_HEAP  __HEAP_BASE EMPTY  __HEAP_SIZE  {   ; Reserve empty region for heap
+  }
+#endif
+
+  ARM_LIB_STACK __STACK_TOP EMPTY -__STACK_SIZE {   ; Reserve empty region for stack
+  }
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  STACKSEAL +0 EMPTY __STACKSEAL_SIZE {             ; Reserve empty region for stack seal immediately after stack
+  }
+#endif
+}
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+LR_CMSE_VENEER __CV_BASE ALIGN 32 __CV_SIZE  {      ; own load/execution region for CMSE Veneers
+  ER_CMSE_VENEER __CV_BASE __CV_SIZE  {
+   *(Veneer$$CMSE)
+  }
+}
+#endif

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23S/RTE/Device/ARMCM23/ac6_linker_script.sct
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23S/RTE/Device/ARMCM23/ac6_linker_script.sct
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE 8
+#else
+#define __STACKSEAL_SIZE 0
+#endif
+
+/*----------------------------------------------------------------------------
+  Scatter File Definitions definition
+ *----------------------------------------------------------------------------*/
+
+LR_ROM0 __ROM0_BASE __ROM0_SIZE  {
+
+  ER_ROM0 __ROM0_BASE __ROM0_SIZE {
+    *.o (RESET, +First)
+    *(InRoot$$Sections)
+    *(+RO +XO)
+  }
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  ER_CMSE_VENEER AlignExpr(+0, 32) (__ROM0_SIZE - AlignExpr(ImageLength(ER_ROM0), 32)) {
+    *(Veneer$$CMSE)
+  }
+#endif
+
+  RW_NOINIT __RAM0_BASE UNINIT (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE) {
+    *(.bss.noinit)
+  }
+
+  RW_RAM0 AlignExpr(+0, 8) (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE - AlignExpr(ImageLength(RW_NOINIT), 8)) {
+    *(+RW +ZI)
+  }
+
+#if __HEAP_SIZE > 0
+  ARM_LIB_HEAP  (AlignExpr(+0, 8)) EMPTY __HEAP_SIZE  {   ; Reserve empty region for heap
+  }
+#endif
+
+  ARM_LIB_STACK (__RAM0_BASE + __RAM0_SIZE - __STACKSEAL_SIZE) EMPTY -__STACK_SIZE {   ; Reserve empty region for stack
+  }
+
+#if __STACKSEAL_SIZE > 0
+  STACKSEAL +0 EMPTY __STACKSEAL_SIZE {             ; Reserve empty region for stack seal immediately after stack
+  }
+#endif
+
+#if __RAM1_SIZE > 0
+  RW_RAM1 __RAM1_BASE __RAM1_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+
+#if __RAM2_SIZE > 0
+  RW_RAM2 __RAM2_BASE __RAM2_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+
+#if __RAM3_SIZE > 0
+  RW_RAM3 __RAM3_BASE __RAM3_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+}
+
+#if __ROM1_SIZE > 0
+LR_ROM1 __ROM1_BASE __ROM1_SIZE  {
+  ER_ROM1 +0 __ROM1_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif
+
+#if __ROM2_SIZE > 0
+LR_ROM2 __ROM2_BASE __ROM2_SIZE  {
+  ER_ROM2 +0 __ROM2_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif
+
+#if __ROM3_SIZE > 0
+LR_ROM3 __ROM3_BASE __ROM3_SIZE  {
+  ER_ROM3 +0 __ROM3_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23S/RTE/Device/ARMCM23/clang_linker_script.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23S/RTE/Device/ARMCM23/clang_linker_script.ld
@@ -1,0 +1,361 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2019 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+/* ----------------------------------------------------------------------------
+  Memory definition
+ *----------------------------------------------------------------------------*/
+MEMORY
+{
+  ROM0  (rx!w)  : ORIGIN = __ROM0_BASE, LENGTH = __ROM0_SIZE
+#if __ROM1_SIZE > 0
+  ROM1  (rx!w)  : ORIGIN = __ROM1_BASE, LENGTH = __ROM1_SIZE
+#endif
+#if __ROM2_SIZE > 0
+  ROM2  (rx!w)  : ORIGIN = __ROM2_BASE, LENGTH = __ROM2_SIZE
+#endif
+#if __ROM3_SIZE > 0
+  ROM3  (rx!w)  : ORIGIN = __ROM3_BASE, LENGTH = __ROM3_SIZE
+#endif
+
+  RAM0  (w!rx) : ORIGIN = __RAM0_BASE, LENGTH = __RAM0_SIZE
+#if __RAM1_SIZE > 0
+  RAM1  (w!rx) : ORIGIN = __RAM1_BASE, LENGTH = __RAM1_SIZE
+#endif
+#if __RAM2_SIZE > 0
+  RAM2  (w!rx) : ORIGIN = __RAM2_BASE, LENGTH = __RAM2_SIZE
+#endif
+#if __RAM3_SIZE > 0
+  RAM3  (w!rx) : ORIGIN = __RAM3_BASE, LENGTH = __RAM3_SIZE
+#endif
+}
+
+ENTRY(Reset_Handler)
+
+PHDRS
+{
+	text PT_LOAD;
+	ram PT_LOAD;
+	ram_init PT_LOAD;
+	tls PT_TLS;
+}
+
+SECTIONS
+{
+	.init : {
+		KEEP (*(.vectors))
+		KEEP (*(.text.init.enter))
+		KEEP (*(.data.init.enter))
+		KEEP (*(SORT_BY_NAME(.init) SORT_BY_NAME(.init.*)))
+	} >ROM0 AT>ROM0 :text
+
+	.text : {
+
+		/* code */
+		*(.text.unlikely .text.unlikely.*)
+		*(.text.startup .text.startup.*)
+		*(.text .text.* .opd .opd.*)
+		*(.gnu.linkonce.t.*)
+		KEEP (*(.fini .fini.*))
+		__text_end = .;
+
+		PROVIDE (__etext = __text_end);
+		PROVIDE (_etext = __text_end);
+		PROVIDE (etext = __text_end);
+
+		/* read-only data */
+		*(.rdata)
+		*(.rodata .rodata.*)
+		*(.gnu.linkonce.r.*)
+
+		*(.srodata.cst16)
+		*(.srodata.cst8)
+		*(.srodata.cst4)
+		*(.srodata.cst2)
+		*(.srodata .srodata.*)
+		*(.data.rel.ro .data.rel.ro.*)
+		*(.got .got.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		/* lists of constructors and destructors */
+		PROVIDE_HIDDEN ( __preinit_array_start = . );
+		KEEP (*(.preinit_array))
+		PROVIDE_HIDDEN ( __preinit_array_end = . );
+
+		PROVIDE_HIDDEN ( __init_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+		KEEP (*(.init_array .ctors))
+		PROVIDE_HIDDEN ( __init_array_end = . );
+
+		PROVIDE_HIDDEN ( __fini_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
+		KEEP (*(.fini_array .dtors))
+		PROVIDE_HIDDEN ( __fini_array_end = . );
+
+	} >ROM0 AT>ROM0 :text
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+	.veneers :
+	{
+		. = ALIGN(32);
+		KEEP(*(.gnu.sgstubs))
+	} > ROM0 AT>ROM0 :text
+#endif
+
+	.toc : {
+		*(.toc .toc.*)
+	} >ROM0 AT>ROM0 :text
+
+	/* additional sections when compiling with C++ exception support */
+	
+	.except_ordered : {
+		*(.gcc_except_table *.gcc_except_table.*)
+		KEEP (*(.eh_frame .eh_frame.*))
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+	} >ROM0 AT>ROM0 :text
+
+	.except_unordered : {
+		. = ALIGN(8);
+
+		PROVIDE(__exidx_start = .);
+		*(.ARM.exidx*)
+		PROVIDE(__exidx_end = .);
+	} >ROM0 AT>ROM0 :text
+	
+
+	/*
+	 * Data values which are preserved across reset
+	 */
+	.preserve (NOLOAD) : {
+		PROVIDE(__preserve_start__ = .);
+		KEEP(*(SORT_BY_NAME(.preserve.*)))
+		KEEP(*(.preserve))
+		PROVIDE(__preserve_end__ = .);
+	} >RAM0 AT>RAM0 :ram
+
+	.data :  {
+		*(.data .data.*)
+		*(.gnu.linkonce.d.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		PROVIDE( __global_pointer$ = . + 0x800 );
+		*(.sdata .sdata.* .sdata2.*)
+		*(.gnu.linkonce.s.*)
+	} >RAM0 AT>ROM0 :ram_init
+	PROVIDE(__data_start = ADDR(.data));
+	PROVIDE(__data_source = LOADADDR(.data));
+
+	/* Thread local initialized data. This gets
+	 * space allocated as it is expected to be placed
+	 * in ram to be used as a template for TLS data blocks
+	 * allocated at runtime. We're slightly abusing that
+	 * by placing the data in flash where it will be copied
+	 * into the allocate ram addresses by the existing
+	 * data initialization code in crt0
+	 */
+	.tdata :  {
+		*(.tdata .tdata.* .gnu.linkonce.td.*)
+		PROVIDE(__data_end = .);
+		PROVIDE(__tdata_end = .);
+	} >RAM0 AT>ROM0 :tls :ram_init
+	PROVIDE( __tls_base = ADDR(.tdata));
+	PROVIDE( __tdata_start = ADDR(.tdata));
+	PROVIDE( __tdata_source = LOADADDR(.tdata) );
+	PROVIDE( __tdata_source_end = LOADADDR(.tdata) + SIZEOF(.tdata) );
+	PROVIDE( __data_source_end = __tdata_source_end );
+	PROVIDE( __tdata_size = SIZEOF(.tdata) );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata),ALIGNOF(.tbss)) );
+
+	PROVIDE( __edata = __data_end );
+	PROVIDE( _edata = __data_end );
+	PROVIDE( edata = __data_end );
+	PROVIDE( __data_size = __data_end - __data_start );
+	PROVIDE( __data_source_size = __data_source_end - __data_source );
+
+	.tbss (NOLOAD) : {
+		*(.tbss .tbss.* .gnu.linkonce.tb.*)
+		*(.tcommon)
+		PROVIDE( __tls_end = . );
+		PROVIDE( __tbss_end = . );
+	} >RAM0 AT>RAM0 :tls :ram
+	PROVIDE( __bss_start = ADDR(.tbss));
+	PROVIDE( __tbss_start = ADDR(.tbss));
+	PROVIDE( __tbss_offset = ADDR(.tbss) - ADDR(.tdata) );
+	PROVIDE( __tbss_size = SIZEOF(.tbss) );
+	PROVIDE( __tls_size = __tls_end - __tls_base );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
+	PROVIDE( __arm32_tls_tcb_offset = MAX(8, __tls_align) );
+	PROVIDE( __arm64_tls_tcb_offset = MAX(16, __tls_align) );
+
+	/*
+	 * The linker special cases .tbss segments which are
+	 * identified as segments which are not loaded and are
+	 * thread_local.
+	 *
+	 * For these segments, the linker does not advance 'dot'
+	 * across them.  We actually need memory allocated for tbss,
+	 * so we create a special segment here just to make room
+	 */
+	/*
+	.tbss_space (NOLOAD) : {
+		. = ADDR(.tbss);
+		. = . + SIZEOF(.tbss);
+	} >RAM0 AT>RAM0 :ram
+	*/
+
+	.bss (NOLOAD) : {
+		*(.sbss*)
+		*(.gnu.linkonce.sb.*)
+		*(.bss .bss.*)
+		*(.gnu.linkonce.b.*)
+		*(COMMON)
+
+		/* Align the heap */
+		. = ALIGN(8);
+		__bss_end = .;
+	} >RAM0 AT>RAM0 :ram
+	PROVIDE( __non_tls_bss_start = ADDR(.bss) );
+	PROVIDE( __end = __bss_end );
+	PROVIDE( _end = __bss_end );
+	PROVIDE( end = __bss_end );
+	PROVIDE( __bss_size = __bss_end - __bss_start );
+
+	/* Make the rest of memory available for heap storage */
+	PROVIDE (__heap_start = __end);
+#ifdef __HEAP_SIZE
+	PROVIDE (__heap_end = __heap_start + __HEAP_SIZE);
+	PROVIDE (__heap_size = __HEAP_SIZE);
+#else
+	PROVIDE (__heap_end = __stack - __STACK_SIZE);
+	PROVIDE (__heap_size = __heap_end - __heap_start);
+#endif
+	.heap (NOLOAD) : {
+		. += __heap_size;
+	} >RAM0 :ram
+
+	/* Define a stack region to make sure it fits in memory */
+	PROVIDE(__stack = ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE);
+	PROVIDE(__stack_limit = __stack - __STACK_SIZE);
+	.stack (__stack_limit) (NOLOAD) : {
+		. += __STACK_SIZE;
+	} >RAM0 :ram
+
+#if __STACKSEAL_SIZE > 0
+	PROVIDE(__stack_seal = __stack);
+  	.stackseal (__stack) (NOLOAD) :
+  	{
+    	. += __STACKSEAL_SIZE;
+  	} >RAM0 :ram
+#endif
+
+	/* Throw away C++ exception handling information */
+
+	/*
+
+	/DISCARD/ : {
+		*(.note .note.*)
+		*(.eh_frame .eh_frame.*)
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+		*(.ARM.exidx*)
+	}
+
+	*/
+
+	/* Stabs debugging sections.  */
+	.stab          0 : { *(.stab) }
+	.stabstr       0 : { *(.stabstr) }
+	.stab.excl     0 : { *(.stab.excl) }
+	.stab.exclstr  0 : { *(.stab.exclstr) }
+	.stab.index    0 : { *(.stab.index) }
+	.stab.indexstr 0 : { *(.stab.indexstr) }
+	.comment       0 : { *(.comment) }
+	.gnu.build.attributes : { *(.gnu.build.attributes .gnu.build.attributes.*) }
+	/* DWARF debug sections.
+	   Symbols in the DWARF debugging sections are relative to the beginning
+	   of the section so we begin them at 0.  */
+	/* DWARF 1.  */
+	.debug          0 : { *(.debug) }
+	.line           0 : { *(.line) }
+	/* GNU DWARF 1 extensions.  */
+	.debug_srcinfo  0 : { *(.debug_srcinfo) }
+	.debug_sfnames  0 : { *(.debug_sfnames) }
+	/* DWARF 1.1 and DWARF 2.  */
+	.debug_aranges  0 : { *(.debug_aranges) }
+	.debug_pubnames 0 : { *(.debug_pubnames) }
+	/* DWARF 2.  */
+	.debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+	.debug_abbrev   0 : { *(.debug_abbrev) }
+	.debug_line     0 : { *(.debug_line .debug_line.* .debug_line_end) }
+	.debug_frame    0 : { *(.debug_frame) }
+	.debug_str      0 : { *(.debug_str) }
+	.debug_loc      0 : { *(.debug_loc) }
+	.debug_macinfo  0 : { *(.debug_macinfo) }
+	/* SGI/MIPS DWARF 2 extensions.  */
+	.debug_weaknames 0 : { *(.debug_weaknames) }
+	.debug_funcnames 0 : { *(.debug_funcnames) }
+	.debug_typenames 0 : { *(.debug_typenames) }
+	.debug_varnames  0 : { *(.debug_varnames) }
+	/* DWARF 3.  */
+	.debug_pubtypes 0 : { *(.debug_pubtypes) }
+	.debug_ranges   0 : { *(.debug_ranges) }
+	/* DWARF 5.  */
+	.debug_addr     0 : { *(.debug_addr) }
+	.debug_line_str 0 : { *(.debug_line_str) }
+	.debug_loclists 0 : { *(.debug_loclists) }
+	.debug_macro    0 : { *(.debug_macro) }
+	.debug_names    0 : { *(.debug_names) }
+	.debug_rnglists 0 : { *(.debug_rnglists) }
+	.debug_str_offsets 0 : { *(.debug_str_offsets) }
+	.debug_sup      0 : { *(.debug_sup) }
+	.gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }
+}
+/*
+ * Check that sections that are copied from flash to RAM have matching
+ * padding, so that a single memcpy() of __data_size copies the correct bytes.
+ */
+ASSERT( __data_size == __data_source_size,
+	"ERROR: .data/.tdata flash size does not match RAM size");

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23S/RTE/Device/ARMCM23/gcc_linker_script.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23S/RTE/Device/ARMCM23/gcc_linker_script.ld
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+/* ----------------------------------------------------------------------------
+  Memory definition
+ *----------------------------------------------------------------------------*/
+MEMORY
+{
+  ROM0  (rx)  : ORIGIN = __ROM0_BASE, LENGTH = __ROM0_SIZE
+#if __ROM1_SIZE > 0
+  ROM1  (rx)  : ORIGIN = __ROM1_BASE, LENGTH = __ROM1_SIZE
+#endif
+#if __ROM2_SIZE > 0
+  ROM2  (rx)  : ORIGIN = __ROM2_BASE, LENGTH = __ROM2_SIZE
+#endif
+#if __ROM3_SIZE > 0
+  ROM3  (rx)  : ORIGIN = __ROM3_BASE, LENGTH = __ROM3_SIZE
+#endif
+
+  RAM0  (rwx) : ORIGIN = __RAM0_BASE, LENGTH = __RAM0_SIZE
+#if __RAM1_SIZE > 0
+  RAM1  (rwx) : ORIGIN = __RAM1_BASE, LENGTH = __RAM1_SIZE
+#endif
+#if __RAM2_SIZE > 0
+  RAM2  (rwx) : ORIGIN = __RAM2_BASE, LENGTH = __RAM2_SIZE
+#endif
+#if __RAM3_SIZE > 0
+  RAM3  (rwx) : ORIGIN = __RAM3_BASE, LENGTH = __RAM3_SIZE
+#endif
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __copy_table_start__
+ *   __copy_table_end__
+ *   __zero_table_start__
+ *   __zero_table_end__
+ *   __etext          (deprecated)
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+  .text :
+  {
+    KEEP(*(.vectors))
+    *(.text*)
+
+    KEEP(*(.init))
+    KEEP(*(.fini))
+
+    /* .ctors */
+    *crtbegin.o(.ctors)
+    *crtbegin?.o(.ctors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+    *(SORT(.ctors.*))
+    *(.ctors)
+
+    /* .dtors */
+    *crtbegin.o(.dtors)
+    *crtbegin?.o(.dtors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+    *(SORT(.dtors.*))
+    *(.dtors)
+
+    *(.rodata*)
+
+    KEEP(*(.eh_frame*))
+  } > ROM0
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  .gnu.sgstubs :
+  {
+    . = ALIGN(32);
+  } > ROM0
+#endif
+
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > ROM0
+
+  __exidx_start = .;
+  .ARM.exidx :
+  {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+  } > ROM0
+  __exidx_end = .;
+
+  .copy.table :
+  {
+    . = ALIGN(4);
+    __copy_table_start__ = .;
+
+    LONG (LOADADDR(.data))
+    LONG (ADDR(.data))
+    LONG (SIZEOF(.data) / 4)
+
+    /* Add each additional data section here */
+/*
+    LONG (LOADADDR(.data2))
+    LONG (ADDR(.data2))
+    LONG (SIZEOF(.data2) / 4)
+*/
+    __copy_table_end__ = .;
+  } > ROM0
+
+  .zero.table :
+  {
+    . = ALIGN(4);
+    __zero_table_start__ = .;
+
+/*  .bss initialization to zero is already done during C Run-Time Startup.
+    LONG (ADDR(.bss))
+    LONG (SIZEOF(.bss) / 4)
+*/
+
+    /* Add each additional bss section here */
+/*
+    LONG (ADDR(.bss2))
+    LONG (SIZEOF(.bss2) / 4)
+*/
+    __zero_table_end__ = .;
+  } > ROM0
+
+  /*
+   * This __etext variable is kept for backward compatibility with older,
+   * ASM based startup files.
+   */
+  PROVIDE(__etext = LOADADDR(.data));
+
+  .data : ALIGN(4)
+  {
+    __data_start__ = .;
+    *(vtable)
+    *(.data)
+    *(.data.*)
+
+    . = ALIGN(4);
+    /* preinit data */
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP(*(.preinit_array))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+
+    . = ALIGN(4);
+    /* init data */
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP(*(SORT(.init_array.*)))
+    KEEP(*(.init_array))
+    PROVIDE_HIDDEN (__init_array_end = .);
+
+    . = ALIGN(4);
+    /* finit data */
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP(*(SORT(.fini_array.*)))
+    KEEP(*(.fini_array))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    /* All data end */
+    __data_end__ = .;
+
+  } > RAM0 AT > ROM0
+
+  /*
+   * Secondary data section, optional
+   *
+   * Remember to add each additional data section
+   * to the .copy.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .data2 : ALIGN(4)
+  {
+    . = ALIGN(4);
+    __data2_start__ = .;
+    *(.data2)
+    *(.data2.*)
+    . = ALIGN(4);
+    __data2_end__ = .;
+
+  } > RAM1 AT > ROM0 
+*/
+
+  .bss :
+  {
+    . = ALIGN(4);
+    __bss_start__ = .;
+    *(.bss)
+    *(.bss.*)
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+  } > RAM0 AT > RAM0
+
+  /*
+   * Secondary bss section, optional
+   *
+   * Remember to add each additional bss section
+   * to the .zero.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .bss2 :
+  {
+    . = ALIGN(4);
+    __bss2_start__ = .;
+    *(.bss2)
+    *(.bss2.*)
+    . = ALIGN(4);
+    __bss2_end__ = .;
+  } > RAM1 AT > RAM1
+*/
+
+  .heap (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE(end = .);
+    . = . + __HEAP_SIZE;
+    . = ALIGN(8);
+    __HeapLimit = .;
+  } > RAM0
+
+  .stack (ORIGIN(RAM0) + LENGTH(RAM0) - __STACK_SIZE - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackLimit = .;
+    . = . + __STACK_SIZE;
+    . = ALIGN(8);
+    __StackTop = .;
+  } > RAM0
+  PROVIDE(__stack = __StackTop);
+
+#if __STACKSEAL_SIZE > 0
+  .stackseal (ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackSeal = .;
+    . = . + 8;
+    . = ALIGN(8);
+  } > RAM0
+#endif
+
+  /* Check if data + heap + stack exceeds RAM limit */
+  ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23S/RTE/Device/ARMCM23/iar_linker_script.icf
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23S/RTE/Device/ARMCM23/iar_linker_script.icf
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+define memory mem with size = 4G;
+
+#if __ROM0_SIZE > 0
+  define region ROM0_region = mem:[from __ROM0_BASE to (__ROM0_BASE+__ROM0_SIZE-1)];
+#else
+  define region ROM0_region = [];
+#endif
+
+#if __ROM1_SIZE > 0
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+#else
+  define region ROM1_region = [];
+#endif
+
+#if __ROM2_SIZE > 0
+  define region ROM2_region = mem:[from __ROM2_BASE to (__ROM2_BASE+__ROM2_SIZE-1)];
+#else
+  define region ROM2_region = [];
+#endif
+
+#if __ROM3_SIZE > 0
+  define region ROM3_region = mem:[from __ROM3_BASE to (__ROM3_BASE+__ROM3_SIZE-1)];
+#else
+  define region ROM3_region = [];
+#endif
+
+define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_region;
+
+#if __RAM0_SIZE > 0
+  define region RAM0_region = mem:[from __RAM0_BASE to (__RAM0_BASE+__RAM0_SIZE-1)];
+#else
+  define region RAM0_region = [];
+#endif
+
+#if __RAM1_SIZE > 0
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+#else
+  define region RAM1_region = [];
+#endif
+
+#if __RAM2_SIZE > 0
+  define region RAM2_region = mem:[from __RAM2_BASE to (__RAM2_BASE+__RAM2_SIZE-1)];
+#else
+  define region RAM2_region = [];
+#endif
+
+#if __RAM3_SIZE > 0
+  define region RAM3_region = mem:[from __RAM3_BASE to (__RAM3_BASE+__RAM3_SIZE-1)];
+#else
+  define region RAM3_region = [];
+#endif
+
+define region RAM_region = RAM0_region | RAM1_region | RAM2_region | RAM3_region;
+
+do not initialize  { section .noinit };
+initialize by copy { readwrite };
+if (isdefinedsymbol(__USE_DLIB_PERTHREAD))
+{
+  // Required in a multi-threaded application
+  initialize by copy with packing = none { section __DLIB_PERTHREAD };
+}
+
+place at address mem:__ROM0_BASE { readonly section .intvec };
+
+if (!isempty(ROM_region))
+{
+  place in ROM_region  { readonly };
+}
+
+if (!isempty(RAM_region))
+{
+  define block CSTACK     with alignment = 8, size = __STACK_SIZE     { };
+  define block PROC_STACK with alignment = 8, size = 0 { };
+  define block HEAP       with alignment = 8, size = __HEAP_SIZE       { };
+  place in RAM_region  { readwrite, block CSTACK, block PROC_STACK, block HEAP };
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23S/RTE/Device/ARMCM23/partition_ARMCM23.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23S/RTE/Device/ARMCM23/partition_ARMCM23.h
@@ -1,0 +1,832 @@
+/**************************************************************************//**
+ * @file     partition_ARMCM23.h
+ * @brief    CMSIS-CORE Initial Setup for Secure / Non-Secure Zones for ARMCM23
+ * @version  V1.0.0
+ * @date     09. July 2018
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2018 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PARTITION_ARMCM23_H
+#define PARTITION_ARMCM23_H
+
+/*
+//-------- <<< Use Configuration Wizard in Context Menu >>> -----------------
+*/
+
+/*
+// <e>Initialize Security Attribution Unit (SAU) CTRL register
+*/
+#define SAU_INIT_CTRL          1
+
+/*
+//   <q> Enable SAU
+//   <i> Value for SAU->CTRL register bit ENABLE
+*/
+#define SAU_INIT_CTRL_ENABLE   1
+
+/*
+//   <o> When SAU is disabled
+//     <0=> All Memory is Secure
+//     <1=> All Memory is Non-Secure
+//   <i> Value for SAU->CTRL register bit ALLNS
+//   <i> When all Memory is Non-Secure (ALLNS is 1), IDAU can override memory map configuration.
+*/
+#define SAU_INIT_CTRL_ALLNS  0
+
+/*
+// </e>
+*/
+
+/*
+// <h>Initialize Security Attribution Unit (SAU) Address Regions
+// <i>SAU configuration specifies regions to be one of:
+// <i> - Secure and Non-Secure Callable
+// <i> - Non-Secure
+// <i>Note: All memory regions not configured by SAU are Secure
+*/
+#define SAU_REGIONS_MAX   8                 /* Max. number of SAU regions */
+
+/*
+//   <e>Initialize SAU Region 0
+//   <i> Setup SAU Region 0 memory attributes
+*/
+#define SAU_INIT_REGION0    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START0     0x00000000      /* start address of SAU region 0 */
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END0       0x001FFFFF      /* end address of SAU region 0 */
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC0       1
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 1
+//   <i> Setup SAU Region 1 memory attributes
+*/
+#define SAU_INIT_REGION1    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START1     0x00200000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END1       0x003FFFFF
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC1       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 2
+//   <i> Setup SAU Region 2 memory attributes
+*/
+#define SAU_INIT_REGION2    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START2     0x20200000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END2       0x203FFFFF
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC2       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 3
+//   <i> Setup SAU Region 3 memory attributes
+*/
+#define SAU_INIT_REGION3    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START3     0x40000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END3       0x40040000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC3       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 4
+//   <i> Setup SAU Region 4 memory attributes
+*/
+#define SAU_INIT_REGION4    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START4     0x00000000      /* start address of SAU region 4 */
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END4       0x00000000      /* end address of SAU region 4 */
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC4       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 5
+//   <i> Setup SAU Region 5 memory attributes
+*/
+#define SAU_INIT_REGION5    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START5     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END5       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC5       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 6
+//   <i> Setup SAU Region 6 memory attributes
+*/
+#define SAU_INIT_REGION6    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START6     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END6       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC6       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 7
+//   <i> Setup SAU Region 7 memory attributes
+*/
+#define SAU_INIT_REGION7    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START7     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END7       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC7       0
+/*
+//   </e>
+*/
+
+/*
+// </h>
+*/
+
+/*
+// <e>Setup behaviour of Sleep and Exception Handling
+*/
+#define SCB_CSR_AIRCR_INIT  1
+
+/*
+//   <o> Deep Sleep can be enabled by
+//     <0=>Secure and Non-Secure state
+//     <1=>Secure state only
+//   <i> Value for SCB->CSR register bit DEEPSLEEPS
+*/
+#define SCB_CSR_DEEPSLEEPS_VAL  1
+
+/*
+//   <o>System reset request accessible from
+//     <0=> Secure and Non-Secure state
+//     <1=> Secure state only
+//   <i> Value for SCB->AIRCR register bit SYSRESETREQS
+*/
+#define SCB_AIRCR_SYSRESETREQS_VAL  1
+
+/*
+//   <o>Priority of Non-Secure exceptions is
+//     <0=> Not altered
+//     <1=> Lowered to 0x80-0xFF
+//   <i> Value for SCB->AIRCR register bit PRIS
+*/
+#define SCB_AIRCR_PRIS_VAL      1
+
+/*
+//   <o>BusFault, HardFault, and NMI target
+//     <0=> Secure state
+//     <1=> Non-Secure state
+//   <i> Value for SCB->AIRCR register bit BFHFNMINS
+*/
+#define SCB_AIRCR_BFHFNMINS_VAL 0
+
+/*
+// </e>
+*/
+
+
+/*
+// <e>Setup behaviour of single SysTick
+*/
+#define SCB_ICSR_INIT 0
+
+/*
+//   <o> in a single SysTick implementation, SysTick is
+//     <0=>Secure
+//     <1=>Non-Secure
+//   <i> Value for SCB->ICSR register bit STTNS
+//   <i> only for single SysTick implementation 
+*/
+#define SCB_ICSR_STTNS_VAL  0
+
+/*
+// </e>
+*/
+
+
+/*
+// <h>Setup Interrupt Target
+*/
+
+/*
+//   <e>Initialize ITNS 0 (Interrupts 0..31)
+*/
+#define NVIC_INIT_ITNS0    0
+
+/*
+// Interrupts 0..31
+//   <o.0>  Interrupt 0   <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 1   <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 2   <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 3   <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 4   <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 5   <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 6   <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 7   <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 8   <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 9   <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 10  <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 11  <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 12  <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 13  <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 14  <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 15  <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 16  <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 17  <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 18  <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 19  <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 20  <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 21  <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 22  <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 23  <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 24  <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 25  <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 26  <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 27  <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 28  <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 29  <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 30  <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 31  <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS0_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 1 (Interrupts 32..63)
+*/
+#define NVIC_INIT_ITNS1    0
+
+/*
+// Interrupts 32..63
+//   <o.0>  Interrupt 32  <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 33  <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 34  <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 35  <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 36  <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 37  <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 38  <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 39  <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 40  <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 41  <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 42  <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 43  <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 44  <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 45  <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 46  <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 47  <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 48  <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 49  <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 50  <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 51  <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 52  <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 53  <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 54  <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 55  <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 56  <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 57  <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 58  <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 59  <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 60  <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 61  <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 62  <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 63  <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS1_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 2 (Interrupts 64..95)
+*/
+#define NVIC_INIT_ITNS2    0
+
+/*
+// Interrupts 64..95
+//   <o.0>  Interrupt 64  <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 65  <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 66  <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 67  <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 68  <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 69  <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 70  <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 71  <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 72  <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 73  <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 74  <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 75  <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 76  <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 77  <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 78  <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 79  <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 80  <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 81  <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 82  <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 83  <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 84  <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 85  <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 86  <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 87  <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 88  <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 89  <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 90  <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 91  <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 92  <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 93  <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 94  <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 95  <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS2_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 3 (Interrupts 96..127)
+*/
+#define NVIC_INIT_ITNS3    0
+
+/*
+// Interrupts 96..127
+//   <o.0>  Interrupt 96  <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 97  <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 98  <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 99  <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 100 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 101 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 102 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 103 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 104 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 105 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 106 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 107 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 108 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 109 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 110 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 111 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 112 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 113 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 114 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 115 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 116 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 117 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 118 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 119 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 120 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 121 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 122 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 123 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 124 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 125 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 126 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 127 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS3_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 4 (Interrupts 128..159)
+*/
+#define NVIC_INIT_ITNS4    0
+
+/*
+// Interrupts 128..159
+//   <o.0>  Interrupt 128 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 129 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 130 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 131 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 132 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 133 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 134 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 135 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 136 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 137 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 138 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 139 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 140 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 141 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 142 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 143 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 144 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 145 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 146 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 147 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 148 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 149 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 150 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 151 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 152 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 153 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 154 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 155 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 156 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 157 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 158 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 159 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS4_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 5 (Interrupts 160..191)
+*/
+#define NVIC_INIT_ITNS5    0
+
+/*
+// Interrupts 160..191
+//   <o.0>  Interrupt 160 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 161 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 162 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 163 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 164 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 165 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 166 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 167 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 168 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 169 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 170 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 171 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 172 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 173 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 174 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 175 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 176 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 177 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 178 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 179 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 180 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 181 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 182 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 183 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 184 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 185 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 186 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 187 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 188 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 189 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 190 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 191 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS5_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 6 (Interrupts 192..223)
+*/
+#define NVIC_INIT_ITNS6    0
+
+/*
+// Interrupts 192..223
+//   <o.0>  Interrupt 192 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 193 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 194 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 195 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 196 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 197 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 198 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 199 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 200 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 201 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 202 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 203 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 204 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 205 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 206 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 207 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 208 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 209 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 210 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 211 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 212 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 213 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 214 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 215 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 216 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 217 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 218 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 219 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 220 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 221 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 222 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 223 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS6_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 7 (Interrupts 224..255)
+*/
+#define NVIC_INIT_ITNS7    0
+
+/*
+// Interrupts 224..255
+//   <o.0>  Interrupt 224 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 225 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 226 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 227 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 228 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 229 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 230 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 231 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 232 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 233 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 234 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 235 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 236 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 237 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 238 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 239 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 240 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 241 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 242 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 243 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 244 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 245 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 246 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 247 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 248 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 249 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 250 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 251 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 252 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 253 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 254 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 255 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS7_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+// </h>
+*/
+
+
+
+/*
+    max 128 SAU regions.
+    SAU regions are defined in partition.h
+ */
+
+#define SAU_INIT_REGION(n) \
+    SAU->RNR  =  (n                                     & SAU_RNR_REGION_Msk); \
+    SAU->RBAR =  (SAU_INIT_START##n                     & SAU_RBAR_BADDR_Msk); \
+    SAU->RLAR =  (SAU_INIT_END##n                       & SAU_RLAR_LADDR_Msk) | \
+                ((SAU_INIT_NSC##n << SAU_RLAR_NSC_Pos)  & SAU_RLAR_NSC_Msk)   | 1U
+
+/**
+  \brief   Setup a SAU Region
+  \details Writes the region information contained in SAU_Region to the
+           registers SAU_RNR, SAU_RBAR, and SAU_RLAR
+ */
+__STATIC_INLINE void TZ_SAU_Setup (void)
+{
+
+#if defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U)
+
+  #if defined (SAU_INIT_REGION0) && (SAU_INIT_REGION0 == 1U)
+    SAU_INIT_REGION(0);
+  #endif
+
+  #if defined (SAU_INIT_REGION1) && (SAU_INIT_REGION1 == 1U)
+    SAU_INIT_REGION(1);
+  #endif
+
+  #if defined (SAU_INIT_REGION2) && (SAU_INIT_REGION2 == 1U)
+    SAU_INIT_REGION(2);
+  #endif
+
+  #if defined (SAU_INIT_REGION3) && (SAU_INIT_REGION3 == 1U)
+    SAU_INIT_REGION(3);
+  #endif
+
+  #if defined (SAU_INIT_REGION4) && (SAU_INIT_REGION4 == 1U)
+    SAU_INIT_REGION(4);
+  #endif
+
+  #if defined (SAU_INIT_REGION5) && (SAU_INIT_REGION5 == 1U)
+    SAU_INIT_REGION(5);
+  #endif
+
+  #if defined (SAU_INIT_REGION6) && (SAU_INIT_REGION6 == 1U)
+    SAU_INIT_REGION(6);
+  #endif
+
+  #if defined (SAU_INIT_REGION7) && (SAU_INIT_REGION7 == 1U)
+    SAU_INIT_REGION(7);
+  #endif
+
+  /* repeat this for all possible SAU regions */
+
+#endif /* defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U) */
+
+
+  #if defined (SAU_INIT_CTRL) && (SAU_INIT_CTRL == 1U)
+    SAU->CTRL = ((SAU_INIT_CTRL_ENABLE << SAU_CTRL_ENABLE_Pos) & SAU_CTRL_ENABLE_Msk) |
+                ((SAU_INIT_CTRL_ALLNS  << SAU_CTRL_ALLNS_Pos)  & SAU_CTRL_ALLNS_Msk)   ;
+  #endif
+
+  #if defined (SCB_CSR_AIRCR_INIT) && (SCB_CSR_AIRCR_INIT == 1U)
+    SCB->SCR   = (SCB->SCR   & ~(SCB_SCR_SLEEPDEEPS_Msk    )) |
+                   ((SCB_CSR_DEEPSLEEPS_VAL     << SCB_SCR_SLEEPDEEPS_Pos)     & SCB_SCR_SLEEPDEEPS_Msk);
+
+    SCB->AIRCR = (SCB->AIRCR & ~(SCB_AIRCR_VECTKEY_Msk   | SCB_AIRCR_SYSRESETREQS_Msk |
+                                 SCB_AIRCR_BFHFNMINS_Msk |  SCB_AIRCR_PRIS_Msk)        )                     |
+                   ((0x05FAU                    << SCB_AIRCR_VECTKEY_Pos)      & SCB_AIRCR_VECTKEY_Msk)      |
+                   ((SCB_AIRCR_SYSRESETREQS_VAL << SCB_AIRCR_SYSRESETREQS_Pos) & SCB_AIRCR_SYSRESETREQS_Msk) |
+                   ((SCB_AIRCR_PRIS_VAL         << SCB_AIRCR_PRIS_Pos)         & SCB_AIRCR_PRIS_Msk)         |
+                   ((SCB_AIRCR_BFHFNMINS_VAL    << SCB_AIRCR_BFHFNMINS_Pos)    & SCB_AIRCR_BFHFNMINS_Msk);
+  #endif /* defined (SCB_CSR_AIRCR_INIT) && (SCB_CSR_AIRCR_INIT == 1U) */
+
+  #if defined (SCB_ICSR_INIT) && (SCB_ICSR_INIT == 1U)
+    SCB->ICSR  = (SCB->ICSR  & ~(SCB_ICSR_STTNS_Msk        )) |
+                   ((SCB_ICSR_STTNS_VAL         << SCB_ICSR_STTNS_Pos)         & SCB_ICSR_STTNS_Msk);
+  #endif /* defined (SCB_ICSR_INIT) && (SCB_ICSR_INIT == 1U) */
+
+  #if defined (NVIC_INIT_ITNS0) && (NVIC_INIT_ITNS0 == 1U)
+    NVIC->ITNS[0] = NVIC_INIT_ITNS0_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS1) && (NVIC_INIT_ITNS1 == 1U)
+    NVIC->ITNS[1] = NVIC_INIT_ITNS1_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS2) && (NVIC_INIT_ITNS2 == 1U)
+    NVIC->ITNS[2] = NVIC_INIT_ITNS2_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS3) && (NVIC_INIT_ITNS3 == 1U)
+    NVIC->ITNS[3] = NVIC_INIT_ITNS3_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS4) && (NVIC_INIT_ITNS4 == 1U)
+    NVIC->ITNS[4] = NVIC_INIT_ITNS4_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS5) && (NVIC_INIT_ITNS5 == 1U)
+    NVIC->ITNS[5] = NVIC_INIT_ITNS5_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS6) && (NVIC_INIT_ITNS6 == 1U)
+    NVIC->ITNS[6] = NVIC_INIT_ITNS6_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS7) && (NVIC_INIT_ITNS7 == 1U)
+    NVIC->ITNS[7] = NVIC_INIT_ITNS7_VAL;
+  #endif
+
+  /* repeat this for all possible ITNS elements */
+
+}
+
+#endif  /* PARTITION_ARMCM23_H */

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23S/RTE/Device/ARMCM23/regions_ARMCM23.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23S/RTE/Device/ARMCM23/regions_ARMCM23.h
@@ -1,0 +1,94 @@
+#ifndef REGIONS_ARMCM23_H
+#define REGIONS_ARMCM23_H
+
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+// <n>Device pack:   ARM::Cortex_DFP@1.0.0-dev16
+// <i>Device pack used to generate this file
+
+// <h>ROM Configuration
+// =======================
+// <h> ROM_S=<__ROM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x00000000
+#define __ROM0_BASE 0x00000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00200000
+#define __ROM0_SIZE 0x00200000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __ROM0_DEFAULT 1
+//   <q>Startup
+//   <i> Selects region to be used for startup code.
+#define __ROM0_STARTUP 1
+// </h>
+
+// <h> ROM_NS=<__ROM1>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x00200000
+#define __ROM1_BASE 0x00200000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00200000
+#define __ROM1_SIZE 0x00200000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __ROM1_DEFAULT 0
+//   <q>Startup
+//   <i> Selects region to be used for startup code.
+#define __ROM1_STARTUP 0
+// </h>
+
+// </h>
+
+// <h>RAM Configuration
+// =======================
+// <h> RAM_S=<__RAM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x20000000
+#define __RAM0_BASE 0x20000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00020000
+#define __RAM0_SIZE 0x00020000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __RAM0_DEFAULT 1
+//   <q>No zero initialize
+//   <i> Excludes region from zero initialization.
+#define __RAM0_NOINIT 0
+// </h>
+
+// <h> RAM_NS=<__RAM1>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x20200000
+#define __RAM1_BASE 0x20200000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00020000
+#define __RAM1_SIZE 0x00020000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __RAM1_DEFAULT 0
+//   <q>No zero initialize
+//   <i> Excludes region from zero initialization.
+#define __RAM1_NOINIT 0
+// </h>
+
+// </h>
+
+// <h>Stack / Heap Configuration
+//   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+#define __STACK_SIZE 0x00000400
+#define __HEAP_SIZE 0x00000C00
+// </h>
+
+
+#endif /* REGIONS_ARMCM23_H */

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23S/RTE/Device/ARMCM23/startup_ARMCM23.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23S/RTE/Device/ARMCM23/startup_ARMCM23.c
@@ -1,0 +1,159 @@
+/******************************************************************************
+ * @file     startup_ARMCM23.c
+ * @brief    CMSIS-Core Device Startup File for a Cortex-M23 Device
+ * @version  V3.0.0
+ * @date     06. April 2023
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (ARMCM23)
+  #include "ARMCM23.h"
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  External References
+ *----------------------------------------------------------------------------*/
+extern uint32_t __INITIAL_SP;
+extern uint32_t __STACK_LIMIT;
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+extern uint32_t __STACK_SEAL;
+#endif
+
+extern __NO_RETURN void __PROGRAM_START(void);
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler  (void);
+            void Default_Handler(void);
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+/* Exceptions */
+void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void HardFault_Handler      (void) __attribute__ ((weak));
+void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+
+void Interrupt0_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt1_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt2_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt3_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt4_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt5_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt6_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt7_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt8_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt9_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[240];
+       const VECTOR_TABLE_Type __VECTOR_TABLE[240] __VECTOR_TABLE_ATTRIBUTE = {
+  (VECTOR_TABLE_Type)(&__INITIAL_SP),       /*     Initial Stack Pointer */
+  Reset_Handler,                            /*     Reset Handler */
+  NMI_Handler,                              /* -14 NMI Handler */
+  HardFault_Handler,                        /* -13 Hard Fault Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  SVC_Handler,                              /*  -5 SVCall Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  PendSV_Handler,                           /*  -2 PendSV Handler */
+  SysTick_Handler,                          /*  -1 SysTick Handler */
+
+  /* Interrupts */
+  Interrupt0_Handler,                       /*   0 Interrupt 0 */
+  Interrupt1_Handler,                       /*   1 Interrupt 1 */
+  Interrupt2_Handler,                       /*   2 Interrupt 2 */
+  Interrupt3_Handler,                       /*   3 Interrupt 3 */
+  Interrupt4_Handler,                       /*   4 Interrupt 4 */
+  Interrupt5_Handler,                       /*   5 Interrupt 5 */
+  Interrupt6_Handler,                       /*   6 Interrupt 6 */
+  Interrupt7_Handler,                       /*   7 Interrupt 7 */
+  Interrupt8_Handler,                       /*   8 Interrupt 8 */
+  Interrupt9_Handler                        /*   9 Interrupt 9 */
+                                            /* Interrupts 10 .. 223 are left out */
+};
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler(void)
+{
+  __set_PSP((uint32_t)(&__INITIAL_SP));
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  __set_MSPLIM((uint32_t)(&__STACK_LIMIT));
+  __set_PSPLIM((uint32_t)(&__STACK_LIMIT));
+
+  __TZ_set_STACKSEAL_S((uint32_t *)(&__STACK_SEAL));
+#endif
+
+  SystemInit();                             /* CMSIS System Initialization */
+  __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
+}
+
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wmissing-noreturn"
+#endif
+
+/*----------------------------------------------------------------------------
+  Hard Fault Handler
+ *----------------------------------------------------------------------------*/
+void HardFault_Handler(void)
+{
+  while(1);
+}
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+void Default_Handler(void)
+{
+  while(1);
+}
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic pop
+#endif
+

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23S/RTE/Device/ARMCM23/system_ARMCM23.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23S/RTE/Device/ARMCM23/system_ARMCM23.c
@@ -1,0 +1,77 @@
+/**************************************************************************//**
+ * @file     system_ARMCM23.c
+ * @brief    CMSIS Device System Source File for
+ *           ARMCM23 Device
+ * @version  V2.0.0
+ * @date     06. April 2023
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (ARMCM23)
+  #include "ARMCM23.h"
+  #if defined (__ARM_FEATURE_CMSE) &&  (__ARM_FEATURE_CMSE == 3U)
+    #include "partition_ARMCM23.h"
+  #endif
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  Define clocks
+ *----------------------------------------------------------------------------*/
+#define  XTAL            (50000000UL)     /* Oscillator frequency */
+
+#define  SYSTEM_CLOCK    (XTAL / 2U)
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[240];
+
+
+/*----------------------------------------------------------------------------
+  System Core Clock Variable
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = SYSTEM_CLOCK;  /* System Core Clock Frequency */
+
+
+/*----------------------------------------------------------------------------
+  System Core Clock update function
+ *----------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)
+{
+  SystemCoreClock = SYSTEM_CLOCK;
+}
+
+/*----------------------------------------------------------------------------
+  System initialization function
+ *----------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t) &(__VECTOR_TABLE[0]);
+#endif
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  TZ_SAU_Setup();
+#endif
+
+  SystemCoreClock = SYSTEM_CLOCK;
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23S/Target.clayer.yml
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23S/Target.clayer.yml
@@ -1,0 +1,35 @@
+layer:
+  type: Target
+  description: CM23S target components and files
+
+  packs:
+    - pack: ARM::Cortex_DFP
+
+  device: ARMCM23
+
+  processor:
+    trustzone: secure
+
+  components:
+    # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
+    - component: ARM::CMSIS:CORE
+    - component: Device:Startup&C Startup
+
+  groups:
+    - group: FVP
+      files:
+        - file: ./model_config.txt
+
+  linker:
+    - for-compiler: AC6
+      script: RTE/Device/$Dname$/ac6_linker_script.sct
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: GCC
+      script: RTE/Device/$Dname$/gcc_linker_script.ld
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: CLANG
+      script: RTE/Device/$Dname$/clang_linker_script.ld
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: IAR
+      script: RTE/Device/$Dname$/iar_linker_script.icf
+      regions: RTE/Device/$Dname$/regions_$Dname$.h

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23S/model_config.txt
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM23S/model_config.txt
@@ -1,0 +1,16 @@
+# Parameters:
+# instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+#----------------------------------------------------------------------------------------------
+fvp_mps2.mps2_visualisation.disable-visualisation=1   # (bool  , init-time) default = '0'      : Enable/disable visualisation
+cpu0.semihosting-enable=1                             # (bool  , init-time) default = '1'      : Enable semihosting SVC traps. Applications that do not use semihosting must set this parameter to false.
+cpu0.semihosting-Thumb_SVC=0xAB                       # (int   , init-time) default = '0xAB'   : T32 SVC number for semihosting : [0x0..0xFF]
+cpu0.semihosting-cmd_line=""                          # (string, init-time) default = ''       : Command line available to semihosting SVC calls
+cpu0.semihosting-heap_base=0x0                        # (int   , init-time) default = '0x0'    : Virtual address of heap base : [0x0..0xFFFFFFFF]
+cpu0.semihosting-heap_limit=0x0                       # (int   , init-time) default = '0x10700000' : Virtual address of top of heap : [0x0..0xFFFFFFFF]
+cpu0.semihosting-stack_base=0x0                       # (int   , init-time) default = '0x10700000' : Virtual address of base of descending stack : [0x0..0xFFFFFFFF]
+cpu0.semihosting-stack_limit=0x0                      # (int   , init-time) default = '0x10800000' : Virtual address of stack limit : [0x0..0xFFFFFFFF]
+cpu0.semihosting-cwd=""                               # (string, init-time) default = ''       : Base directory for semihosting file access.
+idau.NUM_IDAU_REGION=0x0                              # (int   , init-time) default = '0xA'    : 
+cpu0.SECEXT=1                                         # (bool  , init-time) default = '1'      : Whether the ARMv8-M Security Extensions are included
+fvp_mps2.DISABLE_GATING=1                             # (bool  , init-time) default = '0'      : Disable Memory gating logic
+#----------------------------------------------------------------------------------------------

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM3/RTE/Device/ARMCM3/ARMCM3_ac6.sct
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM3/RTE/Device/ARMCM3/ARMCM3_ac6.sct
@@ -1,0 +1,80 @@
+#! armclang -E --target=arm-arm-none-eabi -mcpu=cortex-m3 -xc
+; command above MUST be in first line (no comment above!)
+
+/*
+;-------- <<< Use Configuration Wizard in Context Menu >>> -------------------
+*/
+
+/*--------------------- Flash Configuration ----------------------------------
+; <h> Flash Configuration
+;   <o0> Flash Base Address <0x0-0xFFFFFFFF:8>
+;   <o1> Flash Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __ROM_BASE      0x00000000
+#define __ROM_SIZE      0x00080000
+
+/*--------------------- Embedded RAM Configuration ---------------------------
+; <h> RAM Configuration
+;   <o0> RAM Base Address    <0x0-0xFFFFFFFF:8>
+;   <o1> RAM Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __RAM_BASE      0x20000000
+#define __RAM_SIZE      0x00040000
+
+/*--------------------- Stack / Heap Configuration ---------------------------
+; <h> Stack / Heap Configuration
+;   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+;   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __STACK_SIZE    0x00000200
+#define __HEAP_SIZE     0x00000C00
+
+/*
+;------------- <<< end of configuration section >>> ---------------------------
+*/
+
+
+/*----------------------------------------------------------------------------
+  User Stack & Heap boundary definition
+ *----------------------------------------------------------------------------*/
+#define __STACK_TOP    (__RAM_BASE + __RAM_SIZE)    /* starts at end of RAM */
+#define __HEAP_BASE    (AlignExpr(+0, 8))           /* starts after RW_RAM section, 8 byte aligned */
+
+
+/*----------------------------------------------------------------------------
+  Scatter File Definitions definition
+ *----------------------------------------------------------------------------*/
+#define __RO_BASE       __ROM_BASE
+#define __RO_SIZE       __ROM_SIZE
+
+#define __RW_BASE       __RAM_BASE
+#define __RW_SIZE      (__RAM_SIZE - __STACK_SIZE - __HEAP_SIZE)
+
+
+LR_ROM __RO_BASE __RO_SIZE  {                       ; load region size_region
+  ER_ROM __RO_BASE __RO_SIZE  {                     ; load address = execution address
+   *.o (RESET, +First)
+   *(InRoot$$Sections)
+   .ANY (+RO)
+   .ANY (+XO)
+  }
+
+  RW_NOINIT __RW_BASE UNINIT __RW_SIZE {
+    *(.bss.noinit)
+  }
+
+  RW_RAM AlignExpr(+0, 8) (__RW_SIZE - AlignExpr(ImageLength(RW_NOINIT), 8)) {
+    *(+RW +ZI)
+  }
+
+#if __HEAP_SIZE > 0
+  ARM_LIB_HEAP  __HEAP_BASE EMPTY  __HEAP_SIZE  {   ; Reserve empty region for heap
+  }
+#endif
+
+  ARM_LIB_STACK __STACK_TOP EMPTY -__STACK_SIZE {   ; Reserve empty region for stack
+  }
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM3/RTE/Device/ARMCM3/ARMCM3_gcc.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM3/RTE/Device/ARMCM3/ARMCM3_gcc.ld
@@ -1,0 +1,287 @@
+/******************************************************************************
+ * @file     ARMCM3_gcc.ld
+ * @brief    GNU Linker Script for Cortex-M based device
+ * @version  V2.2.0
+ * @date     23. June 2023
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ *-------- <<< Use Configuration Wizard in Context Menu >>> -------------------
+ */
+
+/*---------------------- Flash Configuration ----------------------------------
+  <h> Flash Configuration
+    <o0> Flash Base Address <0x0-0xFFFFFFFF:8>
+    <o1> Flash Size (in Bytes) <0x0-0xFFFFFFFF:8>
+  </h>
+  -----------------------------------------------------------------------------*/
+__ROM_BASE = 0x00000000;
+__ROM_SIZE = 0x00040000;
+
+/*--------------------- Embedded RAM Configuration ----------------------------
+  <h> RAM Configuration
+    <o0> RAM Base Address    <0x0-0xFFFFFFFF:8>
+    <o1> RAM Size (in Bytes) <0x0-0xFFFFFFFF:8>
+  </h>
+ -----------------------------------------------------------------------------*/
+__RAM_BASE = 0x20000000;
+__RAM_SIZE = 0x00020000;
+
+/*--------------------- Stack / Heap Configuration ----------------------------
+  <h> Stack / Heap Configuration
+    <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+    <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+  </h>
+  -----------------------------------------------------------------------------*/
+__STACK_SIZE = 0x00000400;
+__HEAP_SIZE  = 0x00000C00;
+
+/*
+ *-------------------- <<< end of configuration section >>> -------------------
+ */
+
+MEMORY
+{
+  FLASH (rx)  : ORIGIN = __ROM_BASE, LENGTH = __ROM_SIZE
+  RAM   (rwx) : ORIGIN = __RAM_BASE, LENGTH = __RAM_SIZE
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __copy_table_start__
+ *   __copy_table_end__
+ *   __zero_table_start__
+ *   __zero_table_end__
+ *   __etext          (deprecated)
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+  .text :
+  {
+    KEEP(*(.vectors))
+    *(.text*)
+
+    KEEP(*(.init))
+    KEEP(*(.fini))
+
+    /* .ctors */
+    *crtbegin.o(.ctors)
+    *crtbegin?.o(.ctors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+    *(SORT(.ctors.*))
+    *(.ctors)
+
+    /* .dtors */
+    *crtbegin.o(.dtors)
+    *crtbegin?.o(.dtors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+    *(SORT(.dtors.*))
+    *(.dtors)
+
+    *(.rodata*)
+
+    KEEP(*(.eh_frame*))
+  } > FLASH
+
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > FLASH
+
+  __exidx_start = .;
+  .ARM.exidx :
+  {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+  } > FLASH
+  __exidx_end = .;
+
+  .copy.table :
+  {
+    . = ALIGN(4);
+    __copy_table_start__ = .;
+
+    LONG (LOADADDR(.data))
+    LONG (ADDR(.data))
+    LONG (SIZEOF(.data) / 4)
+
+    /* Add each additional data section here */
+/*
+    LONG (LOADADDR(.data2))
+    LONG (ADDR(.data2))
+    LONG (SIZEOF(.data2) / 4)
+*/
+    __copy_table_end__ = .;
+  } > FLASH
+
+  .zero.table :
+  {
+    . = ALIGN(4);
+    __zero_table_start__ = .;
+
+/*  .bss initialization to zero is already done during C Run-Time Startup.
+    LONG (ADDR(.bss))
+    LONG (SIZEOF(.bss) / 4)
+*/
+
+    /* Add each additional bss section here */
+/*
+    LONG (ADDR(.bss2))
+    LONG (SIZEOF(.bss2) / 4)
+*/
+    __zero_table_end__ = .;
+  } > FLASH
+
+  /*
+   * This __etext variable is kept for backward compatibility with older,
+   * ASM based startup files.
+   */
+  PROVIDE(__etext = LOADADDR(.data));
+
+  .data : ALIGN(4)
+  {
+    __data_start__ = .;
+    *(vtable)
+    *(.data)
+    *(.data.*)
+
+    . = ALIGN(4);
+    /* preinit data */
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP(*(.preinit_array))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+
+    . = ALIGN(4);
+    /* init data */
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP(*(SORT(.init_array.*)))
+    KEEP(*(.init_array))
+    PROVIDE_HIDDEN (__init_array_end = .);
+
+    . = ALIGN(4);
+    /* finit data */
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP(*(SORT(.fini_array.*)))
+    KEEP(*(.fini_array))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    /* All data end */
+    __data_end__ = .;
+
+  } > RAM AT > FLASH
+
+  /*
+   * Secondary data section, optional
+   *
+   * Remember to add each additional data section
+   * to the .copy.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .data2 : ALIGN(4)
+  {
+    . = ALIGN(4);
+    __data2_start__ = .;
+    *(.data2)
+    *(.data2.*)
+    . = ALIGN(4);
+    __data2_end__ = .;
+
+  } > RAM2 AT > FLASH
+*/
+
+  .bss :
+  {
+    . = ALIGN(4);
+    __bss_start__ = .;
+    *(.bss)
+    *(.bss.*)
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+  } > RAM AT > RAM
+
+  /*
+   * Secondary bss section, optional
+   *
+   * Remember to add each additional bss section
+   * to the .zero.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .bss2 :
+  {
+    . = ALIGN(4);
+    __bss2_start__ = .;
+    *(.bss2)
+    *(.bss2.*)
+    . = ALIGN(4);
+    __bss2_end__ = .;
+  } > RAM2 AT > RAM2
+*/
+
+  .heap (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE(end = .);
+    . = . + __HEAP_SIZE;
+    . = ALIGN(8);
+    __HeapLimit = .;
+  } > RAM
+
+  .stack (ORIGIN(RAM) + LENGTH(RAM) - __STACK_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackLimit = .;
+    . = . + __STACK_SIZE;
+    . = ALIGN(8);
+    __StackTop = .;
+  } > RAM
+  PROVIDE(__stack = __StackTop);
+
+  /* Check if data + heap + stack exceeds RAM limit */
+  ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM3/RTE/Device/ARMCM3/ac6_linker_script.sct
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM3/RTE/Device/ARMCM3/ac6_linker_script.sct
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE 8
+#else
+#define __STACKSEAL_SIZE 0
+#endif
+
+/*----------------------------------------------------------------------------
+  Scatter File Definitions definition
+ *----------------------------------------------------------------------------*/
+
+LR_ROM0 __ROM0_BASE __ROM0_SIZE  {
+
+  ER_ROM0 __ROM0_BASE __ROM0_SIZE {
+    *.o (RESET, +First)
+    *(InRoot$$Sections)
+    *(+RO +XO)
+  }
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  ER_CMSE_VENEER AlignExpr(+0, 32) (__ROM0_SIZE - AlignExpr(ImageLength(ER_ROM0), 32)) {
+    *(Veneer$$CMSE)
+  }
+#endif
+
+  RW_NOINIT __RAM0_BASE UNINIT (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE) {
+    *(.bss.noinit)
+  }
+
+  RW_RAM0 AlignExpr(+0, 8) (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE - AlignExpr(ImageLength(RW_NOINIT), 8)) {
+    *(+RW +ZI)
+  }
+
+#if __HEAP_SIZE > 0
+  ARM_LIB_HEAP  (AlignExpr(+0, 8)) EMPTY __HEAP_SIZE  {   ; Reserve empty region for heap
+  }
+#endif
+
+  ARM_LIB_STACK (__RAM0_BASE + __RAM0_SIZE - __STACKSEAL_SIZE) EMPTY -__STACK_SIZE {   ; Reserve empty region for stack
+  }
+
+#if __STACKSEAL_SIZE > 0
+  STACKSEAL +0 EMPTY __STACKSEAL_SIZE {             ; Reserve empty region for stack seal immediately after stack
+  }
+#endif
+
+#if __RAM1_SIZE > 0
+  RW_RAM1 __RAM1_BASE __RAM1_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+
+#if __RAM2_SIZE > 0
+  RW_RAM2 __RAM2_BASE __RAM2_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+
+#if __RAM3_SIZE > 0
+  RW_RAM3 __RAM3_BASE __RAM3_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+}
+
+#if __ROM1_SIZE > 0
+LR_ROM1 __ROM1_BASE __ROM1_SIZE  {
+  ER_ROM1 +0 __ROM1_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif
+
+#if __ROM2_SIZE > 0
+LR_ROM2 __ROM2_BASE __ROM2_SIZE  {
+  ER_ROM2 +0 __ROM2_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif
+
+#if __ROM3_SIZE > 0
+LR_ROM3 __ROM3_BASE __ROM3_SIZE  {
+  ER_ROM3 +0 __ROM3_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM3/RTE/Device/ARMCM3/clang_linker_script.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM3/RTE/Device/ARMCM3/clang_linker_script.ld
@@ -1,0 +1,361 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2019 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+/* ----------------------------------------------------------------------------
+  Memory definition
+ *----------------------------------------------------------------------------*/
+MEMORY
+{
+  ROM0  (rx!w)  : ORIGIN = __ROM0_BASE, LENGTH = __ROM0_SIZE
+#if __ROM1_SIZE > 0
+  ROM1  (rx!w)  : ORIGIN = __ROM1_BASE, LENGTH = __ROM1_SIZE
+#endif
+#if __ROM2_SIZE > 0
+  ROM2  (rx!w)  : ORIGIN = __ROM2_BASE, LENGTH = __ROM2_SIZE
+#endif
+#if __ROM3_SIZE > 0
+  ROM3  (rx!w)  : ORIGIN = __ROM3_BASE, LENGTH = __ROM3_SIZE
+#endif
+
+  RAM0  (w!rx) : ORIGIN = __RAM0_BASE, LENGTH = __RAM0_SIZE
+#if __RAM1_SIZE > 0
+  RAM1  (w!rx) : ORIGIN = __RAM1_BASE, LENGTH = __RAM1_SIZE
+#endif
+#if __RAM2_SIZE > 0
+  RAM2  (w!rx) : ORIGIN = __RAM2_BASE, LENGTH = __RAM2_SIZE
+#endif
+#if __RAM3_SIZE > 0
+  RAM3  (w!rx) : ORIGIN = __RAM3_BASE, LENGTH = __RAM3_SIZE
+#endif
+}
+
+ENTRY(Reset_Handler)
+
+PHDRS
+{
+	text PT_LOAD;
+	ram PT_LOAD;
+	ram_init PT_LOAD;
+	tls PT_TLS;
+}
+
+SECTIONS
+{
+	.init : {
+		KEEP (*(.vectors))
+		KEEP (*(.text.init.enter))
+		KEEP (*(.data.init.enter))
+		KEEP (*(SORT_BY_NAME(.init) SORT_BY_NAME(.init.*)))
+	} >ROM0 AT>ROM0 :text
+
+	.text : {
+
+		/* code */
+		*(.text.unlikely .text.unlikely.*)
+		*(.text.startup .text.startup.*)
+		*(.text .text.* .opd .opd.*)
+		*(.gnu.linkonce.t.*)
+		KEEP (*(.fini .fini.*))
+		__text_end = .;
+
+		PROVIDE (__etext = __text_end);
+		PROVIDE (_etext = __text_end);
+		PROVIDE (etext = __text_end);
+
+		/* read-only data */
+		*(.rdata)
+		*(.rodata .rodata.*)
+		*(.gnu.linkonce.r.*)
+
+		*(.srodata.cst16)
+		*(.srodata.cst8)
+		*(.srodata.cst4)
+		*(.srodata.cst2)
+		*(.srodata .srodata.*)
+		*(.data.rel.ro .data.rel.ro.*)
+		*(.got .got.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		/* lists of constructors and destructors */
+		PROVIDE_HIDDEN ( __preinit_array_start = . );
+		KEEP (*(.preinit_array))
+		PROVIDE_HIDDEN ( __preinit_array_end = . );
+
+		PROVIDE_HIDDEN ( __init_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+		KEEP (*(.init_array .ctors))
+		PROVIDE_HIDDEN ( __init_array_end = . );
+
+		PROVIDE_HIDDEN ( __fini_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
+		KEEP (*(.fini_array .dtors))
+		PROVIDE_HIDDEN ( __fini_array_end = . );
+
+	} >ROM0 AT>ROM0 :text
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+	.veneers :
+	{
+		. = ALIGN(32);
+		KEEP(*(.gnu.sgstubs))
+	} > ROM0 AT>ROM0 :text
+#endif
+
+	.toc : {
+		*(.toc .toc.*)
+	} >ROM0 AT>ROM0 :text
+
+	/* additional sections when compiling with C++ exception support */
+	
+	.except_ordered : {
+		*(.gcc_except_table *.gcc_except_table.*)
+		KEEP (*(.eh_frame .eh_frame.*))
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+	} >ROM0 AT>ROM0 :text
+
+	.except_unordered : {
+		. = ALIGN(8);
+
+		PROVIDE(__exidx_start = .);
+		*(.ARM.exidx*)
+		PROVIDE(__exidx_end = .);
+	} >ROM0 AT>ROM0 :text
+	
+
+	/*
+	 * Data values which are preserved across reset
+	 */
+	.preserve (NOLOAD) : {
+		PROVIDE(__preserve_start__ = .);
+		KEEP(*(SORT_BY_NAME(.preserve.*)))
+		KEEP(*(.preserve))
+		PROVIDE(__preserve_end__ = .);
+	} >RAM0 AT>RAM0 :ram
+
+	.data :  {
+		*(.data .data.*)
+		*(.gnu.linkonce.d.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		PROVIDE( __global_pointer$ = . + 0x800 );
+		*(.sdata .sdata.* .sdata2.*)
+		*(.gnu.linkonce.s.*)
+	} >RAM0 AT>ROM0 :ram_init
+	PROVIDE(__data_start = ADDR(.data));
+	PROVIDE(__data_source = LOADADDR(.data));
+
+	/* Thread local initialized data. This gets
+	 * space allocated as it is expected to be placed
+	 * in ram to be used as a template for TLS data blocks
+	 * allocated at runtime. We're slightly abusing that
+	 * by placing the data in flash where it will be copied
+	 * into the allocate ram addresses by the existing
+	 * data initialization code in crt0
+	 */
+	.tdata :  {
+		*(.tdata .tdata.* .gnu.linkonce.td.*)
+		PROVIDE(__data_end = .);
+		PROVIDE(__tdata_end = .);
+	} >RAM0 AT>ROM0 :tls :ram_init
+	PROVIDE( __tls_base = ADDR(.tdata));
+	PROVIDE( __tdata_start = ADDR(.tdata));
+	PROVIDE( __tdata_source = LOADADDR(.tdata) );
+	PROVIDE( __tdata_source_end = LOADADDR(.tdata) + SIZEOF(.tdata) );
+	PROVIDE( __data_source_end = __tdata_source_end );
+	PROVIDE( __tdata_size = SIZEOF(.tdata) );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata),ALIGNOF(.tbss)) );
+
+	PROVIDE( __edata = __data_end );
+	PROVIDE( _edata = __data_end );
+	PROVIDE( edata = __data_end );
+	PROVIDE( __data_size = __data_end - __data_start );
+	PROVIDE( __data_source_size = __data_source_end - __data_source );
+
+	.tbss (NOLOAD) : {
+		*(.tbss .tbss.* .gnu.linkonce.tb.*)
+		*(.tcommon)
+		PROVIDE( __tls_end = . );
+		PROVIDE( __tbss_end = . );
+	} >RAM0 AT>RAM0 :tls :ram
+	PROVIDE( __bss_start = ADDR(.tbss));
+	PROVIDE( __tbss_start = ADDR(.tbss));
+	PROVIDE( __tbss_offset = ADDR(.tbss) - ADDR(.tdata) );
+	PROVIDE( __tbss_size = SIZEOF(.tbss) );
+	PROVIDE( __tls_size = __tls_end - __tls_base );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
+	PROVIDE( __arm32_tls_tcb_offset = MAX(8, __tls_align) );
+	PROVIDE( __arm64_tls_tcb_offset = MAX(16, __tls_align) );
+
+	/*
+	 * The linker special cases .tbss segments which are
+	 * identified as segments which are not loaded and are
+	 * thread_local.
+	 *
+	 * For these segments, the linker does not advance 'dot'
+	 * across them.  We actually need memory allocated for tbss,
+	 * so we create a special segment here just to make room
+	 */
+	/*
+	.tbss_space (NOLOAD) : {
+		. = ADDR(.tbss);
+		. = . + SIZEOF(.tbss);
+	} >RAM0 AT>RAM0 :ram
+	*/
+
+	.bss (NOLOAD) : {
+		*(.sbss*)
+		*(.gnu.linkonce.sb.*)
+		*(.bss .bss.*)
+		*(.gnu.linkonce.b.*)
+		*(COMMON)
+
+		/* Align the heap */
+		. = ALIGN(8);
+		__bss_end = .;
+	} >RAM0 AT>RAM0 :ram
+	PROVIDE( __non_tls_bss_start = ADDR(.bss) );
+	PROVIDE( __end = __bss_end );
+	PROVIDE( _end = __bss_end );
+	PROVIDE( end = __bss_end );
+	PROVIDE( __bss_size = __bss_end - __bss_start );
+
+	/* Make the rest of memory available for heap storage */
+	PROVIDE (__heap_start = __end);
+#ifdef __HEAP_SIZE
+	PROVIDE (__heap_end = __heap_start + __HEAP_SIZE);
+	PROVIDE (__heap_size = __HEAP_SIZE);
+#else
+	PROVIDE (__heap_end = __stack - __STACK_SIZE);
+	PROVIDE (__heap_size = __heap_end - __heap_start);
+#endif
+	.heap (NOLOAD) : {
+		. += __heap_size;
+	} >RAM0 :ram
+
+	/* Define a stack region to make sure it fits in memory */
+	PROVIDE(__stack = ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE);
+	PROVIDE(__stack_limit = __stack - __STACK_SIZE);
+	.stack (__stack_limit) (NOLOAD) : {
+		. += __STACK_SIZE;
+	} >RAM0 :ram
+
+#if __STACKSEAL_SIZE > 0
+	PROVIDE(__stack_seal = __stack);
+  	.stackseal (__stack) (NOLOAD) :
+  	{
+    	. += __STACKSEAL_SIZE;
+  	} >RAM0 :ram
+#endif
+
+	/* Throw away C++ exception handling information */
+
+	/*
+
+	/DISCARD/ : {
+		*(.note .note.*)
+		*(.eh_frame .eh_frame.*)
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+		*(.ARM.exidx*)
+	}
+
+	*/
+
+	/* Stabs debugging sections.  */
+	.stab          0 : { *(.stab) }
+	.stabstr       0 : { *(.stabstr) }
+	.stab.excl     0 : { *(.stab.excl) }
+	.stab.exclstr  0 : { *(.stab.exclstr) }
+	.stab.index    0 : { *(.stab.index) }
+	.stab.indexstr 0 : { *(.stab.indexstr) }
+	.comment       0 : { *(.comment) }
+	.gnu.build.attributes : { *(.gnu.build.attributes .gnu.build.attributes.*) }
+	/* DWARF debug sections.
+	   Symbols in the DWARF debugging sections are relative to the beginning
+	   of the section so we begin them at 0.  */
+	/* DWARF 1.  */
+	.debug          0 : { *(.debug) }
+	.line           0 : { *(.line) }
+	/* GNU DWARF 1 extensions.  */
+	.debug_srcinfo  0 : { *(.debug_srcinfo) }
+	.debug_sfnames  0 : { *(.debug_sfnames) }
+	/* DWARF 1.1 and DWARF 2.  */
+	.debug_aranges  0 : { *(.debug_aranges) }
+	.debug_pubnames 0 : { *(.debug_pubnames) }
+	/* DWARF 2.  */
+	.debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+	.debug_abbrev   0 : { *(.debug_abbrev) }
+	.debug_line     0 : { *(.debug_line .debug_line.* .debug_line_end) }
+	.debug_frame    0 : { *(.debug_frame) }
+	.debug_str      0 : { *(.debug_str) }
+	.debug_loc      0 : { *(.debug_loc) }
+	.debug_macinfo  0 : { *(.debug_macinfo) }
+	/* SGI/MIPS DWARF 2 extensions.  */
+	.debug_weaknames 0 : { *(.debug_weaknames) }
+	.debug_funcnames 0 : { *(.debug_funcnames) }
+	.debug_typenames 0 : { *(.debug_typenames) }
+	.debug_varnames  0 : { *(.debug_varnames) }
+	/* DWARF 3.  */
+	.debug_pubtypes 0 : { *(.debug_pubtypes) }
+	.debug_ranges   0 : { *(.debug_ranges) }
+	/* DWARF 5.  */
+	.debug_addr     0 : { *(.debug_addr) }
+	.debug_line_str 0 : { *(.debug_line_str) }
+	.debug_loclists 0 : { *(.debug_loclists) }
+	.debug_macro    0 : { *(.debug_macro) }
+	.debug_names    0 : { *(.debug_names) }
+	.debug_rnglists 0 : { *(.debug_rnglists) }
+	.debug_str_offsets 0 : { *(.debug_str_offsets) }
+	.debug_sup      0 : { *(.debug_sup) }
+	.gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }
+}
+/*
+ * Check that sections that are copied from flash to RAM have matching
+ * padding, so that a single memcpy() of __data_size copies the correct bytes.
+ */
+ASSERT( __data_size == __data_source_size,
+	"ERROR: .data/.tdata flash size does not match RAM size");

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM3/RTE/Device/ARMCM3/gcc_linker_script.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM3/RTE/Device/ARMCM3/gcc_linker_script.ld
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+/* ----------------------------------------------------------------------------
+  Memory definition
+ *----------------------------------------------------------------------------*/
+MEMORY
+{
+  ROM0  (rx)  : ORIGIN = __ROM0_BASE, LENGTH = __ROM0_SIZE
+#if __ROM1_SIZE > 0
+  ROM1  (rx)  : ORIGIN = __ROM1_BASE, LENGTH = __ROM1_SIZE
+#endif
+#if __ROM2_SIZE > 0
+  ROM2  (rx)  : ORIGIN = __ROM2_BASE, LENGTH = __ROM2_SIZE
+#endif
+#if __ROM3_SIZE > 0
+  ROM3  (rx)  : ORIGIN = __ROM3_BASE, LENGTH = __ROM3_SIZE
+#endif
+
+  RAM0  (rwx) : ORIGIN = __RAM0_BASE, LENGTH = __RAM0_SIZE
+#if __RAM1_SIZE > 0
+  RAM1  (rwx) : ORIGIN = __RAM1_BASE, LENGTH = __RAM1_SIZE
+#endif
+#if __RAM2_SIZE > 0
+  RAM2  (rwx) : ORIGIN = __RAM2_BASE, LENGTH = __RAM2_SIZE
+#endif
+#if __RAM3_SIZE > 0
+  RAM3  (rwx) : ORIGIN = __RAM3_BASE, LENGTH = __RAM3_SIZE
+#endif
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __copy_table_start__
+ *   __copy_table_end__
+ *   __zero_table_start__
+ *   __zero_table_end__
+ *   __etext          (deprecated)
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+  .text :
+  {
+    KEEP(*(.vectors))
+    *(.text*)
+
+    KEEP(*(.init))
+    KEEP(*(.fini))
+
+    /* .ctors */
+    *crtbegin.o(.ctors)
+    *crtbegin?.o(.ctors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+    *(SORT(.ctors.*))
+    *(.ctors)
+
+    /* .dtors */
+    *crtbegin.o(.dtors)
+    *crtbegin?.o(.dtors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+    *(SORT(.dtors.*))
+    *(.dtors)
+
+    *(.rodata*)
+
+    KEEP(*(.eh_frame*))
+  } > ROM0
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  .gnu.sgstubs :
+  {
+    . = ALIGN(32);
+  } > ROM0
+#endif
+
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > ROM0
+
+  __exidx_start = .;
+  .ARM.exidx :
+  {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+  } > ROM0
+  __exidx_end = .;
+
+  .copy.table :
+  {
+    . = ALIGN(4);
+    __copy_table_start__ = .;
+
+    LONG (LOADADDR(.data))
+    LONG (ADDR(.data))
+    LONG (SIZEOF(.data) / 4)
+
+    /* Add each additional data section here */
+/*
+    LONG (LOADADDR(.data2))
+    LONG (ADDR(.data2))
+    LONG (SIZEOF(.data2) / 4)
+*/
+    __copy_table_end__ = .;
+  } > ROM0
+
+  .zero.table :
+  {
+    . = ALIGN(4);
+    __zero_table_start__ = .;
+
+/*  .bss initialization to zero is already done during C Run-Time Startup.
+    LONG (ADDR(.bss))
+    LONG (SIZEOF(.bss) / 4)
+*/
+
+    /* Add each additional bss section here */
+/*
+    LONG (ADDR(.bss2))
+    LONG (SIZEOF(.bss2) / 4)
+*/
+    __zero_table_end__ = .;
+  } > ROM0
+
+  /*
+   * This __etext variable is kept for backward compatibility with older,
+   * ASM based startup files.
+   */
+  PROVIDE(__etext = LOADADDR(.data));
+
+  .data : ALIGN(4)
+  {
+    __data_start__ = .;
+    *(vtable)
+    *(.data)
+    *(.data.*)
+
+    . = ALIGN(4);
+    /* preinit data */
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP(*(.preinit_array))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+
+    . = ALIGN(4);
+    /* init data */
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP(*(SORT(.init_array.*)))
+    KEEP(*(.init_array))
+    PROVIDE_HIDDEN (__init_array_end = .);
+
+    . = ALIGN(4);
+    /* finit data */
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP(*(SORT(.fini_array.*)))
+    KEEP(*(.fini_array))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    /* All data end */
+    __data_end__ = .;
+
+  } > RAM0 AT > ROM0
+
+  /*
+   * Secondary data section, optional
+   *
+   * Remember to add each additional data section
+   * to the .copy.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .data2 : ALIGN(4)
+  {
+    . = ALIGN(4);
+    __data2_start__ = .;
+    *(.data2)
+    *(.data2.*)
+    . = ALIGN(4);
+    __data2_end__ = .;
+
+  } > RAM1 AT > ROM0 
+*/
+
+  .bss :
+  {
+    . = ALIGN(4);
+    __bss_start__ = .;
+    *(.bss)
+    *(.bss.*)
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+  } > RAM0 AT > RAM0
+
+  /*
+   * Secondary bss section, optional
+   *
+   * Remember to add each additional bss section
+   * to the .zero.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .bss2 :
+  {
+    . = ALIGN(4);
+    __bss2_start__ = .;
+    *(.bss2)
+    *(.bss2.*)
+    . = ALIGN(4);
+    __bss2_end__ = .;
+  } > RAM1 AT > RAM1
+*/
+
+  .heap (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE(end = .);
+    . = . + __HEAP_SIZE;
+    . = ALIGN(8);
+    __HeapLimit = .;
+  } > RAM0
+
+  .stack (ORIGIN(RAM0) + LENGTH(RAM0) - __STACK_SIZE - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackLimit = .;
+    . = . + __STACK_SIZE;
+    . = ALIGN(8);
+    __StackTop = .;
+  } > RAM0
+  PROVIDE(__stack = __StackTop);
+
+#if __STACKSEAL_SIZE > 0
+  .stackseal (ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackSeal = .;
+    . = . + 8;
+    . = ALIGN(8);
+  } > RAM0
+#endif
+
+  /* Check if data + heap + stack exceeds RAM limit */
+  ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM3/RTE/Device/ARMCM3/iar_linker_script.icf
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM3/RTE/Device/ARMCM3/iar_linker_script.icf
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+define memory mem with size = 4G;
+
+#if __ROM0_SIZE > 0
+  define region ROM0_region = mem:[from __ROM0_BASE to (__ROM0_BASE+__ROM0_SIZE-1)];
+#else
+  define region ROM0_region = [];
+#endif
+
+#if __ROM1_SIZE > 0
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+#else
+  define region ROM1_region = [];
+#endif
+
+#if __ROM2_SIZE > 0
+  define region ROM2_region = mem:[from __ROM2_BASE to (__ROM2_BASE+__ROM2_SIZE-1)];
+#else
+  define region ROM2_region = [];
+#endif
+
+#if __ROM3_SIZE > 0
+  define region ROM3_region = mem:[from __ROM3_BASE to (__ROM3_BASE+__ROM3_SIZE-1)];
+#else
+  define region ROM3_region = [];
+#endif
+
+define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_region;
+
+#if __RAM0_SIZE > 0
+  define region RAM0_region = mem:[from __RAM0_BASE to (__RAM0_BASE+__RAM0_SIZE-1)];
+#else
+  define region RAM0_region = [];
+#endif
+
+#if __RAM1_SIZE > 0
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+#else
+  define region RAM1_region = [];
+#endif
+
+#if __RAM2_SIZE > 0
+  define region RAM2_region = mem:[from __RAM2_BASE to (__RAM2_BASE+__RAM2_SIZE-1)];
+#else
+  define region RAM2_region = [];
+#endif
+
+#if __RAM3_SIZE > 0
+  define region RAM3_region = mem:[from __RAM3_BASE to (__RAM3_BASE+__RAM3_SIZE-1)];
+#else
+  define region RAM3_region = [];
+#endif
+
+define region RAM_region = RAM0_region | RAM1_region | RAM2_region | RAM3_region;
+
+do not initialize  { section .noinit };
+initialize by copy { readwrite };
+if (isdefinedsymbol(__USE_DLIB_PERTHREAD))
+{
+  // Required in a multi-threaded application
+  initialize by copy with packing = none { section __DLIB_PERTHREAD };
+}
+
+place at address mem:__ROM0_BASE { readonly section .intvec };
+
+if (!isempty(ROM_region))
+{
+  place in ROM_region  { readonly };
+}
+
+if (!isempty(RAM_region))
+{
+  define block CSTACK     with alignment = 8, size = __STACK_SIZE     { };
+  define block PROC_STACK with alignment = 8, size = 0 { };
+  define block HEAP       with alignment = 8, size = __HEAP_SIZE       { };
+  place in RAM_region  { readwrite, block CSTACK, block PROC_STACK, block HEAP };
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM3/RTE/Device/ARMCM3/regions_ARMCM3.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM3/RTE/Device/ARMCM3/regions_ARMCM3.h
@@ -1,0 +1,60 @@
+#ifndef REGIONS_ARMCM3_H
+#define REGIONS_ARMCM3_H
+
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+// <n>Device pack:   ARM::Cortex_DFP@1.0.0-dev16
+// <i>Device pack used to generate this file
+
+// <h>ROM Configuration
+// =======================
+// <h> ROM=<__ROM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x00000000
+#define __ROM0_BASE 0x00000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00040000
+#define __ROM0_SIZE 0x00040000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __ROM0_DEFAULT 1
+//   <q>Startup
+//   <i> Selects region to be used for startup code.
+#define __ROM0_STARTUP 1
+// </h>
+
+// </h>
+
+// <h>RAM Configuration
+// =======================
+// <h> RAM=<__RAM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x20000000
+#define __RAM0_BASE 0x20000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00020000
+#define __RAM0_SIZE 0x00020000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __RAM0_DEFAULT 1
+//   <q>No zero initialize
+//   <i> Excludes region from zero initialization.
+#define __RAM0_NOINIT 0
+// </h>
+
+// </h>
+
+// <h>Stack / Heap Configuration
+//   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+#define __STACK_SIZE 0x00000400
+#define __HEAP_SIZE 0x00000C00
+// </h>
+
+
+#endif /* REGIONS_ARMCM3_H */

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM3/RTE/Device/ARMCM3/startup_ARMCM3.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM3/RTE/Device/ARMCM3/startup_ARMCM3.c
@@ -1,0 +1,150 @@
+/******************************************************************************
+ * @file     startup_ARMCM3.c
+ * @brief    CMSIS-Core(M) Device Startup File for a Cortex-M3 Device
+ * @version  V2.0.3
+ * @date     31. March 2020
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2020 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (ARMCM3)
+  #include "ARMCM3.h"
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  External References
+ *----------------------------------------------------------------------------*/
+extern uint32_t __INITIAL_SP;
+
+extern __NO_RETURN void __PROGRAM_START(void);
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler  (void);
+            void Default_Handler(void);
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+/* Exceptions */
+void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void HardFault_Handler      (void) __attribute__ ((weak));
+void MemManage_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
+void BusFault_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void UsageFault_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void DebugMon_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+
+void Interrupt0_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt1_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt2_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt3_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt4_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt5_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt6_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt7_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt8_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt9_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[240];
+       const VECTOR_TABLE_Type __VECTOR_TABLE[240] __VECTOR_TABLE_ATTRIBUTE = {
+  (VECTOR_TABLE_Type)(&__INITIAL_SP),       /*     Initial Stack Pointer */
+  Reset_Handler,                            /*     Reset Handler */
+  NMI_Handler,                              /* -14 NMI Handler */
+  HardFault_Handler,                        /* -13 Hard Fault Handler */
+  MemManage_Handler,                        /* -12 MPU Fault Handler */
+  BusFault_Handler,                         /* -11 Bus Fault Handler */
+  UsageFault_Handler,                       /* -10 Usage Fault Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  SVC_Handler,                              /*  -5 SVC Handler */
+  DebugMon_Handler,                         /*  -4 Debug Monitor Handler */
+  0,                                        /*     Reserved */
+  PendSV_Handler,                           /*  -2 PendSV Handler */
+  SysTick_Handler,                          /*  -1 SysTick Handler */
+
+  /* Interrupts */
+  Interrupt0_Handler,                       /*   0 Interrupt 0 */
+  Interrupt1_Handler,                       /*   1 Interrupt 1 */
+  Interrupt2_Handler,                       /*   2 Interrupt 2 */
+  Interrupt3_Handler,                       /*   3 Interrupt 3 */
+  Interrupt4_Handler,                       /*   4 Interrupt 4 */
+  Interrupt5_Handler,                       /*   5 Interrupt 5 */
+  Interrupt6_Handler,                       /*   6 Interrupt 6 */
+  Interrupt7_Handler,                       /*   7 Interrupt 7 */
+  Interrupt8_Handler,                       /*   8 Interrupt 8 */
+  Interrupt9_Handler                        /*   9 Interrupt 9 */
+                                            /* Interrupts 10 .. 223 are left out */
+};
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler(void)
+{
+  SystemInit();                             /* CMSIS System Initialization */
+  __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
+}
+
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wmissing-noreturn"
+#endif
+
+/*----------------------------------------------------------------------------
+  Hard Fault Handler
+ *----------------------------------------------------------------------------*/
+void HardFault_Handler(void)
+{
+  while(1);
+}
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+void Default_Handler(void)
+{
+  while(1);
+}
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic pop
+#endif
+

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM3/RTE/Device/ARMCM3/system_ARMCM3.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM3/RTE/Device/ARMCM3/system_ARMCM3.c
@@ -1,0 +1,65 @@
+/**************************************************************************//**
+ * @file     system_ARMCM3.c
+ * @brief    CMSIS Device System Source File for
+ *           ARMCM3 Device
+ * @version  V1.0.1
+ * @date     15. November 2019
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ARMCM3.h"
+
+/*----------------------------------------------------------------------------
+  Define clocks
+ *----------------------------------------------------------------------------*/
+#define  XTAL            (50000000UL)     /* Oscillator frequency */
+
+#define  SYSTEM_CLOCK    (XTAL / 2U)
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[240];
+
+/*----------------------------------------------------------------------------
+  System Core Clock Variable
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = SYSTEM_CLOCK;  /* System Core Clock Frequency */
+
+
+/*----------------------------------------------------------------------------
+  System Core Clock update function
+ *----------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)
+{
+  SystemCoreClock = SYSTEM_CLOCK;
+}
+
+/*----------------------------------------------------------------------------
+  System initialization function
+ *----------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t) &(__VECTOR_TABLE[0]);
+#endif
+
+  SystemCoreClock = SYSTEM_CLOCK;
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM3/RTE/Device/ARMCM3/tiac_arm.cmd
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM3/RTE/Device/ARMCM3/tiac_arm.cmd
@@ -1,0 +1,41 @@
+/****************************************************************************/
+/* tiac_arm.cmd - COMMAND FILE FOR LINKING ARM C PROGRAMS                   */
+/*                                                                          */
+/*   Description: This file is a sample command file that can be used       */
+/*                for linking programs built with the TI Arm Clang          */
+/*                Compiler.   Use it as a guideline; you may want to change */
+/*                the allocation scheme according to the size of your       */
+/*                program and the memory layout of your target system.      */
+/*                                                                          */
+/****************************************************************************/
+-c                                         /* LINK USING C CONVENTIONS      */
+-stack  0x4000                             /* SOFTWARE STACK SIZE           */
+-heap   0x4000                             /* HEAP AREA SIZE                */
+--args 0x1000
+
+/* SPECIFY THE SYSTEM MEMORY MAP */
+MEMORY
+{
+    V_MEM    : org = 0x00000000   len = 0x00001000  /* INT VECTOR */
+    P_MEM    : org = 0x00001000   len = 0x20000000  /* PROGRAM MEMORY (ROM) */
+    D_MEM    : org = 0x20001000   len = 0x20000000  /* DATA MEMORY    (RAM) */
+}
+
+/* SPECIFY THE SECTIONS ALLOCATION INTO MEMORY */
+SECTIONS
+{
+    .intvecs    : {} > 0x0             /* INTERRUPT VECTORS                 */
+    .bss        : {} > D_MEM           /* GLOBAL & STATIC VARS              */
+    .data       : {} > D_MEM
+    .sysmem     : {} > D_MEM           /* DYNAMIC MEMORY ALLOCATION AREA    */
+    .stack      : {} > D_MEM           /* SOFTWARE SYSTEM STACK             */
+
+    .text       : {} > P_MEM           /* CODE                              */
+    .cinit      : {} > P_MEM           /* INITIALIZATION TABLES             */
+    .const      : {} > P_MEM           /* CONSTANT DATA                     */
+    .rodata     : {} > P_MEM, palign(4)
+    .init_array : {} > P_MEM           /* C++ CONSTRUCTOR TABLES            */
+
+
+    .TI.ramfunc : {} load=P_MEM, run=D_MEM, table(BINIT)
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM3/Target.clayer.yml
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM3/Target.clayer.yml
@@ -1,0 +1,32 @@
+layer:
+  type: Target
+  description: CM3 target components and files
+
+  packs:
+    - pack: ARM::Cortex_DFP
+
+  device: ARMCM3
+
+  components:
+    # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
+    - component: ARM::CMSIS:CORE
+    - component: Device:Startup&C Startup
+
+  groups:
+    - group: FVP
+      files:
+        - file: ./model_config.txt
+
+  linker:
+    - for-compiler: AC6
+      script: RTE/Device/$Dname$/ac6_linker_script.sct
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: GCC
+      script: RTE/Device/$Dname$/gcc_linker_script.ld
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: CLANG
+      script: RTE/Device/$Dname$/clang_linker_script.ld
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: IAR
+      script: RTE/Device/$Dname$/iar_linker_script.icf
+      regions: RTE/Device/$Dname$/regions_$Dname$.h

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM3/model_config.txt
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM3/model_config.txt
@@ -1,0 +1,13 @@
+# Parameters:
+# instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+#----------------------------------------------------------------------------------------------
+fvp_mps2.mps2_visualisation.disable-visualisation=1   # (bool  , init-time) default = '0'      : Enable/disable visualisation
+armcortexm3ct.semihosting-enable=1                    # (bool  , init-time) default = '1'      : Enable semihosting SVC traps. Applications that do not use semihosting must set this parameter to false.
+armcortexm3ct.semihosting-Thumb_SVC=0xAB              # (int   , init-time) default = '0xAB'   : T32 SVC number for semihosting : [0x0..0xFF]
+armcortexm3ct.semihosting-cmd_line=""                 # (string, init-time) default = ''       : Command line available to semihosting SVC calls
+armcortexm3ct.semihosting-heap_base=0x0               # (int   , init-time) default = '0x0'    : Virtual address of heap base : [0x0..0xFFFFFFFF]
+armcortexm3ct.semihosting-heap_limit=0x0              # (int   , init-time) default = '0x10700000' : Virtual address of top of heap : [0x0..0xFFFFFFFF]
+armcortexm3ct.semihosting-stack_base=0x0              # (int   , init-time) default = '0x10700000' : Virtual address of base of descending stack : [0x0..0xFFFFFFFF]
+armcortexm3ct.semihosting-stack_limit=0x0             # (int   , init-time) default = '0x10800000' : Virtual address of stack limit : [0x0..0xFFFFFFFF]
+armcortexm3ct.semihosting-cwd=""                      # (string, init-time) default = ''       : Base directory for semihosting file access.
+#----------------------------------------------------------------------------------------------

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33/RTE/Device/ARMCM33/ac6_linker_script.sct
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33/RTE/Device/ARMCM33/ac6_linker_script.sct
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE 8
+#else
+#define __STACKSEAL_SIZE 0
+#endif
+
+/*----------------------------------------------------------------------------
+  Scatter File Definitions definition
+ *----------------------------------------------------------------------------*/
+
+LR_ROM0 __ROM0_BASE __ROM0_SIZE  {
+
+  ER_ROM0 __ROM0_BASE __ROM0_SIZE {
+    *.o (RESET, +First)
+    *(InRoot$$Sections)
+    *(+RO +XO)
+  }
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  ER_CMSE_VENEER AlignExpr(+0, 32) (__ROM0_SIZE - AlignExpr(ImageLength(ER_ROM0), 32)) {
+    *(Veneer$$CMSE)
+  }
+#endif
+
+  RW_NOINIT __RAM0_BASE UNINIT (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE) {
+    *(.bss.noinit)
+  }
+
+  RW_RAM0 AlignExpr(+0, 8) (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE - AlignExpr(ImageLength(RW_NOINIT), 8)) {
+    *(+RW +ZI)
+  }
+
+#if __HEAP_SIZE > 0
+  ARM_LIB_HEAP  (AlignExpr(+0, 8)) EMPTY __HEAP_SIZE  {   ; Reserve empty region for heap
+  }
+#endif
+
+  ARM_LIB_STACK (__RAM0_BASE + __RAM0_SIZE - __STACKSEAL_SIZE) EMPTY -__STACK_SIZE {   ; Reserve empty region for stack
+  }
+
+#if __STACKSEAL_SIZE > 0
+  STACKSEAL +0 EMPTY __STACKSEAL_SIZE {             ; Reserve empty region for stack seal immediately after stack
+  }
+#endif
+
+#if __RAM1_SIZE > 0
+  RW_RAM1 __RAM1_BASE __RAM1_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+
+#if __RAM2_SIZE > 0
+  RW_RAM2 __RAM2_BASE __RAM2_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+
+#if __RAM3_SIZE > 0
+  RW_RAM3 __RAM3_BASE __RAM3_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+}
+
+#if __ROM1_SIZE > 0
+LR_ROM1 __ROM1_BASE __ROM1_SIZE  {
+  ER_ROM1 +0 __ROM1_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif
+
+#if __ROM2_SIZE > 0
+LR_ROM2 __ROM2_BASE __ROM2_SIZE  {
+  ER_ROM2 +0 __ROM2_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif
+
+#if __ROM3_SIZE > 0
+LR_ROM3 __ROM3_BASE __ROM3_SIZE  {
+  ER_ROM3 +0 __ROM3_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33/RTE/Device/ARMCM33/clang_linker_script.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33/RTE/Device/ARMCM33/clang_linker_script.ld
@@ -1,0 +1,361 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2019 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+/* ----------------------------------------------------------------------------
+  Memory definition
+ *----------------------------------------------------------------------------*/
+MEMORY
+{
+  ROM0  (rx!w)  : ORIGIN = __ROM0_BASE, LENGTH = __ROM0_SIZE
+#if __ROM1_SIZE > 0
+  ROM1  (rx!w)  : ORIGIN = __ROM1_BASE, LENGTH = __ROM1_SIZE
+#endif
+#if __ROM2_SIZE > 0
+  ROM2  (rx!w)  : ORIGIN = __ROM2_BASE, LENGTH = __ROM2_SIZE
+#endif
+#if __ROM3_SIZE > 0
+  ROM3  (rx!w)  : ORIGIN = __ROM3_BASE, LENGTH = __ROM3_SIZE
+#endif
+
+  RAM0  (w!rx) : ORIGIN = __RAM0_BASE, LENGTH = __RAM0_SIZE
+#if __RAM1_SIZE > 0
+  RAM1  (w!rx) : ORIGIN = __RAM1_BASE, LENGTH = __RAM1_SIZE
+#endif
+#if __RAM2_SIZE > 0
+  RAM2  (w!rx) : ORIGIN = __RAM2_BASE, LENGTH = __RAM2_SIZE
+#endif
+#if __RAM3_SIZE > 0
+  RAM3  (w!rx) : ORIGIN = __RAM3_BASE, LENGTH = __RAM3_SIZE
+#endif
+}
+
+ENTRY(Reset_Handler)
+
+PHDRS
+{
+	text PT_LOAD;
+	ram PT_LOAD;
+	ram_init PT_LOAD;
+	tls PT_TLS;
+}
+
+SECTIONS
+{
+	.init : {
+		KEEP (*(.vectors))
+		KEEP (*(.text.init.enter))
+		KEEP (*(.data.init.enter))
+		KEEP (*(SORT_BY_NAME(.init) SORT_BY_NAME(.init.*)))
+	} >ROM0 AT>ROM0 :text
+
+	.text : {
+
+		/* code */
+		*(.text.unlikely .text.unlikely.*)
+		*(.text.startup .text.startup.*)
+		*(.text .text.* .opd .opd.*)
+		*(.gnu.linkonce.t.*)
+		KEEP (*(.fini .fini.*))
+		__text_end = .;
+
+		PROVIDE (__etext = __text_end);
+		PROVIDE (_etext = __text_end);
+		PROVIDE (etext = __text_end);
+
+		/* read-only data */
+		*(.rdata)
+		*(.rodata .rodata.*)
+		*(.gnu.linkonce.r.*)
+
+		*(.srodata.cst16)
+		*(.srodata.cst8)
+		*(.srodata.cst4)
+		*(.srodata.cst2)
+		*(.srodata .srodata.*)
+		*(.data.rel.ro .data.rel.ro.*)
+		*(.got .got.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		/* lists of constructors and destructors */
+		PROVIDE_HIDDEN ( __preinit_array_start = . );
+		KEEP (*(.preinit_array))
+		PROVIDE_HIDDEN ( __preinit_array_end = . );
+
+		PROVIDE_HIDDEN ( __init_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+		KEEP (*(.init_array .ctors))
+		PROVIDE_HIDDEN ( __init_array_end = . );
+
+		PROVIDE_HIDDEN ( __fini_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
+		KEEP (*(.fini_array .dtors))
+		PROVIDE_HIDDEN ( __fini_array_end = . );
+
+	} >ROM0 AT>ROM0 :text
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+	.veneers :
+	{
+		. = ALIGN(32);
+		KEEP(*(.gnu.sgstubs))
+	} > ROM0 AT>ROM0 :text
+#endif
+
+	.toc : {
+		*(.toc .toc.*)
+	} >ROM0 AT>ROM0 :text
+
+	/* additional sections when compiling with C++ exception support */
+	
+	.except_ordered : {
+		*(.gcc_except_table *.gcc_except_table.*)
+		KEEP (*(.eh_frame .eh_frame.*))
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+	} >ROM0 AT>ROM0 :text
+
+	.except_unordered : {
+		. = ALIGN(8);
+
+		PROVIDE(__exidx_start = .);
+		*(.ARM.exidx*)
+		PROVIDE(__exidx_end = .);
+	} >ROM0 AT>ROM0 :text
+	
+
+	/*
+	 * Data values which are preserved across reset
+	 */
+	.preserve (NOLOAD) : {
+		PROVIDE(__preserve_start__ = .);
+		KEEP(*(SORT_BY_NAME(.preserve.*)))
+		KEEP(*(.preserve))
+		PROVIDE(__preserve_end__ = .);
+	} >RAM0 AT>RAM0 :ram
+
+	.data :  {
+		*(.data .data.*)
+		*(.gnu.linkonce.d.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		PROVIDE( __global_pointer$ = . + 0x800 );
+		*(.sdata .sdata.* .sdata2.*)
+		*(.gnu.linkonce.s.*)
+	} >RAM0 AT>ROM0 :ram_init
+	PROVIDE(__data_start = ADDR(.data));
+	PROVIDE(__data_source = LOADADDR(.data));
+
+	/* Thread local initialized data. This gets
+	 * space allocated as it is expected to be placed
+	 * in ram to be used as a template for TLS data blocks
+	 * allocated at runtime. We're slightly abusing that
+	 * by placing the data in flash where it will be copied
+	 * into the allocate ram addresses by the existing
+	 * data initialization code in crt0
+	 */
+	.tdata :  {
+		*(.tdata .tdata.* .gnu.linkonce.td.*)
+		PROVIDE(__data_end = .);
+		PROVIDE(__tdata_end = .);
+	} >RAM0 AT>ROM0 :tls :ram_init
+	PROVIDE( __tls_base = ADDR(.tdata));
+	PROVIDE( __tdata_start = ADDR(.tdata));
+	PROVIDE( __tdata_source = LOADADDR(.tdata) );
+	PROVIDE( __tdata_source_end = LOADADDR(.tdata) + SIZEOF(.tdata) );
+	PROVIDE( __data_source_end = __tdata_source_end );
+	PROVIDE( __tdata_size = SIZEOF(.tdata) );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata),ALIGNOF(.tbss)) );
+
+	PROVIDE( __edata = __data_end );
+	PROVIDE( _edata = __data_end );
+	PROVIDE( edata = __data_end );
+	PROVIDE( __data_size = __data_end - __data_start );
+	PROVIDE( __data_source_size = __data_source_end - __data_source );
+
+	.tbss (NOLOAD) : {
+		*(.tbss .tbss.* .gnu.linkonce.tb.*)
+		*(.tcommon)
+		PROVIDE( __tls_end = . );
+		PROVIDE( __tbss_end = . );
+	} >RAM0 AT>RAM0 :tls :ram
+	PROVIDE( __bss_start = ADDR(.tbss));
+	PROVIDE( __tbss_start = ADDR(.tbss));
+	PROVIDE( __tbss_offset = ADDR(.tbss) - ADDR(.tdata) );
+	PROVIDE( __tbss_size = SIZEOF(.tbss) );
+	PROVIDE( __tls_size = __tls_end - __tls_base );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
+	PROVIDE( __arm32_tls_tcb_offset = MAX(8, __tls_align) );
+	PROVIDE( __arm64_tls_tcb_offset = MAX(16, __tls_align) );
+
+	/*
+	 * The linker special cases .tbss segments which are
+	 * identified as segments which are not loaded and are
+	 * thread_local.
+	 *
+	 * For these segments, the linker does not advance 'dot'
+	 * across them.  We actually need memory allocated for tbss,
+	 * so we create a special segment here just to make room
+	 */
+	/*
+	.tbss_space (NOLOAD) : {
+		. = ADDR(.tbss);
+		. = . + SIZEOF(.tbss);
+	} >RAM0 AT>RAM0 :ram
+	*/
+
+	.bss (NOLOAD) : {
+		*(.sbss*)
+		*(.gnu.linkonce.sb.*)
+		*(.bss .bss.*)
+		*(.gnu.linkonce.b.*)
+		*(COMMON)
+
+		/* Align the heap */
+		. = ALIGN(8);
+		__bss_end = .;
+	} >RAM0 AT>RAM0 :ram
+	PROVIDE( __non_tls_bss_start = ADDR(.bss) );
+	PROVIDE( __end = __bss_end );
+	PROVIDE( _end = __bss_end );
+	PROVIDE( end = __bss_end );
+	PROVIDE( __bss_size = __bss_end - __bss_start );
+
+	/* Make the rest of memory available for heap storage */
+	PROVIDE (__heap_start = __end);
+#ifdef __HEAP_SIZE
+	PROVIDE (__heap_end = __heap_start + __HEAP_SIZE);
+	PROVIDE (__heap_size = __HEAP_SIZE);
+#else
+	PROVIDE (__heap_end = __stack - __STACK_SIZE);
+	PROVIDE (__heap_size = __heap_end - __heap_start);
+#endif
+	.heap (NOLOAD) : {
+		. += __heap_size;
+	} >RAM0 :ram
+
+	/* Define a stack region to make sure it fits in memory */
+	PROVIDE(__stack = ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE);
+	PROVIDE(__stack_limit = __stack - __STACK_SIZE);
+	.stack (__stack_limit) (NOLOAD) : {
+		. += __STACK_SIZE;
+	} >RAM0 :ram
+
+#if __STACKSEAL_SIZE > 0
+	PROVIDE(__stack_seal = __stack);
+  	.stackseal (__stack) (NOLOAD) :
+  	{
+    	. += __STACKSEAL_SIZE;
+  	} >RAM0 :ram
+#endif
+
+	/* Throw away C++ exception handling information */
+
+	/*
+
+	/DISCARD/ : {
+		*(.note .note.*)
+		*(.eh_frame .eh_frame.*)
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+		*(.ARM.exidx*)
+	}
+
+	*/
+
+	/* Stabs debugging sections.  */
+	.stab          0 : { *(.stab) }
+	.stabstr       0 : { *(.stabstr) }
+	.stab.excl     0 : { *(.stab.excl) }
+	.stab.exclstr  0 : { *(.stab.exclstr) }
+	.stab.index    0 : { *(.stab.index) }
+	.stab.indexstr 0 : { *(.stab.indexstr) }
+	.comment       0 : { *(.comment) }
+	.gnu.build.attributes : { *(.gnu.build.attributes .gnu.build.attributes.*) }
+	/* DWARF debug sections.
+	   Symbols in the DWARF debugging sections are relative to the beginning
+	   of the section so we begin them at 0.  */
+	/* DWARF 1.  */
+	.debug          0 : { *(.debug) }
+	.line           0 : { *(.line) }
+	/* GNU DWARF 1 extensions.  */
+	.debug_srcinfo  0 : { *(.debug_srcinfo) }
+	.debug_sfnames  0 : { *(.debug_sfnames) }
+	/* DWARF 1.1 and DWARF 2.  */
+	.debug_aranges  0 : { *(.debug_aranges) }
+	.debug_pubnames 0 : { *(.debug_pubnames) }
+	/* DWARF 2.  */
+	.debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+	.debug_abbrev   0 : { *(.debug_abbrev) }
+	.debug_line     0 : { *(.debug_line .debug_line.* .debug_line_end) }
+	.debug_frame    0 : { *(.debug_frame) }
+	.debug_str      0 : { *(.debug_str) }
+	.debug_loc      0 : { *(.debug_loc) }
+	.debug_macinfo  0 : { *(.debug_macinfo) }
+	/* SGI/MIPS DWARF 2 extensions.  */
+	.debug_weaknames 0 : { *(.debug_weaknames) }
+	.debug_funcnames 0 : { *(.debug_funcnames) }
+	.debug_typenames 0 : { *(.debug_typenames) }
+	.debug_varnames  0 : { *(.debug_varnames) }
+	/* DWARF 3.  */
+	.debug_pubtypes 0 : { *(.debug_pubtypes) }
+	.debug_ranges   0 : { *(.debug_ranges) }
+	/* DWARF 5.  */
+	.debug_addr     0 : { *(.debug_addr) }
+	.debug_line_str 0 : { *(.debug_line_str) }
+	.debug_loclists 0 : { *(.debug_loclists) }
+	.debug_macro    0 : { *(.debug_macro) }
+	.debug_names    0 : { *(.debug_names) }
+	.debug_rnglists 0 : { *(.debug_rnglists) }
+	.debug_str_offsets 0 : { *(.debug_str_offsets) }
+	.debug_sup      0 : { *(.debug_sup) }
+	.gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }
+}
+/*
+ * Check that sections that are copied from flash to RAM have matching
+ * padding, so that a single memcpy() of __data_size copies the correct bytes.
+ */
+ASSERT( __data_size == __data_source_size,
+	"ERROR: .data/.tdata flash size does not match RAM size");

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33/RTE/Device/ARMCM33/gcc_linker_script.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33/RTE/Device/ARMCM33/gcc_linker_script.ld
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+/* ----------------------------------------------------------------------------
+  Memory definition
+ *----------------------------------------------------------------------------*/
+MEMORY
+{
+  ROM0  (rx)  : ORIGIN = __ROM0_BASE, LENGTH = __ROM0_SIZE
+#if __ROM1_SIZE > 0
+  ROM1  (rx)  : ORIGIN = __ROM1_BASE, LENGTH = __ROM1_SIZE
+#endif
+#if __ROM2_SIZE > 0
+  ROM2  (rx)  : ORIGIN = __ROM2_BASE, LENGTH = __ROM2_SIZE
+#endif
+#if __ROM3_SIZE > 0
+  ROM3  (rx)  : ORIGIN = __ROM3_BASE, LENGTH = __ROM3_SIZE
+#endif
+
+  RAM0  (rwx) : ORIGIN = __RAM0_BASE, LENGTH = __RAM0_SIZE
+#if __RAM1_SIZE > 0
+  RAM1  (rwx) : ORIGIN = __RAM1_BASE, LENGTH = __RAM1_SIZE
+#endif
+#if __RAM2_SIZE > 0
+  RAM2  (rwx) : ORIGIN = __RAM2_BASE, LENGTH = __RAM2_SIZE
+#endif
+#if __RAM3_SIZE > 0
+  RAM3  (rwx) : ORIGIN = __RAM3_BASE, LENGTH = __RAM3_SIZE
+#endif
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __copy_table_start__
+ *   __copy_table_end__
+ *   __zero_table_start__
+ *   __zero_table_end__
+ *   __etext          (deprecated)
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+  .text :
+  {
+    KEEP(*(.vectors))
+    *(.text*)
+
+    KEEP(*(.init))
+    KEEP(*(.fini))
+
+    /* .ctors */
+    *crtbegin.o(.ctors)
+    *crtbegin?.o(.ctors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+    *(SORT(.ctors.*))
+    *(.ctors)
+
+    /* .dtors */
+    *crtbegin.o(.dtors)
+    *crtbegin?.o(.dtors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+    *(SORT(.dtors.*))
+    *(.dtors)
+
+    *(.rodata*)
+
+    KEEP(*(.eh_frame*))
+  } > ROM0
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  .gnu.sgstubs :
+  {
+    . = ALIGN(32);
+  } > ROM0
+#endif
+
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > ROM0
+
+  __exidx_start = .;
+  .ARM.exidx :
+  {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+  } > ROM0
+  __exidx_end = .;
+
+  .copy.table :
+  {
+    . = ALIGN(4);
+    __copy_table_start__ = .;
+
+    LONG (LOADADDR(.data))
+    LONG (ADDR(.data))
+    LONG (SIZEOF(.data) / 4)
+
+    /* Add each additional data section here */
+/*
+    LONG (LOADADDR(.data2))
+    LONG (ADDR(.data2))
+    LONG (SIZEOF(.data2) / 4)
+*/
+    __copy_table_end__ = .;
+  } > ROM0
+
+  .zero.table :
+  {
+    . = ALIGN(4);
+    __zero_table_start__ = .;
+
+/*  .bss initialization to zero is already done during C Run-Time Startup.
+    LONG (ADDR(.bss))
+    LONG (SIZEOF(.bss) / 4)
+*/
+
+    /* Add each additional bss section here */
+/*
+    LONG (ADDR(.bss2))
+    LONG (SIZEOF(.bss2) / 4)
+*/
+    __zero_table_end__ = .;
+  } > ROM0
+
+  /*
+   * This __etext variable is kept for backward compatibility with older,
+   * ASM based startup files.
+   */
+  PROVIDE(__etext = LOADADDR(.data));
+
+  .data : ALIGN(4)
+  {
+    __data_start__ = .;
+    *(vtable)
+    *(.data)
+    *(.data.*)
+
+    . = ALIGN(4);
+    /* preinit data */
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP(*(.preinit_array))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+
+    . = ALIGN(4);
+    /* init data */
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP(*(SORT(.init_array.*)))
+    KEEP(*(.init_array))
+    PROVIDE_HIDDEN (__init_array_end = .);
+
+    . = ALIGN(4);
+    /* finit data */
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP(*(SORT(.fini_array.*)))
+    KEEP(*(.fini_array))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    /* All data end */
+    __data_end__ = .;
+
+  } > RAM0 AT > ROM0
+
+  /*
+   * Secondary data section, optional
+   *
+   * Remember to add each additional data section
+   * to the .copy.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .data2 : ALIGN(4)
+  {
+    . = ALIGN(4);
+    __data2_start__ = .;
+    *(.data2)
+    *(.data2.*)
+    . = ALIGN(4);
+    __data2_end__ = .;
+
+  } > RAM1 AT > ROM0 
+*/
+
+  .bss :
+  {
+    . = ALIGN(4);
+    __bss_start__ = .;
+    *(.bss)
+    *(.bss.*)
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+  } > RAM0 AT > RAM0
+
+  /*
+   * Secondary bss section, optional
+   *
+   * Remember to add each additional bss section
+   * to the .zero.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .bss2 :
+  {
+    . = ALIGN(4);
+    __bss2_start__ = .;
+    *(.bss2)
+    *(.bss2.*)
+    . = ALIGN(4);
+    __bss2_end__ = .;
+  } > RAM1 AT > RAM1
+*/
+
+  .heap (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE(end = .);
+    . = . + __HEAP_SIZE;
+    . = ALIGN(8);
+    __HeapLimit = .;
+  } > RAM0
+
+  .stack (ORIGIN(RAM0) + LENGTH(RAM0) - __STACK_SIZE - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackLimit = .;
+    . = . + __STACK_SIZE;
+    . = ALIGN(8);
+    __StackTop = .;
+  } > RAM0
+  PROVIDE(__stack = __StackTop);
+
+#if __STACKSEAL_SIZE > 0
+  .stackseal (ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackSeal = .;
+    . = . + 8;
+    . = ALIGN(8);
+  } > RAM0
+#endif
+
+  /* Check if data + heap + stack exceeds RAM limit */
+  ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33/RTE/Device/ARMCM33/iar_linker_script.icf
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33/RTE/Device/ARMCM33/iar_linker_script.icf
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+define memory mem with size = 4G;
+
+#if __ROM0_SIZE > 0
+  define region ROM0_region = mem:[from __ROM0_BASE to (__ROM0_BASE+__ROM0_SIZE-1)];
+#else
+  define region ROM0_region = [];
+#endif
+
+#if __ROM1_SIZE > 0
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+#else
+  define region ROM1_region = [];
+#endif
+
+#if __ROM2_SIZE > 0
+  define region ROM2_region = mem:[from __ROM2_BASE to (__ROM2_BASE+__ROM2_SIZE-1)];
+#else
+  define region ROM2_region = [];
+#endif
+
+#if __ROM3_SIZE > 0
+  define region ROM3_region = mem:[from __ROM3_BASE to (__ROM3_BASE+__ROM3_SIZE-1)];
+#else
+  define region ROM3_region = [];
+#endif
+
+define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_region;
+
+#if __RAM0_SIZE > 0
+  define region RAM0_region = mem:[from __RAM0_BASE to (__RAM0_BASE+__RAM0_SIZE-1)];
+#else
+  define region RAM0_region = [];
+#endif
+
+#if __RAM1_SIZE > 0
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+#else
+  define region RAM1_region = [];
+#endif
+
+#if __RAM2_SIZE > 0
+  define region RAM2_region = mem:[from __RAM2_BASE to (__RAM2_BASE+__RAM2_SIZE-1)];
+#else
+  define region RAM2_region = [];
+#endif
+
+#if __RAM3_SIZE > 0
+  define region RAM3_region = mem:[from __RAM3_BASE to (__RAM3_BASE+__RAM3_SIZE-1)];
+#else
+  define region RAM3_region = [];
+#endif
+
+define region RAM_region = RAM0_region | RAM1_region | RAM2_region | RAM3_region;
+
+do not initialize  { section .noinit };
+initialize by copy { readwrite };
+if (isdefinedsymbol(__USE_DLIB_PERTHREAD))
+{
+  // Required in a multi-threaded application
+  initialize by copy with packing = none { section __DLIB_PERTHREAD };
+}
+
+place at address mem:__ROM0_BASE { readonly section .intvec };
+
+if (!isempty(ROM_region))
+{
+  place in ROM_region  { readonly };
+}
+
+if (!isempty(RAM_region))
+{
+  define block CSTACK     with alignment = 8, size = __STACK_SIZE     { };
+  define block PROC_STACK with alignment = 8, size = 0 { };
+  define block HEAP       with alignment = 8, size = __HEAP_SIZE       { };
+  place in RAM_region  { readwrite, block CSTACK, block PROC_STACK, block HEAP };
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33/RTE/Device/ARMCM33/regions_ARMCM33.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33/RTE/Device/ARMCM33/regions_ARMCM33.h
@@ -1,0 +1,94 @@
+#ifndef REGIONS_ARMCM33_H
+#define REGIONS_ARMCM33_H
+
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+// <n>Device pack:   ARM::Cortex_DFP@1.0.0-dev16
+// <i>Device pack used to generate this file
+
+// <h>ROM Configuration
+// =======================
+// <h> ROM_S=<__ROM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x00000000
+#define __ROM0_BASE 0x00000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00200000
+#define __ROM0_SIZE 0x00200000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __ROM0_DEFAULT 1
+//   <q>Startup
+//   <i> Selects region to be used for startup code.
+#define __ROM0_STARTUP 1
+// </h>
+
+// <h> ROM_NS=<__ROM1>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x00200000
+#define __ROM1_BASE 0x00200000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00200000
+#define __ROM1_SIZE 0x00200000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __ROM1_DEFAULT 0
+//   <q>Startup
+//   <i> Selects region to be used for startup code.
+#define __ROM1_STARTUP 0
+// </h>
+
+// </h>
+
+// <h>RAM Configuration
+// =======================
+// <h> RAM_S=<__RAM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x20000000
+#define __RAM0_BASE 0x20000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00020000
+#define __RAM0_SIZE 0x00020000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __RAM0_DEFAULT 1
+//   <q>No zero initialize
+//   <i> Excludes region from zero initialization.
+#define __RAM0_NOINIT 0
+// </h>
+
+// <h> RAM_NS=<__RAM1>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x20200000
+#define __RAM1_BASE 0x20200000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00020000
+#define __RAM1_SIZE 0x00020000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __RAM1_DEFAULT 0
+//   <q>No zero initialize
+//   <i> Excludes region from zero initialization.
+#define __RAM1_NOINIT 0
+// </h>
+
+// </h>
+
+// <h>Stack / Heap Configuration
+//   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+#define __STACK_SIZE 0x00000400
+#define __HEAP_SIZE 0x00000C00
+// </h>
+
+
+#endif /* REGIONS_ARMCM33_H */

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33/RTE/Device/ARMCM33/startup_ARMCM33.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33/RTE/Device/ARMCM33/startup_ARMCM33.c
@@ -1,0 +1,164 @@
+/******************************************************************************
+ * @file     startup_ARMCM33.c
+ * @brief    CMSIS-Core Device Startup File for Cortex-M33 Device
+ * @version  V3.0.0
+ * @date     06. April 2023
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (ARMCM33)
+  #include "ARMCM33.h"
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  External References
+ *----------------------------------------------------------------------------*/
+extern uint32_t __INITIAL_SP;
+extern uint32_t __STACK_LIMIT;
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+extern uint32_t __STACK_SEAL;
+#endif
+
+extern __NO_RETURN void __PROGRAM_START(void);
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler  (void);
+            void Default_Handler(void);
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+/* Exceptions */
+void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void HardFault_Handler      (void) __attribute__ ((weak));
+void MemManage_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
+void BusFault_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void UsageFault_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void SecureFault_Handler    (void) __attribute__ ((weak, alias("Default_Handler")));
+void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void DebugMon_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+
+void Interrupt0_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt1_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt2_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt3_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt4_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt5_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt6_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt7_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt8_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt9_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[496];
+       const VECTOR_TABLE_Type __VECTOR_TABLE[496] __VECTOR_TABLE_ATTRIBUTE = {
+  (VECTOR_TABLE_Type)(&__INITIAL_SP),       /*     Initial Stack Pointer */
+  Reset_Handler,                            /*     Reset Handler */
+  NMI_Handler,                              /* -14 NMI Handler */
+  HardFault_Handler,                        /* -13 Hard Fault Handler */
+  MemManage_Handler,                        /* -12 MPU Fault Handler */
+  BusFault_Handler,                         /* -11 Bus Fault Handler */
+  UsageFault_Handler,                       /* -10 Usage Fault Handler */
+  SecureFault_Handler,                      /*  -9 Secure Fault Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  SVC_Handler,                              /*  -5 SVCall Handler */
+  DebugMon_Handler,                         /*  -4 Debug Monitor Handler */
+  0,                                        /*     Reserved */
+  PendSV_Handler,                           /*  -2 PendSV Handler */
+  SysTick_Handler,                          /*  -1 SysTick Handler */
+
+  /* Interrupts */
+  Interrupt0_Handler,                       /*   0 Interrupt 0 */
+  Interrupt1_Handler,                       /*   1 Interrupt 1 */
+  Interrupt2_Handler,                       /*   2 Interrupt 2 */
+  Interrupt3_Handler,                       /*   3 Interrupt 3 */
+  Interrupt4_Handler,                       /*   4 Interrupt 4 */
+  Interrupt5_Handler,                       /*   5 Interrupt 5 */
+  Interrupt6_Handler,                       /*   6 Interrupt 6 */
+  Interrupt7_Handler,                       /*   7 Interrupt 7 */
+  Interrupt8_Handler,                       /*   8 Interrupt 8 */
+  Interrupt9_Handler                        /*   9 Interrupt 9 */
+                                            /* Interrupts 10 .. 480 are left out */
+};
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler(void)
+{
+  __set_PSP((uint32_t)(&__INITIAL_SP));
+
+  __set_MSPLIM((uint32_t)(&__STACK_LIMIT));
+  __set_PSPLIM((uint32_t)(&__STACK_LIMIT));
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  __TZ_set_STACKSEAL_S((uint32_t *)(&__STACK_SEAL));
+#endif
+
+  SystemInit();                             /* CMSIS System Initialization */
+  __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
+}
+
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wmissing-noreturn"
+#endif
+
+/*----------------------------------------------------------------------------
+  Hard Fault Handler
+ *----------------------------------------------------------------------------*/
+void HardFault_Handler(void)
+{
+  while(1);
+}
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+void Default_Handler(void)
+{
+  while(1);
+}
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic pop
+#endif
+

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33/RTE/Device/ARMCM33/system_ARMCM33.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33/RTE/Device/ARMCM33/system_ARMCM33.c
@@ -1,0 +1,86 @@
+/**************************************************************************//**
+ * @file     system_ARMCM33.c
+ * @brief    CMSIS Device System Source File for
+ *           ARMCM33 Device
+ * @version  V2.0.0
+ * @date     06. Aril 2023
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (ARMCM33)
+  #include "ARMCM33.h"
+  #if defined (__ARM_FEATURE_CMSE) &&  (__ARM_FEATURE_CMSE == 3U)
+    #include "partition_ARMCM33.h"
+  #endif
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  Define clocks
+ *----------------------------------------------------------------------------*/
+#define  XTAL            (50000000UL)     /* Oscillator frequency */
+
+#define  SYSTEM_CLOCK    (XTAL / 2U)
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[496];
+
+
+/*----------------------------------------------------------------------------
+  System Core Clock Variable
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = SYSTEM_CLOCK;  /* System Core Clock Frequency */
+
+
+/*----------------------------------------------------------------------------
+  System Core Clock update function
+ *----------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)
+{
+  SystemCoreClock = SYSTEM_CLOCK;
+}
+
+/*----------------------------------------------------------------------------
+  System initialization function
+ *----------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t) &(__VECTOR_TABLE[0]);
+#endif
+
+#if defined (__FPU_USED) && (__FPU_USED == 1U)
+  SCB->CPACR |= ((3U << 10U*2U) |           /* enable CP10 Full Access */
+                 (3U << 11U*2U)  );         /* enable CP11 Full Access */
+#endif
+
+#ifdef UNALIGNED_SUPPORT_DISABLE
+  SCB->CCR |= SCB_CCR_UNALIGN_TRP_Msk;
+#endif
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  TZ_SAU_Setup();
+#endif
+
+  SystemCoreClock = SYSTEM_CLOCK;
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33/Target.clayer.yml
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33/Target.clayer.yml
@@ -1,0 +1,35 @@
+layer:
+  type: Target
+  description: CM33 target components and files
+
+  packs:
+    - pack: ARM::Cortex_DFP
+
+  device: ARMCM33
+
+  processor:
+    trustzone: off
+
+  components:
+    # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
+    - component: ARM::CMSIS:CORE
+    - component: Device:Startup&C Startup
+
+  groups:
+    - group: FVP
+      files:
+        - file: ./model_config.txt
+
+  linker:
+    - for-compiler: AC6
+      script: RTE/Device/$Dname$/ac6_linker_script.sct
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: GCC
+      script: RTE/Device/$Dname$/gcc_linker_script.ld
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: CLANG
+      script: RTE/Device/$Dname$/clang_linker_script.ld
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: IAR
+      script: RTE/Device/$Dname$/iar_linker_script.icf
+      regions: RTE/Device/$Dname$/regions_$Dname$.h

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33/model_config.txt
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33/model_config.txt
@@ -1,0 +1,32 @@
+# Parameters:
+# instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+#----------------------------------------------------------------------------------------------
+fvp_mps2.mps2_visualisation.disable-visualisation=1   # (bool  , init-time) default = '0'      : Enable/disable visualisation
+cpu0.FPU=1                                            # (bool  , init-time) default = '1'      : Set whether the model has VFP support
+cpu0.DSP=1                                            # (bool  , init-time) default = '1'      : Set whether the model has the DSP extension
+cpu0.semihosting-enable=1                             # (bool  , init-time) default = '1'      : Enable semihosting SVC traps. Applications that do not use semihosting must set this parameter to false.
+cpu0.semihosting-Thumb_SVC=0xAB                       # (int   , init-time) default = '0xAB'   : T32 SVC number for semihosting : [0x0..0xFF]
+cpu0.semihosting-cmd_line=""                          # (string, init-time) default = ''       : Command line available to semihosting SVC calls
+cpu0.semihosting-heap_base=0x0                        # (int   , init-time) default = '0x0'    : Virtual address of heap base : [0x0..0xFFFFFFFF]
+cpu0.semihosting-heap_limit=0x0                       # (int   , init-time) default = '0x10700000' : Virtual address of top of heap : [0x0..0xFFFFFFFF]
+cpu0.semihosting-stack_base=0x0                       # (int   , init-time) default = '0x10700000' : Virtual address of base of descending stack : [0x0..0xFFFFFFFF]
+cpu0.semihosting-stack_limit=0x0                      # (int   , init-time) default = '0x10800000' : Virtual address of stack limit : [0x0..0xFFFFFFFF]
+cpu0.semihosting-cwd=""                               # (string, init-time) default = ''       : Base directory for semihosting file access.
+cpu0.MPU_S=0x8                                        # (int   , init-time) default = '0x8'    : Number of regions in the Secure MPU. If Security Extentions are absent, this is ignored : [0x0..0x10]
+cpu0.MPU_NS=0x8                                       # (int   , init-time) default = '0x8'    : Number of regions in the Non-Secure MPU. If Security Extentions are absent, this is the total number of MPU regions : [0x0..0x10]
+cpu0.ITM=0                                            # (bool  , init-time) default = '1'      : Level of instrumentation trace supported. false : No ITM trace included, true: ITM trace included
+cpu0.IRQLVL=0x3                                       # (int   , init-time) default = '0x3'    : Number of bits of interrupt priority : [0x3..0x8]
+cpu0.BIGENDINIT=0                                     # (bool  , init-time) default = '0'      : Initialize processor to big endian mode
+cpu0.INITSVTOR=0x00000000                             # (int   , init-time) default = '0x10000000' : Secure vector-table offset at reset : [0x0..0xFFFFFF80]
+cpu0.INITNSVTOR=0x0                                   # (int   , init-time) default = '0x0'    : Non-Secure vector-table offset at reset : [0x0..0xFFFFFF80]
+cpu0.SAU=0x0                                          # (int   , init-time) default = '0x4'    : Number of SAU regions (0 => no SAU) : [0x0..0x8]
+cpu0.SAU_CTRL.ENABLE=0                                # (bool  , init-time) default = '0'      : Enable SAU at reset
+cpu0.SAU_CTRL.ALLNS=0                                 # (bool  , init-time) default = '0'      : At reset, the SAU treats entire memory space as NS when the SAU is disabled if this is set
+idau.NUM_IDAU_REGION=0x0                              # (int   , init-time) default = '0xA'    : 
+cpu0.LOCK_SAU=0                                       # (bool  , init-time) default = '0'      : Lock down of SAU registers write
+cpu0.LOCK_S_MPU=0                                     # (bool  , init-time) default = '0'      : Lock down of Secure MPU registers write
+cpu0.LOCK_NS_MPU=0                                    # (bool  , init-time) default = '0'      : Lock down of Non-Secure MPU registers write
+cpu0.CPIF=1                                           # (bool  , init-time) default = '1'      : Specifies whether the external coprocessor interface is included
+cpu0.SECEXT=0                                         # (bool  , init-time) default = '1'      : Whether the ARMv8-M Security Extensions are included
+fvp_mps2.DISABLE_GATING=1                             # (bool  , init-time) default = '0'      : Disable Memory gating logic
+#----------------------------------------------------------------------------------------------

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33NS/RTE/Device/ARMCM33/ac6_linker_script.sct
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33NS/RTE/Device/ARMCM33/ac6_linker_script.sct
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE 8
+#else
+#define __STACKSEAL_SIZE 0
+#endif
+
+/*----------------------------------------------------------------------------
+  Scatter File Definitions definition
+ *----------------------------------------------------------------------------*/
+
+LR_ROM0 __ROM0_BASE __ROM0_SIZE  {
+
+  ER_ROM0 __ROM0_BASE __ROM0_SIZE {
+    *.o (RESET, +First)
+    *(InRoot$$Sections)
+    *(+RO +XO)
+  }
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  ER_CMSE_VENEER AlignExpr(+0, 32) (__ROM0_SIZE - AlignExpr(ImageLength(ER_ROM0), 32)) {
+    *(Veneer$$CMSE)
+  }
+#endif
+
+  RW_NOINIT __RAM0_BASE UNINIT (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE) {
+    *(.bss.noinit)
+  }
+
+  RW_RAM0 AlignExpr(+0, 8) (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE - AlignExpr(ImageLength(RW_NOINIT), 8)) {
+    *(+RW +ZI)
+  }
+
+#if __HEAP_SIZE > 0
+  ARM_LIB_HEAP  (AlignExpr(+0, 8)) EMPTY __HEAP_SIZE  {   ; Reserve empty region for heap
+  }
+#endif
+
+  ARM_LIB_STACK (__RAM0_BASE + __RAM0_SIZE - __STACKSEAL_SIZE) EMPTY -__STACK_SIZE {   ; Reserve empty region for stack
+  }
+
+#if __STACKSEAL_SIZE > 0
+  STACKSEAL +0 EMPTY __STACKSEAL_SIZE {             ; Reserve empty region for stack seal immediately after stack
+  }
+#endif
+
+#if __RAM1_SIZE > 0
+  RW_RAM1 __RAM1_BASE __RAM1_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+
+#if __RAM2_SIZE > 0
+  RW_RAM2 __RAM2_BASE __RAM2_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+
+#if __RAM3_SIZE > 0
+  RW_RAM3 __RAM3_BASE __RAM3_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+}
+
+#if __ROM1_SIZE > 0
+LR_ROM1 __ROM1_BASE __ROM1_SIZE  {
+  ER_ROM1 +0 __ROM1_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif
+
+#if __ROM2_SIZE > 0
+LR_ROM2 __ROM2_BASE __ROM2_SIZE  {
+  ER_ROM2 +0 __ROM2_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif
+
+#if __ROM3_SIZE > 0
+LR_ROM3 __ROM3_BASE __ROM3_SIZE  {
+  ER_ROM3 +0 __ROM3_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33NS/RTE/Device/ARMCM33/clang_linker_script.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33NS/RTE/Device/ARMCM33/clang_linker_script.ld
@@ -1,0 +1,361 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2019 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+/* ----------------------------------------------------------------------------
+  Memory definition
+ *----------------------------------------------------------------------------*/
+MEMORY
+{
+  ROM0  (rx!w)  : ORIGIN = __ROM0_BASE, LENGTH = __ROM0_SIZE
+#if __ROM1_SIZE > 0
+  ROM1  (rx!w)  : ORIGIN = __ROM1_BASE, LENGTH = __ROM1_SIZE
+#endif
+#if __ROM2_SIZE > 0
+  ROM2  (rx!w)  : ORIGIN = __ROM2_BASE, LENGTH = __ROM2_SIZE
+#endif
+#if __ROM3_SIZE > 0
+  ROM3  (rx!w)  : ORIGIN = __ROM3_BASE, LENGTH = __ROM3_SIZE
+#endif
+
+  RAM0  (w!rx) : ORIGIN = __RAM0_BASE, LENGTH = __RAM0_SIZE
+#if __RAM1_SIZE > 0
+  RAM1  (w!rx) : ORIGIN = __RAM1_BASE, LENGTH = __RAM1_SIZE
+#endif
+#if __RAM2_SIZE > 0
+  RAM2  (w!rx) : ORIGIN = __RAM2_BASE, LENGTH = __RAM2_SIZE
+#endif
+#if __RAM3_SIZE > 0
+  RAM3  (w!rx) : ORIGIN = __RAM3_BASE, LENGTH = __RAM3_SIZE
+#endif
+}
+
+ENTRY(Reset_Handler)
+
+PHDRS
+{
+	text PT_LOAD;
+	ram PT_LOAD;
+	ram_init PT_LOAD;
+	tls PT_TLS;
+}
+
+SECTIONS
+{
+	.init : {
+		KEEP (*(.vectors))
+		KEEP (*(.text.init.enter))
+		KEEP (*(.data.init.enter))
+		KEEP (*(SORT_BY_NAME(.init) SORT_BY_NAME(.init.*)))
+	} >ROM0 AT>ROM0 :text
+
+	.text : {
+
+		/* code */
+		*(.text.unlikely .text.unlikely.*)
+		*(.text.startup .text.startup.*)
+		*(.text .text.* .opd .opd.*)
+		*(.gnu.linkonce.t.*)
+		KEEP (*(.fini .fini.*))
+		__text_end = .;
+
+		PROVIDE (__etext = __text_end);
+		PROVIDE (_etext = __text_end);
+		PROVIDE (etext = __text_end);
+
+		/* read-only data */
+		*(.rdata)
+		*(.rodata .rodata.*)
+		*(.gnu.linkonce.r.*)
+
+		*(.srodata.cst16)
+		*(.srodata.cst8)
+		*(.srodata.cst4)
+		*(.srodata.cst2)
+		*(.srodata .srodata.*)
+		*(.data.rel.ro .data.rel.ro.*)
+		*(.got .got.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		/* lists of constructors and destructors */
+		PROVIDE_HIDDEN ( __preinit_array_start = . );
+		KEEP (*(.preinit_array))
+		PROVIDE_HIDDEN ( __preinit_array_end = . );
+
+		PROVIDE_HIDDEN ( __init_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+		KEEP (*(.init_array .ctors))
+		PROVIDE_HIDDEN ( __init_array_end = . );
+
+		PROVIDE_HIDDEN ( __fini_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
+		KEEP (*(.fini_array .dtors))
+		PROVIDE_HIDDEN ( __fini_array_end = . );
+
+	} >ROM0 AT>ROM0 :text
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+	.veneers :
+	{
+		. = ALIGN(32);
+		KEEP(*(.gnu.sgstubs))
+	} > ROM0 AT>ROM0 :text
+#endif
+
+	.toc : {
+		*(.toc .toc.*)
+	} >ROM0 AT>ROM0 :text
+
+	/* additional sections when compiling with C++ exception support */
+	
+	.except_ordered : {
+		*(.gcc_except_table *.gcc_except_table.*)
+		KEEP (*(.eh_frame .eh_frame.*))
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+	} >ROM0 AT>ROM0 :text
+
+	.except_unordered : {
+		. = ALIGN(8);
+
+		PROVIDE(__exidx_start = .);
+		*(.ARM.exidx*)
+		PROVIDE(__exidx_end = .);
+	} >ROM0 AT>ROM0 :text
+	
+
+	/*
+	 * Data values which are preserved across reset
+	 */
+	.preserve (NOLOAD) : {
+		PROVIDE(__preserve_start__ = .);
+		KEEP(*(SORT_BY_NAME(.preserve.*)))
+		KEEP(*(.preserve))
+		PROVIDE(__preserve_end__ = .);
+	} >RAM0 AT>RAM0 :ram
+
+	.data :  {
+		*(.data .data.*)
+		*(.gnu.linkonce.d.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		PROVIDE( __global_pointer$ = . + 0x800 );
+		*(.sdata .sdata.* .sdata2.*)
+		*(.gnu.linkonce.s.*)
+	} >RAM0 AT>ROM0 :ram_init
+	PROVIDE(__data_start = ADDR(.data));
+	PROVIDE(__data_source = LOADADDR(.data));
+
+	/* Thread local initialized data. This gets
+	 * space allocated as it is expected to be placed
+	 * in ram to be used as a template for TLS data blocks
+	 * allocated at runtime. We're slightly abusing that
+	 * by placing the data in flash where it will be copied
+	 * into the allocate ram addresses by the existing
+	 * data initialization code in crt0
+	 */
+	.tdata :  {
+		*(.tdata .tdata.* .gnu.linkonce.td.*)
+		PROVIDE(__data_end = .);
+		PROVIDE(__tdata_end = .);
+	} >RAM0 AT>ROM0 :tls :ram_init
+	PROVIDE( __tls_base = ADDR(.tdata));
+	PROVIDE( __tdata_start = ADDR(.tdata));
+	PROVIDE( __tdata_source = LOADADDR(.tdata) );
+	PROVIDE( __tdata_source_end = LOADADDR(.tdata) + SIZEOF(.tdata) );
+	PROVIDE( __data_source_end = __tdata_source_end );
+	PROVIDE( __tdata_size = SIZEOF(.tdata) );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata),ALIGNOF(.tbss)) );
+
+	PROVIDE( __edata = __data_end );
+	PROVIDE( _edata = __data_end );
+	PROVIDE( edata = __data_end );
+	PROVIDE( __data_size = __data_end - __data_start );
+	PROVIDE( __data_source_size = __data_source_end - __data_source );
+
+	.tbss (NOLOAD) : {
+		*(.tbss .tbss.* .gnu.linkonce.tb.*)
+		*(.tcommon)
+		PROVIDE( __tls_end = . );
+		PROVIDE( __tbss_end = . );
+	} >RAM0 AT>RAM0 :tls :ram
+	PROVIDE( __bss_start = ADDR(.tbss));
+	PROVIDE( __tbss_start = ADDR(.tbss));
+	PROVIDE( __tbss_offset = ADDR(.tbss) - ADDR(.tdata) );
+	PROVIDE( __tbss_size = SIZEOF(.tbss) );
+	PROVIDE( __tls_size = __tls_end - __tls_base );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
+	PROVIDE( __arm32_tls_tcb_offset = MAX(8, __tls_align) );
+	PROVIDE( __arm64_tls_tcb_offset = MAX(16, __tls_align) );
+
+	/*
+	 * The linker special cases .tbss segments which are
+	 * identified as segments which are not loaded and are
+	 * thread_local.
+	 *
+	 * For these segments, the linker does not advance 'dot'
+	 * across them.  We actually need memory allocated for tbss,
+	 * so we create a special segment here just to make room
+	 */
+	/*
+	.tbss_space (NOLOAD) : {
+		. = ADDR(.tbss);
+		. = . + SIZEOF(.tbss);
+	} >RAM0 AT>RAM0 :ram
+	*/
+
+	.bss (NOLOAD) : {
+		*(.sbss*)
+		*(.gnu.linkonce.sb.*)
+		*(.bss .bss.*)
+		*(.gnu.linkonce.b.*)
+		*(COMMON)
+
+		/* Align the heap */
+		. = ALIGN(8);
+		__bss_end = .;
+	} >RAM0 AT>RAM0 :ram
+	PROVIDE( __non_tls_bss_start = ADDR(.bss) );
+	PROVIDE( __end = __bss_end );
+	PROVIDE( _end = __bss_end );
+	PROVIDE( end = __bss_end );
+	PROVIDE( __bss_size = __bss_end - __bss_start );
+
+	/* Make the rest of memory available for heap storage */
+	PROVIDE (__heap_start = __end);
+#ifdef __HEAP_SIZE
+	PROVIDE (__heap_end = __heap_start + __HEAP_SIZE);
+	PROVIDE (__heap_size = __HEAP_SIZE);
+#else
+	PROVIDE (__heap_end = __stack - __STACK_SIZE);
+	PROVIDE (__heap_size = __heap_end - __heap_start);
+#endif
+	.heap (NOLOAD) : {
+		. += __heap_size;
+	} >RAM0 :ram
+
+	/* Define a stack region to make sure it fits in memory */
+	PROVIDE(__stack = ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE);
+	PROVIDE(__stack_limit = __stack - __STACK_SIZE);
+	.stack (__stack_limit) (NOLOAD) : {
+		. += __STACK_SIZE;
+	} >RAM0 :ram
+
+#if __STACKSEAL_SIZE > 0
+	PROVIDE(__stack_seal = __stack);
+  	.stackseal (__stack) (NOLOAD) :
+  	{
+    	. += __STACKSEAL_SIZE;
+  	} >RAM0 :ram
+#endif
+
+	/* Throw away C++ exception handling information */
+
+	/*
+
+	/DISCARD/ : {
+		*(.note .note.*)
+		*(.eh_frame .eh_frame.*)
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+		*(.ARM.exidx*)
+	}
+
+	*/
+
+	/* Stabs debugging sections.  */
+	.stab          0 : { *(.stab) }
+	.stabstr       0 : { *(.stabstr) }
+	.stab.excl     0 : { *(.stab.excl) }
+	.stab.exclstr  0 : { *(.stab.exclstr) }
+	.stab.index    0 : { *(.stab.index) }
+	.stab.indexstr 0 : { *(.stab.indexstr) }
+	.comment       0 : { *(.comment) }
+	.gnu.build.attributes : { *(.gnu.build.attributes .gnu.build.attributes.*) }
+	/* DWARF debug sections.
+	   Symbols in the DWARF debugging sections are relative to the beginning
+	   of the section so we begin them at 0.  */
+	/* DWARF 1.  */
+	.debug          0 : { *(.debug) }
+	.line           0 : { *(.line) }
+	/* GNU DWARF 1 extensions.  */
+	.debug_srcinfo  0 : { *(.debug_srcinfo) }
+	.debug_sfnames  0 : { *(.debug_sfnames) }
+	/* DWARF 1.1 and DWARF 2.  */
+	.debug_aranges  0 : { *(.debug_aranges) }
+	.debug_pubnames 0 : { *(.debug_pubnames) }
+	/* DWARF 2.  */
+	.debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+	.debug_abbrev   0 : { *(.debug_abbrev) }
+	.debug_line     0 : { *(.debug_line .debug_line.* .debug_line_end) }
+	.debug_frame    0 : { *(.debug_frame) }
+	.debug_str      0 : { *(.debug_str) }
+	.debug_loc      0 : { *(.debug_loc) }
+	.debug_macinfo  0 : { *(.debug_macinfo) }
+	/* SGI/MIPS DWARF 2 extensions.  */
+	.debug_weaknames 0 : { *(.debug_weaknames) }
+	.debug_funcnames 0 : { *(.debug_funcnames) }
+	.debug_typenames 0 : { *(.debug_typenames) }
+	.debug_varnames  0 : { *(.debug_varnames) }
+	/* DWARF 3.  */
+	.debug_pubtypes 0 : { *(.debug_pubtypes) }
+	.debug_ranges   0 : { *(.debug_ranges) }
+	/* DWARF 5.  */
+	.debug_addr     0 : { *(.debug_addr) }
+	.debug_line_str 0 : { *(.debug_line_str) }
+	.debug_loclists 0 : { *(.debug_loclists) }
+	.debug_macro    0 : { *(.debug_macro) }
+	.debug_names    0 : { *(.debug_names) }
+	.debug_rnglists 0 : { *(.debug_rnglists) }
+	.debug_str_offsets 0 : { *(.debug_str_offsets) }
+	.debug_sup      0 : { *(.debug_sup) }
+	.gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }
+}
+/*
+ * Check that sections that are copied from flash to RAM have matching
+ * padding, so that a single memcpy() of __data_size copies the correct bytes.
+ */
+ASSERT( __data_size == __data_source_size,
+	"ERROR: .data/.tdata flash size does not match RAM size");

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33NS/RTE/Device/ARMCM33/gcc_linker_script.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33NS/RTE/Device/ARMCM33/gcc_linker_script.ld
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+/* ----------------------------------------------------------------------------
+  Memory definition
+ *----------------------------------------------------------------------------*/
+MEMORY
+{
+  ROM0  (rx)  : ORIGIN = __ROM0_BASE, LENGTH = __ROM0_SIZE
+#if __ROM1_SIZE > 0
+  ROM1  (rx)  : ORIGIN = __ROM1_BASE, LENGTH = __ROM1_SIZE
+#endif
+#if __ROM2_SIZE > 0
+  ROM2  (rx)  : ORIGIN = __ROM2_BASE, LENGTH = __ROM2_SIZE
+#endif
+#if __ROM3_SIZE > 0
+  ROM3  (rx)  : ORIGIN = __ROM3_BASE, LENGTH = __ROM3_SIZE
+#endif
+
+  RAM0  (rwx) : ORIGIN = __RAM0_BASE, LENGTH = __RAM0_SIZE
+#if __RAM1_SIZE > 0
+  RAM1  (rwx) : ORIGIN = __RAM1_BASE, LENGTH = __RAM1_SIZE
+#endif
+#if __RAM2_SIZE > 0
+  RAM2  (rwx) : ORIGIN = __RAM2_BASE, LENGTH = __RAM2_SIZE
+#endif
+#if __RAM3_SIZE > 0
+  RAM3  (rwx) : ORIGIN = __RAM3_BASE, LENGTH = __RAM3_SIZE
+#endif
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __copy_table_start__
+ *   __copy_table_end__
+ *   __zero_table_start__
+ *   __zero_table_end__
+ *   __etext          (deprecated)
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+  .text :
+  {
+    KEEP(*(.vectors))
+    *(.text*)
+
+    KEEP(*(.init))
+    KEEP(*(.fini))
+
+    /* .ctors */
+    *crtbegin.o(.ctors)
+    *crtbegin?.o(.ctors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+    *(SORT(.ctors.*))
+    *(.ctors)
+
+    /* .dtors */
+    *crtbegin.o(.dtors)
+    *crtbegin?.o(.dtors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+    *(SORT(.dtors.*))
+    *(.dtors)
+
+    *(.rodata*)
+
+    KEEP(*(.eh_frame*))
+  } > ROM0
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  .gnu.sgstubs :
+  {
+    . = ALIGN(32);
+  } > ROM0
+#endif
+
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > ROM0
+
+  __exidx_start = .;
+  .ARM.exidx :
+  {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+  } > ROM0
+  __exidx_end = .;
+
+  .copy.table :
+  {
+    . = ALIGN(4);
+    __copy_table_start__ = .;
+
+    LONG (LOADADDR(.data))
+    LONG (ADDR(.data))
+    LONG (SIZEOF(.data) / 4)
+
+    /* Add each additional data section here */
+/*
+    LONG (LOADADDR(.data2))
+    LONG (ADDR(.data2))
+    LONG (SIZEOF(.data2) / 4)
+*/
+    __copy_table_end__ = .;
+  } > ROM0
+
+  .zero.table :
+  {
+    . = ALIGN(4);
+    __zero_table_start__ = .;
+
+/*  .bss initialization to zero is already done during C Run-Time Startup.
+    LONG (ADDR(.bss))
+    LONG (SIZEOF(.bss) / 4)
+*/
+
+    /* Add each additional bss section here */
+/*
+    LONG (ADDR(.bss2))
+    LONG (SIZEOF(.bss2) / 4)
+*/
+    __zero_table_end__ = .;
+  } > ROM0
+
+  /*
+   * This __etext variable is kept for backward compatibility with older,
+   * ASM based startup files.
+   */
+  PROVIDE(__etext = LOADADDR(.data));
+
+  .data : ALIGN(4)
+  {
+    __data_start__ = .;
+    *(vtable)
+    *(.data)
+    *(.data.*)
+
+    . = ALIGN(4);
+    /* preinit data */
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP(*(.preinit_array))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+
+    . = ALIGN(4);
+    /* init data */
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP(*(SORT(.init_array.*)))
+    KEEP(*(.init_array))
+    PROVIDE_HIDDEN (__init_array_end = .);
+
+    . = ALIGN(4);
+    /* finit data */
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP(*(SORT(.fini_array.*)))
+    KEEP(*(.fini_array))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    /* All data end */
+    __data_end__ = .;
+
+  } > RAM0 AT > ROM0
+
+  /*
+   * Secondary data section, optional
+   *
+   * Remember to add each additional data section
+   * to the .copy.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .data2 : ALIGN(4)
+  {
+    . = ALIGN(4);
+    __data2_start__ = .;
+    *(.data2)
+    *(.data2.*)
+    . = ALIGN(4);
+    __data2_end__ = .;
+
+  } > RAM1 AT > ROM0 
+*/
+
+  .bss :
+  {
+    . = ALIGN(4);
+    __bss_start__ = .;
+    *(.bss)
+    *(.bss.*)
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+  } > RAM0 AT > RAM0
+
+  /*
+   * Secondary bss section, optional
+   *
+   * Remember to add each additional bss section
+   * to the .zero.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .bss2 :
+  {
+    . = ALIGN(4);
+    __bss2_start__ = .;
+    *(.bss2)
+    *(.bss2.*)
+    . = ALIGN(4);
+    __bss2_end__ = .;
+  } > RAM1 AT > RAM1
+*/
+
+  .heap (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE(end = .);
+    . = . + __HEAP_SIZE;
+    . = ALIGN(8);
+    __HeapLimit = .;
+  } > RAM0
+
+  .stack (ORIGIN(RAM0) + LENGTH(RAM0) - __STACK_SIZE - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackLimit = .;
+    . = . + __STACK_SIZE;
+    . = ALIGN(8);
+    __StackTop = .;
+  } > RAM0
+  PROVIDE(__stack = __StackTop);
+
+#if __STACKSEAL_SIZE > 0
+  .stackseal (ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackSeal = .;
+    . = . + 8;
+    . = ALIGN(8);
+  } > RAM0
+#endif
+
+  /* Check if data + heap + stack exceeds RAM limit */
+  ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33NS/RTE/Device/ARMCM33/iar_linker_script.icf
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33NS/RTE/Device/ARMCM33/iar_linker_script.icf
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+define memory mem with size = 4G;
+
+#if __ROM0_SIZE > 0
+  define region ROM0_region = mem:[from __ROM0_BASE to (__ROM0_BASE+__ROM0_SIZE-1)];
+#else
+  define region ROM0_region = [];
+#endif
+
+#if __ROM1_SIZE > 0
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+#else
+  define region ROM1_region = [];
+#endif
+
+#if __ROM2_SIZE > 0
+  define region ROM2_region = mem:[from __ROM2_BASE to (__ROM2_BASE+__ROM2_SIZE-1)];
+#else
+  define region ROM2_region = [];
+#endif
+
+#if __ROM3_SIZE > 0
+  define region ROM3_region = mem:[from __ROM3_BASE to (__ROM3_BASE+__ROM3_SIZE-1)];
+#else
+  define region ROM3_region = [];
+#endif
+
+define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_region;
+
+#if __RAM0_SIZE > 0
+  define region RAM0_region = mem:[from __RAM0_BASE to (__RAM0_BASE+__RAM0_SIZE-1)];
+#else
+  define region RAM0_region = [];
+#endif
+
+#if __RAM1_SIZE > 0
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+#else
+  define region RAM1_region = [];
+#endif
+
+#if __RAM2_SIZE > 0
+  define region RAM2_region = mem:[from __RAM2_BASE to (__RAM2_BASE+__RAM2_SIZE-1)];
+#else
+  define region RAM2_region = [];
+#endif
+
+#if __RAM3_SIZE > 0
+  define region RAM3_region = mem:[from __RAM3_BASE to (__RAM3_BASE+__RAM3_SIZE-1)];
+#else
+  define region RAM3_region = [];
+#endif
+
+define region RAM_region = RAM0_region | RAM1_region | RAM2_region | RAM3_region;
+
+do not initialize  { section .noinit };
+initialize by copy { readwrite };
+if (isdefinedsymbol(__USE_DLIB_PERTHREAD))
+{
+  // Required in a multi-threaded application
+  initialize by copy with packing = none { section __DLIB_PERTHREAD };
+}
+
+place at address mem:__ROM0_BASE { readonly section .intvec };
+
+if (!isempty(ROM_region))
+{
+  place in ROM_region  { readonly };
+}
+
+if (!isempty(RAM_region))
+{
+  define block CSTACK     with alignment = 8, size = __STACK_SIZE     { };
+  define block PROC_STACK with alignment = 8, size = 0 { };
+  define block HEAP       with alignment = 8, size = __HEAP_SIZE       { };
+  place in RAM_region  { readwrite, block CSTACK, block PROC_STACK, block HEAP };
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33NS/RTE/Device/ARMCM33/regions_ARMCM33.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33NS/RTE/Device/ARMCM33/regions_ARMCM33.h
@@ -1,0 +1,94 @@
+#ifndef REGIONS_ARMCM33_H
+#define REGIONS_ARMCM33_H
+
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+// <n>Device pack:   ARM::Cortex_DFP@1.0.0-dev16
+// <i>Device pack used to generate this file
+
+// <h>ROM Configuration
+// =======================
+// <h> ROM_S=<__ROM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x00000000
+#define __ROM0_BASE 0x00200000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00200000
+#define __ROM0_SIZE 0x00200000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __ROM0_DEFAULT 1
+//   <q>Startup
+//   <i> Selects region to be used for startup code.
+#define __ROM0_STARTUP 1
+// </h>
+
+// <h> ROM_NS=<__ROM1>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x00200000
+#define __ROM1_BASE 0x00000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00200000
+#define __ROM1_SIZE 0x00200000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __ROM1_DEFAULT 0
+//   <q>Startup
+//   <i> Selects region to be used for startup code.
+#define __ROM1_STARTUP 0
+// </h>
+
+// </h>
+
+// <h>RAM Configuration
+// =======================
+// <h> RAM_S=<__RAM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x20000000
+#define __RAM0_BASE 0x20200000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00020000
+#define __RAM0_SIZE 0x00020000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __RAM0_DEFAULT 1
+//   <q>No zero initialize
+//   <i> Excludes region from zero initialization.
+#define __RAM0_NOINIT 0
+// </h>
+
+// <h> RAM_NS=<__RAM1>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x20200000
+#define __RAM1_BASE 0x20000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00020000
+#define __RAM1_SIZE 0x00020000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __RAM1_DEFAULT 0
+//   <q>No zero initialize
+//   <i> Excludes region from zero initialization.
+#define __RAM1_NOINIT 0
+// </h>
+
+// </h>
+
+// <h>Stack / Heap Configuration
+//   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+#define __STACK_SIZE 0x00000400
+#define __HEAP_SIZE 0x00000C00
+// </h>
+
+
+#endif /* REGIONS_ARMCM33_H */

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33NS/RTE/Device/ARMCM33/startup_ARMCM33.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33NS/RTE/Device/ARMCM33/startup_ARMCM33.c
@@ -1,0 +1,164 @@
+/******************************************************************************
+ * @file     startup_ARMCM33.c
+ * @brief    CMSIS-Core Device Startup File for Cortex-M33 Device
+ * @version  V3.0.0
+ * @date     06. April 2023
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (ARMCM33)
+  #include "ARMCM33.h"
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  External References
+ *----------------------------------------------------------------------------*/
+extern uint32_t __INITIAL_SP;
+extern uint32_t __STACK_LIMIT;
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+extern uint32_t __STACK_SEAL;
+#endif
+
+extern __NO_RETURN void __PROGRAM_START(void);
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler  (void);
+            void Default_Handler(void);
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+/* Exceptions */
+void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void HardFault_Handler      (void) __attribute__ ((weak));
+void MemManage_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
+void BusFault_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void UsageFault_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void SecureFault_Handler    (void) __attribute__ ((weak, alias("Default_Handler")));
+void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void DebugMon_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+
+void Interrupt0_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt1_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt2_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt3_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt4_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt5_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt6_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt7_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt8_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt9_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[496];
+       const VECTOR_TABLE_Type __VECTOR_TABLE[496] __VECTOR_TABLE_ATTRIBUTE = {
+  (VECTOR_TABLE_Type)(&__INITIAL_SP),       /*     Initial Stack Pointer */
+  Reset_Handler,                            /*     Reset Handler */
+  NMI_Handler,                              /* -14 NMI Handler */
+  HardFault_Handler,                        /* -13 Hard Fault Handler */
+  MemManage_Handler,                        /* -12 MPU Fault Handler */
+  BusFault_Handler,                         /* -11 Bus Fault Handler */
+  UsageFault_Handler,                       /* -10 Usage Fault Handler */
+  SecureFault_Handler,                      /*  -9 Secure Fault Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  SVC_Handler,                              /*  -5 SVCall Handler */
+  DebugMon_Handler,                         /*  -4 Debug Monitor Handler */
+  0,                                        /*     Reserved */
+  PendSV_Handler,                           /*  -2 PendSV Handler */
+  SysTick_Handler,                          /*  -1 SysTick Handler */
+
+  /* Interrupts */
+  Interrupt0_Handler,                       /*   0 Interrupt 0 */
+  Interrupt1_Handler,                       /*   1 Interrupt 1 */
+  Interrupt2_Handler,                       /*   2 Interrupt 2 */
+  Interrupt3_Handler,                       /*   3 Interrupt 3 */
+  Interrupt4_Handler,                       /*   4 Interrupt 4 */
+  Interrupt5_Handler,                       /*   5 Interrupt 5 */
+  Interrupt6_Handler,                       /*   6 Interrupt 6 */
+  Interrupt7_Handler,                       /*   7 Interrupt 7 */
+  Interrupt8_Handler,                       /*   8 Interrupt 8 */
+  Interrupt9_Handler                        /*   9 Interrupt 9 */
+                                            /* Interrupts 10 .. 480 are left out */
+};
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler(void)
+{
+  __set_PSP((uint32_t)(&__INITIAL_SP));
+
+  __set_MSPLIM((uint32_t)(&__STACK_LIMIT));
+  __set_PSPLIM((uint32_t)(&__STACK_LIMIT));
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  __TZ_set_STACKSEAL_S((uint32_t *)(&__STACK_SEAL));
+#endif
+
+  SystemInit();                             /* CMSIS System Initialization */
+  __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
+}
+
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wmissing-noreturn"
+#endif
+
+/*----------------------------------------------------------------------------
+  Hard Fault Handler
+ *----------------------------------------------------------------------------*/
+void HardFault_Handler(void)
+{
+  while(1);
+}
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+void Default_Handler(void)
+{
+  while(1);
+}
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic pop
+#endif
+

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33NS/RTE/Device/ARMCM33/system_ARMCM33.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33NS/RTE/Device/ARMCM33/system_ARMCM33.c
@@ -1,0 +1,86 @@
+/**************************************************************************//**
+ * @file     system_ARMCM33.c
+ * @brief    CMSIS Device System Source File for
+ *           ARMCM33 Device
+ * @version  V2.0.0
+ * @date     06. Aril 2023
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (ARMCM33)
+  #include "ARMCM33.h"
+  #if defined (__ARM_FEATURE_CMSE) &&  (__ARM_FEATURE_CMSE == 3U)
+    #include "partition_ARMCM33.h"
+  #endif
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  Define clocks
+ *----------------------------------------------------------------------------*/
+#define  XTAL            (50000000UL)     /* Oscillator frequency */
+
+#define  SYSTEM_CLOCK    (XTAL / 2U)
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[496];
+
+
+/*----------------------------------------------------------------------------
+  System Core Clock Variable
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = SYSTEM_CLOCK;  /* System Core Clock Frequency */
+
+
+/*----------------------------------------------------------------------------
+  System Core Clock update function
+ *----------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)
+{
+  SystemCoreClock = SYSTEM_CLOCK;
+}
+
+/*----------------------------------------------------------------------------
+  System initialization function
+ *----------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t) &(__VECTOR_TABLE[0]);
+#endif
+
+#if defined (__FPU_USED) && (__FPU_USED == 1U)
+  SCB->CPACR |= ((3U << 10U*2U) |           /* enable CP10 Full Access */
+                 (3U << 11U*2U)  );         /* enable CP11 Full Access */
+#endif
+
+#ifdef UNALIGNED_SUPPORT_DISABLE
+  SCB->CCR |= SCB_CCR_UNALIGN_TRP_Msk;
+#endif
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  TZ_SAU_Setup();
+#endif
+
+  SystemCoreClock = SYSTEM_CLOCK;
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33NS/Target.clayer.yml
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33NS/Target.clayer.yml
@@ -1,0 +1,35 @@
+layer:
+  type: Target
+  description: CM33NS target components and files
+
+  packs:
+    - pack: ARM::Cortex_DFP
+
+  device: ARMCM33
+
+  processor:
+    trustzone: non-secure
+
+  components:
+    # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
+    - component: ARM::CMSIS:CORE
+    - component: Device:Startup&C Startup
+
+  groups:
+    - group: FVP
+      files:
+        - file: ./model_config.txt
+
+  linker:
+    - for-compiler: AC6
+      script: RTE/Device/$Dname$/ac6_linker_script.sct
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: GCC
+      script: RTE/Device/$Dname$/gcc_linker_script.ld
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: CLANG
+      script: RTE/Device/$Dname$/clang_linker_script.ld
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: IAR
+      script: RTE/Device/$Dname$/iar_linker_script.icf
+      regions: RTE/Device/$Dname$/regions_$Dname$.h

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33NS/model_config.txt
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33NS/model_config.txt
@@ -1,0 +1,32 @@
+# Parameters:
+# instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+#----------------------------------------------------------------------------------------------
+fvp_mps2.mps2_visualisation.disable-visualisation=1   # (bool  , init-time) default = '0'      : Enable/disable visualisation
+cpu0.FPU=1                                            # (bool  , init-time) default = '1'      : Set whether the model has VFP support
+cpu0.DSP=1                                            # (bool  , init-time) default = '1'      : Set whether the model has the DSP extension
+cpu0.semihosting-enable=1                             # (bool  , init-time) default = '1'      : Enable semihosting SVC traps. Applications that do not use semihosting must set this parameter to false.
+cpu0.semihosting-Thumb_SVC=0xAB                       # (int   , init-time) default = '0xAB'   : T32 SVC number for semihosting : [0x0..0xFF]
+cpu0.semihosting-cmd_line=""                          # (string, init-time) default = ''       : Command line available to semihosting SVC calls
+cpu0.semihosting-heap_base=0x0                        # (int   , init-time) default = '0x0'    : Virtual address of heap base : [0x0..0xFFFFFFFF]
+cpu0.semihosting-heap_limit=0x0                       # (int   , init-time) default = '0x10700000' : Virtual address of top of heap : [0x0..0xFFFFFFFF]
+cpu0.semihosting-stack_base=0x0                       # (int   , init-time) default = '0x10700000' : Virtual address of base of descending stack : [0x0..0xFFFFFFFF]
+cpu0.semihosting-stack_limit=0x0                      # (int   , init-time) default = '0x10800000' : Virtual address of stack limit : [0x0..0xFFFFFFFF]
+cpu0.semihosting-cwd=""                               # (string, init-time) default = ''       : Base directory for semihosting file access.
+cpu0.MPU_S=0x8                                        # (int   , init-time) default = '0x8'    : Number of regions in the Secure MPU. If Security Extentions are absent, this is ignored : [0x0..0x10]
+cpu0.MPU_NS=0x8                                       # (int   , init-time) default = '0x8'    : Number of regions in the Non-Secure MPU. If Security Extentions are absent, this is the total number of MPU regions : [0x0..0x10]
+cpu0.ITM=0                                            # (bool  , init-time) default = '1'      : Level of instrumentation trace supported. false : No ITM trace included, true: ITM trace included
+cpu0.IRQLVL=0x3                                       # (int   , init-time) default = '0x3'    : Number of bits of interrupt priority : [0x3..0x8]
+cpu0.BIGENDINIT=0                                     # (bool  , init-time) default = '0'      : Initialize processor to big endian mode
+cpu0.INITSVTOR=0x00000000                             # (int   , init-time) default = '0x10000000' : Secure vector-table offset at reset : [0x0..0xFFFFFF80]
+cpu0.INITNSVTOR=0x0                                   # (int   , init-time) default = '0x0'    : Non-Secure vector-table offset at reset : [0x0..0xFFFFFF80]
+cpu0.SAU=0x8                                          # (int   , init-time) default = '0x4'    : Number of SAU regions (0 => no SAU) : [0x0..0x8]
+cpu0.SAU_CTRL.ENABLE=0                                # (bool  , init-time) default = '0'      : Enable SAU at reset
+cpu0.SAU_CTRL.ALLNS=0                                 # (bool  , init-time) default = '0'      : At reset, the SAU treats entire memory space as NS when the SAU is disabled if this is set
+idau.NUM_IDAU_REGION=0x0                              # (int   , init-time) default = '0xA'    : 
+cpu0.LOCK_SAU=0                                       # (bool  , init-time) default = '0'      : Lock down of SAU registers write
+cpu0.LOCK_S_MPU=0                                     # (bool  , init-time) default = '0'      : Lock down of Secure MPU registers write
+cpu0.LOCK_NS_MPU=0                                    # (bool  , init-time) default = '0'      : Lock down of Non-Secure MPU registers write
+cpu0.CPIF=1                                           # (bool  , init-time) default = '1'      : Specifies whether the external coprocessor interface is included
+cpu0.SECEXT=1                                         # (bool  , init-time) default = '1'      : Whether the ARMv8-M Security Extensions are included
+fvp_mps2.DISABLE_GATING=1                             # (bool  , init-time) default = '0'      : Disable Memory gating logic
+#----------------------------------------------------------------------------------------------

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33S/RTE/Device/ARMCM33/ac6_linker_script.sct
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33S/RTE/Device/ARMCM33/ac6_linker_script.sct
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE 8
+#else
+#define __STACKSEAL_SIZE 0
+#endif
+
+/*----------------------------------------------------------------------------
+  Scatter File Definitions definition
+ *----------------------------------------------------------------------------*/
+
+LR_ROM0 __ROM0_BASE __ROM0_SIZE  {
+
+  ER_ROM0 __ROM0_BASE __ROM0_SIZE {
+    *.o (RESET, +First)
+    *(InRoot$$Sections)
+    *(+RO +XO)
+  }
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  ER_CMSE_VENEER AlignExpr(+0, 32) (__ROM0_SIZE - AlignExpr(ImageLength(ER_ROM0), 32)) {
+    *(Veneer$$CMSE)
+  }
+#endif
+
+  RW_NOINIT __RAM0_BASE UNINIT (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE) {
+    *(.bss.noinit)
+  }
+
+  RW_RAM0 AlignExpr(+0, 8) (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE - AlignExpr(ImageLength(RW_NOINIT), 8)) {
+    *(+RW +ZI)
+  }
+
+#if __HEAP_SIZE > 0
+  ARM_LIB_HEAP  (AlignExpr(+0, 8)) EMPTY __HEAP_SIZE  {   ; Reserve empty region for heap
+  }
+#endif
+
+  ARM_LIB_STACK (__RAM0_BASE + __RAM0_SIZE - __STACKSEAL_SIZE) EMPTY -__STACK_SIZE {   ; Reserve empty region for stack
+  }
+
+#if __STACKSEAL_SIZE > 0
+  STACKSEAL +0 EMPTY __STACKSEAL_SIZE {             ; Reserve empty region for stack seal immediately after stack
+  }
+#endif
+
+#if __RAM1_SIZE > 0
+  RW_RAM1 __RAM1_BASE __RAM1_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+
+#if __RAM2_SIZE > 0
+  RW_RAM2 __RAM2_BASE __RAM2_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+
+#if __RAM3_SIZE > 0
+  RW_RAM3 __RAM3_BASE __RAM3_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+}
+
+#if __ROM1_SIZE > 0
+LR_ROM1 __ROM1_BASE __ROM1_SIZE  {
+  ER_ROM1 +0 __ROM1_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif
+
+#if __ROM2_SIZE > 0
+LR_ROM2 __ROM2_BASE __ROM2_SIZE  {
+  ER_ROM2 +0 __ROM2_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif
+
+#if __ROM3_SIZE > 0
+LR_ROM3 __ROM3_BASE __ROM3_SIZE  {
+  ER_ROM3 +0 __ROM3_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33S/RTE/Device/ARMCM33/clang_linker_script.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33S/RTE/Device/ARMCM33/clang_linker_script.ld
@@ -1,0 +1,361 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2019 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+/* ----------------------------------------------------------------------------
+  Memory definition
+ *----------------------------------------------------------------------------*/
+MEMORY
+{
+  ROM0  (rx!w)  : ORIGIN = __ROM0_BASE, LENGTH = __ROM0_SIZE
+#if __ROM1_SIZE > 0
+  ROM1  (rx!w)  : ORIGIN = __ROM1_BASE, LENGTH = __ROM1_SIZE
+#endif
+#if __ROM2_SIZE > 0
+  ROM2  (rx!w)  : ORIGIN = __ROM2_BASE, LENGTH = __ROM2_SIZE
+#endif
+#if __ROM3_SIZE > 0
+  ROM3  (rx!w)  : ORIGIN = __ROM3_BASE, LENGTH = __ROM3_SIZE
+#endif
+
+  RAM0  (w!rx) : ORIGIN = __RAM0_BASE, LENGTH = __RAM0_SIZE
+#if __RAM1_SIZE > 0
+  RAM1  (w!rx) : ORIGIN = __RAM1_BASE, LENGTH = __RAM1_SIZE
+#endif
+#if __RAM2_SIZE > 0
+  RAM2  (w!rx) : ORIGIN = __RAM2_BASE, LENGTH = __RAM2_SIZE
+#endif
+#if __RAM3_SIZE > 0
+  RAM3  (w!rx) : ORIGIN = __RAM3_BASE, LENGTH = __RAM3_SIZE
+#endif
+}
+
+ENTRY(Reset_Handler)
+
+PHDRS
+{
+	text PT_LOAD;
+	ram PT_LOAD;
+	ram_init PT_LOAD;
+	tls PT_TLS;
+}
+
+SECTIONS
+{
+	.init : {
+		KEEP (*(.vectors))
+		KEEP (*(.text.init.enter))
+		KEEP (*(.data.init.enter))
+		KEEP (*(SORT_BY_NAME(.init) SORT_BY_NAME(.init.*)))
+	} >ROM0 AT>ROM0 :text
+
+	.text : {
+
+		/* code */
+		*(.text.unlikely .text.unlikely.*)
+		*(.text.startup .text.startup.*)
+		*(.text .text.* .opd .opd.*)
+		*(.gnu.linkonce.t.*)
+		KEEP (*(.fini .fini.*))
+		__text_end = .;
+
+		PROVIDE (__etext = __text_end);
+		PROVIDE (_etext = __text_end);
+		PROVIDE (etext = __text_end);
+
+		/* read-only data */
+		*(.rdata)
+		*(.rodata .rodata.*)
+		*(.gnu.linkonce.r.*)
+
+		*(.srodata.cst16)
+		*(.srodata.cst8)
+		*(.srodata.cst4)
+		*(.srodata.cst2)
+		*(.srodata .srodata.*)
+		*(.data.rel.ro .data.rel.ro.*)
+		*(.got .got.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		/* lists of constructors and destructors */
+		PROVIDE_HIDDEN ( __preinit_array_start = . );
+		KEEP (*(.preinit_array))
+		PROVIDE_HIDDEN ( __preinit_array_end = . );
+
+		PROVIDE_HIDDEN ( __init_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+		KEEP (*(.init_array .ctors))
+		PROVIDE_HIDDEN ( __init_array_end = . );
+
+		PROVIDE_HIDDEN ( __fini_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
+		KEEP (*(.fini_array .dtors))
+		PROVIDE_HIDDEN ( __fini_array_end = . );
+
+	} >ROM0 AT>ROM0 :text
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+	.veneers :
+	{
+		. = ALIGN(32);
+		KEEP(*(.gnu.sgstubs))
+	} > ROM0 AT>ROM0 :text
+#endif
+
+	.toc : {
+		*(.toc .toc.*)
+	} >ROM0 AT>ROM0 :text
+
+	/* additional sections when compiling with C++ exception support */
+	
+	.except_ordered : {
+		*(.gcc_except_table *.gcc_except_table.*)
+		KEEP (*(.eh_frame .eh_frame.*))
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+	} >ROM0 AT>ROM0 :text
+
+	.except_unordered : {
+		. = ALIGN(8);
+
+		PROVIDE(__exidx_start = .);
+		*(.ARM.exidx*)
+		PROVIDE(__exidx_end = .);
+	} >ROM0 AT>ROM0 :text
+	
+
+	/*
+	 * Data values which are preserved across reset
+	 */
+	.preserve (NOLOAD) : {
+		PROVIDE(__preserve_start__ = .);
+		KEEP(*(SORT_BY_NAME(.preserve.*)))
+		KEEP(*(.preserve))
+		PROVIDE(__preserve_end__ = .);
+	} >RAM0 AT>RAM0 :ram
+
+	.data :  {
+		*(.data .data.*)
+		*(.gnu.linkonce.d.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		PROVIDE( __global_pointer$ = . + 0x800 );
+		*(.sdata .sdata.* .sdata2.*)
+		*(.gnu.linkonce.s.*)
+	} >RAM0 AT>ROM0 :ram_init
+	PROVIDE(__data_start = ADDR(.data));
+	PROVIDE(__data_source = LOADADDR(.data));
+
+	/* Thread local initialized data. This gets
+	 * space allocated as it is expected to be placed
+	 * in ram to be used as a template for TLS data blocks
+	 * allocated at runtime. We're slightly abusing that
+	 * by placing the data in flash where it will be copied
+	 * into the allocate ram addresses by the existing
+	 * data initialization code in crt0
+	 */
+	.tdata :  {
+		*(.tdata .tdata.* .gnu.linkonce.td.*)
+		PROVIDE(__data_end = .);
+		PROVIDE(__tdata_end = .);
+	} >RAM0 AT>ROM0 :tls :ram_init
+	PROVIDE( __tls_base = ADDR(.tdata));
+	PROVIDE( __tdata_start = ADDR(.tdata));
+	PROVIDE( __tdata_source = LOADADDR(.tdata) );
+	PROVIDE( __tdata_source_end = LOADADDR(.tdata) + SIZEOF(.tdata) );
+	PROVIDE( __data_source_end = __tdata_source_end );
+	PROVIDE( __tdata_size = SIZEOF(.tdata) );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata),ALIGNOF(.tbss)) );
+
+	PROVIDE( __edata = __data_end );
+	PROVIDE( _edata = __data_end );
+	PROVIDE( edata = __data_end );
+	PROVIDE( __data_size = __data_end - __data_start );
+	PROVIDE( __data_source_size = __data_source_end - __data_source );
+
+	.tbss (NOLOAD) : {
+		*(.tbss .tbss.* .gnu.linkonce.tb.*)
+		*(.tcommon)
+		PROVIDE( __tls_end = . );
+		PROVIDE( __tbss_end = . );
+	} >RAM0 AT>RAM0 :tls :ram
+	PROVIDE( __bss_start = ADDR(.tbss));
+	PROVIDE( __tbss_start = ADDR(.tbss));
+	PROVIDE( __tbss_offset = ADDR(.tbss) - ADDR(.tdata) );
+	PROVIDE( __tbss_size = SIZEOF(.tbss) );
+	PROVIDE( __tls_size = __tls_end - __tls_base );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
+	PROVIDE( __arm32_tls_tcb_offset = MAX(8, __tls_align) );
+	PROVIDE( __arm64_tls_tcb_offset = MAX(16, __tls_align) );
+
+	/*
+	 * The linker special cases .tbss segments which are
+	 * identified as segments which are not loaded and are
+	 * thread_local.
+	 *
+	 * For these segments, the linker does not advance 'dot'
+	 * across them.  We actually need memory allocated for tbss,
+	 * so we create a special segment here just to make room
+	 */
+	/*
+	.tbss_space (NOLOAD) : {
+		. = ADDR(.tbss);
+		. = . + SIZEOF(.tbss);
+	} >RAM0 AT>RAM0 :ram
+	*/
+
+	.bss (NOLOAD) : {
+		*(.sbss*)
+		*(.gnu.linkonce.sb.*)
+		*(.bss .bss.*)
+		*(.gnu.linkonce.b.*)
+		*(COMMON)
+
+		/* Align the heap */
+		. = ALIGN(8);
+		__bss_end = .;
+	} >RAM0 AT>RAM0 :ram
+	PROVIDE( __non_tls_bss_start = ADDR(.bss) );
+	PROVIDE( __end = __bss_end );
+	PROVIDE( _end = __bss_end );
+	PROVIDE( end = __bss_end );
+	PROVIDE( __bss_size = __bss_end - __bss_start );
+
+	/* Make the rest of memory available for heap storage */
+	PROVIDE (__heap_start = __end);
+#ifdef __HEAP_SIZE
+	PROVIDE (__heap_end = __heap_start + __HEAP_SIZE);
+	PROVIDE (__heap_size = __HEAP_SIZE);
+#else
+	PROVIDE (__heap_end = __stack - __STACK_SIZE);
+	PROVIDE (__heap_size = __heap_end - __heap_start);
+#endif
+	.heap (NOLOAD) : {
+		. += __heap_size;
+	} >RAM0 :ram
+
+	/* Define a stack region to make sure it fits in memory */
+	PROVIDE(__stack = ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE);
+	PROVIDE(__stack_limit = __stack - __STACK_SIZE);
+	.stack (__stack_limit) (NOLOAD) : {
+		. += __STACK_SIZE;
+	} >RAM0 :ram
+
+#if __STACKSEAL_SIZE > 0
+	PROVIDE(__stack_seal = __stack);
+  	.stackseal (__stack) (NOLOAD) :
+  	{
+    	. += __STACKSEAL_SIZE;
+  	} >RAM0 :ram
+#endif
+
+	/* Throw away C++ exception handling information */
+
+	/*
+
+	/DISCARD/ : {
+		*(.note .note.*)
+		*(.eh_frame .eh_frame.*)
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+		*(.ARM.exidx*)
+	}
+
+	*/
+
+	/* Stabs debugging sections.  */
+	.stab          0 : { *(.stab) }
+	.stabstr       0 : { *(.stabstr) }
+	.stab.excl     0 : { *(.stab.excl) }
+	.stab.exclstr  0 : { *(.stab.exclstr) }
+	.stab.index    0 : { *(.stab.index) }
+	.stab.indexstr 0 : { *(.stab.indexstr) }
+	.comment       0 : { *(.comment) }
+	.gnu.build.attributes : { *(.gnu.build.attributes .gnu.build.attributes.*) }
+	/* DWARF debug sections.
+	   Symbols in the DWARF debugging sections are relative to the beginning
+	   of the section so we begin them at 0.  */
+	/* DWARF 1.  */
+	.debug          0 : { *(.debug) }
+	.line           0 : { *(.line) }
+	/* GNU DWARF 1 extensions.  */
+	.debug_srcinfo  0 : { *(.debug_srcinfo) }
+	.debug_sfnames  0 : { *(.debug_sfnames) }
+	/* DWARF 1.1 and DWARF 2.  */
+	.debug_aranges  0 : { *(.debug_aranges) }
+	.debug_pubnames 0 : { *(.debug_pubnames) }
+	/* DWARF 2.  */
+	.debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+	.debug_abbrev   0 : { *(.debug_abbrev) }
+	.debug_line     0 : { *(.debug_line .debug_line.* .debug_line_end) }
+	.debug_frame    0 : { *(.debug_frame) }
+	.debug_str      0 : { *(.debug_str) }
+	.debug_loc      0 : { *(.debug_loc) }
+	.debug_macinfo  0 : { *(.debug_macinfo) }
+	/* SGI/MIPS DWARF 2 extensions.  */
+	.debug_weaknames 0 : { *(.debug_weaknames) }
+	.debug_funcnames 0 : { *(.debug_funcnames) }
+	.debug_typenames 0 : { *(.debug_typenames) }
+	.debug_varnames  0 : { *(.debug_varnames) }
+	/* DWARF 3.  */
+	.debug_pubtypes 0 : { *(.debug_pubtypes) }
+	.debug_ranges   0 : { *(.debug_ranges) }
+	/* DWARF 5.  */
+	.debug_addr     0 : { *(.debug_addr) }
+	.debug_line_str 0 : { *(.debug_line_str) }
+	.debug_loclists 0 : { *(.debug_loclists) }
+	.debug_macro    0 : { *(.debug_macro) }
+	.debug_names    0 : { *(.debug_names) }
+	.debug_rnglists 0 : { *(.debug_rnglists) }
+	.debug_str_offsets 0 : { *(.debug_str_offsets) }
+	.debug_sup      0 : { *(.debug_sup) }
+	.gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }
+}
+/*
+ * Check that sections that are copied from flash to RAM have matching
+ * padding, so that a single memcpy() of __data_size copies the correct bytes.
+ */
+ASSERT( __data_size == __data_source_size,
+	"ERROR: .data/.tdata flash size does not match RAM size");

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33S/RTE/Device/ARMCM33/gcc_linker_script.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33S/RTE/Device/ARMCM33/gcc_linker_script.ld
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+/* ----------------------------------------------------------------------------
+  Memory definition
+ *----------------------------------------------------------------------------*/
+MEMORY
+{
+  ROM0  (rx)  : ORIGIN = __ROM0_BASE, LENGTH = __ROM0_SIZE
+#if __ROM1_SIZE > 0
+  ROM1  (rx)  : ORIGIN = __ROM1_BASE, LENGTH = __ROM1_SIZE
+#endif
+#if __ROM2_SIZE > 0
+  ROM2  (rx)  : ORIGIN = __ROM2_BASE, LENGTH = __ROM2_SIZE
+#endif
+#if __ROM3_SIZE > 0
+  ROM3  (rx)  : ORIGIN = __ROM3_BASE, LENGTH = __ROM3_SIZE
+#endif
+
+  RAM0  (rwx) : ORIGIN = __RAM0_BASE, LENGTH = __RAM0_SIZE
+#if __RAM1_SIZE > 0
+  RAM1  (rwx) : ORIGIN = __RAM1_BASE, LENGTH = __RAM1_SIZE
+#endif
+#if __RAM2_SIZE > 0
+  RAM2  (rwx) : ORIGIN = __RAM2_BASE, LENGTH = __RAM2_SIZE
+#endif
+#if __RAM3_SIZE > 0
+  RAM3  (rwx) : ORIGIN = __RAM3_BASE, LENGTH = __RAM3_SIZE
+#endif
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __copy_table_start__
+ *   __copy_table_end__
+ *   __zero_table_start__
+ *   __zero_table_end__
+ *   __etext          (deprecated)
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+  .text :
+  {
+    KEEP(*(.vectors))
+    *(.text*)
+
+    KEEP(*(.init))
+    KEEP(*(.fini))
+
+    /* .ctors */
+    *crtbegin.o(.ctors)
+    *crtbegin?.o(.ctors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+    *(SORT(.ctors.*))
+    *(.ctors)
+
+    /* .dtors */
+    *crtbegin.o(.dtors)
+    *crtbegin?.o(.dtors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+    *(SORT(.dtors.*))
+    *(.dtors)
+
+    *(.rodata*)
+
+    KEEP(*(.eh_frame*))
+  } > ROM0
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  .gnu.sgstubs :
+  {
+    . = ALIGN(32);
+  } > ROM0
+#endif
+
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > ROM0
+
+  __exidx_start = .;
+  .ARM.exidx :
+  {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+  } > ROM0
+  __exidx_end = .;
+
+  .copy.table :
+  {
+    . = ALIGN(4);
+    __copy_table_start__ = .;
+
+    LONG (LOADADDR(.data))
+    LONG (ADDR(.data))
+    LONG (SIZEOF(.data) / 4)
+
+    /* Add each additional data section here */
+/*
+    LONG (LOADADDR(.data2))
+    LONG (ADDR(.data2))
+    LONG (SIZEOF(.data2) / 4)
+*/
+    __copy_table_end__ = .;
+  } > ROM0
+
+  .zero.table :
+  {
+    . = ALIGN(4);
+    __zero_table_start__ = .;
+
+/*  .bss initialization to zero is already done during C Run-Time Startup.
+    LONG (ADDR(.bss))
+    LONG (SIZEOF(.bss) / 4)
+*/
+
+    /* Add each additional bss section here */
+/*
+    LONG (ADDR(.bss2))
+    LONG (SIZEOF(.bss2) / 4)
+*/
+    __zero_table_end__ = .;
+  } > ROM0
+
+  /*
+   * This __etext variable is kept for backward compatibility with older,
+   * ASM based startup files.
+   */
+  PROVIDE(__etext = LOADADDR(.data));
+
+  .data : ALIGN(4)
+  {
+    __data_start__ = .;
+    *(vtable)
+    *(.data)
+    *(.data.*)
+
+    . = ALIGN(4);
+    /* preinit data */
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP(*(.preinit_array))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+
+    . = ALIGN(4);
+    /* init data */
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP(*(SORT(.init_array.*)))
+    KEEP(*(.init_array))
+    PROVIDE_HIDDEN (__init_array_end = .);
+
+    . = ALIGN(4);
+    /* finit data */
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP(*(SORT(.fini_array.*)))
+    KEEP(*(.fini_array))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    /* All data end */
+    __data_end__ = .;
+
+  } > RAM0 AT > ROM0
+
+  /*
+   * Secondary data section, optional
+   *
+   * Remember to add each additional data section
+   * to the .copy.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .data2 : ALIGN(4)
+  {
+    . = ALIGN(4);
+    __data2_start__ = .;
+    *(.data2)
+    *(.data2.*)
+    . = ALIGN(4);
+    __data2_end__ = .;
+
+  } > RAM1 AT > ROM0 
+*/
+
+  .bss :
+  {
+    . = ALIGN(4);
+    __bss_start__ = .;
+    *(.bss)
+    *(.bss.*)
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+  } > RAM0 AT > RAM0
+
+  /*
+   * Secondary bss section, optional
+   *
+   * Remember to add each additional bss section
+   * to the .zero.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .bss2 :
+  {
+    . = ALIGN(4);
+    __bss2_start__ = .;
+    *(.bss2)
+    *(.bss2.*)
+    . = ALIGN(4);
+    __bss2_end__ = .;
+  } > RAM1 AT > RAM1
+*/
+
+  .heap (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE(end = .);
+    . = . + __HEAP_SIZE;
+    . = ALIGN(8);
+    __HeapLimit = .;
+  } > RAM0
+
+  .stack (ORIGIN(RAM0) + LENGTH(RAM0) - __STACK_SIZE - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackLimit = .;
+    . = . + __STACK_SIZE;
+    . = ALIGN(8);
+    __StackTop = .;
+  } > RAM0
+  PROVIDE(__stack = __StackTop);
+
+#if __STACKSEAL_SIZE > 0
+  .stackseal (ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackSeal = .;
+    . = . + 8;
+    . = ALIGN(8);
+  } > RAM0
+#endif
+
+  /* Check if data + heap + stack exceeds RAM limit */
+  ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33S/RTE/Device/ARMCM33/iar_linker_script.icf
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33S/RTE/Device/ARMCM33/iar_linker_script.icf
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+define memory mem with size = 4G;
+
+#if __ROM0_SIZE > 0
+  define region ROM0_region = mem:[from __ROM0_BASE to (__ROM0_BASE+__ROM0_SIZE-1)];
+#else
+  define region ROM0_region = [];
+#endif
+
+#if __ROM1_SIZE > 0
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+#else
+  define region ROM1_region = [];
+#endif
+
+#if __ROM2_SIZE > 0
+  define region ROM2_region = mem:[from __ROM2_BASE to (__ROM2_BASE+__ROM2_SIZE-1)];
+#else
+  define region ROM2_region = [];
+#endif
+
+#if __ROM3_SIZE > 0
+  define region ROM3_region = mem:[from __ROM3_BASE to (__ROM3_BASE+__ROM3_SIZE-1)];
+#else
+  define region ROM3_region = [];
+#endif
+
+define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_region;
+
+#if __RAM0_SIZE > 0
+  define region RAM0_region = mem:[from __RAM0_BASE to (__RAM0_BASE+__RAM0_SIZE-1)];
+#else
+  define region RAM0_region = [];
+#endif
+
+#if __RAM1_SIZE > 0
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+#else
+  define region RAM1_region = [];
+#endif
+
+#if __RAM2_SIZE > 0
+  define region RAM2_region = mem:[from __RAM2_BASE to (__RAM2_BASE+__RAM2_SIZE-1)];
+#else
+  define region RAM2_region = [];
+#endif
+
+#if __RAM3_SIZE > 0
+  define region RAM3_region = mem:[from __RAM3_BASE to (__RAM3_BASE+__RAM3_SIZE-1)];
+#else
+  define region RAM3_region = [];
+#endif
+
+define region RAM_region = RAM0_region | RAM1_region | RAM2_region | RAM3_region;
+
+do not initialize  { section .noinit };
+initialize by copy { readwrite };
+if (isdefinedsymbol(__USE_DLIB_PERTHREAD))
+{
+  // Required in a multi-threaded application
+  initialize by copy with packing = none { section __DLIB_PERTHREAD };
+}
+
+place at address mem:__ROM0_BASE { readonly section .intvec };
+
+if (!isempty(ROM_region))
+{
+  place in ROM_region  { readonly };
+}
+
+if (!isempty(RAM_region))
+{
+  define block CSTACK     with alignment = 8, size = __STACK_SIZE     { };
+  define block PROC_STACK with alignment = 8, size = 0 { };
+  define block HEAP       with alignment = 8, size = __HEAP_SIZE       { };
+  place in RAM_region  { readwrite, block CSTACK, block PROC_STACK, block HEAP };
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33S/RTE/Device/ARMCM33/partition_ARMCM33.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33S/RTE/Device/ARMCM33/partition_ARMCM33.h
@@ -1,0 +1,1260 @@
+/**************************************************************************//**
+ * @file     partition_ARMCM33.h
+ * @brief    CMSIS-CORE Initial Setup for Secure / Non-Secure Zones for ARMCM33
+ * @version  V1.1.1
+ * @date     12. March 2019
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PARTITION_ARMCM33_H
+#define PARTITION_ARMCM33_H
+
+/*
+//-------- <<< Use Configuration Wizard in Context Menu >>> -----------------
+*/
+
+/*
+// <e>Initialize Security Attribution Unit (SAU) CTRL register
+*/
+#define SAU_INIT_CTRL          1
+
+/*
+//   <q> Enable SAU
+//   <i> Value for SAU->CTRL register bit ENABLE
+*/
+#define SAU_INIT_CTRL_ENABLE   1
+
+/*
+//   <o> When SAU is disabled
+//     <0=> All Memory is Secure
+//     <1=> All Memory is Non-Secure
+//   <i> Value for SAU->CTRL register bit ALLNS
+//   <i> When all Memory is Non-Secure (ALLNS is 1), IDAU can override memory map configuration.
+*/
+#define SAU_INIT_CTRL_ALLNS  0
+
+/*
+// </e>
+*/
+
+/*
+// <h>Initialize Security Attribution Unit (SAU) Address Regions
+// <i>SAU configuration specifies regions to be one of:
+// <i> - Secure and Non-Secure Callable
+// <i> - Non-Secure
+// <i>Note: All memory regions not configured by SAU are Secure
+*/
+#define SAU_REGIONS_MAX   8                 /* Max. number of SAU regions */
+
+/*
+//   <e>Initialize SAU Region 0
+//   <i> Setup SAU Region 0 memory attributes
+*/
+#define SAU_INIT_REGION0    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START0     0x00000000      /* start address of SAU region 0 */
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END0       0x001FFFFF      /* end address of SAU region 0 */
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC0       1
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 1
+//   <i> Setup SAU Region 1 memory attributes
+*/
+#define SAU_INIT_REGION1    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START1     0x00200000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END1       0x003FFFFF
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC1       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 2
+//   <i> Setup SAU Region 2 memory attributes
+*/
+#define SAU_INIT_REGION2    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START2     0x20200000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END2       0x203FFFFF
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC2       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 3
+//   <i> Setup SAU Region 3 memory attributes
+*/
+#define SAU_INIT_REGION3    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START3     0x40000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END3       0x40040000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC3       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 4
+//   <i> Setup SAU Region 4 memory attributes
+*/
+#define SAU_INIT_REGION4    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START4     0x00000000      /* start address of SAU region 4 */
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END4       0x00000000      /* end address of SAU region 4 */
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC4       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 5
+//   <i> Setup SAU Region 5 memory attributes
+*/
+#define SAU_INIT_REGION5    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START5     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END5       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC5       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 6
+//   <i> Setup SAU Region 6 memory attributes
+*/
+#define SAU_INIT_REGION6    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START6     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END6       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC6       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 7
+//   <i> Setup SAU Region 7 memory attributes
+*/
+#define SAU_INIT_REGION7    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START7     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END7       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC7       0
+/*
+//   </e>
+*/
+
+/*
+// </h>
+*/
+
+/*
+// <e>Setup behaviour of Sleep and Exception Handling
+*/
+#define SCB_CSR_AIRCR_INIT  1
+
+/*
+//   <o> Deep Sleep can be enabled by
+//     <0=>Secure and Non-Secure state
+//     <1=>Secure state only
+//   <i> Value for SCB->CSR register bit DEEPSLEEPS
+*/
+#define SCB_CSR_DEEPSLEEPS_VAL  1
+
+/*
+//   <o>System reset request accessible from
+//     <0=> Secure and Non-Secure state
+//     <1=> Secure state only
+//   <i> Value for SCB->AIRCR register bit SYSRESETREQS
+*/
+#define SCB_AIRCR_SYSRESETREQS_VAL  1
+
+/*
+//   <o>Priority of Non-Secure exceptions is
+//     <0=> Not altered
+//     <1=> Lowered to 0x80-0xFF
+//   <i> Value for SCB->AIRCR register bit PRIS
+*/
+#define SCB_AIRCR_PRIS_VAL      1
+
+/*
+//   <o>BusFault, HardFault, and NMI target
+//     <0=> Secure state
+//     <1=> Non-Secure state
+//   <i> Value for SCB->AIRCR register bit BFHFNMINS
+*/
+#define SCB_AIRCR_BFHFNMINS_VAL 0
+
+/*
+// </e>
+*/
+
+/*
+// <e>Setup behaviour of Floating Point Unit
+*/
+#define TZ_FPU_NS_USAGE 1
+
+/*
+// <o>Floating Point Unit usage
+//     <0=> Secure state only
+//     <3=> Secure and Non-Secure state
+//   <i> Value for SCB->NSACR register bits CP10, CP11
+*/
+#define SCB_NSACR_CP10_11_VAL       3
+
+/*
+// <o>Treat floating-point registers as Secure
+//     <0=> Disabled
+//     <1=> Enabled
+//   <i> Value for FPU->FPCCR register bit TS
+*/
+#define FPU_FPCCR_TS_VAL            0
+
+/*
+// <o>Clear on return (CLRONRET) accessibility
+//     <0=> Secure and Non-Secure state
+//     <1=> Secure state only
+//   <i> Value for FPU->FPCCR register bit CLRONRETS
+*/
+#define FPU_FPCCR_CLRONRETS_VAL     0
+
+/*
+// <o>Clear floating-point caller saved registers on exception return
+//     <0=> Disabled
+//     <1=> Enabled
+//   <i> Value for FPU->FPCCR register bit CLRONRET
+*/
+#define FPU_FPCCR_CLRONRET_VAL      1
+
+/*
+// </e>
+*/
+
+/*
+// <h>Setup Interrupt Target
+*/
+
+/*
+//   <e>Initialize ITNS 0 (Interrupts 0..31)
+*/
+#define NVIC_INIT_ITNS0    0
+
+/*
+// Interrupts 0..31
+//   <o.0>  Interrupt 0   <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 1   <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 2   <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 3   <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 4   <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 5   <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 6   <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 7   <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 8   <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 9   <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 10  <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 11  <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 12  <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 13  <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 14  <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 15  <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 16  <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 17  <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 18  <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 19  <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 20  <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 21  <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 22  <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 23  <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 24  <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 25  <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 26  <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 27  <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 28  <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 29  <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 30  <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 31  <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS0_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 1 (Interrupts 32..63)
+*/
+#define NVIC_INIT_ITNS1    0
+
+/*
+// Interrupts 32..63
+//   <o.0>  Interrupt 32  <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 33  <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 34  <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 35  <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 36  <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 37  <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 38  <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 39  <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 40  <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 41  <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 42  <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 43  <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 44  <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 45  <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 46  <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 47  <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 48  <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 49  <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 50  <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 51  <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 52  <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 53  <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 54  <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 55  <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 56  <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 57  <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 58  <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 59  <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 60  <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 61  <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 62  <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 63  <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS1_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 2 (Interrupts 64..95)
+*/
+#define NVIC_INIT_ITNS2    0
+
+/*
+// Interrupts 64..95
+//   <o.0>  Interrupt 64  <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 65  <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 66  <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 67  <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 68  <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 69  <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 70  <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 71  <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 72  <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 73  <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 74  <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 75  <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 76  <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 77  <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 78  <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 79  <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 80  <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 81  <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 82  <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 83  <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 84  <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 85  <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 86  <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 87  <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 88  <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 89  <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 90  <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 91  <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 92  <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 93  <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 94  <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 95  <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS2_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 3 (Interrupts 96..127)
+*/
+#define NVIC_INIT_ITNS3    0
+
+/*
+// Interrupts 96..127
+//   <o.0>  Interrupt 96  <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 97  <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 98  <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 99  <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 100 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 101 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 102 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 103 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 104 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 105 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 106 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 107 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 108 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 109 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 110 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 111 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 112 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 113 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 114 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 115 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 116 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 117 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 118 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 119 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 120 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 121 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 122 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 123 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 124 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 125 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 126 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 127 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS3_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 4 (Interrupts 128..159)
+*/
+#define NVIC_INIT_ITNS4    0
+
+/*
+// Interrupts 128..159
+//   <o.0>  Interrupt 128 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 129 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 130 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 131 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 132 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 133 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 134 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 135 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 136 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 137 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 138 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 139 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 140 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 141 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 142 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 143 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 144 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 145 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 146 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 147 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 148 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 149 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 150 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 151 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 152 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 153 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 154 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 155 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 156 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 157 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 158 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 159 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS4_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 5 (Interrupts 160..191)
+*/
+#define NVIC_INIT_ITNS5    0
+
+/*
+// Interrupts 160..191
+//   <o.0>  Interrupt 160 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 161 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 162 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 163 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 164 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 165 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 166 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 167 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 168 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 169 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 170 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 171 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 172 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 173 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 174 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 175 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 176 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 177 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 178 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 179 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 180 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 181 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 182 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 183 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 184 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 185 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 186 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 187 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 188 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 189 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 190 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 191 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS5_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 6 (Interrupts 192..223)
+*/
+#define NVIC_INIT_ITNS6    0
+
+/*
+// Interrupts 192..223
+//   <o.0>  Interrupt 192 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 193 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 194 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 195 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 196 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 197 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 198 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 199 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 200 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 201 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 202 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 203 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 204 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 205 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 206 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 207 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 208 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 209 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 210 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 211 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 212 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 213 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 214 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 215 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 216 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 217 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 218 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 219 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 220 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 221 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 222 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 223 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS6_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 7 (Interrupts 224..255)
+*/
+#define NVIC_INIT_ITNS7    0
+
+/*
+// Interrupts 224..255
+//   <o.0>  Interrupt 224 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 225 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 226 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 227 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 228 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 229 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 230 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 231 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 232 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 233 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 234 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 235 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 236 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 237 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 238 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 239 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 240 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 241 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 242 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 243 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 244 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 245 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 246 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 247 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 248 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 249 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 250 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 251 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 252 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 253 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 254 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 255 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS7_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 8 (Interrupts 256..287)
+*/
+#define NVIC_INIT_ITNS8    0
+
+/*
+// Interrupts 256..287
+//   <o.0>  Interrupt 256 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 257 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 258 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 259 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 260 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 261 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 262 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 263 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 264 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 265 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 266 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 267 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 268 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 269 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 270 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 271 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 272 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 273 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 274 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 275 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 276 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 277 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 278 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 279 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 280 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 281 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 282 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 283 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 284 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 285 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 286 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 287 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS8_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 9 (Interrupts 288..319)
+*/
+#define NVIC_INIT_ITNS9    0
+
+/*
+// Interrupts 288..319
+//   <o.0>  Interrupt 288 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 289 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 290 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 291 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 292 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 293 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 294 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 295 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 296 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 297 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 298 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 299 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 300 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 301 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 302 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 303 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 304 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 305 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 306 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 307 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 308 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 309 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 310 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 311 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 312 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 313 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 314 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 315 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 316 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 317 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 318 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 319 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS9_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 10 (Interrupts 320..351)
+*/
+#define NVIC_INIT_ITNS10   0
+
+/*
+// Interrupts 320..351
+//   <o.0>  Interrupt 320 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 321 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 322 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 323 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 324 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 325 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 326 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 327 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 328 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 329 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 330 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 331 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 332 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 333 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 334 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 335 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 336 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 337 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 338 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 339 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 340 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 341 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 342 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 343 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 344 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 345 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 346 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 347 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 348 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 349 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 350 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 351 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS10_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 11 (Interrupts 352..383)
+*/
+#define NVIC_INIT_ITNS11   0
+
+/*
+// Interrupts 352..383
+//   <o.0>  Interrupt 352 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 353 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 354 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 355 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 356 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 357 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 358 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 359 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 360 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 361 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 362 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 363 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 364 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 365 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 366 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 367 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 368 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 369 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 370 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 371 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 372 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 373 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 374 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 375 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 376 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 377 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 378 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 379 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 380 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 381 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 382 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 383 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS11_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 12 (Interrupts 384..415)
+*/
+#define NVIC_INIT_ITNS12   0
+
+/*
+// Interrupts 384..415
+//   <o.0>  Interrupt 384 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 385 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 386 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 387 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 388 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 389 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 390 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 391 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 392 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 393 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 394 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 395 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 396 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 397 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 398 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 399 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 400 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 401 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 402 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 403 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 404 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 405 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 406 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 407 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 408 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 409 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 410 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 411 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 412 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 413 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 414 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 415 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS12_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 13 (Interrupts 416..447)
+*/
+#define NVIC_INIT_ITNS13   0
+
+/*
+// Interrupts 416..447
+//   <o.0>  Interrupt 416 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 417 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 418 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 419 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 420 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 421 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 422 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 423 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 424 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 425 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 426 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 427 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 428 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 429 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 430 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 431 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 432 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 433 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 434 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 435 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 436 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 437 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 438 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 439 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 440 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 441 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 442 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 443 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 444 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 445 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 446 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 447 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS13_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 14 (Interrupts 448..479)
+*/
+#define NVIC_INIT_ITNS14   0
+
+/*
+// Interrupts 448..479
+//   <o.0>  Interrupt 448 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 449 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 450 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 451 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 452 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 453 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 454 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 455 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 456 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 457 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 458 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 459 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 460 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 461 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 462 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 463 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 464 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 465 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 466 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 467 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 468 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 469 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 470 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 471 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 472 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 473 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 474 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 475 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 476 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 477 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 478 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 479 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS14_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 15 (Interrupts 480..511)
+*/
+#define NVIC_INIT_ITNS15   0
+
+/*
+// Interrupts 480..511
+//   <o.0>  Interrupt 480 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 481 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 482 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 483 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 484 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 485 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 486 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 487 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 488 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 489 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 490 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 491 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 492 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 493 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 494 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 495 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 496 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 497 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 498 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 499 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 500 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 501 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 502 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 503 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 504 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 505 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 506 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 507 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 508 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 509 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 510 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 511 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS15_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+// </h>
+*/
+
+
+
+/*
+    max 128 SAU regions.
+    SAU regions are defined in partition.h
+ */
+
+#define SAU_INIT_REGION(n) \
+    SAU->RNR  =  (n                                     & SAU_RNR_REGION_Msk); \
+    SAU->RBAR =  (SAU_INIT_START##n                     & SAU_RBAR_BADDR_Msk); \
+    SAU->RLAR =  (SAU_INIT_END##n                       & SAU_RLAR_LADDR_Msk) | \
+                ((SAU_INIT_NSC##n << SAU_RLAR_NSC_Pos)  & SAU_RLAR_NSC_Msk)   | 1U
+
+/**
+  \brief   Setup a SAU Region
+  \details Writes the region information contained in SAU_Region to the
+           registers SAU_RNR, SAU_RBAR, and SAU_RLAR
+ */
+__STATIC_INLINE void TZ_SAU_Setup (void)
+{
+
+#if defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U)
+
+  #if defined (SAU_INIT_REGION0) && (SAU_INIT_REGION0 == 1U)
+    SAU_INIT_REGION(0);
+  #endif
+
+  #if defined (SAU_INIT_REGION1) && (SAU_INIT_REGION1 == 1U)
+    SAU_INIT_REGION(1);
+  #endif
+
+  #if defined (SAU_INIT_REGION2) && (SAU_INIT_REGION2 == 1U)
+    SAU_INIT_REGION(2);
+  #endif
+
+  #if defined (SAU_INIT_REGION3) && (SAU_INIT_REGION3 == 1U)
+    SAU_INIT_REGION(3);
+  #endif
+
+  #if defined (SAU_INIT_REGION4) && (SAU_INIT_REGION4 == 1U)
+    SAU_INIT_REGION(4);
+  #endif
+
+  #if defined (SAU_INIT_REGION5) && (SAU_INIT_REGION5 == 1U)
+    SAU_INIT_REGION(5);
+  #endif
+
+  #if defined (SAU_INIT_REGION6) && (SAU_INIT_REGION6 == 1U)
+    SAU_INIT_REGION(6);
+  #endif
+
+  #if defined (SAU_INIT_REGION7) && (SAU_INIT_REGION7 == 1U)
+    SAU_INIT_REGION(7);
+  #endif
+
+  /* repeat this for all possible SAU regions */
+
+#endif /* defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U) */
+
+
+  #if defined (SAU_INIT_CTRL) && (SAU_INIT_CTRL == 1U)
+    SAU->CTRL = ((SAU_INIT_CTRL_ENABLE << SAU_CTRL_ENABLE_Pos) & SAU_CTRL_ENABLE_Msk) |
+                ((SAU_INIT_CTRL_ALLNS  << SAU_CTRL_ALLNS_Pos)  & SAU_CTRL_ALLNS_Msk)   ;
+  #endif
+
+  #if defined (SCB_CSR_AIRCR_INIT) && (SCB_CSR_AIRCR_INIT == 1U)
+    SCB->SCR   = (SCB->SCR   & ~(SCB_SCR_SLEEPDEEPS_Msk    )) |
+                   ((SCB_CSR_DEEPSLEEPS_VAL     << SCB_SCR_SLEEPDEEPS_Pos)     & SCB_SCR_SLEEPDEEPS_Msk);
+
+    SCB->AIRCR = (SCB->AIRCR & ~(SCB_AIRCR_VECTKEY_Msk   | SCB_AIRCR_SYSRESETREQS_Msk |
+                                 SCB_AIRCR_BFHFNMINS_Msk | SCB_AIRCR_PRIS_Msk          ))                    |
+                   ((0x05FAU                    << SCB_AIRCR_VECTKEY_Pos)      & SCB_AIRCR_VECTKEY_Msk)      |
+                   ((SCB_AIRCR_SYSRESETREQS_VAL << SCB_AIRCR_SYSRESETREQS_Pos) & SCB_AIRCR_SYSRESETREQS_Msk) |
+                   ((SCB_AIRCR_PRIS_VAL         << SCB_AIRCR_PRIS_Pos)         & SCB_AIRCR_PRIS_Msk)         |
+                   ((SCB_AIRCR_BFHFNMINS_VAL    << SCB_AIRCR_BFHFNMINS_Pos)    & SCB_AIRCR_BFHFNMINS_Msk);
+  #endif /* defined (SCB_CSR_AIRCR_INIT) && (SCB_CSR_AIRCR_INIT == 1U) */
+
+  #if defined (__FPU_USED) && (__FPU_USED == 1U) && \
+      defined (TZ_FPU_NS_USAGE) && (TZ_FPU_NS_USAGE == 1U)
+
+    SCB->NSACR = (SCB->NSACR & ~(SCB_NSACR_CP10_Msk | SCB_NSACR_CP11_Msk)) |
+                   ((SCB_NSACR_CP10_11_VAL << SCB_NSACR_CP10_Pos) & (SCB_NSACR_CP10_Msk | SCB_NSACR_CP11_Msk));
+
+    FPU->FPCCR = (FPU->FPCCR & ~(FPU_FPCCR_TS_Msk | FPU_FPCCR_CLRONRETS_Msk | FPU_FPCCR_CLRONRET_Msk)) |
+                   ((FPU_FPCCR_TS_VAL        << FPU_FPCCR_TS_Pos       ) & FPU_FPCCR_TS_Msk       ) |
+                   ((FPU_FPCCR_CLRONRETS_VAL << FPU_FPCCR_CLRONRETS_Pos) & FPU_FPCCR_CLRONRETS_Msk) |
+                   ((FPU_FPCCR_CLRONRET_VAL  << FPU_FPCCR_CLRONRET_Pos ) & FPU_FPCCR_CLRONRET_Msk );
+  #endif
+
+  #if defined (NVIC_INIT_ITNS0) && (NVIC_INIT_ITNS0 == 1U)
+    NVIC->ITNS[0] = NVIC_INIT_ITNS0_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS1) && (NVIC_INIT_ITNS1 == 1U)
+    NVIC->ITNS[1] = NVIC_INIT_ITNS1_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS2) && (NVIC_INIT_ITNS2 == 1U)
+    NVIC->ITNS[2] = NVIC_INIT_ITNS2_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS3) && (NVIC_INIT_ITNS3 == 1U)
+    NVIC->ITNS[3] = NVIC_INIT_ITNS3_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS4) && (NVIC_INIT_ITNS4 == 1U)
+    NVIC->ITNS[4] = NVIC_INIT_ITNS4_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS5) && (NVIC_INIT_ITNS5 == 1U)
+    NVIC->ITNS[5] = NVIC_INIT_ITNS5_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS6) && (NVIC_INIT_ITNS6 == 1U)
+    NVIC->ITNS[6] = NVIC_INIT_ITNS6_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS7) && (NVIC_INIT_ITNS7 == 1U)
+    NVIC->ITNS[7] = NVIC_INIT_ITNS7_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS8) && (NVIC_INIT_ITNS8 == 1U)
+    NVIC->ITNS[8] = NVIC_INIT_ITNS8_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS9) && (NVIC_INIT_ITNS9 == 1U)
+    NVIC->ITNS[9] = NVIC_INIT_ITNS9_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS10) && (NVIC_INIT_ITNS10 == 1U)
+    NVIC->ITNS[10] = NVIC_INIT_ITNS10_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS11) && (NVIC_INIT_ITNS11 == 1U)
+    NVIC->ITNS[11] = NVIC_INIT_ITNS11_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS12) && (NVIC_INIT_ITNS12 == 1U)
+    NVIC->ITNS[12] = NVIC_INIT_ITNS12_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS13) && (NVIC_INIT_ITNS13 == 1U)
+    NVIC->ITNS[13] = NVIC_INIT_ITNS13_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS14) && (NVIC_INIT_ITNS14 == 1U)
+    NVIC->ITNS[14] = NVIC_INIT_ITNS14_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS15) && (NVIC_INIT_ITNS15 == 1U)
+    NVIC->ITNS[15] = NVIC_INIT_ITNS15_VAL;
+  #endif
+
+  /* repeat this for all possible ITNS elements */
+
+}
+
+#endif  /* PARTITION_ARMCM33_H */

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33S/RTE/Device/ARMCM33/regions_ARMCM33.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33S/RTE/Device/ARMCM33/regions_ARMCM33.h
@@ -1,0 +1,94 @@
+#ifndef REGIONS_ARMCM33_H
+#define REGIONS_ARMCM33_H
+
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+// <n>Device pack:   ARM::Cortex_DFP@1.0.0-dev16
+// <i>Device pack used to generate this file
+
+// <h>ROM Configuration
+// =======================
+// <h> ROM_S=<__ROM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x00000000
+#define __ROM0_BASE 0x00000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00200000
+#define __ROM0_SIZE 0x00200000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __ROM0_DEFAULT 1
+//   <q>Startup
+//   <i> Selects region to be used for startup code.
+#define __ROM0_STARTUP 1
+// </h>
+
+// <h> ROM_NS=<__ROM1>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x00200000
+#define __ROM1_BASE 0x00200000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00200000
+#define __ROM1_SIZE 0x00200000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __ROM1_DEFAULT 0
+//   <q>Startup
+//   <i> Selects region to be used for startup code.
+#define __ROM1_STARTUP 0
+// </h>
+
+// </h>
+
+// <h>RAM Configuration
+// =======================
+// <h> RAM_S=<__RAM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x20000000
+#define __RAM0_BASE 0x20000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00020000
+#define __RAM0_SIZE 0x00020000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __RAM0_DEFAULT 1
+//   <q>No zero initialize
+//   <i> Excludes region from zero initialization.
+#define __RAM0_NOINIT 0
+// </h>
+
+// <h> RAM_NS=<__RAM1>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x20200000
+#define __RAM1_BASE 0x20200000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00020000
+#define __RAM1_SIZE 0x00020000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __RAM1_DEFAULT 0
+//   <q>No zero initialize
+//   <i> Excludes region from zero initialization.
+#define __RAM1_NOINIT 0
+// </h>
+
+// </h>
+
+// <h>Stack / Heap Configuration
+//   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+#define __STACK_SIZE 0x00000400
+#define __HEAP_SIZE 0x00000C00
+// </h>
+
+
+#endif /* REGIONS_ARMCM33_H */

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33S/RTE/Device/ARMCM33/startup_ARMCM33.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33S/RTE/Device/ARMCM33/startup_ARMCM33.c
@@ -1,0 +1,164 @@
+/******************************************************************************
+ * @file     startup_ARMCM33.c
+ * @brief    CMSIS-Core Device Startup File for Cortex-M33 Device
+ * @version  V3.0.0
+ * @date     06. April 2023
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (ARMCM33)
+  #include "ARMCM33.h"
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  External References
+ *----------------------------------------------------------------------------*/
+extern uint32_t __INITIAL_SP;
+extern uint32_t __STACK_LIMIT;
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+extern uint32_t __STACK_SEAL;
+#endif
+
+extern __NO_RETURN void __PROGRAM_START(void);
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler  (void);
+            void Default_Handler(void);
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+/* Exceptions */
+void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void HardFault_Handler      (void) __attribute__ ((weak));
+void MemManage_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
+void BusFault_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void UsageFault_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void SecureFault_Handler    (void) __attribute__ ((weak, alias("Default_Handler")));
+void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void DebugMon_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+
+void Interrupt0_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt1_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt2_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt3_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt4_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt5_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt6_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt7_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt8_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt9_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[496];
+       const VECTOR_TABLE_Type __VECTOR_TABLE[496] __VECTOR_TABLE_ATTRIBUTE = {
+  (VECTOR_TABLE_Type)(&__INITIAL_SP),       /*     Initial Stack Pointer */
+  Reset_Handler,                            /*     Reset Handler */
+  NMI_Handler,                              /* -14 NMI Handler */
+  HardFault_Handler,                        /* -13 Hard Fault Handler */
+  MemManage_Handler,                        /* -12 MPU Fault Handler */
+  BusFault_Handler,                         /* -11 Bus Fault Handler */
+  UsageFault_Handler,                       /* -10 Usage Fault Handler */
+  SecureFault_Handler,                      /*  -9 Secure Fault Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  SVC_Handler,                              /*  -5 SVCall Handler */
+  DebugMon_Handler,                         /*  -4 Debug Monitor Handler */
+  0,                                        /*     Reserved */
+  PendSV_Handler,                           /*  -2 PendSV Handler */
+  SysTick_Handler,                          /*  -1 SysTick Handler */
+
+  /* Interrupts */
+  Interrupt0_Handler,                       /*   0 Interrupt 0 */
+  Interrupt1_Handler,                       /*   1 Interrupt 1 */
+  Interrupt2_Handler,                       /*   2 Interrupt 2 */
+  Interrupt3_Handler,                       /*   3 Interrupt 3 */
+  Interrupt4_Handler,                       /*   4 Interrupt 4 */
+  Interrupt5_Handler,                       /*   5 Interrupt 5 */
+  Interrupt6_Handler,                       /*   6 Interrupt 6 */
+  Interrupt7_Handler,                       /*   7 Interrupt 7 */
+  Interrupt8_Handler,                       /*   8 Interrupt 8 */
+  Interrupt9_Handler                        /*   9 Interrupt 9 */
+                                            /* Interrupts 10 .. 480 are left out */
+};
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler(void)
+{
+  __set_PSP((uint32_t)(&__INITIAL_SP));
+
+  __set_MSPLIM((uint32_t)(&__STACK_LIMIT));
+  __set_PSPLIM((uint32_t)(&__STACK_LIMIT));
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  __TZ_set_STACKSEAL_S((uint32_t *)(&__STACK_SEAL));
+#endif
+
+  SystemInit();                             /* CMSIS System Initialization */
+  __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
+}
+
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wmissing-noreturn"
+#endif
+
+/*----------------------------------------------------------------------------
+  Hard Fault Handler
+ *----------------------------------------------------------------------------*/
+void HardFault_Handler(void)
+{
+  while(1);
+}
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+void Default_Handler(void)
+{
+  while(1);
+}
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic pop
+#endif
+

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33S/RTE/Device/ARMCM33/system_ARMCM33.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33S/RTE/Device/ARMCM33/system_ARMCM33.c
@@ -1,0 +1,86 @@
+/**************************************************************************//**
+ * @file     system_ARMCM33.c
+ * @brief    CMSIS Device System Source File for
+ *           ARMCM33 Device
+ * @version  V2.0.0
+ * @date     06. Aril 2023
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (ARMCM33)
+  #include "ARMCM33.h"
+  #if defined (__ARM_FEATURE_CMSE) &&  (__ARM_FEATURE_CMSE == 3U)
+    #include "partition_ARMCM33.h"
+  #endif
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  Define clocks
+ *----------------------------------------------------------------------------*/
+#define  XTAL            (50000000UL)     /* Oscillator frequency */
+
+#define  SYSTEM_CLOCK    (XTAL / 2U)
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[496];
+
+
+/*----------------------------------------------------------------------------
+  System Core Clock Variable
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = SYSTEM_CLOCK;  /* System Core Clock Frequency */
+
+
+/*----------------------------------------------------------------------------
+  System Core Clock update function
+ *----------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)
+{
+  SystemCoreClock = SYSTEM_CLOCK;
+}
+
+/*----------------------------------------------------------------------------
+  System initialization function
+ *----------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t) &(__VECTOR_TABLE[0]);
+#endif
+
+#if defined (__FPU_USED) && (__FPU_USED == 1U)
+  SCB->CPACR |= ((3U << 10U*2U) |           /* enable CP10 Full Access */
+                 (3U << 11U*2U)  );         /* enable CP11 Full Access */
+#endif
+
+#ifdef UNALIGNED_SUPPORT_DISABLE
+  SCB->CCR |= SCB_CCR_UNALIGN_TRP_Msk;
+#endif
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  TZ_SAU_Setup();
+#endif
+
+  SystemCoreClock = SYSTEM_CLOCK;
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33S/Target.clayer.yml
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33S/Target.clayer.yml
@@ -1,0 +1,35 @@
+layer:
+  type: Target
+  description: CM33S target components and files
+
+  packs:
+    - pack: ARM::Cortex_DFP
+
+  device: ARMCM33
+
+  processor:
+    trustzone: secure
+
+  components:
+    # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
+    - component: ARM::CMSIS:CORE
+    - component: Device:Startup&C Startup
+
+  groups:
+    - group: FVP
+      files:
+        - file: ./model_config.txt
+
+  linker:
+    - for-compiler: AC6
+      script: RTE/Device/$Dname$/ac6_linker_script.sct
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: GCC
+      script: RTE/Device/$Dname$/gcc_linker_script.ld
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: CLANG
+      script: RTE/Device/$Dname$/clang_linker_script.ld
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: IAR
+      script: RTE/Device/$Dname$/iar_linker_script.icf
+      regions: RTE/Device/$Dname$/regions_$Dname$.h

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33S/model_config.txt
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM33S/model_config.txt
@@ -1,0 +1,32 @@
+# Parameters:
+# instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+#----------------------------------------------------------------------------------------------
+fvp_mps2.mps2_visualisation.disable-visualisation=1   # (bool  , init-time) default = '0'      : Enable/disable visualisation
+cpu0.FPU=1                                            # (bool  , init-time) default = '1'      : Set whether the model has VFP support
+cpu0.DSP=1                                            # (bool  , init-time) default = '1'      : Set whether the model has the DSP extension
+cpu0.semihosting-enable=1                             # (bool  , init-time) default = '1'      : Enable semihosting SVC traps. Applications that do not use semihosting must set this parameter to false.
+cpu0.semihosting-Thumb_SVC=0xAB                       # (int   , init-time) default = '0xAB'   : T32 SVC number for semihosting : [0x0..0xFF]
+cpu0.semihosting-cmd_line=""                          # (string, init-time) default = ''       : Command line available to semihosting SVC calls
+cpu0.semihosting-heap_base=0x0                        # (int   , init-time) default = '0x0'    : Virtual address of heap base : [0x0..0xFFFFFFFF]
+cpu0.semihosting-heap_limit=0x0                       # (int   , init-time) default = '0x10700000' : Virtual address of top of heap : [0x0..0xFFFFFFFF]
+cpu0.semihosting-stack_base=0x0                       # (int   , init-time) default = '0x10700000' : Virtual address of base of descending stack : [0x0..0xFFFFFFFF]
+cpu0.semihosting-stack_limit=0x0                      # (int   , init-time) default = '0x10800000' : Virtual address of stack limit : [0x0..0xFFFFFFFF]
+cpu0.semihosting-cwd=""                               # (string, init-time) default = ''       : Base directory for semihosting file access.
+cpu0.MPU_S=0x8                                        # (int   , init-time) default = '0x8'    : Number of regions in the Secure MPU. If Security Extentions are absent, this is ignored : [0x0..0x10]
+cpu0.MPU_NS=0x8                                       # (int   , init-time) default = '0x8'    : Number of regions in the Non-Secure MPU. If Security Extentions are absent, this is the total number of MPU regions : [0x0..0x10]
+cpu0.ITM=0                                            # (bool  , init-time) default = '1'      : Level of instrumentation trace supported. false : No ITM trace included, true: ITM trace included
+cpu0.IRQLVL=0x3                                       # (int   , init-time) default = '0x3'    : Number of bits of interrupt priority : [0x3..0x8]
+cpu0.BIGENDINIT=0                                     # (bool  , init-time) default = '0'      : Initialize processor to big endian mode
+cpu0.INITSVTOR=0x00000000                             # (int   , init-time) default = '0x10000000' : Secure vector-table offset at reset : [0x0..0xFFFFFF80]
+cpu0.INITNSVTOR=0x0                                   # (int   , init-time) default = '0x0'    : Non-Secure vector-table offset at reset : [0x0..0xFFFFFF80]
+cpu0.SAU=0x8                                          # (int   , init-time) default = '0x4'    : Number of SAU regions (0 => no SAU) : [0x0..0x8]
+cpu0.SAU_CTRL.ENABLE=0                                # (bool  , init-time) default = '0'      : Enable SAU at reset
+cpu0.SAU_CTRL.ALLNS=0                                 # (bool  , init-time) default = '0'      : At reset, the SAU treats entire memory space as NS when the SAU is disabled if this is set
+idau.NUM_IDAU_REGION=0x0                              # (int   , init-time) default = '0xA'    : 
+cpu0.LOCK_SAU=0                                       # (bool  , init-time) default = '0'      : Lock down of SAU registers write
+cpu0.LOCK_S_MPU=0                                     # (bool  , init-time) default = '0'      : Lock down of Secure MPU registers write
+cpu0.LOCK_NS_MPU=0                                    # (bool  , init-time) default = '0'      : Lock down of Non-Secure MPU registers write
+cpu0.CPIF=1                                           # (bool  , init-time) default = '1'      : Specifies whether the external coprocessor interface is included
+cpu0.SECEXT=1                                         # (bool  , init-time) default = '1'      : Whether the ARMv8-M Security Extensions are included
+fvp_mps2.DISABLE_GATING=1                             # (bool  , init-time) default = '0'      : Disable Memory gating logic
+#----------------------------------------------------------------------------------------------

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35P/RTE/Device/ARMCM35P/ac6_linker_script.sct
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35P/RTE/Device/ARMCM35P/ac6_linker_script.sct
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE 8
+#else
+#define __STACKSEAL_SIZE 0
+#endif
+
+/*----------------------------------------------------------------------------
+  Scatter File Definitions definition
+ *----------------------------------------------------------------------------*/
+
+LR_ROM0 __ROM0_BASE __ROM0_SIZE  {
+
+  ER_ROM0 __ROM0_BASE __ROM0_SIZE {
+    *.o (RESET, +First)
+    *(InRoot$$Sections)
+    *(+RO +XO)
+  }
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  ER_CMSE_VENEER AlignExpr(+0, 32) (__ROM0_SIZE - AlignExpr(ImageLength(ER_ROM0), 32)) {
+    *(Veneer$$CMSE)
+  }
+#endif
+
+  RW_NOINIT __RAM0_BASE UNINIT (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE) {
+    *(.bss.noinit)
+  }
+
+  RW_RAM0 AlignExpr(+0, 8) (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE - AlignExpr(ImageLength(RW_NOINIT), 8)) {
+    *(+RW +ZI)
+  }
+
+#if __HEAP_SIZE > 0
+  ARM_LIB_HEAP  (AlignExpr(+0, 8)) EMPTY __HEAP_SIZE  {   ; Reserve empty region for heap
+  }
+#endif
+
+  ARM_LIB_STACK (__RAM0_BASE + __RAM0_SIZE - __STACKSEAL_SIZE) EMPTY -__STACK_SIZE {   ; Reserve empty region for stack
+  }
+
+#if __STACKSEAL_SIZE > 0
+  STACKSEAL +0 EMPTY __STACKSEAL_SIZE {             ; Reserve empty region for stack seal immediately after stack
+  }
+#endif
+
+#if __RAM1_SIZE > 0
+  RW_RAM1 __RAM1_BASE __RAM1_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+
+#if __RAM2_SIZE > 0
+  RW_RAM2 __RAM2_BASE __RAM2_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+
+#if __RAM3_SIZE > 0
+  RW_RAM3 __RAM3_BASE __RAM3_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+}
+
+#if __ROM1_SIZE > 0
+LR_ROM1 __ROM1_BASE __ROM1_SIZE  {
+  ER_ROM1 +0 __ROM1_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif
+
+#if __ROM2_SIZE > 0
+LR_ROM2 __ROM2_BASE __ROM2_SIZE  {
+  ER_ROM2 +0 __ROM2_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif
+
+#if __ROM3_SIZE > 0
+LR_ROM3 __ROM3_BASE __ROM3_SIZE  {
+  ER_ROM3 +0 __ROM3_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35P/RTE/Device/ARMCM35P/clang_linker_script.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35P/RTE/Device/ARMCM35P/clang_linker_script.ld
@@ -1,0 +1,361 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2019 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+/* ----------------------------------------------------------------------------
+  Memory definition
+ *----------------------------------------------------------------------------*/
+MEMORY
+{
+  ROM0  (rx!w)  : ORIGIN = __ROM0_BASE, LENGTH = __ROM0_SIZE
+#if __ROM1_SIZE > 0
+  ROM1  (rx!w)  : ORIGIN = __ROM1_BASE, LENGTH = __ROM1_SIZE
+#endif
+#if __ROM2_SIZE > 0
+  ROM2  (rx!w)  : ORIGIN = __ROM2_BASE, LENGTH = __ROM2_SIZE
+#endif
+#if __ROM3_SIZE > 0
+  ROM3  (rx!w)  : ORIGIN = __ROM3_BASE, LENGTH = __ROM3_SIZE
+#endif
+
+  RAM0  (w!rx) : ORIGIN = __RAM0_BASE, LENGTH = __RAM0_SIZE
+#if __RAM1_SIZE > 0
+  RAM1  (w!rx) : ORIGIN = __RAM1_BASE, LENGTH = __RAM1_SIZE
+#endif
+#if __RAM2_SIZE > 0
+  RAM2  (w!rx) : ORIGIN = __RAM2_BASE, LENGTH = __RAM2_SIZE
+#endif
+#if __RAM3_SIZE > 0
+  RAM3  (w!rx) : ORIGIN = __RAM3_BASE, LENGTH = __RAM3_SIZE
+#endif
+}
+
+ENTRY(Reset_Handler)
+
+PHDRS
+{
+	text PT_LOAD;
+	ram PT_LOAD;
+	ram_init PT_LOAD;
+	tls PT_TLS;
+}
+
+SECTIONS
+{
+	.init : {
+		KEEP (*(.vectors))
+		KEEP (*(.text.init.enter))
+		KEEP (*(.data.init.enter))
+		KEEP (*(SORT_BY_NAME(.init) SORT_BY_NAME(.init.*)))
+	} >ROM0 AT>ROM0 :text
+
+	.text : {
+
+		/* code */
+		*(.text.unlikely .text.unlikely.*)
+		*(.text.startup .text.startup.*)
+		*(.text .text.* .opd .opd.*)
+		*(.gnu.linkonce.t.*)
+		KEEP (*(.fini .fini.*))
+		__text_end = .;
+
+		PROVIDE (__etext = __text_end);
+		PROVIDE (_etext = __text_end);
+		PROVIDE (etext = __text_end);
+
+		/* read-only data */
+		*(.rdata)
+		*(.rodata .rodata.*)
+		*(.gnu.linkonce.r.*)
+
+		*(.srodata.cst16)
+		*(.srodata.cst8)
+		*(.srodata.cst4)
+		*(.srodata.cst2)
+		*(.srodata .srodata.*)
+		*(.data.rel.ro .data.rel.ro.*)
+		*(.got .got.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		/* lists of constructors and destructors */
+		PROVIDE_HIDDEN ( __preinit_array_start = . );
+		KEEP (*(.preinit_array))
+		PROVIDE_HIDDEN ( __preinit_array_end = . );
+
+		PROVIDE_HIDDEN ( __init_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+		KEEP (*(.init_array .ctors))
+		PROVIDE_HIDDEN ( __init_array_end = . );
+
+		PROVIDE_HIDDEN ( __fini_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
+		KEEP (*(.fini_array .dtors))
+		PROVIDE_HIDDEN ( __fini_array_end = . );
+
+	} >ROM0 AT>ROM0 :text
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+	.veneers :
+	{
+		. = ALIGN(32);
+		KEEP(*(.gnu.sgstubs))
+	} > ROM0 AT>ROM0 :text
+#endif
+
+	.toc : {
+		*(.toc .toc.*)
+	} >ROM0 AT>ROM0 :text
+
+	/* additional sections when compiling with C++ exception support */
+	
+	.except_ordered : {
+		*(.gcc_except_table *.gcc_except_table.*)
+		KEEP (*(.eh_frame .eh_frame.*))
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+	} >ROM0 AT>ROM0 :text
+
+	.except_unordered : {
+		. = ALIGN(8);
+
+		PROVIDE(__exidx_start = .);
+		*(.ARM.exidx*)
+		PROVIDE(__exidx_end = .);
+	} >ROM0 AT>ROM0 :text
+	
+
+	/*
+	 * Data values which are preserved across reset
+	 */
+	.preserve (NOLOAD) : {
+		PROVIDE(__preserve_start__ = .);
+		KEEP(*(SORT_BY_NAME(.preserve.*)))
+		KEEP(*(.preserve))
+		PROVIDE(__preserve_end__ = .);
+	} >RAM0 AT>RAM0 :ram
+
+	.data :  {
+		*(.data .data.*)
+		*(.gnu.linkonce.d.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		PROVIDE( __global_pointer$ = . + 0x800 );
+		*(.sdata .sdata.* .sdata2.*)
+		*(.gnu.linkonce.s.*)
+	} >RAM0 AT>ROM0 :ram_init
+	PROVIDE(__data_start = ADDR(.data));
+	PROVIDE(__data_source = LOADADDR(.data));
+
+	/* Thread local initialized data. This gets
+	 * space allocated as it is expected to be placed
+	 * in ram to be used as a template for TLS data blocks
+	 * allocated at runtime. We're slightly abusing that
+	 * by placing the data in flash where it will be copied
+	 * into the allocate ram addresses by the existing
+	 * data initialization code in crt0
+	 */
+	.tdata :  {
+		*(.tdata .tdata.* .gnu.linkonce.td.*)
+		PROVIDE(__data_end = .);
+		PROVIDE(__tdata_end = .);
+	} >RAM0 AT>ROM0 :tls :ram_init
+	PROVIDE( __tls_base = ADDR(.tdata));
+	PROVIDE( __tdata_start = ADDR(.tdata));
+	PROVIDE( __tdata_source = LOADADDR(.tdata) );
+	PROVIDE( __tdata_source_end = LOADADDR(.tdata) + SIZEOF(.tdata) );
+	PROVIDE( __data_source_end = __tdata_source_end );
+	PROVIDE( __tdata_size = SIZEOF(.tdata) );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata),ALIGNOF(.tbss)) );
+
+	PROVIDE( __edata = __data_end );
+	PROVIDE( _edata = __data_end );
+	PROVIDE( edata = __data_end );
+	PROVIDE( __data_size = __data_end - __data_start );
+	PROVIDE( __data_source_size = __data_source_end - __data_source );
+
+	.tbss (NOLOAD) : {
+		*(.tbss .tbss.* .gnu.linkonce.tb.*)
+		*(.tcommon)
+		PROVIDE( __tls_end = . );
+		PROVIDE( __tbss_end = . );
+	} >RAM0 AT>RAM0 :tls :ram
+	PROVIDE( __bss_start = ADDR(.tbss));
+	PROVIDE( __tbss_start = ADDR(.tbss));
+	PROVIDE( __tbss_offset = ADDR(.tbss) - ADDR(.tdata) );
+	PROVIDE( __tbss_size = SIZEOF(.tbss) );
+	PROVIDE( __tls_size = __tls_end - __tls_base );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
+	PROVIDE( __arm32_tls_tcb_offset = MAX(8, __tls_align) );
+	PROVIDE( __arm64_tls_tcb_offset = MAX(16, __tls_align) );
+
+	/*
+	 * The linker special cases .tbss segments which are
+	 * identified as segments which are not loaded and are
+	 * thread_local.
+	 *
+	 * For these segments, the linker does not advance 'dot'
+	 * across them.  We actually need memory allocated for tbss,
+	 * so we create a special segment here just to make room
+	 */
+	/*
+	.tbss_space (NOLOAD) : {
+		. = ADDR(.tbss);
+		. = . + SIZEOF(.tbss);
+	} >RAM0 AT>RAM0 :ram
+	*/
+
+	.bss (NOLOAD) : {
+		*(.sbss*)
+		*(.gnu.linkonce.sb.*)
+		*(.bss .bss.*)
+		*(.gnu.linkonce.b.*)
+		*(COMMON)
+
+		/* Align the heap */
+		. = ALIGN(8);
+		__bss_end = .;
+	} >RAM0 AT>RAM0 :ram
+	PROVIDE( __non_tls_bss_start = ADDR(.bss) );
+	PROVIDE( __end = __bss_end );
+	PROVIDE( _end = __bss_end );
+	PROVIDE( end = __bss_end );
+	PROVIDE( __bss_size = __bss_end - __bss_start );
+
+	/* Make the rest of memory available for heap storage */
+	PROVIDE (__heap_start = __end);
+#ifdef __HEAP_SIZE
+	PROVIDE (__heap_end = __heap_start + __HEAP_SIZE);
+	PROVIDE (__heap_size = __HEAP_SIZE);
+#else
+	PROVIDE (__heap_end = __stack - __STACK_SIZE);
+	PROVIDE (__heap_size = __heap_end - __heap_start);
+#endif
+	.heap (NOLOAD) : {
+		. += __heap_size;
+	} >RAM0 :ram
+
+	/* Define a stack region to make sure it fits in memory */
+	PROVIDE(__stack = ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE);
+	PROVIDE(__stack_limit = __stack - __STACK_SIZE);
+	.stack (__stack_limit) (NOLOAD) : {
+		. += __STACK_SIZE;
+	} >RAM0 :ram
+
+#if __STACKSEAL_SIZE > 0
+	PROVIDE(__stack_seal = __stack);
+  	.stackseal (__stack) (NOLOAD) :
+  	{
+    	. += __STACKSEAL_SIZE;
+  	} >RAM0 :ram
+#endif
+
+	/* Throw away C++ exception handling information */
+
+	/*
+
+	/DISCARD/ : {
+		*(.note .note.*)
+		*(.eh_frame .eh_frame.*)
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+		*(.ARM.exidx*)
+	}
+
+	*/
+
+	/* Stabs debugging sections.  */
+	.stab          0 : { *(.stab) }
+	.stabstr       0 : { *(.stabstr) }
+	.stab.excl     0 : { *(.stab.excl) }
+	.stab.exclstr  0 : { *(.stab.exclstr) }
+	.stab.index    0 : { *(.stab.index) }
+	.stab.indexstr 0 : { *(.stab.indexstr) }
+	.comment       0 : { *(.comment) }
+	.gnu.build.attributes : { *(.gnu.build.attributes .gnu.build.attributes.*) }
+	/* DWARF debug sections.
+	   Symbols in the DWARF debugging sections are relative to the beginning
+	   of the section so we begin them at 0.  */
+	/* DWARF 1.  */
+	.debug          0 : { *(.debug) }
+	.line           0 : { *(.line) }
+	/* GNU DWARF 1 extensions.  */
+	.debug_srcinfo  0 : { *(.debug_srcinfo) }
+	.debug_sfnames  0 : { *(.debug_sfnames) }
+	/* DWARF 1.1 and DWARF 2.  */
+	.debug_aranges  0 : { *(.debug_aranges) }
+	.debug_pubnames 0 : { *(.debug_pubnames) }
+	/* DWARF 2.  */
+	.debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+	.debug_abbrev   0 : { *(.debug_abbrev) }
+	.debug_line     0 : { *(.debug_line .debug_line.* .debug_line_end) }
+	.debug_frame    0 : { *(.debug_frame) }
+	.debug_str      0 : { *(.debug_str) }
+	.debug_loc      0 : { *(.debug_loc) }
+	.debug_macinfo  0 : { *(.debug_macinfo) }
+	/* SGI/MIPS DWARF 2 extensions.  */
+	.debug_weaknames 0 : { *(.debug_weaknames) }
+	.debug_funcnames 0 : { *(.debug_funcnames) }
+	.debug_typenames 0 : { *(.debug_typenames) }
+	.debug_varnames  0 : { *(.debug_varnames) }
+	/* DWARF 3.  */
+	.debug_pubtypes 0 : { *(.debug_pubtypes) }
+	.debug_ranges   0 : { *(.debug_ranges) }
+	/* DWARF 5.  */
+	.debug_addr     0 : { *(.debug_addr) }
+	.debug_line_str 0 : { *(.debug_line_str) }
+	.debug_loclists 0 : { *(.debug_loclists) }
+	.debug_macro    0 : { *(.debug_macro) }
+	.debug_names    0 : { *(.debug_names) }
+	.debug_rnglists 0 : { *(.debug_rnglists) }
+	.debug_str_offsets 0 : { *(.debug_str_offsets) }
+	.debug_sup      0 : { *(.debug_sup) }
+	.gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }
+}
+/*
+ * Check that sections that are copied from flash to RAM have matching
+ * padding, so that a single memcpy() of __data_size copies the correct bytes.
+ */
+ASSERT( __data_size == __data_source_size,
+	"ERROR: .data/.tdata flash size does not match RAM size");

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35P/RTE/Device/ARMCM35P/gcc_linker_script.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35P/RTE/Device/ARMCM35P/gcc_linker_script.ld
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+/* ----------------------------------------------------------------------------
+  Memory definition
+ *----------------------------------------------------------------------------*/
+MEMORY
+{
+  ROM0  (rx)  : ORIGIN = __ROM0_BASE, LENGTH = __ROM0_SIZE
+#if __ROM1_SIZE > 0
+  ROM1  (rx)  : ORIGIN = __ROM1_BASE, LENGTH = __ROM1_SIZE
+#endif
+#if __ROM2_SIZE > 0
+  ROM2  (rx)  : ORIGIN = __ROM2_BASE, LENGTH = __ROM2_SIZE
+#endif
+#if __ROM3_SIZE > 0
+  ROM3  (rx)  : ORIGIN = __ROM3_BASE, LENGTH = __ROM3_SIZE
+#endif
+
+  RAM0  (rwx) : ORIGIN = __RAM0_BASE, LENGTH = __RAM0_SIZE
+#if __RAM1_SIZE > 0
+  RAM1  (rwx) : ORIGIN = __RAM1_BASE, LENGTH = __RAM1_SIZE
+#endif
+#if __RAM2_SIZE > 0
+  RAM2  (rwx) : ORIGIN = __RAM2_BASE, LENGTH = __RAM2_SIZE
+#endif
+#if __RAM3_SIZE > 0
+  RAM3  (rwx) : ORIGIN = __RAM3_BASE, LENGTH = __RAM3_SIZE
+#endif
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __copy_table_start__
+ *   __copy_table_end__
+ *   __zero_table_start__
+ *   __zero_table_end__
+ *   __etext          (deprecated)
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+  .text :
+  {
+    KEEP(*(.vectors))
+    *(.text*)
+
+    KEEP(*(.init))
+    KEEP(*(.fini))
+
+    /* .ctors */
+    *crtbegin.o(.ctors)
+    *crtbegin?.o(.ctors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+    *(SORT(.ctors.*))
+    *(.ctors)
+
+    /* .dtors */
+    *crtbegin.o(.dtors)
+    *crtbegin?.o(.dtors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+    *(SORT(.dtors.*))
+    *(.dtors)
+
+    *(.rodata*)
+
+    KEEP(*(.eh_frame*))
+  } > ROM0
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  .gnu.sgstubs :
+  {
+    . = ALIGN(32);
+  } > ROM0
+#endif
+
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > ROM0
+
+  __exidx_start = .;
+  .ARM.exidx :
+  {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+  } > ROM0
+  __exidx_end = .;
+
+  .copy.table :
+  {
+    . = ALIGN(4);
+    __copy_table_start__ = .;
+
+    LONG (LOADADDR(.data))
+    LONG (ADDR(.data))
+    LONG (SIZEOF(.data) / 4)
+
+    /* Add each additional data section here */
+/*
+    LONG (LOADADDR(.data2))
+    LONG (ADDR(.data2))
+    LONG (SIZEOF(.data2) / 4)
+*/
+    __copy_table_end__ = .;
+  } > ROM0
+
+  .zero.table :
+  {
+    . = ALIGN(4);
+    __zero_table_start__ = .;
+
+/*  .bss initialization to zero is already done during C Run-Time Startup.
+    LONG (ADDR(.bss))
+    LONG (SIZEOF(.bss) / 4)
+*/
+
+    /* Add each additional bss section here */
+/*
+    LONG (ADDR(.bss2))
+    LONG (SIZEOF(.bss2) / 4)
+*/
+    __zero_table_end__ = .;
+  } > ROM0
+
+  /*
+   * This __etext variable is kept for backward compatibility with older,
+   * ASM based startup files.
+   */
+  PROVIDE(__etext = LOADADDR(.data));
+
+  .data : ALIGN(4)
+  {
+    __data_start__ = .;
+    *(vtable)
+    *(.data)
+    *(.data.*)
+
+    . = ALIGN(4);
+    /* preinit data */
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP(*(.preinit_array))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+
+    . = ALIGN(4);
+    /* init data */
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP(*(SORT(.init_array.*)))
+    KEEP(*(.init_array))
+    PROVIDE_HIDDEN (__init_array_end = .);
+
+    . = ALIGN(4);
+    /* finit data */
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP(*(SORT(.fini_array.*)))
+    KEEP(*(.fini_array))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    /* All data end */
+    __data_end__ = .;
+
+  } > RAM0 AT > ROM0
+
+  /*
+   * Secondary data section, optional
+   *
+   * Remember to add each additional data section
+   * to the .copy.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .data2 : ALIGN(4)
+  {
+    . = ALIGN(4);
+    __data2_start__ = .;
+    *(.data2)
+    *(.data2.*)
+    . = ALIGN(4);
+    __data2_end__ = .;
+
+  } > RAM1 AT > ROM0 
+*/
+
+  .bss :
+  {
+    . = ALIGN(4);
+    __bss_start__ = .;
+    *(.bss)
+    *(.bss.*)
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+  } > RAM0 AT > RAM0
+
+  /*
+   * Secondary bss section, optional
+   *
+   * Remember to add each additional bss section
+   * to the .zero.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .bss2 :
+  {
+    . = ALIGN(4);
+    __bss2_start__ = .;
+    *(.bss2)
+    *(.bss2.*)
+    . = ALIGN(4);
+    __bss2_end__ = .;
+  } > RAM1 AT > RAM1
+*/
+
+  .heap (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE(end = .);
+    . = . + __HEAP_SIZE;
+    . = ALIGN(8);
+    __HeapLimit = .;
+  } > RAM0
+
+  .stack (ORIGIN(RAM0) + LENGTH(RAM0) - __STACK_SIZE - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackLimit = .;
+    . = . + __STACK_SIZE;
+    . = ALIGN(8);
+    __StackTop = .;
+  } > RAM0
+  PROVIDE(__stack = __StackTop);
+
+#if __STACKSEAL_SIZE > 0
+  .stackseal (ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackSeal = .;
+    . = . + 8;
+    . = ALIGN(8);
+  } > RAM0
+#endif
+
+  /* Check if data + heap + stack exceeds RAM limit */
+  ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35P/RTE/Device/ARMCM35P/iar_linker_script.icf
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35P/RTE/Device/ARMCM35P/iar_linker_script.icf
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+define memory mem with size = 4G;
+
+#if __ROM0_SIZE > 0
+  define region ROM0_region = mem:[from __ROM0_BASE to (__ROM0_BASE+__ROM0_SIZE-1)];
+#else
+  define region ROM0_region = [];
+#endif
+
+#if __ROM1_SIZE > 0
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+#else
+  define region ROM1_region = [];
+#endif
+
+#if __ROM2_SIZE > 0
+  define region ROM2_region = mem:[from __ROM2_BASE to (__ROM2_BASE+__ROM2_SIZE-1)];
+#else
+  define region ROM2_region = [];
+#endif
+
+#if __ROM3_SIZE > 0
+  define region ROM3_region = mem:[from __ROM3_BASE to (__ROM3_BASE+__ROM3_SIZE-1)];
+#else
+  define region ROM3_region = [];
+#endif
+
+define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_region;
+
+#if __RAM0_SIZE > 0
+  define region RAM0_region = mem:[from __RAM0_BASE to (__RAM0_BASE+__RAM0_SIZE-1)];
+#else
+  define region RAM0_region = [];
+#endif
+
+#if __RAM1_SIZE > 0
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+#else
+  define region RAM1_region = [];
+#endif
+
+#if __RAM2_SIZE > 0
+  define region RAM2_region = mem:[from __RAM2_BASE to (__RAM2_BASE+__RAM2_SIZE-1)];
+#else
+  define region RAM2_region = [];
+#endif
+
+#if __RAM3_SIZE > 0
+  define region RAM3_region = mem:[from __RAM3_BASE to (__RAM3_BASE+__RAM3_SIZE-1)];
+#else
+  define region RAM3_region = [];
+#endif
+
+define region RAM_region = RAM0_region | RAM1_region | RAM2_region | RAM3_region;
+
+do not initialize  { section .noinit };
+initialize by copy { readwrite };
+if (isdefinedsymbol(__USE_DLIB_PERTHREAD))
+{
+  // Required in a multi-threaded application
+  initialize by copy with packing = none { section __DLIB_PERTHREAD };
+}
+
+place at address mem:__ROM0_BASE { readonly section .intvec };
+
+if (!isempty(ROM_region))
+{
+  place in ROM_region  { readonly };
+}
+
+if (!isempty(RAM_region))
+{
+  define block CSTACK     with alignment = 8, size = __STACK_SIZE     { };
+  define block PROC_STACK with alignment = 8, size = 0 { };
+  define block HEAP       with alignment = 8, size = __HEAP_SIZE       { };
+  place in RAM_region  { readwrite, block CSTACK, block PROC_STACK, block HEAP };
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35P/RTE/Device/ARMCM35P/regions_ARMCM35P.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35P/RTE/Device/ARMCM35P/regions_ARMCM35P.h
@@ -1,0 +1,94 @@
+#ifndef REGIONS_ARMCM35P_H
+#define REGIONS_ARMCM35P_H
+
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+// <n>Device pack:   ARM::Cortex_DFP@1.0.0-dev16
+// <i>Device pack used to generate this file
+
+// <h>ROM Configuration
+// =======================
+// <h> ROM_S=<__ROM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x00000000
+#define __ROM0_BASE 0x00000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00200000
+#define __ROM0_SIZE 0x00200000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __ROM0_DEFAULT 1
+//   <q>Startup
+//   <i> Selects region to be used for startup code.
+#define __ROM0_STARTUP 1
+// </h>
+
+// <h> ROM_NS=<__ROM1>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x00200000
+#define __ROM1_BASE 0x00200000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00200000
+#define __ROM1_SIZE 0x00200000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __ROM1_DEFAULT 0
+//   <q>Startup
+//   <i> Selects region to be used for startup code.
+#define __ROM1_STARTUP 0
+// </h>
+
+// </h>
+
+// <h>RAM Configuration
+// =======================
+// <h> RAM_S=<__RAM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x20000000
+#define __RAM0_BASE 0x20000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00020000
+#define __RAM0_SIZE 0x00020000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __RAM0_DEFAULT 1
+//   <q>No zero initialize
+//   <i> Excludes region from zero initialization.
+#define __RAM0_NOINIT 0
+// </h>
+
+// <h> RAM_NS=<__RAM1>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x20200000
+#define __RAM1_BASE 0x20200000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00020000
+#define __RAM1_SIZE 0x00020000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __RAM1_DEFAULT 0
+//   <q>No zero initialize
+//   <i> Excludes region from zero initialization.
+#define __RAM1_NOINIT 0
+// </h>
+
+// </h>
+
+// <h>Stack / Heap Configuration
+//   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+#define __STACK_SIZE 0x00000400
+#define __HEAP_SIZE 0x00000C00
+// </h>
+
+
+#endif /* REGIONS_ARMCM35P_H */

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35P/RTE/Device/ARMCM35P/startup_ARMCM35P.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35P/RTE/Device/ARMCM35P/startup_ARMCM35P.c
@@ -1,0 +1,164 @@
+/******************************************************************************
+ * @file     startup_ARMCM35P.c
+ * @brief    CMSIS-Core Device Startup File for Cortex-M35P Device
+ * @version  V3.0.0
+ * @date     13. July 2023
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (ARMCM35P)
+  #include "ARMCM35P.h"
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  External References
+ *----------------------------------------------------------------------------*/
+extern uint32_t __INITIAL_SP;
+extern uint32_t __STACK_LIMIT;
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+extern uint32_t __STACK_SEAL;
+#endif
+
+extern __NO_RETURN void __PROGRAM_START(void);
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler  (void);
+            void Default_Handler(void);
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+/* Exceptions */
+void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void HardFault_Handler      (void) __attribute__ ((weak));
+void MemManage_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
+void BusFault_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void UsageFault_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void SecureFault_Handler    (void) __attribute__ ((weak, alias("Default_Handler")));
+void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void DebugMon_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+
+void Interrupt0_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt1_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt2_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt3_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt4_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt5_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt6_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt7_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt8_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt9_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[496];
+       const VECTOR_TABLE_Type __VECTOR_TABLE[496] __VECTOR_TABLE_ATTRIBUTE = {
+  (VECTOR_TABLE_Type)(&__INITIAL_SP),       /*     Initial Stack Pointer */
+  Reset_Handler,                            /*     Reset Handler */
+  NMI_Handler,                              /* -14 NMI Handler */
+  HardFault_Handler,                        /* -13 Hard Fault Handler */
+  MemManage_Handler,                        /* -12 MPU Fault Handler */
+  BusFault_Handler,                         /* -11 Bus Fault Handler */
+  UsageFault_Handler,                       /* -10 Usage Fault Handler */
+  SecureFault_Handler,                      /*  -9 Secure Fault Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  SVC_Handler,                              /*  -5 SVC Handler */
+  DebugMon_Handler,                         /*  -4 Debug Monitor Handler */
+  0,                                        /*     Reserved */
+  PendSV_Handler,                           /*  -2 PendSV Handler */
+  SysTick_Handler,                          /*  -1 SysTick Handler */
+
+  /* Interrupts */
+  Interrupt0_Handler,                       /*   0 Interrupt 0 */
+  Interrupt1_Handler,                       /*   1 Interrupt 1 */
+  Interrupt2_Handler,                       /*   2 Interrupt 2 */
+  Interrupt3_Handler,                       /*   3 Interrupt 3 */
+  Interrupt4_Handler,                       /*   4 Interrupt 4 */
+  Interrupt5_Handler,                       /*   5 Interrupt 5 */
+  Interrupt6_Handler,                       /*   6 Interrupt 6 */
+  Interrupt7_Handler,                       /*   7 Interrupt 7 */
+  Interrupt8_Handler,                       /*   8 Interrupt 8 */
+  Interrupt9_Handler                        /*   9 Interrupt 9 */
+                                            /* Interrupts 10 .. 480 are left out */
+};
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler(void)
+{
+  __set_PSP((uint32_t)(&__INITIAL_SP));
+
+  __set_MSPLIM((uint32_t)(&__STACK_LIMIT));
+  __set_PSPLIM((uint32_t)(&__STACK_LIMIT));
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  __TZ_set_STACKSEAL_S((uint32_t *)(&__STACK_SEAL));
+#endif
+
+  SystemInit();                             /* CMSIS System Initialization */
+  __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
+}
+
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wmissing-noreturn"
+#endif
+
+/*----------------------------------------------------------------------------
+  Hard Fault Handler
+ *----------------------------------------------------------------------------*/
+void HardFault_Handler(void)
+{
+  while(1);
+}
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+void Default_Handler(void)
+{
+  while(1);
+}
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic pop
+#endif
+

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35P/RTE/Device/ARMCM35P/system_ARMCM35P.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35P/RTE/Device/ARMCM35P/system_ARMCM35P.c
@@ -1,0 +1,86 @@
+/**************************************************************************//**
+ * @file     system_ARMCM35P.c
+ * @brief    CMSIS Device System Source File for
+ *           ARMCM35P Device
+ * @version  V2.0.0
+ * @date     13. July 2023
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (ARMCM35P)
+  #include "ARMCM35P.h"
+  #if defined (__ARM_FEATURE_CMSE) &&  (__ARM_FEATURE_CMSE == 3U)
+    #include "partition_ARMCM35P.h"
+  #endif
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  Define clocks
+ *----------------------------------------------------------------------------*/
+#define  XTAL            (50000000UL)     /* Oscillator frequency */
+
+#define  SYSTEM_CLOCK    (XTAL / 2U)
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[496];
+
+
+/*----------------------------------------------------------------------------
+  System Core Clock Variable
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = SYSTEM_CLOCK;  /* System Core Clock Frequency */
+
+
+/*----------------------------------------------------------------------------
+  System Core Clock update function
+ *----------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)
+{
+  SystemCoreClock = SYSTEM_CLOCK;
+}
+
+/*----------------------------------------------------------------------------
+  System initialization function
+ *----------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t) &(__VECTOR_TABLE[0]);
+#endif
+
+#if defined (__FPU_USED) && (__FPU_USED == 1U)
+  SCB->CPACR |= ((3U << 10U*2U) |           /* enable CP10 Full Access */
+                 (3U << 11U*2U)  );         /* enable CP11 Full Access */
+#endif
+
+#ifdef UNALIGNED_SUPPORT_DISABLE
+  SCB->CCR |= SCB_CCR_UNALIGN_TRP_Msk;
+#endif
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  TZ_SAU_Setup();
+#endif
+
+  SystemCoreClock = SYSTEM_CLOCK;
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35P/Target.clayer.yml
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35P/Target.clayer.yml
@@ -1,0 +1,35 @@
+layer:
+  type: Target
+  description: CM35P target components and files
+
+  packs:
+    - pack: ARM::Cortex_DFP
+
+  device: ARMCM35P
+
+  processor:
+    trustzone: off
+
+  components:
+    # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
+    - component: ARM::CMSIS:CORE
+    - component: Device:Startup&C Startup
+
+  groups:
+    - group: FVP
+      files:
+        - file: ./model_config.txt
+
+  linker:
+    - for-compiler: AC6
+      script: RTE/Device/$Dname$/ac6_linker_script.sct
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: GCC
+      script: RTE/Device/$Dname$/gcc_linker_script.ld
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: CLANG
+      script: RTE/Device/$Dname$/clang_linker_script.ld
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: IAR
+      script: RTE/Device/$Dname$/iar_linker_script.icf
+      regions: RTE/Device/$Dname$/regions_$Dname$.h

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35P/model_config.txt
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35P/model_config.txt
@@ -1,0 +1,32 @@
+# Parameters:
+# instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+#----------------------------------------------------------------------------------------------
+fvp_mps2.mps2_visualisation.disable-visualisation=1   # (bool  , init-time) default = '0'      : Enable/disable visualisation
+cpu0.FPU=1                                            # (bool  , init-time) default = '1'      : Set whether the model has VFP support
+cpu0.DSP=1                                            # (bool  , init-time) default = '1'      : Set whether the model has the DSP extension
+cpu0.semihosting-enable=1                             # (bool  , init-time) default = '1'      : Enable semihosting SVC traps. Applications that do not use semihosting must set this parameter to false.
+cpu0.semihosting-Thumb_SVC=0xAB                       # (int   , init-time) default = '0xAB'   : T32 SVC number for semihosting : [0x0..0xFF]
+cpu0.semihosting-cmd_line=""                          # (string, init-time) default = ''       : Command line available to semihosting SVC calls
+cpu0.semihosting-heap_base=0x0                        # (int   , init-time) default = '0x0'    : Virtual address of heap base : [0x0..0xFFFFFFFF]
+cpu0.semihosting-heap_limit=0x0                       # (int   , init-time) default = '0x10700000' : Virtual address of top of heap : [0x0..0xFFFFFFFF]
+cpu0.semihosting-stack_base=0x0                       # (int   , init-time) default = '0x10700000' : Virtual address of base of descending stack : [0x0..0xFFFFFFFF]
+cpu0.semihosting-stack_limit=0x0                      # (int   , init-time) default = '0x10800000' : Virtual address of stack limit : [0x0..0xFFFFFFFF]
+cpu0.semihosting-cwd=""                               # (string, init-time) default = ''       : Base directory for semihosting file access.
+cpu0.MPU_S=0x8                                        # (int   , init-time) default = '0x8'    : Number of regions in the Secure MPU. If Security Extentions are absent, this is ignored : [0x0..0x10]
+cpu0.MPU_NS=0x8                                       # (int   , init-time) default = '0x8'    : Number of regions in the Non-Secure MPU. If Security Extentions are absent, this is the total number of MPU regions : [0x0..0x10]
+cpu0.ITM=0                                            # (bool  , init-time) default = '1'      : Level of instrumentation trace supported. false : No ITM trace included, true: ITM trace included
+cpu0.IRQLVL=0x3                                       # (int   , init-time) default = '0x3'    : Number of bits of interrupt priority : [0x3..0x8]
+cpu0.BIGENDINIT=0                                     # (bool  , init-time) default = '0'      : Initialize processor to big endian mode
+cpu0.INITSVTOR=0x00000000                             # (int   , init-time) default = '0x10000000' : Secure vector-table offset at reset : [0x0..0xFFFFFF80]
+cpu0.INITNSVTOR=0x0                                   # (int   , init-time) default = '0x0'    : Non-Secure vector-table offset at reset : [0x0..0xFFFFFF80]
+cpu0.SAU=0x0                                          # (int   , init-time) default = '0x4'    : Number of SAU regions (0 => no SAU) : [0x0..0x8]
+cpu0.SAU_CTRL.ENABLE=0                                # (bool  , init-time) default = '0'      : Enable SAU at reset
+cpu0.SAU_CTRL.ALLNS=0                                 # (bool  , init-time) default = '0'      : At reset, the SAU treats entire memory space as NS when the SAU is disabled if this is set
+idau.NUM_IDAU_REGION=0x0                              # (int   , init-time) default = '0xA'    : 
+cpu0.LOCK_SAU=0                                       # (bool  , init-time) default = '0'      : Lock down of SAU registers write
+cpu0.LOCK_S_MPU=0                                     # (bool  , init-time) default = '0'      : Lock down of Secure MPU registers write
+cpu0.LOCK_NS_MPU=0                                    # (bool  , init-time) default = '0'      : Lock down of Non-Secure MPU registers write
+cpu0.CPIF=1                                           # (bool  , init-time) default = '1'      : Specifies whether the external coprocessor interface is included
+cpu0.SECEXT=0                                         # (bool  , init-time) default = '1'      : Whether the ARMv8-M Security Extensions are included
+fvp_mps2.DISABLE_GATING=1                             # (bool  , init-time) default = '0'      : Disable Memory gating logic
+#----------------------------------------------------------------------------------------------

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35PNS/RTE/Device/ARMCM35P/ac6_linker_script.sct
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35PNS/RTE/Device/ARMCM35P/ac6_linker_script.sct
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE 8
+#else
+#define __STACKSEAL_SIZE 0
+#endif
+
+/*----------------------------------------------------------------------------
+  Scatter File Definitions definition
+ *----------------------------------------------------------------------------*/
+
+LR_ROM0 __ROM0_BASE __ROM0_SIZE  {
+
+  ER_ROM0 __ROM0_BASE __ROM0_SIZE {
+    *.o (RESET, +First)
+    *(InRoot$$Sections)
+    *(+RO +XO)
+  }
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  ER_CMSE_VENEER AlignExpr(+0, 32) (__ROM0_SIZE - AlignExpr(ImageLength(ER_ROM0), 32)) {
+    *(Veneer$$CMSE)
+  }
+#endif
+
+  RW_NOINIT __RAM0_BASE UNINIT (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE) {
+    *(.bss.noinit)
+  }
+
+  RW_RAM0 AlignExpr(+0, 8) (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE - AlignExpr(ImageLength(RW_NOINIT), 8)) {
+    *(+RW +ZI)
+  }
+
+#if __HEAP_SIZE > 0
+  ARM_LIB_HEAP  (AlignExpr(+0, 8)) EMPTY __HEAP_SIZE  {   ; Reserve empty region for heap
+  }
+#endif
+
+  ARM_LIB_STACK (__RAM0_BASE + __RAM0_SIZE - __STACKSEAL_SIZE) EMPTY -__STACK_SIZE {   ; Reserve empty region for stack
+  }
+
+#if __STACKSEAL_SIZE > 0
+  STACKSEAL +0 EMPTY __STACKSEAL_SIZE {             ; Reserve empty region for stack seal immediately after stack
+  }
+#endif
+
+#if __RAM1_SIZE > 0
+  RW_RAM1 __RAM1_BASE __RAM1_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+
+#if __RAM2_SIZE > 0
+  RW_RAM2 __RAM2_BASE __RAM2_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+
+#if __RAM3_SIZE > 0
+  RW_RAM3 __RAM3_BASE __RAM3_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+}
+
+#if __ROM1_SIZE > 0
+LR_ROM1 __ROM1_BASE __ROM1_SIZE  {
+  ER_ROM1 +0 __ROM1_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif
+
+#if __ROM2_SIZE > 0
+LR_ROM2 __ROM2_BASE __ROM2_SIZE  {
+  ER_ROM2 +0 __ROM2_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif
+
+#if __ROM3_SIZE > 0
+LR_ROM3 __ROM3_BASE __ROM3_SIZE  {
+  ER_ROM3 +0 __ROM3_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35PNS/RTE/Device/ARMCM35P/clang_linker_script.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35PNS/RTE/Device/ARMCM35P/clang_linker_script.ld
@@ -1,0 +1,361 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2019 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+/* ----------------------------------------------------------------------------
+  Memory definition
+ *----------------------------------------------------------------------------*/
+MEMORY
+{
+  ROM0  (rx!w)  : ORIGIN = __ROM0_BASE, LENGTH = __ROM0_SIZE
+#if __ROM1_SIZE > 0
+  ROM1  (rx!w)  : ORIGIN = __ROM1_BASE, LENGTH = __ROM1_SIZE
+#endif
+#if __ROM2_SIZE > 0
+  ROM2  (rx!w)  : ORIGIN = __ROM2_BASE, LENGTH = __ROM2_SIZE
+#endif
+#if __ROM3_SIZE > 0
+  ROM3  (rx!w)  : ORIGIN = __ROM3_BASE, LENGTH = __ROM3_SIZE
+#endif
+
+  RAM0  (w!rx) : ORIGIN = __RAM0_BASE, LENGTH = __RAM0_SIZE
+#if __RAM1_SIZE > 0
+  RAM1  (w!rx) : ORIGIN = __RAM1_BASE, LENGTH = __RAM1_SIZE
+#endif
+#if __RAM2_SIZE > 0
+  RAM2  (w!rx) : ORIGIN = __RAM2_BASE, LENGTH = __RAM2_SIZE
+#endif
+#if __RAM3_SIZE > 0
+  RAM3  (w!rx) : ORIGIN = __RAM3_BASE, LENGTH = __RAM3_SIZE
+#endif
+}
+
+ENTRY(Reset_Handler)
+
+PHDRS
+{
+	text PT_LOAD;
+	ram PT_LOAD;
+	ram_init PT_LOAD;
+	tls PT_TLS;
+}
+
+SECTIONS
+{
+	.init : {
+		KEEP (*(.vectors))
+		KEEP (*(.text.init.enter))
+		KEEP (*(.data.init.enter))
+		KEEP (*(SORT_BY_NAME(.init) SORT_BY_NAME(.init.*)))
+	} >ROM0 AT>ROM0 :text
+
+	.text : {
+
+		/* code */
+		*(.text.unlikely .text.unlikely.*)
+		*(.text.startup .text.startup.*)
+		*(.text .text.* .opd .opd.*)
+		*(.gnu.linkonce.t.*)
+		KEEP (*(.fini .fini.*))
+		__text_end = .;
+
+		PROVIDE (__etext = __text_end);
+		PROVIDE (_etext = __text_end);
+		PROVIDE (etext = __text_end);
+
+		/* read-only data */
+		*(.rdata)
+		*(.rodata .rodata.*)
+		*(.gnu.linkonce.r.*)
+
+		*(.srodata.cst16)
+		*(.srodata.cst8)
+		*(.srodata.cst4)
+		*(.srodata.cst2)
+		*(.srodata .srodata.*)
+		*(.data.rel.ro .data.rel.ro.*)
+		*(.got .got.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		/* lists of constructors and destructors */
+		PROVIDE_HIDDEN ( __preinit_array_start = . );
+		KEEP (*(.preinit_array))
+		PROVIDE_HIDDEN ( __preinit_array_end = . );
+
+		PROVIDE_HIDDEN ( __init_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+		KEEP (*(.init_array .ctors))
+		PROVIDE_HIDDEN ( __init_array_end = . );
+
+		PROVIDE_HIDDEN ( __fini_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
+		KEEP (*(.fini_array .dtors))
+		PROVIDE_HIDDEN ( __fini_array_end = . );
+
+	} >ROM0 AT>ROM0 :text
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+	.veneers :
+	{
+		. = ALIGN(32);
+		KEEP(*(.gnu.sgstubs))
+	} > ROM0 AT>ROM0 :text
+#endif
+
+	.toc : {
+		*(.toc .toc.*)
+	} >ROM0 AT>ROM0 :text
+
+	/* additional sections when compiling with C++ exception support */
+	
+	.except_ordered : {
+		*(.gcc_except_table *.gcc_except_table.*)
+		KEEP (*(.eh_frame .eh_frame.*))
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+	} >ROM0 AT>ROM0 :text
+
+	.except_unordered : {
+		. = ALIGN(8);
+
+		PROVIDE(__exidx_start = .);
+		*(.ARM.exidx*)
+		PROVIDE(__exidx_end = .);
+	} >ROM0 AT>ROM0 :text
+	
+
+	/*
+	 * Data values which are preserved across reset
+	 */
+	.preserve (NOLOAD) : {
+		PROVIDE(__preserve_start__ = .);
+		KEEP(*(SORT_BY_NAME(.preserve.*)))
+		KEEP(*(.preserve))
+		PROVIDE(__preserve_end__ = .);
+	} >RAM0 AT>RAM0 :ram
+
+	.data :  {
+		*(.data .data.*)
+		*(.gnu.linkonce.d.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		PROVIDE( __global_pointer$ = . + 0x800 );
+		*(.sdata .sdata.* .sdata2.*)
+		*(.gnu.linkonce.s.*)
+	} >RAM0 AT>ROM0 :ram_init
+	PROVIDE(__data_start = ADDR(.data));
+	PROVIDE(__data_source = LOADADDR(.data));
+
+	/* Thread local initialized data. This gets
+	 * space allocated as it is expected to be placed
+	 * in ram to be used as a template for TLS data blocks
+	 * allocated at runtime. We're slightly abusing that
+	 * by placing the data in flash where it will be copied
+	 * into the allocate ram addresses by the existing
+	 * data initialization code in crt0
+	 */
+	.tdata :  {
+		*(.tdata .tdata.* .gnu.linkonce.td.*)
+		PROVIDE(__data_end = .);
+		PROVIDE(__tdata_end = .);
+	} >RAM0 AT>ROM0 :tls :ram_init
+	PROVIDE( __tls_base = ADDR(.tdata));
+	PROVIDE( __tdata_start = ADDR(.tdata));
+	PROVIDE( __tdata_source = LOADADDR(.tdata) );
+	PROVIDE( __tdata_source_end = LOADADDR(.tdata) + SIZEOF(.tdata) );
+	PROVIDE( __data_source_end = __tdata_source_end );
+	PROVIDE( __tdata_size = SIZEOF(.tdata) );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata),ALIGNOF(.tbss)) );
+
+	PROVIDE( __edata = __data_end );
+	PROVIDE( _edata = __data_end );
+	PROVIDE( edata = __data_end );
+	PROVIDE( __data_size = __data_end - __data_start );
+	PROVIDE( __data_source_size = __data_source_end - __data_source );
+
+	.tbss (NOLOAD) : {
+		*(.tbss .tbss.* .gnu.linkonce.tb.*)
+		*(.tcommon)
+		PROVIDE( __tls_end = . );
+		PROVIDE( __tbss_end = . );
+	} >RAM0 AT>RAM0 :tls :ram
+	PROVIDE( __bss_start = ADDR(.tbss));
+	PROVIDE( __tbss_start = ADDR(.tbss));
+	PROVIDE( __tbss_offset = ADDR(.tbss) - ADDR(.tdata) );
+	PROVIDE( __tbss_size = SIZEOF(.tbss) );
+	PROVIDE( __tls_size = __tls_end - __tls_base );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
+	PROVIDE( __arm32_tls_tcb_offset = MAX(8, __tls_align) );
+	PROVIDE( __arm64_tls_tcb_offset = MAX(16, __tls_align) );
+
+	/*
+	 * The linker special cases .tbss segments which are
+	 * identified as segments which are not loaded and are
+	 * thread_local.
+	 *
+	 * For these segments, the linker does not advance 'dot'
+	 * across them.  We actually need memory allocated for tbss,
+	 * so we create a special segment here just to make room
+	 */
+	/*
+	.tbss_space (NOLOAD) : {
+		. = ADDR(.tbss);
+		. = . + SIZEOF(.tbss);
+	} >RAM0 AT>RAM0 :ram
+	*/
+
+	.bss (NOLOAD) : {
+		*(.sbss*)
+		*(.gnu.linkonce.sb.*)
+		*(.bss .bss.*)
+		*(.gnu.linkonce.b.*)
+		*(COMMON)
+
+		/* Align the heap */
+		. = ALIGN(8);
+		__bss_end = .;
+	} >RAM0 AT>RAM0 :ram
+	PROVIDE( __non_tls_bss_start = ADDR(.bss) );
+	PROVIDE( __end = __bss_end );
+	PROVIDE( _end = __bss_end );
+	PROVIDE( end = __bss_end );
+	PROVIDE( __bss_size = __bss_end - __bss_start );
+
+	/* Make the rest of memory available for heap storage */
+	PROVIDE (__heap_start = __end);
+#ifdef __HEAP_SIZE
+	PROVIDE (__heap_end = __heap_start + __HEAP_SIZE);
+	PROVIDE (__heap_size = __HEAP_SIZE);
+#else
+	PROVIDE (__heap_end = __stack - __STACK_SIZE);
+	PROVIDE (__heap_size = __heap_end - __heap_start);
+#endif
+	.heap (NOLOAD) : {
+		. += __heap_size;
+	} >RAM0 :ram
+
+	/* Define a stack region to make sure it fits in memory */
+	PROVIDE(__stack = ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE);
+	PROVIDE(__stack_limit = __stack - __STACK_SIZE);
+	.stack (__stack_limit) (NOLOAD) : {
+		. += __STACK_SIZE;
+	} >RAM0 :ram
+
+#if __STACKSEAL_SIZE > 0
+	PROVIDE(__stack_seal = __stack);
+  	.stackseal (__stack) (NOLOAD) :
+  	{
+    	. += __STACKSEAL_SIZE;
+  	} >RAM0 :ram
+#endif
+
+	/* Throw away C++ exception handling information */
+
+	/*
+
+	/DISCARD/ : {
+		*(.note .note.*)
+		*(.eh_frame .eh_frame.*)
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+		*(.ARM.exidx*)
+	}
+
+	*/
+
+	/* Stabs debugging sections.  */
+	.stab          0 : { *(.stab) }
+	.stabstr       0 : { *(.stabstr) }
+	.stab.excl     0 : { *(.stab.excl) }
+	.stab.exclstr  0 : { *(.stab.exclstr) }
+	.stab.index    0 : { *(.stab.index) }
+	.stab.indexstr 0 : { *(.stab.indexstr) }
+	.comment       0 : { *(.comment) }
+	.gnu.build.attributes : { *(.gnu.build.attributes .gnu.build.attributes.*) }
+	/* DWARF debug sections.
+	   Symbols in the DWARF debugging sections are relative to the beginning
+	   of the section so we begin them at 0.  */
+	/* DWARF 1.  */
+	.debug          0 : { *(.debug) }
+	.line           0 : { *(.line) }
+	/* GNU DWARF 1 extensions.  */
+	.debug_srcinfo  0 : { *(.debug_srcinfo) }
+	.debug_sfnames  0 : { *(.debug_sfnames) }
+	/* DWARF 1.1 and DWARF 2.  */
+	.debug_aranges  0 : { *(.debug_aranges) }
+	.debug_pubnames 0 : { *(.debug_pubnames) }
+	/* DWARF 2.  */
+	.debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+	.debug_abbrev   0 : { *(.debug_abbrev) }
+	.debug_line     0 : { *(.debug_line .debug_line.* .debug_line_end) }
+	.debug_frame    0 : { *(.debug_frame) }
+	.debug_str      0 : { *(.debug_str) }
+	.debug_loc      0 : { *(.debug_loc) }
+	.debug_macinfo  0 : { *(.debug_macinfo) }
+	/* SGI/MIPS DWARF 2 extensions.  */
+	.debug_weaknames 0 : { *(.debug_weaknames) }
+	.debug_funcnames 0 : { *(.debug_funcnames) }
+	.debug_typenames 0 : { *(.debug_typenames) }
+	.debug_varnames  0 : { *(.debug_varnames) }
+	/* DWARF 3.  */
+	.debug_pubtypes 0 : { *(.debug_pubtypes) }
+	.debug_ranges   0 : { *(.debug_ranges) }
+	/* DWARF 5.  */
+	.debug_addr     0 : { *(.debug_addr) }
+	.debug_line_str 0 : { *(.debug_line_str) }
+	.debug_loclists 0 : { *(.debug_loclists) }
+	.debug_macro    0 : { *(.debug_macro) }
+	.debug_names    0 : { *(.debug_names) }
+	.debug_rnglists 0 : { *(.debug_rnglists) }
+	.debug_str_offsets 0 : { *(.debug_str_offsets) }
+	.debug_sup      0 : { *(.debug_sup) }
+	.gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }
+}
+/*
+ * Check that sections that are copied from flash to RAM have matching
+ * padding, so that a single memcpy() of __data_size copies the correct bytes.
+ */
+ASSERT( __data_size == __data_source_size,
+	"ERROR: .data/.tdata flash size does not match RAM size");

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35PNS/RTE/Device/ARMCM35P/gcc_linker_script.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35PNS/RTE/Device/ARMCM35P/gcc_linker_script.ld
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+/* ----------------------------------------------------------------------------
+  Memory definition
+ *----------------------------------------------------------------------------*/
+MEMORY
+{
+  ROM0  (rx)  : ORIGIN = __ROM0_BASE, LENGTH = __ROM0_SIZE
+#if __ROM1_SIZE > 0
+  ROM1  (rx)  : ORIGIN = __ROM1_BASE, LENGTH = __ROM1_SIZE
+#endif
+#if __ROM2_SIZE > 0
+  ROM2  (rx)  : ORIGIN = __ROM2_BASE, LENGTH = __ROM2_SIZE
+#endif
+#if __ROM3_SIZE > 0
+  ROM3  (rx)  : ORIGIN = __ROM3_BASE, LENGTH = __ROM3_SIZE
+#endif
+
+  RAM0  (rwx) : ORIGIN = __RAM0_BASE, LENGTH = __RAM0_SIZE
+#if __RAM1_SIZE > 0
+  RAM1  (rwx) : ORIGIN = __RAM1_BASE, LENGTH = __RAM1_SIZE
+#endif
+#if __RAM2_SIZE > 0
+  RAM2  (rwx) : ORIGIN = __RAM2_BASE, LENGTH = __RAM2_SIZE
+#endif
+#if __RAM3_SIZE > 0
+  RAM3  (rwx) : ORIGIN = __RAM3_BASE, LENGTH = __RAM3_SIZE
+#endif
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __copy_table_start__
+ *   __copy_table_end__
+ *   __zero_table_start__
+ *   __zero_table_end__
+ *   __etext          (deprecated)
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+  .text :
+  {
+    KEEP(*(.vectors))
+    *(.text*)
+
+    KEEP(*(.init))
+    KEEP(*(.fini))
+
+    /* .ctors */
+    *crtbegin.o(.ctors)
+    *crtbegin?.o(.ctors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+    *(SORT(.ctors.*))
+    *(.ctors)
+
+    /* .dtors */
+    *crtbegin.o(.dtors)
+    *crtbegin?.o(.dtors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+    *(SORT(.dtors.*))
+    *(.dtors)
+
+    *(.rodata*)
+
+    KEEP(*(.eh_frame*))
+  } > ROM0
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  .gnu.sgstubs :
+  {
+    . = ALIGN(32);
+  } > ROM0
+#endif
+
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > ROM0
+
+  __exidx_start = .;
+  .ARM.exidx :
+  {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+  } > ROM0
+  __exidx_end = .;
+
+  .copy.table :
+  {
+    . = ALIGN(4);
+    __copy_table_start__ = .;
+
+    LONG (LOADADDR(.data))
+    LONG (ADDR(.data))
+    LONG (SIZEOF(.data) / 4)
+
+    /* Add each additional data section here */
+/*
+    LONG (LOADADDR(.data2))
+    LONG (ADDR(.data2))
+    LONG (SIZEOF(.data2) / 4)
+*/
+    __copy_table_end__ = .;
+  } > ROM0
+
+  .zero.table :
+  {
+    . = ALIGN(4);
+    __zero_table_start__ = .;
+
+/*  .bss initialization to zero is already done during C Run-Time Startup.
+    LONG (ADDR(.bss))
+    LONG (SIZEOF(.bss) / 4)
+*/
+
+    /* Add each additional bss section here */
+/*
+    LONG (ADDR(.bss2))
+    LONG (SIZEOF(.bss2) / 4)
+*/
+    __zero_table_end__ = .;
+  } > ROM0
+
+  /*
+   * This __etext variable is kept for backward compatibility with older,
+   * ASM based startup files.
+   */
+  PROVIDE(__etext = LOADADDR(.data));
+
+  .data : ALIGN(4)
+  {
+    __data_start__ = .;
+    *(vtable)
+    *(.data)
+    *(.data.*)
+
+    . = ALIGN(4);
+    /* preinit data */
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP(*(.preinit_array))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+
+    . = ALIGN(4);
+    /* init data */
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP(*(SORT(.init_array.*)))
+    KEEP(*(.init_array))
+    PROVIDE_HIDDEN (__init_array_end = .);
+
+    . = ALIGN(4);
+    /* finit data */
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP(*(SORT(.fini_array.*)))
+    KEEP(*(.fini_array))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    /* All data end */
+    __data_end__ = .;
+
+  } > RAM0 AT > ROM0
+
+  /*
+   * Secondary data section, optional
+   *
+   * Remember to add each additional data section
+   * to the .copy.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .data2 : ALIGN(4)
+  {
+    . = ALIGN(4);
+    __data2_start__ = .;
+    *(.data2)
+    *(.data2.*)
+    . = ALIGN(4);
+    __data2_end__ = .;
+
+  } > RAM1 AT > ROM0 
+*/
+
+  .bss :
+  {
+    . = ALIGN(4);
+    __bss_start__ = .;
+    *(.bss)
+    *(.bss.*)
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+  } > RAM0 AT > RAM0
+
+  /*
+   * Secondary bss section, optional
+   *
+   * Remember to add each additional bss section
+   * to the .zero.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .bss2 :
+  {
+    . = ALIGN(4);
+    __bss2_start__ = .;
+    *(.bss2)
+    *(.bss2.*)
+    . = ALIGN(4);
+    __bss2_end__ = .;
+  } > RAM1 AT > RAM1
+*/
+
+  .heap (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE(end = .);
+    . = . + __HEAP_SIZE;
+    . = ALIGN(8);
+    __HeapLimit = .;
+  } > RAM0
+
+  .stack (ORIGIN(RAM0) + LENGTH(RAM0) - __STACK_SIZE - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackLimit = .;
+    . = . + __STACK_SIZE;
+    . = ALIGN(8);
+    __StackTop = .;
+  } > RAM0
+  PROVIDE(__stack = __StackTop);
+
+#if __STACKSEAL_SIZE > 0
+  .stackseal (ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackSeal = .;
+    . = . + 8;
+    . = ALIGN(8);
+  } > RAM0
+#endif
+
+  /* Check if data + heap + stack exceeds RAM limit */
+  ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35PNS/RTE/Device/ARMCM35P/iar_linker_script.icf
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35PNS/RTE/Device/ARMCM35P/iar_linker_script.icf
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+define memory mem with size = 4G;
+
+#if __ROM0_SIZE > 0
+  define region ROM0_region = mem:[from __ROM0_BASE to (__ROM0_BASE+__ROM0_SIZE-1)];
+#else
+  define region ROM0_region = [];
+#endif
+
+#if __ROM1_SIZE > 0
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+#else
+  define region ROM1_region = [];
+#endif
+
+#if __ROM2_SIZE > 0
+  define region ROM2_region = mem:[from __ROM2_BASE to (__ROM2_BASE+__ROM2_SIZE-1)];
+#else
+  define region ROM2_region = [];
+#endif
+
+#if __ROM3_SIZE > 0
+  define region ROM3_region = mem:[from __ROM3_BASE to (__ROM3_BASE+__ROM3_SIZE-1)];
+#else
+  define region ROM3_region = [];
+#endif
+
+define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_region;
+
+#if __RAM0_SIZE > 0
+  define region RAM0_region = mem:[from __RAM0_BASE to (__RAM0_BASE+__RAM0_SIZE-1)];
+#else
+  define region RAM0_region = [];
+#endif
+
+#if __RAM1_SIZE > 0
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+#else
+  define region RAM1_region = [];
+#endif
+
+#if __RAM2_SIZE > 0
+  define region RAM2_region = mem:[from __RAM2_BASE to (__RAM2_BASE+__RAM2_SIZE-1)];
+#else
+  define region RAM2_region = [];
+#endif
+
+#if __RAM3_SIZE > 0
+  define region RAM3_region = mem:[from __RAM3_BASE to (__RAM3_BASE+__RAM3_SIZE-1)];
+#else
+  define region RAM3_region = [];
+#endif
+
+define region RAM_region = RAM0_region | RAM1_region | RAM2_region | RAM3_region;
+
+do not initialize  { section .noinit };
+initialize by copy { readwrite };
+if (isdefinedsymbol(__USE_DLIB_PERTHREAD))
+{
+  // Required in a multi-threaded application
+  initialize by copy with packing = none { section __DLIB_PERTHREAD };
+}
+
+place at address mem:__ROM0_BASE { readonly section .intvec };
+
+if (!isempty(ROM_region))
+{
+  place in ROM_region  { readonly };
+}
+
+if (!isempty(RAM_region))
+{
+  define block CSTACK     with alignment = 8, size = __STACK_SIZE     { };
+  define block PROC_STACK with alignment = 8, size = 0 { };
+  define block HEAP       with alignment = 8, size = __HEAP_SIZE       { };
+  place in RAM_region  { readwrite, block CSTACK, block PROC_STACK, block HEAP };
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35PNS/RTE/Device/ARMCM35P/regions_ARMCM35P.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35PNS/RTE/Device/ARMCM35P/regions_ARMCM35P.h
@@ -1,0 +1,94 @@
+#ifndef REGIONS_ARMCM35P_H
+#define REGIONS_ARMCM35P_H
+
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+// <n>Device pack:   ARM::Cortex_DFP@1.0.0-dev16
+// <i>Device pack used to generate this file
+
+// <h>ROM Configuration
+// =======================
+// <h> ROM_S=<__ROM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x00000000
+#define __ROM0_BASE 0x00200000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00200000
+#define __ROM0_SIZE 0x00200000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __ROM0_DEFAULT 1
+//   <q>Startup
+//   <i> Selects region to be used for startup code.
+#define __ROM0_STARTUP 1
+// </h>
+
+// <h> ROM_NS=<__ROM1>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x00200000
+#define __ROM1_BASE 0x00000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00200000
+#define __ROM1_SIZE 0x00200000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __ROM1_DEFAULT 0
+//   <q>Startup
+//   <i> Selects region to be used for startup code.
+#define __ROM1_STARTUP 0
+// </h>
+
+// </h>
+
+// <h>RAM Configuration
+// =======================
+// <h> RAM_S=<__RAM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x20000000
+#define __RAM0_BASE 0x20200000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00020000
+#define __RAM0_SIZE 0x00020000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __RAM0_DEFAULT 1
+//   <q>No zero initialize
+//   <i> Excludes region from zero initialization.
+#define __RAM0_NOINIT 0
+// </h>
+
+// <h> RAM_NS=<__RAM1>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x20200000
+#define __RAM1_BASE 0x20000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00020000
+#define __RAM1_SIZE 0x00020000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __RAM1_DEFAULT 0
+//   <q>No zero initialize
+//   <i> Excludes region from zero initialization.
+#define __RAM1_NOINIT 0
+// </h>
+
+// </h>
+
+// <h>Stack / Heap Configuration
+//   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+#define __STACK_SIZE 0x00000400
+#define __HEAP_SIZE 0x00000C00
+// </h>
+
+
+#endif /* REGIONS_ARMCM35P_H */

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35PNS/RTE/Device/ARMCM35P/startup_ARMCM35P.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35PNS/RTE/Device/ARMCM35P/startup_ARMCM35P.c
@@ -1,0 +1,164 @@
+/******************************************************************************
+ * @file     startup_ARMCM35P.c
+ * @brief    CMSIS-Core Device Startup File for Cortex-M35P Device
+ * @version  V3.0.0
+ * @date     13. July 2023
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (ARMCM35P)
+  #include "ARMCM35P.h"
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  External References
+ *----------------------------------------------------------------------------*/
+extern uint32_t __INITIAL_SP;
+extern uint32_t __STACK_LIMIT;
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+extern uint32_t __STACK_SEAL;
+#endif
+
+extern __NO_RETURN void __PROGRAM_START(void);
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler  (void);
+            void Default_Handler(void);
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+/* Exceptions */
+void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void HardFault_Handler      (void) __attribute__ ((weak));
+void MemManage_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
+void BusFault_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void UsageFault_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void SecureFault_Handler    (void) __attribute__ ((weak, alias("Default_Handler")));
+void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void DebugMon_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+
+void Interrupt0_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt1_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt2_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt3_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt4_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt5_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt6_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt7_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt8_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt9_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[496];
+       const VECTOR_TABLE_Type __VECTOR_TABLE[496] __VECTOR_TABLE_ATTRIBUTE = {
+  (VECTOR_TABLE_Type)(&__INITIAL_SP),       /*     Initial Stack Pointer */
+  Reset_Handler,                            /*     Reset Handler */
+  NMI_Handler,                              /* -14 NMI Handler */
+  HardFault_Handler,                        /* -13 Hard Fault Handler */
+  MemManage_Handler,                        /* -12 MPU Fault Handler */
+  BusFault_Handler,                         /* -11 Bus Fault Handler */
+  UsageFault_Handler,                       /* -10 Usage Fault Handler */
+  SecureFault_Handler,                      /*  -9 Secure Fault Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  SVC_Handler,                              /*  -5 SVC Handler */
+  DebugMon_Handler,                         /*  -4 Debug Monitor Handler */
+  0,                                        /*     Reserved */
+  PendSV_Handler,                           /*  -2 PendSV Handler */
+  SysTick_Handler,                          /*  -1 SysTick Handler */
+
+  /* Interrupts */
+  Interrupt0_Handler,                       /*   0 Interrupt 0 */
+  Interrupt1_Handler,                       /*   1 Interrupt 1 */
+  Interrupt2_Handler,                       /*   2 Interrupt 2 */
+  Interrupt3_Handler,                       /*   3 Interrupt 3 */
+  Interrupt4_Handler,                       /*   4 Interrupt 4 */
+  Interrupt5_Handler,                       /*   5 Interrupt 5 */
+  Interrupt6_Handler,                       /*   6 Interrupt 6 */
+  Interrupt7_Handler,                       /*   7 Interrupt 7 */
+  Interrupt8_Handler,                       /*   8 Interrupt 8 */
+  Interrupt9_Handler                        /*   9 Interrupt 9 */
+                                            /* Interrupts 10 .. 480 are left out */
+};
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler(void)
+{
+  __set_PSP((uint32_t)(&__INITIAL_SP));
+
+  __set_MSPLIM((uint32_t)(&__STACK_LIMIT));
+  __set_PSPLIM((uint32_t)(&__STACK_LIMIT));
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  __TZ_set_STACKSEAL_S((uint32_t *)(&__STACK_SEAL));
+#endif
+
+  SystemInit();                             /* CMSIS System Initialization */
+  __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
+}
+
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wmissing-noreturn"
+#endif
+
+/*----------------------------------------------------------------------------
+  Hard Fault Handler
+ *----------------------------------------------------------------------------*/
+void HardFault_Handler(void)
+{
+  while(1);
+}
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+void Default_Handler(void)
+{
+  while(1);
+}
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic pop
+#endif
+

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35PNS/RTE/Device/ARMCM35P/system_ARMCM35P.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35PNS/RTE/Device/ARMCM35P/system_ARMCM35P.c
@@ -1,0 +1,86 @@
+/**************************************************************************//**
+ * @file     system_ARMCM35P.c
+ * @brief    CMSIS Device System Source File for
+ *           ARMCM35P Device
+ * @version  V2.0.0
+ * @date     13. July 2023
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (ARMCM35P)
+  #include "ARMCM35P.h"
+  #if defined (__ARM_FEATURE_CMSE) &&  (__ARM_FEATURE_CMSE == 3U)
+    #include "partition_ARMCM35P.h"
+  #endif
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  Define clocks
+ *----------------------------------------------------------------------------*/
+#define  XTAL            (50000000UL)     /* Oscillator frequency */
+
+#define  SYSTEM_CLOCK    (XTAL / 2U)
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[496];
+
+
+/*----------------------------------------------------------------------------
+  System Core Clock Variable
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = SYSTEM_CLOCK;  /* System Core Clock Frequency */
+
+
+/*----------------------------------------------------------------------------
+  System Core Clock update function
+ *----------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)
+{
+  SystemCoreClock = SYSTEM_CLOCK;
+}
+
+/*----------------------------------------------------------------------------
+  System initialization function
+ *----------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t) &(__VECTOR_TABLE[0]);
+#endif
+
+#if defined (__FPU_USED) && (__FPU_USED == 1U)
+  SCB->CPACR |= ((3U << 10U*2U) |           /* enable CP10 Full Access */
+                 (3U << 11U*2U)  );         /* enable CP11 Full Access */
+#endif
+
+#ifdef UNALIGNED_SUPPORT_DISABLE
+  SCB->CCR |= SCB_CCR_UNALIGN_TRP_Msk;
+#endif
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  TZ_SAU_Setup();
+#endif
+
+  SystemCoreClock = SYSTEM_CLOCK;
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35PNS/Target.clayer.yml
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35PNS/Target.clayer.yml
@@ -1,0 +1,35 @@
+layer:
+  type: Target
+  description: CM35PNS target components and files
+
+  packs:
+    - pack: ARM::Cortex_DFP
+
+  device: ARMCM35P
+
+  processor:
+    trustzone: non-secure
+
+  components:
+    # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
+    - component: ARM::CMSIS:CORE
+    - component: Device:Startup&C Startup
+
+  groups:
+    - group: FVP
+      files:
+        - file: ./model_config.txt
+
+  linker:
+    - for-compiler: AC6
+      script: RTE/Device/$Dname$/ac6_linker_script.sct
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: GCC
+      script: RTE/Device/$Dname$/gcc_linker_script.ld
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: CLANG
+      script: RTE/Device/$Dname$/clang_linker_script.ld
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: IAR
+      script: RTE/Device/$Dname$/iar_linker_script.icf
+      regions: RTE/Device/$Dname$/regions_$Dname$.h

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35PNS/model_config.txt
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35PNS/model_config.txt
@@ -1,0 +1,32 @@
+# Parameters:
+# instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+#----------------------------------------------------------------------------------------------
+fvp_mps2.mps2_visualisation.disable-visualisation=1   # (bool  , init-time) default = '0'      : Enable/disable visualisation
+cpu0.FPU=1                                            # (bool  , init-time) default = '1'      : Set whether the model has VFP support
+cpu0.DSP=1                                            # (bool  , init-time) default = '1'      : Set whether the model has the DSP extension
+cpu0.semihosting-enable=1                             # (bool  , init-time) default = '1'      : Enable semihosting SVC traps. Applications that do not use semihosting must set this parameter to false.
+cpu0.semihosting-Thumb_SVC=0xAB                       # (int   , init-time) default = '0xAB'   : T32 SVC number for semihosting : [0x0..0xFF]
+cpu0.semihosting-cmd_line=""                          # (string, init-time) default = ''       : Command line available to semihosting SVC calls
+cpu0.semihosting-heap_base=0x0                        # (int   , init-time) default = '0x0'    : Virtual address of heap base : [0x0..0xFFFFFFFF]
+cpu0.semihosting-heap_limit=0x0                       # (int   , init-time) default = '0x10700000' : Virtual address of top of heap : [0x0..0xFFFFFFFF]
+cpu0.semihosting-stack_base=0x0                       # (int   , init-time) default = '0x10700000' : Virtual address of base of descending stack : [0x0..0xFFFFFFFF]
+cpu0.semihosting-stack_limit=0x0                      # (int   , init-time) default = '0x10800000' : Virtual address of stack limit : [0x0..0xFFFFFFFF]
+cpu0.semihosting-cwd=""                               # (string, init-time) default = ''       : Base directory for semihosting file access.
+cpu0.MPU_S=0x8                                        # (int   , init-time) default = '0x8'    : Number of regions in the Secure MPU. If Security Extentions are absent, this is ignored : [0x0..0x10]
+cpu0.MPU_NS=0x8                                       # (int   , init-time) default = '0x8'    : Number of regions in the Non-Secure MPU. If Security Extentions are absent, this is the total number of MPU regions : [0x0..0x10]
+cpu0.ITM=0                                            # (bool  , init-time) default = '1'      : Level of instrumentation trace supported. false : No ITM trace included, true: ITM trace included
+cpu0.IRQLVL=0x3                                       # (int   , init-time) default = '0x3'    : Number of bits of interrupt priority : [0x3..0x8]
+cpu0.BIGENDINIT=0                                     # (bool  , init-time) default = '0'      : Initialize processor to big endian mode
+cpu0.INITSVTOR=0x00000000                             # (int   , init-time) default = '0x10000000' : Secure vector-table offset at reset : [0x0..0xFFFFFF80]
+cpu0.INITNSVTOR=0x0                                   # (int   , init-time) default = '0x0'    : Non-Secure vector-table offset at reset : [0x0..0xFFFFFF80]
+cpu0.SAU=0x8                                          # (int   , init-time) default = '0x4'    : Number of SAU regions (0 => no SAU) : [0x0..0x8]
+cpu0.SAU_CTRL.ENABLE=0                                # (bool  , init-time) default = '0'      : Enable SAU at reset
+cpu0.SAU_CTRL.ALLNS=0                                 # (bool  , init-time) default = '0'      : At reset, the SAU treats entire memory space as NS when the SAU is disabled if this is set
+idau.NUM_IDAU_REGION=0x0                              # (int   , init-time) default = '0xA'    : 
+cpu0.LOCK_SAU=0                                       # (bool  , init-time) default = '0'      : Lock down of SAU registers write
+cpu0.LOCK_S_MPU=0                                     # (bool  , init-time) default = '0'      : Lock down of Secure MPU registers write
+cpu0.LOCK_NS_MPU=0                                    # (bool  , init-time) default = '0'      : Lock down of Non-Secure MPU registers write
+cpu0.CPIF=1                                           # (bool  , init-time) default = '1'      : Specifies whether the external coprocessor interface is included
+cpu0.SECEXT=1                                         # (bool  , init-time) default = '1'      : Whether the ARMv8-M Security Extensions are included
+fvp_mps2.DISABLE_GATING=1                             # (bool  , init-time) default = '0'      : Disable Memory gating logic
+#----------------------------------------------------------------------------------------------

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35PS/RTE/Device/ARMCM35P/ac6_linker_script.sct
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35PS/RTE/Device/ARMCM35P/ac6_linker_script.sct
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE 8
+#else
+#define __STACKSEAL_SIZE 0
+#endif
+
+/*----------------------------------------------------------------------------
+  Scatter File Definitions definition
+ *----------------------------------------------------------------------------*/
+
+LR_ROM0 __ROM0_BASE __ROM0_SIZE  {
+
+  ER_ROM0 __ROM0_BASE __ROM0_SIZE {
+    *.o (RESET, +First)
+    *(InRoot$$Sections)
+    *(+RO +XO)
+  }
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  ER_CMSE_VENEER AlignExpr(+0, 32) (__ROM0_SIZE - AlignExpr(ImageLength(ER_ROM0), 32)) {
+    *(Veneer$$CMSE)
+  }
+#endif
+
+  RW_NOINIT __RAM0_BASE UNINIT (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE) {
+    *(.bss.noinit)
+  }
+
+  RW_RAM0 AlignExpr(+0, 8) (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE - AlignExpr(ImageLength(RW_NOINIT), 8)) {
+    *(+RW +ZI)
+  }
+
+#if __HEAP_SIZE > 0
+  ARM_LIB_HEAP  (AlignExpr(+0, 8)) EMPTY __HEAP_SIZE  {   ; Reserve empty region for heap
+  }
+#endif
+
+  ARM_LIB_STACK (__RAM0_BASE + __RAM0_SIZE - __STACKSEAL_SIZE) EMPTY -__STACK_SIZE {   ; Reserve empty region for stack
+  }
+
+#if __STACKSEAL_SIZE > 0
+  STACKSEAL +0 EMPTY __STACKSEAL_SIZE {             ; Reserve empty region for stack seal immediately after stack
+  }
+#endif
+
+#if __RAM1_SIZE > 0
+  RW_RAM1 __RAM1_BASE __RAM1_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+
+#if __RAM2_SIZE > 0
+  RW_RAM2 __RAM2_BASE __RAM2_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+
+#if __RAM3_SIZE > 0
+  RW_RAM3 __RAM3_BASE __RAM3_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+}
+
+#if __ROM1_SIZE > 0
+LR_ROM1 __ROM1_BASE __ROM1_SIZE  {
+  ER_ROM1 +0 __ROM1_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif
+
+#if __ROM2_SIZE > 0
+LR_ROM2 __ROM2_BASE __ROM2_SIZE  {
+  ER_ROM2 +0 __ROM2_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif
+
+#if __ROM3_SIZE > 0
+LR_ROM3 __ROM3_BASE __ROM3_SIZE  {
+  ER_ROM3 +0 __ROM3_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35PS/RTE/Device/ARMCM35P/clang_linker_script.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35PS/RTE/Device/ARMCM35P/clang_linker_script.ld
@@ -1,0 +1,361 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2019 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+/* ----------------------------------------------------------------------------
+  Memory definition
+ *----------------------------------------------------------------------------*/
+MEMORY
+{
+  ROM0  (rx!w)  : ORIGIN = __ROM0_BASE, LENGTH = __ROM0_SIZE
+#if __ROM1_SIZE > 0
+  ROM1  (rx!w)  : ORIGIN = __ROM1_BASE, LENGTH = __ROM1_SIZE
+#endif
+#if __ROM2_SIZE > 0
+  ROM2  (rx!w)  : ORIGIN = __ROM2_BASE, LENGTH = __ROM2_SIZE
+#endif
+#if __ROM3_SIZE > 0
+  ROM3  (rx!w)  : ORIGIN = __ROM3_BASE, LENGTH = __ROM3_SIZE
+#endif
+
+  RAM0  (w!rx) : ORIGIN = __RAM0_BASE, LENGTH = __RAM0_SIZE
+#if __RAM1_SIZE > 0
+  RAM1  (w!rx) : ORIGIN = __RAM1_BASE, LENGTH = __RAM1_SIZE
+#endif
+#if __RAM2_SIZE > 0
+  RAM2  (w!rx) : ORIGIN = __RAM2_BASE, LENGTH = __RAM2_SIZE
+#endif
+#if __RAM3_SIZE > 0
+  RAM3  (w!rx) : ORIGIN = __RAM3_BASE, LENGTH = __RAM3_SIZE
+#endif
+}
+
+ENTRY(Reset_Handler)
+
+PHDRS
+{
+	text PT_LOAD;
+	ram PT_LOAD;
+	ram_init PT_LOAD;
+	tls PT_TLS;
+}
+
+SECTIONS
+{
+	.init : {
+		KEEP (*(.vectors))
+		KEEP (*(.text.init.enter))
+		KEEP (*(.data.init.enter))
+		KEEP (*(SORT_BY_NAME(.init) SORT_BY_NAME(.init.*)))
+	} >ROM0 AT>ROM0 :text
+
+	.text : {
+
+		/* code */
+		*(.text.unlikely .text.unlikely.*)
+		*(.text.startup .text.startup.*)
+		*(.text .text.* .opd .opd.*)
+		*(.gnu.linkonce.t.*)
+		KEEP (*(.fini .fini.*))
+		__text_end = .;
+
+		PROVIDE (__etext = __text_end);
+		PROVIDE (_etext = __text_end);
+		PROVIDE (etext = __text_end);
+
+		/* read-only data */
+		*(.rdata)
+		*(.rodata .rodata.*)
+		*(.gnu.linkonce.r.*)
+
+		*(.srodata.cst16)
+		*(.srodata.cst8)
+		*(.srodata.cst4)
+		*(.srodata.cst2)
+		*(.srodata .srodata.*)
+		*(.data.rel.ro .data.rel.ro.*)
+		*(.got .got.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		/* lists of constructors and destructors */
+		PROVIDE_HIDDEN ( __preinit_array_start = . );
+		KEEP (*(.preinit_array))
+		PROVIDE_HIDDEN ( __preinit_array_end = . );
+
+		PROVIDE_HIDDEN ( __init_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+		KEEP (*(.init_array .ctors))
+		PROVIDE_HIDDEN ( __init_array_end = . );
+
+		PROVIDE_HIDDEN ( __fini_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
+		KEEP (*(.fini_array .dtors))
+		PROVIDE_HIDDEN ( __fini_array_end = . );
+
+	} >ROM0 AT>ROM0 :text
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+	.veneers :
+	{
+		. = ALIGN(32);
+		KEEP(*(.gnu.sgstubs))
+	} > ROM0 AT>ROM0 :text
+#endif
+
+	.toc : {
+		*(.toc .toc.*)
+	} >ROM0 AT>ROM0 :text
+
+	/* additional sections when compiling with C++ exception support */
+	
+	.except_ordered : {
+		*(.gcc_except_table *.gcc_except_table.*)
+		KEEP (*(.eh_frame .eh_frame.*))
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+	} >ROM0 AT>ROM0 :text
+
+	.except_unordered : {
+		. = ALIGN(8);
+
+		PROVIDE(__exidx_start = .);
+		*(.ARM.exidx*)
+		PROVIDE(__exidx_end = .);
+	} >ROM0 AT>ROM0 :text
+	
+
+	/*
+	 * Data values which are preserved across reset
+	 */
+	.preserve (NOLOAD) : {
+		PROVIDE(__preserve_start__ = .);
+		KEEP(*(SORT_BY_NAME(.preserve.*)))
+		KEEP(*(.preserve))
+		PROVIDE(__preserve_end__ = .);
+	} >RAM0 AT>RAM0 :ram
+
+	.data :  {
+		*(.data .data.*)
+		*(.gnu.linkonce.d.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		PROVIDE( __global_pointer$ = . + 0x800 );
+		*(.sdata .sdata.* .sdata2.*)
+		*(.gnu.linkonce.s.*)
+	} >RAM0 AT>ROM0 :ram_init
+	PROVIDE(__data_start = ADDR(.data));
+	PROVIDE(__data_source = LOADADDR(.data));
+
+	/* Thread local initialized data. This gets
+	 * space allocated as it is expected to be placed
+	 * in ram to be used as a template for TLS data blocks
+	 * allocated at runtime. We're slightly abusing that
+	 * by placing the data in flash where it will be copied
+	 * into the allocate ram addresses by the existing
+	 * data initialization code in crt0
+	 */
+	.tdata :  {
+		*(.tdata .tdata.* .gnu.linkonce.td.*)
+		PROVIDE(__data_end = .);
+		PROVIDE(__tdata_end = .);
+	} >RAM0 AT>ROM0 :tls :ram_init
+	PROVIDE( __tls_base = ADDR(.tdata));
+	PROVIDE( __tdata_start = ADDR(.tdata));
+	PROVIDE( __tdata_source = LOADADDR(.tdata) );
+	PROVIDE( __tdata_source_end = LOADADDR(.tdata) + SIZEOF(.tdata) );
+	PROVIDE( __data_source_end = __tdata_source_end );
+	PROVIDE( __tdata_size = SIZEOF(.tdata) );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata),ALIGNOF(.tbss)) );
+
+	PROVIDE( __edata = __data_end );
+	PROVIDE( _edata = __data_end );
+	PROVIDE( edata = __data_end );
+	PROVIDE( __data_size = __data_end - __data_start );
+	PROVIDE( __data_source_size = __data_source_end - __data_source );
+
+	.tbss (NOLOAD) : {
+		*(.tbss .tbss.* .gnu.linkonce.tb.*)
+		*(.tcommon)
+		PROVIDE( __tls_end = . );
+		PROVIDE( __tbss_end = . );
+	} >RAM0 AT>RAM0 :tls :ram
+	PROVIDE( __bss_start = ADDR(.tbss));
+	PROVIDE( __tbss_start = ADDR(.tbss));
+	PROVIDE( __tbss_offset = ADDR(.tbss) - ADDR(.tdata) );
+	PROVIDE( __tbss_size = SIZEOF(.tbss) );
+	PROVIDE( __tls_size = __tls_end - __tls_base );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
+	PROVIDE( __arm32_tls_tcb_offset = MAX(8, __tls_align) );
+	PROVIDE( __arm64_tls_tcb_offset = MAX(16, __tls_align) );
+
+	/*
+	 * The linker special cases .tbss segments which are
+	 * identified as segments which are not loaded and are
+	 * thread_local.
+	 *
+	 * For these segments, the linker does not advance 'dot'
+	 * across them.  We actually need memory allocated for tbss,
+	 * so we create a special segment here just to make room
+	 */
+	/*
+	.tbss_space (NOLOAD) : {
+		. = ADDR(.tbss);
+		. = . + SIZEOF(.tbss);
+	} >RAM0 AT>RAM0 :ram
+	*/
+
+	.bss (NOLOAD) : {
+		*(.sbss*)
+		*(.gnu.linkonce.sb.*)
+		*(.bss .bss.*)
+		*(.gnu.linkonce.b.*)
+		*(COMMON)
+
+		/* Align the heap */
+		. = ALIGN(8);
+		__bss_end = .;
+	} >RAM0 AT>RAM0 :ram
+	PROVIDE( __non_tls_bss_start = ADDR(.bss) );
+	PROVIDE( __end = __bss_end );
+	PROVIDE( _end = __bss_end );
+	PROVIDE( end = __bss_end );
+	PROVIDE( __bss_size = __bss_end - __bss_start );
+
+	/* Make the rest of memory available for heap storage */
+	PROVIDE (__heap_start = __end);
+#ifdef __HEAP_SIZE
+	PROVIDE (__heap_end = __heap_start + __HEAP_SIZE);
+	PROVIDE (__heap_size = __HEAP_SIZE);
+#else
+	PROVIDE (__heap_end = __stack - __STACK_SIZE);
+	PROVIDE (__heap_size = __heap_end - __heap_start);
+#endif
+	.heap (NOLOAD) : {
+		. += __heap_size;
+	} >RAM0 :ram
+
+	/* Define a stack region to make sure it fits in memory */
+	PROVIDE(__stack = ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE);
+	PROVIDE(__stack_limit = __stack - __STACK_SIZE);
+	.stack (__stack_limit) (NOLOAD) : {
+		. += __STACK_SIZE;
+	} >RAM0 :ram
+
+#if __STACKSEAL_SIZE > 0
+	PROVIDE(__stack_seal = __stack);
+  	.stackseal (__stack) (NOLOAD) :
+  	{
+    	. += __STACKSEAL_SIZE;
+  	} >RAM0 :ram
+#endif
+
+	/* Throw away C++ exception handling information */
+
+	/*
+
+	/DISCARD/ : {
+		*(.note .note.*)
+		*(.eh_frame .eh_frame.*)
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+		*(.ARM.exidx*)
+	}
+
+	*/
+
+	/* Stabs debugging sections.  */
+	.stab          0 : { *(.stab) }
+	.stabstr       0 : { *(.stabstr) }
+	.stab.excl     0 : { *(.stab.excl) }
+	.stab.exclstr  0 : { *(.stab.exclstr) }
+	.stab.index    0 : { *(.stab.index) }
+	.stab.indexstr 0 : { *(.stab.indexstr) }
+	.comment       0 : { *(.comment) }
+	.gnu.build.attributes : { *(.gnu.build.attributes .gnu.build.attributes.*) }
+	/* DWARF debug sections.
+	   Symbols in the DWARF debugging sections are relative to the beginning
+	   of the section so we begin them at 0.  */
+	/* DWARF 1.  */
+	.debug          0 : { *(.debug) }
+	.line           0 : { *(.line) }
+	/* GNU DWARF 1 extensions.  */
+	.debug_srcinfo  0 : { *(.debug_srcinfo) }
+	.debug_sfnames  0 : { *(.debug_sfnames) }
+	/* DWARF 1.1 and DWARF 2.  */
+	.debug_aranges  0 : { *(.debug_aranges) }
+	.debug_pubnames 0 : { *(.debug_pubnames) }
+	/* DWARF 2.  */
+	.debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+	.debug_abbrev   0 : { *(.debug_abbrev) }
+	.debug_line     0 : { *(.debug_line .debug_line.* .debug_line_end) }
+	.debug_frame    0 : { *(.debug_frame) }
+	.debug_str      0 : { *(.debug_str) }
+	.debug_loc      0 : { *(.debug_loc) }
+	.debug_macinfo  0 : { *(.debug_macinfo) }
+	/* SGI/MIPS DWARF 2 extensions.  */
+	.debug_weaknames 0 : { *(.debug_weaknames) }
+	.debug_funcnames 0 : { *(.debug_funcnames) }
+	.debug_typenames 0 : { *(.debug_typenames) }
+	.debug_varnames  0 : { *(.debug_varnames) }
+	/* DWARF 3.  */
+	.debug_pubtypes 0 : { *(.debug_pubtypes) }
+	.debug_ranges   0 : { *(.debug_ranges) }
+	/* DWARF 5.  */
+	.debug_addr     0 : { *(.debug_addr) }
+	.debug_line_str 0 : { *(.debug_line_str) }
+	.debug_loclists 0 : { *(.debug_loclists) }
+	.debug_macro    0 : { *(.debug_macro) }
+	.debug_names    0 : { *(.debug_names) }
+	.debug_rnglists 0 : { *(.debug_rnglists) }
+	.debug_str_offsets 0 : { *(.debug_str_offsets) }
+	.debug_sup      0 : { *(.debug_sup) }
+	.gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }
+}
+/*
+ * Check that sections that are copied from flash to RAM have matching
+ * padding, so that a single memcpy() of __data_size copies the correct bytes.
+ */
+ASSERT( __data_size == __data_source_size,
+	"ERROR: .data/.tdata flash size does not match RAM size");

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35PS/RTE/Device/ARMCM35P/gcc_linker_script.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35PS/RTE/Device/ARMCM35P/gcc_linker_script.ld
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+/* ----------------------------------------------------------------------------
+  Memory definition
+ *----------------------------------------------------------------------------*/
+MEMORY
+{
+  ROM0  (rx)  : ORIGIN = __ROM0_BASE, LENGTH = __ROM0_SIZE
+#if __ROM1_SIZE > 0
+  ROM1  (rx)  : ORIGIN = __ROM1_BASE, LENGTH = __ROM1_SIZE
+#endif
+#if __ROM2_SIZE > 0
+  ROM2  (rx)  : ORIGIN = __ROM2_BASE, LENGTH = __ROM2_SIZE
+#endif
+#if __ROM3_SIZE > 0
+  ROM3  (rx)  : ORIGIN = __ROM3_BASE, LENGTH = __ROM3_SIZE
+#endif
+
+  RAM0  (rwx) : ORIGIN = __RAM0_BASE, LENGTH = __RAM0_SIZE
+#if __RAM1_SIZE > 0
+  RAM1  (rwx) : ORIGIN = __RAM1_BASE, LENGTH = __RAM1_SIZE
+#endif
+#if __RAM2_SIZE > 0
+  RAM2  (rwx) : ORIGIN = __RAM2_BASE, LENGTH = __RAM2_SIZE
+#endif
+#if __RAM3_SIZE > 0
+  RAM3  (rwx) : ORIGIN = __RAM3_BASE, LENGTH = __RAM3_SIZE
+#endif
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __copy_table_start__
+ *   __copy_table_end__
+ *   __zero_table_start__
+ *   __zero_table_end__
+ *   __etext          (deprecated)
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+  .text :
+  {
+    KEEP(*(.vectors))
+    *(.text*)
+
+    KEEP(*(.init))
+    KEEP(*(.fini))
+
+    /* .ctors */
+    *crtbegin.o(.ctors)
+    *crtbegin?.o(.ctors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+    *(SORT(.ctors.*))
+    *(.ctors)
+
+    /* .dtors */
+    *crtbegin.o(.dtors)
+    *crtbegin?.o(.dtors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+    *(SORT(.dtors.*))
+    *(.dtors)
+
+    *(.rodata*)
+
+    KEEP(*(.eh_frame*))
+  } > ROM0
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  .gnu.sgstubs :
+  {
+    . = ALIGN(32);
+  } > ROM0
+#endif
+
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > ROM0
+
+  __exidx_start = .;
+  .ARM.exidx :
+  {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+  } > ROM0
+  __exidx_end = .;
+
+  .copy.table :
+  {
+    . = ALIGN(4);
+    __copy_table_start__ = .;
+
+    LONG (LOADADDR(.data))
+    LONG (ADDR(.data))
+    LONG (SIZEOF(.data) / 4)
+
+    /* Add each additional data section here */
+/*
+    LONG (LOADADDR(.data2))
+    LONG (ADDR(.data2))
+    LONG (SIZEOF(.data2) / 4)
+*/
+    __copy_table_end__ = .;
+  } > ROM0
+
+  .zero.table :
+  {
+    . = ALIGN(4);
+    __zero_table_start__ = .;
+
+/*  .bss initialization to zero is already done during C Run-Time Startup.
+    LONG (ADDR(.bss))
+    LONG (SIZEOF(.bss) / 4)
+*/
+
+    /* Add each additional bss section here */
+/*
+    LONG (ADDR(.bss2))
+    LONG (SIZEOF(.bss2) / 4)
+*/
+    __zero_table_end__ = .;
+  } > ROM0
+
+  /*
+   * This __etext variable is kept for backward compatibility with older,
+   * ASM based startup files.
+   */
+  PROVIDE(__etext = LOADADDR(.data));
+
+  .data : ALIGN(4)
+  {
+    __data_start__ = .;
+    *(vtable)
+    *(.data)
+    *(.data.*)
+
+    . = ALIGN(4);
+    /* preinit data */
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP(*(.preinit_array))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+
+    . = ALIGN(4);
+    /* init data */
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP(*(SORT(.init_array.*)))
+    KEEP(*(.init_array))
+    PROVIDE_HIDDEN (__init_array_end = .);
+
+    . = ALIGN(4);
+    /* finit data */
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP(*(SORT(.fini_array.*)))
+    KEEP(*(.fini_array))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    /* All data end */
+    __data_end__ = .;
+
+  } > RAM0 AT > ROM0
+
+  /*
+   * Secondary data section, optional
+   *
+   * Remember to add each additional data section
+   * to the .copy.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .data2 : ALIGN(4)
+  {
+    . = ALIGN(4);
+    __data2_start__ = .;
+    *(.data2)
+    *(.data2.*)
+    . = ALIGN(4);
+    __data2_end__ = .;
+
+  } > RAM1 AT > ROM0 
+*/
+
+  .bss :
+  {
+    . = ALIGN(4);
+    __bss_start__ = .;
+    *(.bss)
+    *(.bss.*)
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+  } > RAM0 AT > RAM0
+
+  /*
+   * Secondary bss section, optional
+   *
+   * Remember to add each additional bss section
+   * to the .zero.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .bss2 :
+  {
+    . = ALIGN(4);
+    __bss2_start__ = .;
+    *(.bss2)
+    *(.bss2.*)
+    . = ALIGN(4);
+    __bss2_end__ = .;
+  } > RAM1 AT > RAM1
+*/
+
+  .heap (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE(end = .);
+    . = . + __HEAP_SIZE;
+    . = ALIGN(8);
+    __HeapLimit = .;
+  } > RAM0
+
+  .stack (ORIGIN(RAM0) + LENGTH(RAM0) - __STACK_SIZE - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackLimit = .;
+    . = . + __STACK_SIZE;
+    . = ALIGN(8);
+    __StackTop = .;
+  } > RAM0
+  PROVIDE(__stack = __StackTop);
+
+#if __STACKSEAL_SIZE > 0
+  .stackseal (ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackSeal = .;
+    . = . + 8;
+    . = ALIGN(8);
+  } > RAM0
+#endif
+
+  /* Check if data + heap + stack exceeds RAM limit */
+  ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35PS/RTE/Device/ARMCM35P/iar_linker_script.icf
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35PS/RTE/Device/ARMCM35P/iar_linker_script.icf
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+define memory mem with size = 4G;
+
+#if __ROM0_SIZE > 0
+  define region ROM0_region = mem:[from __ROM0_BASE to (__ROM0_BASE+__ROM0_SIZE-1)];
+#else
+  define region ROM0_region = [];
+#endif
+
+#if __ROM1_SIZE > 0
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+#else
+  define region ROM1_region = [];
+#endif
+
+#if __ROM2_SIZE > 0
+  define region ROM2_region = mem:[from __ROM2_BASE to (__ROM2_BASE+__ROM2_SIZE-1)];
+#else
+  define region ROM2_region = [];
+#endif
+
+#if __ROM3_SIZE > 0
+  define region ROM3_region = mem:[from __ROM3_BASE to (__ROM3_BASE+__ROM3_SIZE-1)];
+#else
+  define region ROM3_region = [];
+#endif
+
+define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_region;
+
+#if __RAM0_SIZE > 0
+  define region RAM0_region = mem:[from __RAM0_BASE to (__RAM0_BASE+__RAM0_SIZE-1)];
+#else
+  define region RAM0_region = [];
+#endif
+
+#if __RAM1_SIZE > 0
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+#else
+  define region RAM1_region = [];
+#endif
+
+#if __RAM2_SIZE > 0
+  define region RAM2_region = mem:[from __RAM2_BASE to (__RAM2_BASE+__RAM2_SIZE-1)];
+#else
+  define region RAM2_region = [];
+#endif
+
+#if __RAM3_SIZE > 0
+  define region RAM3_region = mem:[from __RAM3_BASE to (__RAM3_BASE+__RAM3_SIZE-1)];
+#else
+  define region RAM3_region = [];
+#endif
+
+define region RAM_region = RAM0_region | RAM1_region | RAM2_region | RAM3_region;
+
+do not initialize  { section .noinit };
+initialize by copy { readwrite };
+if (isdefinedsymbol(__USE_DLIB_PERTHREAD))
+{
+  // Required in a multi-threaded application
+  initialize by copy with packing = none { section __DLIB_PERTHREAD };
+}
+
+place at address mem:__ROM0_BASE { readonly section .intvec };
+
+if (!isempty(ROM_region))
+{
+  place in ROM_region  { readonly };
+}
+
+if (!isempty(RAM_region))
+{
+  define block CSTACK     with alignment = 8, size = __STACK_SIZE     { };
+  define block PROC_STACK with alignment = 8, size = 0 { };
+  define block HEAP       with alignment = 8, size = __HEAP_SIZE       { };
+  place in RAM_region  { readwrite, block CSTACK, block PROC_STACK, block HEAP };
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35PS/RTE/Device/ARMCM35P/partition_ARMCM35P.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35PS/RTE/Device/ARMCM35P/partition_ARMCM35P.h
@@ -1,0 +1,1260 @@
+/**************************************************************************//**
+ * @file     partition_ARMCM35P.h
+ * @brief    CMSIS-CORE Initial Setup for Secure / Non-Secure Zones for ARMCM35P
+ * @version  V1.0.0
+ * @date     03. September 2018
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2018 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PARTITION_ARMCM35P_H
+#define PARTITION_ARMCM35P_H
+
+/*
+//-------- <<< Use Configuration Wizard in Context Menu >>> -----------------
+*/
+
+/*
+// <e>Initialize Security Attribution Unit (SAU) CTRL register
+*/
+#define SAU_INIT_CTRL          1
+
+/*
+//   <q> Enable SAU
+//   <i> Value for SAU->CTRL register bit ENABLE
+*/
+#define SAU_INIT_CTRL_ENABLE   1
+
+/*
+//   <o> When SAU is disabled
+//     <0=> All Memory is Secure
+//     <1=> All Memory is Non-Secure
+//   <i> Value for SAU->CTRL register bit ALLNS
+//   <i> When all Memory is Non-Secure (ALLNS is 1), IDAU can override memory map configuration.
+*/
+#define SAU_INIT_CTRL_ALLNS  0
+
+/*
+// </e>
+*/
+
+/*
+// <h>Initialize Security Attribution Unit (SAU) Address Regions
+// <i>SAU configuration specifies regions to be one of:
+// <i> - Secure and Non-Secure Callable
+// <i> - Non-Secure
+// <i>Note: All memory regions not configured by SAU are Secure
+*/
+#define SAU_REGIONS_MAX   8                 /* Max. number of SAU regions */
+
+/*
+//   <e>Initialize SAU Region 0
+//   <i> Setup SAU Region 0 memory attributes
+*/
+#define SAU_INIT_REGION0    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START0     0x00000000      /* start address of SAU region 0 */
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END0       0x001FFFFF      /* end address of SAU region 0 */
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC0       1
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 1
+//   <i> Setup SAU Region 1 memory attributes
+*/
+#define SAU_INIT_REGION1    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START1     0x00200000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END1       0x003FFFFF
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC1       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 2
+//   <i> Setup SAU Region 2 memory attributes
+*/
+#define SAU_INIT_REGION2    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START2     0x20200000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END2       0x203FFFFF
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC2       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 3
+//   <i> Setup SAU Region 3 memory attributes
+*/
+#define SAU_INIT_REGION3    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START3     0x40000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END3       0x40040000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC3       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 4
+//   <i> Setup SAU Region 4 memory attributes
+*/
+#define SAU_INIT_REGION4    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START4     0x00000000      /* start address of SAU region 4 */
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END4       0x00000000      /* end address of SAU region 4 */
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC4       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 5
+//   <i> Setup SAU Region 5 memory attributes
+*/
+#define SAU_INIT_REGION5    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START5     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END5       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC5       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 6
+//   <i> Setup SAU Region 6 memory attributes
+*/
+#define SAU_INIT_REGION6    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START6     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END6       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC6       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 7
+//   <i> Setup SAU Region 7 memory attributes
+*/
+#define SAU_INIT_REGION7    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START7     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END7       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC7       0
+/*
+//   </e>
+*/
+
+/*
+// </h>
+*/
+
+/*
+// <e>Setup behaviour of Sleep and Exception Handling
+*/
+#define SCB_CSR_AIRCR_INIT  1
+
+/*
+//   <o> Deep Sleep can be enabled by
+//     <0=>Secure and Non-Secure state
+//     <1=>Secure state only
+//   <i> Value for SCB->CSR register bit DEEPSLEEPS
+*/
+#define SCB_CSR_DEEPSLEEPS_VAL  1
+
+/*
+//   <o>System reset request accessible from
+//     <0=> Secure and Non-Secure state
+//     <1=> Secure state only
+//   <i> Value for SCB->AIRCR register bit SYSRESETREQS
+*/
+#define SCB_AIRCR_SYSRESETREQS_VAL  1
+
+/*
+//   <o>Priority of Non-Secure exceptions is
+//     <0=> Not altered
+//     <1=> Lowered to 0x80-0xFF
+//   <i> Value for SCB->AIRCR register bit PRIS
+*/
+#define SCB_AIRCR_PRIS_VAL      1
+
+/*
+//   <o>BusFault, HardFault, and NMI target
+//     <0=> Secure state
+//     <1=> Non-Secure state
+//   <i> Value for SCB->AIRCR register bit BFHFNMINS
+*/
+#define SCB_AIRCR_BFHFNMINS_VAL 0
+
+/*
+// </e>
+*/
+
+/*
+// <e>Setup behaviour of Floating Point Unit
+*/
+#define TZ_FPU_NS_USAGE 1
+
+/*
+// <o>Floating Point Unit usage
+//     <0=> Secure state only
+//     <3=> Secure and Non-Secure state
+//   <i> Value for SCB->NSACR register bits CP10, CP11
+*/
+#define SCB_NSACR_CP10_11_VAL       3
+
+/*
+// <o>Treat floating-point registers as Secure
+//     <0=> Disabled
+//     <1=> Enabled
+//   <i> Value for FPU->FPCCR register bit TS
+*/
+#define FPU_FPCCR_TS_VAL            0
+
+/*
+// <o>Clear on return (CLRONRET) accessibility
+//     <0=> Secure and Non-Secure state
+//     <1=> Secure state only
+//   <i> Value for FPU->FPCCR register bit CLRONRETS
+*/
+#define FPU_FPCCR_CLRONRETS_VAL     0
+
+/*
+// <o>Clear floating-point caller saved registers on exception return
+//     <0=> Disabled
+//     <1=> Enabled
+//   <i> Value for FPU->FPCCR register bit CLRONRET
+*/
+#define FPU_FPCCR_CLRONRET_VAL      1
+
+/*
+// </e>
+*/
+
+/*
+// <h>Setup Interrupt Target
+*/
+
+/*
+//   <e>Initialize ITNS 0 (Interrupts 0..31)
+*/
+#define NVIC_INIT_ITNS0    0
+
+/*
+// Interrupts 0..31
+//   <o.0>  Interrupt 0   <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 1   <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 2   <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 3   <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 4   <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 5   <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 6   <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 7   <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 8   <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 9   <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 10  <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 11  <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 12  <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 13  <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 14  <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 15  <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 16  <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 17  <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 18  <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 19  <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 20  <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 21  <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 22  <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 23  <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 24  <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 25  <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 26  <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 27  <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 28  <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 29  <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 30  <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 31  <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS0_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 1 (Interrupts 32..63)
+*/
+#define NVIC_INIT_ITNS1    0
+
+/*
+// Interrupts 32..63
+//   <o.0>  Interrupt 32  <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 33  <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 34  <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 35  <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 36  <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 37  <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 38  <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 39  <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 40  <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 41  <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 42  <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 43  <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 44  <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 45  <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 46  <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 47  <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 48  <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 49  <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 50  <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 51  <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 52  <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 53  <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 54  <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 55  <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 56  <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 57  <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 58  <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 59  <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 60  <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 61  <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 62  <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 63  <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS1_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 2 (Interrupts 64..95)
+*/
+#define NVIC_INIT_ITNS2    0
+
+/*
+// Interrupts 64..95
+//   <o.0>  Interrupt 64  <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 65  <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 66  <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 67  <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 68  <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 69  <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 70  <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 71  <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 72  <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 73  <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 74  <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 75  <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 76  <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 77  <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 78  <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 79  <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 80  <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 81  <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 82  <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 83  <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 84  <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 85  <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 86  <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 87  <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 88  <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 89  <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 90  <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 91  <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 92  <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 93  <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 94  <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 95  <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS2_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 3 (Interrupts 96..127)
+*/
+#define NVIC_INIT_ITNS3    0
+
+/*
+// Interrupts 96..127
+//   <o.0>  Interrupt 96  <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 97  <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 98  <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 99  <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 100 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 101 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 102 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 103 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 104 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 105 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 106 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 107 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 108 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 109 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 110 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 111 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 112 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 113 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 114 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 115 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 116 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 117 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 118 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 119 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 120 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 121 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 122 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 123 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 124 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 125 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 126 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 127 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS3_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 4 (Interrupts 128..159)
+*/
+#define NVIC_INIT_ITNS4    0
+
+/*
+// Interrupts 128..159
+//   <o.0>  Interrupt 128 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 129 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 130 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 131 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 132 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 133 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 134 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 135 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 136 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 137 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 138 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 139 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 140 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 141 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 142 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 143 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 144 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 145 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 146 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 147 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 148 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 149 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 150 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 151 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 152 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 153 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 154 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 155 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 156 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 157 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 158 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 159 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS4_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 5 (Interrupts 160..191)
+*/
+#define NVIC_INIT_ITNS5    0
+
+/*
+// Interrupts 160..191
+//   <o.0>  Interrupt 160 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 161 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 162 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 163 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 164 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 165 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 166 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 167 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 168 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 169 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 170 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 171 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 172 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 173 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 174 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 175 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 176 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 177 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 178 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 179 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 180 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 181 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 182 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 183 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 184 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 185 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 186 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 187 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 188 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 189 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 190 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 191 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS5_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 6 (Interrupts 192..223)
+*/
+#define NVIC_INIT_ITNS6    0
+
+/*
+// Interrupts 192..223
+//   <o.0>  Interrupt 192 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 193 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 194 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 195 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 196 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 197 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 198 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 199 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 200 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 201 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 202 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 203 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 204 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 205 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 206 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 207 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 208 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 209 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 210 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 211 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 212 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 213 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 214 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 215 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 216 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 217 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 218 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 219 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 220 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 221 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 222 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 223 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS6_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 7 (Interrupts 224..255)
+*/
+#define NVIC_INIT_ITNS7    0
+
+/*
+// Interrupts 224..255
+//   <o.0>  Interrupt 224 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 225 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 226 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 227 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 228 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 229 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 230 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 231 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 232 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 233 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 234 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 235 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 236 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 237 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 238 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 239 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 240 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 241 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 242 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 243 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 244 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 245 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 246 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 247 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 248 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 249 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 250 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 251 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 252 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 253 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 254 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 255 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS7_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 8 (Interrupts 256..287)
+*/
+#define NVIC_INIT_ITNS8    0
+
+/*
+// Interrupts 256..287
+//   <o.0>  Interrupt 256 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 257 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 258 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 259 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 260 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 261 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 262 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 263 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 264 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 265 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 266 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 267 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 268 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 269 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 270 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 271 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 272 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 273 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 274 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 275 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 276 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 277 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 278 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 279 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 280 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 281 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 282 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 283 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 284 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 285 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 286 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 287 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS8_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 9 (Interrupts 288..319)
+*/
+#define NVIC_INIT_ITNS9    0
+
+/*
+// Interrupts 288..319
+//   <o.0>  Interrupt 288 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 289 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 290 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 291 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 292 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 293 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 294 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 295 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 296 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 297 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 298 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 299 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 300 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 301 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 302 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 303 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 304 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 305 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 306 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 307 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 308 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 309 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 310 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 311 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 312 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 313 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 314 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 315 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 316 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 317 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 318 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 319 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS9_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 10 (Interrupts 320..351)
+*/
+#define NVIC_INIT_ITNS10   0
+
+/*
+// Interrupts 320..351
+//   <o.0>  Interrupt 320 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 321 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 322 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 323 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 324 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 325 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 326 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 327 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 328 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 329 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 330 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 331 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 332 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 333 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 334 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 335 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 336 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 337 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 338 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 339 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 340 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 341 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 342 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 343 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 344 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 345 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 346 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 347 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 348 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 349 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 350 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 351 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS10_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 11 (Interrupts 352..383)
+*/
+#define NVIC_INIT_ITNS11   0
+
+/*
+// Interrupts 352..383
+//   <o.0>  Interrupt 352 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 353 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 354 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 355 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 356 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 357 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 358 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 359 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 360 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 361 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 362 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 363 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 364 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 365 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 366 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 367 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 368 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 369 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 370 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 371 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 372 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 373 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 374 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 375 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 376 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 377 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 378 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 379 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 380 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 381 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 382 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 383 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS11_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 12 (Interrupts 384..415)
+*/
+#define NVIC_INIT_ITNS12   0
+
+/*
+// Interrupts 384..415
+//   <o.0>  Interrupt 384 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 385 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 386 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 387 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 388 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 389 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 390 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 391 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 392 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 393 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 394 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 395 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 396 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 397 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 398 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 399 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 400 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 401 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 402 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 403 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 404 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 405 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 406 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 407 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 408 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 409 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 410 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 411 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 412 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 413 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 414 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 415 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS12_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 13 (Interrupts 416..447)
+*/
+#define NVIC_INIT_ITNS13   0
+
+/*
+// Interrupts 416..447
+//   <o.0>  Interrupt 416 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 417 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 418 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 419 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 420 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 421 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 422 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 423 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 424 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 425 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 426 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 427 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 428 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 429 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 430 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 431 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 432 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 433 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 434 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 435 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 436 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 437 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 438 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 439 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 440 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 441 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 442 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 443 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 444 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 445 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 446 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 447 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS13_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 14 (Interrupts 448..479)
+*/
+#define NVIC_INIT_ITNS14   0
+
+/*
+// Interrupts 448..479
+//   <o.0>  Interrupt 448 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 449 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 450 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 451 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 452 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 453 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 454 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 455 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 456 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 457 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 458 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 459 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 460 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 461 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 462 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 463 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 464 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 465 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 466 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 467 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 468 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 469 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 470 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 471 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 472 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 473 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 474 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 475 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 476 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 477 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 478 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 479 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS14_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 15 (Interrupts 480..511)
+*/
+#define NVIC_INIT_ITNS15   0
+
+/*
+// Interrupts 480..511
+//   <o.0>  Interrupt 480 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 481 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 482 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 483 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 484 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 485 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 486 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 487 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 488 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 489 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 490 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 491 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 492 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 493 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 494 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 495 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 496 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 497 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 498 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 499 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 500 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 501 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 502 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 503 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 504 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 505 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 506 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 507 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 508 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 509 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 510 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 511 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS15_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+// </h>
+*/
+
+
+
+/*
+    max 128 SAU regions.
+    SAU regions are defined in partition.h
+ */
+
+#define SAU_INIT_REGION(n) \
+    SAU->RNR  =  (n                                     & SAU_RNR_REGION_Msk); \
+    SAU->RBAR =  (SAU_INIT_START##n                     & SAU_RBAR_BADDR_Msk); \
+    SAU->RLAR =  (SAU_INIT_END##n                       & SAU_RLAR_LADDR_Msk) | \
+                ((SAU_INIT_NSC##n << SAU_RLAR_NSC_Pos)  & SAU_RLAR_NSC_Msk)   | 1U
+
+/**
+  \brief   Setup a SAU Region
+  \details Writes the region information contained in SAU_Region to the
+           registers SAU_RNR, SAU_RBAR, and SAU_RLAR
+ */
+__STATIC_INLINE void TZ_SAU_Setup (void)
+{
+
+#if defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U)
+
+  #if defined (SAU_INIT_REGION0) && (SAU_INIT_REGION0 == 1U)
+    SAU_INIT_REGION(0);
+  #endif
+
+  #if defined (SAU_INIT_REGION1) && (SAU_INIT_REGION1 == 1U)
+    SAU_INIT_REGION(1);
+  #endif
+
+  #if defined (SAU_INIT_REGION2) && (SAU_INIT_REGION2 == 1U)
+    SAU_INIT_REGION(2);
+  #endif
+
+  #if defined (SAU_INIT_REGION3) && (SAU_INIT_REGION3 == 1U)
+    SAU_INIT_REGION(3);
+  #endif
+
+  #if defined (SAU_INIT_REGION4) && (SAU_INIT_REGION4 == 1U)
+    SAU_INIT_REGION(4);
+  #endif
+
+  #if defined (SAU_INIT_REGION5) && (SAU_INIT_REGION5 == 1U)
+    SAU_INIT_REGION(5);
+  #endif
+
+  #if defined (SAU_INIT_REGION6) && (SAU_INIT_REGION6 == 1U)
+    SAU_INIT_REGION(6);
+  #endif
+
+  #if defined (SAU_INIT_REGION7) && (SAU_INIT_REGION7 == 1U)
+    SAU_INIT_REGION(7);
+  #endif
+
+  /* repeat this for all possible SAU regions */
+
+#endif /* defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U) */
+
+
+  #if defined (SAU_INIT_CTRL) && (SAU_INIT_CTRL == 1U)
+    SAU->CTRL = ((SAU_INIT_CTRL_ENABLE << SAU_CTRL_ENABLE_Pos) & SAU_CTRL_ENABLE_Msk) |
+                ((SAU_INIT_CTRL_ALLNS  << SAU_CTRL_ALLNS_Pos)  & SAU_CTRL_ALLNS_Msk)   ;
+  #endif
+
+  #if defined (SCB_CSR_AIRCR_INIT) && (SCB_CSR_AIRCR_INIT == 1U)
+    SCB->SCR   = (SCB->SCR   & ~(SCB_SCR_SLEEPDEEPS_Msk    )) |
+                   ((SCB_CSR_DEEPSLEEPS_VAL     << SCB_SCR_SLEEPDEEPS_Pos)     & SCB_SCR_SLEEPDEEPS_Msk);
+
+    SCB->AIRCR = (SCB->AIRCR & ~(SCB_AIRCR_VECTKEY_Msk   | SCB_AIRCR_SYSRESETREQS_Msk |
+                                 SCB_AIRCR_BFHFNMINS_Msk | SCB_AIRCR_PRIS_Msk          ))                    |
+                   ((0x05FAU                    << SCB_AIRCR_VECTKEY_Pos)      & SCB_AIRCR_VECTKEY_Msk)      |
+                   ((SCB_AIRCR_SYSRESETREQS_VAL << SCB_AIRCR_SYSRESETREQS_Pos) & SCB_AIRCR_SYSRESETREQS_Msk) |
+                   ((SCB_AIRCR_PRIS_VAL         << SCB_AIRCR_PRIS_Pos)         & SCB_AIRCR_PRIS_Msk)         |
+                   ((SCB_AIRCR_BFHFNMINS_VAL    << SCB_AIRCR_BFHFNMINS_Pos)    & SCB_AIRCR_BFHFNMINS_Msk);
+  #endif /* defined (SCB_CSR_AIRCR_INIT) && (SCB_CSR_AIRCR_INIT == 1U) */
+
+  #if defined (__FPU_USED) && (__FPU_USED == 1U) && \
+      defined (TZ_FPU_NS_USAGE) && (TZ_FPU_NS_USAGE == 1U)
+
+    SCB->NSACR = (SCB->NSACR & ~(SCB_NSACR_CP10_Msk | SCB_NSACR_CP11_Msk)) |
+                   ((SCB_NSACR_CP10_11_VAL << SCB_NSACR_CP10_Pos) & (SCB_NSACR_CP10_Msk | SCB_NSACR_CP11_Msk));
+
+    FPU->FPCCR = (FPU->FPCCR & ~(FPU_FPCCR_TS_Msk | FPU_FPCCR_CLRONRETS_Msk | FPU_FPCCR_CLRONRET_Msk)) |
+                   ((FPU_FPCCR_TS_VAL        << FPU_FPCCR_TS_Pos       ) & FPU_FPCCR_TS_Msk       ) |
+                   ((FPU_FPCCR_CLRONRETS_VAL << FPU_FPCCR_CLRONRETS_Pos) & FPU_FPCCR_CLRONRETS_Msk) |
+                   ((FPU_FPCCR_CLRONRET_VAL  << FPU_FPCCR_CLRONRET_Pos ) & FPU_FPCCR_CLRONRET_Msk );
+  #endif
+
+  #if defined (NVIC_INIT_ITNS0) && (NVIC_INIT_ITNS0 == 1U)
+    NVIC->ITNS[0] = NVIC_INIT_ITNS0_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS1) && (NVIC_INIT_ITNS1 == 1U)
+    NVIC->ITNS[1] = NVIC_INIT_ITNS1_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS2) && (NVIC_INIT_ITNS2 == 1U)
+    NVIC->ITNS[2] = NVIC_INIT_ITNS2_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS3) && (NVIC_INIT_ITNS3 == 1U)
+    NVIC->ITNS[3] = NVIC_INIT_ITNS3_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS4) && (NVIC_INIT_ITNS4 == 1U)
+    NVIC->ITNS[4] = NVIC_INIT_ITNS4_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS5) && (NVIC_INIT_ITNS5 == 1U)
+    NVIC->ITNS[5] = NVIC_INIT_ITNS5_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS6) && (NVIC_INIT_ITNS6 == 1U)
+    NVIC->ITNS[6] = NVIC_INIT_ITNS6_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS7) && (NVIC_INIT_ITNS7 == 1U)
+    NVIC->ITNS[7] = NVIC_INIT_ITNS7_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS8) && (NVIC_INIT_ITNS8 == 1U)
+    NVIC->ITNS[8] = NVIC_INIT_ITNS8_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS9) && (NVIC_INIT_ITNS9 == 1U)
+    NVIC->ITNS[9] = NVIC_INIT_ITNS9_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS10) && (NVIC_INIT_ITNS10 == 1U)
+    NVIC->ITNS[10] = NVIC_INIT_ITNS10_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS11) && (NVIC_INIT_ITNS11 == 1U)
+    NVIC->ITNS[11] = NVIC_INIT_ITNS11_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS12) && (NVIC_INIT_ITNS12 == 1U)
+    NVIC->ITNS[12] = NVIC_INIT_ITNS12_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS13) && (NVIC_INIT_ITNS13 == 1U)
+    NVIC->ITNS[13] = NVIC_INIT_ITNS13_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS14) && (NVIC_INIT_ITNS14 == 1U)
+    NVIC->ITNS[14] = NVIC_INIT_ITNS14_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS15) && (NVIC_INIT_ITNS15 == 1U)
+    NVIC->ITNS[15] = NVIC_INIT_ITNS15_VAL;
+  #endif
+
+  /* repeat this for all possible ITNS elements */
+
+}
+
+#endif  /* PARTITION_ARMCM35P_H */

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35PS/RTE/Device/ARMCM35P/regions_ARMCM35P.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35PS/RTE/Device/ARMCM35P/regions_ARMCM35P.h
@@ -1,0 +1,94 @@
+#ifndef REGIONS_ARMCM35P_H
+#define REGIONS_ARMCM35P_H
+
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+// <n>Device pack:   ARM::Cortex_DFP@1.0.0-dev16
+// <i>Device pack used to generate this file
+
+// <h>ROM Configuration
+// =======================
+// <h> ROM_S=<__ROM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x00000000
+#define __ROM0_BASE 0x00000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00200000
+#define __ROM0_SIZE 0x00200000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __ROM0_DEFAULT 1
+//   <q>Startup
+//   <i> Selects region to be used for startup code.
+#define __ROM0_STARTUP 1
+// </h>
+
+// <h> ROM_NS=<__ROM1>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x00200000
+#define __ROM1_BASE 0x00200000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00200000
+#define __ROM1_SIZE 0x00200000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __ROM1_DEFAULT 0
+//   <q>Startup
+//   <i> Selects region to be used for startup code.
+#define __ROM1_STARTUP 0
+// </h>
+
+// </h>
+
+// <h>RAM Configuration
+// =======================
+// <h> RAM_S=<__RAM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x20000000
+#define __RAM0_BASE 0x20000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00020000
+#define __RAM0_SIZE 0x00020000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __RAM0_DEFAULT 1
+//   <q>No zero initialize
+//   <i> Excludes region from zero initialization.
+#define __RAM0_NOINIT 0
+// </h>
+
+// <h> RAM_NS=<__RAM1>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x20200000
+#define __RAM1_BASE 0x20200000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00020000
+#define __RAM1_SIZE 0x00020000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __RAM1_DEFAULT 0
+//   <q>No zero initialize
+//   <i> Excludes region from zero initialization.
+#define __RAM1_NOINIT 0
+// </h>
+
+// </h>
+
+// <h>Stack / Heap Configuration
+//   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+#define __STACK_SIZE 0x00000400
+#define __HEAP_SIZE 0x00000C00
+// </h>
+
+
+#endif /* REGIONS_ARMCM35P_H */

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35PS/RTE/Device/ARMCM35P/startup_ARMCM35P.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35PS/RTE/Device/ARMCM35P/startup_ARMCM35P.c
@@ -1,0 +1,164 @@
+/******************************************************************************
+ * @file     startup_ARMCM35P.c
+ * @brief    CMSIS-Core Device Startup File for Cortex-M35P Device
+ * @version  V3.0.0
+ * @date     13. July 2023
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (ARMCM35P)
+  #include "ARMCM35P.h"
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  External References
+ *----------------------------------------------------------------------------*/
+extern uint32_t __INITIAL_SP;
+extern uint32_t __STACK_LIMIT;
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+extern uint32_t __STACK_SEAL;
+#endif
+
+extern __NO_RETURN void __PROGRAM_START(void);
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler  (void);
+            void Default_Handler(void);
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+/* Exceptions */
+void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void HardFault_Handler      (void) __attribute__ ((weak));
+void MemManage_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
+void BusFault_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void UsageFault_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void SecureFault_Handler    (void) __attribute__ ((weak, alias("Default_Handler")));
+void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void DebugMon_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+
+void Interrupt0_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt1_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt2_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt3_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt4_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt5_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt6_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt7_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt8_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt9_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[496];
+       const VECTOR_TABLE_Type __VECTOR_TABLE[496] __VECTOR_TABLE_ATTRIBUTE = {
+  (VECTOR_TABLE_Type)(&__INITIAL_SP),       /*     Initial Stack Pointer */
+  Reset_Handler,                            /*     Reset Handler */
+  NMI_Handler,                              /* -14 NMI Handler */
+  HardFault_Handler,                        /* -13 Hard Fault Handler */
+  MemManage_Handler,                        /* -12 MPU Fault Handler */
+  BusFault_Handler,                         /* -11 Bus Fault Handler */
+  UsageFault_Handler,                       /* -10 Usage Fault Handler */
+  SecureFault_Handler,                      /*  -9 Secure Fault Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  SVC_Handler,                              /*  -5 SVC Handler */
+  DebugMon_Handler,                         /*  -4 Debug Monitor Handler */
+  0,                                        /*     Reserved */
+  PendSV_Handler,                           /*  -2 PendSV Handler */
+  SysTick_Handler,                          /*  -1 SysTick Handler */
+
+  /* Interrupts */
+  Interrupt0_Handler,                       /*   0 Interrupt 0 */
+  Interrupt1_Handler,                       /*   1 Interrupt 1 */
+  Interrupt2_Handler,                       /*   2 Interrupt 2 */
+  Interrupt3_Handler,                       /*   3 Interrupt 3 */
+  Interrupt4_Handler,                       /*   4 Interrupt 4 */
+  Interrupt5_Handler,                       /*   5 Interrupt 5 */
+  Interrupt6_Handler,                       /*   6 Interrupt 6 */
+  Interrupt7_Handler,                       /*   7 Interrupt 7 */
+  Interrupt8_Handler,                       /*   8 Interrupt 8 */
+  Interrupt9_Handler                        /*   9 Interrupt 9 */
+                                            /* Interrupts 10 .. 480 are left out */
+};
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler(void)
+{
+  __set_PSP((uint32_t)(&__INITIAL_SP));
+
+  __set_MSPLIM((uint32_t)(&__STACK_LIMIT));
+  __set_PSPLIM((uint32_t)(&__STACK_LIMIT));
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  __TZ_set_STACKSEAL_S((uint32_t *)(&__STACK_SEAL));
+#endif
+
+  SystemInit();                             /* CMSIS System Initialization */
+  __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
+}
+
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wmissing-noreturn"
+#endif
+
+/*----------------------------------------------------------------------------
+  Hard Fault Handler
+ *----------------------------------------------------------------------------*/
+void HardFault_Handler(void)
+{
+  while(1);
+}
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+void Default_Handler(void)
+{
+  while(1);
+}
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic pop
+#endif
+

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35PS/RTE/Device/ARMCM35P/system_ARMCM35P.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35PS/RTE/Device/ARMCM35P/system_ARMCM35P.c
@@ -1,0 +1,86 @@
+/**************************************************************************//**
+ * @file     system_ARMCM35P.c
+ * @brief    CMSIS Device System Source File for
+ *           ARMCM35P Device
+ * @version  V2.0.0
+ * @date     13. July 2023
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (ARMCM35P)
+  #include "ARMCM35P.h"
+  #if defined (__ARM_FEATURE_CMSE) &&  (__ARM_FEATURE_CMSE == 3U)
+    #include "partition_ARMCM35P.h"
+  #endif
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  Define clocks
+ *----------------------------------------------------------------------------*/
+#define  XTAL            (50000000UL)     /* Oscillator frequency */
+
+#define  SYSTEM_CLOCK    (XTAL / 2U)
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[496];
+
+
+/*----------------------------------------------------------------------------
+  System Core Clock Variable
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = SYSTEM_CLOCK;  /* System Core Clock Frequency */
+
+
+/*----------------------------------------------------------------------------
+  System Core Clock update function
+ *----------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)
+{
+  SystemCoreClock = SYSTEM_CLOCK;
+}
+
+/*----------------------------------------------------------------------------
+  System initialization function
+ *----------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t) &(__VECTOR_TABLE[0]);
+#endif
+
+#if defined (__FPU_USED) && (__FPU_USED == 1U)
+  SCB->CPACR |= ((3U << 10U*2U) |           /* enable CP10 Full Access */
+                 (3U << 11U*2U)  );         /* enable CP11 Full Access */
+#endif
+
+#ifdef UNALIGNED_SUPPORT_DISABLE
+  SCB->CCR |= SCB_CCR_UNALIGN_TRP_Msk;
+#endif
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  TZ_SAU_Setup();
+#endif
+
+  SystemCoreClock = SYSTEM_CLOCK;
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35PS/Target.clayer.yml
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35PS/Target.clayer.yml
@@ -1,0 +1,35 @@
+layer:
+  type: Target
+  description: CM35PS target components and files
+
+  packs:
+    - pack: ARM::Cortex_DFP
+
+  device: ARMCM35P
+
+  processor:
+    trustzone: secure
+
+  components:
+    # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
+    - component: ARM::CMSIS:CORE
+    - component: Device:Startup&C Startup
+
+  groups:
+    - group: FVP
+      files:
+        - file: ./model_config.txt
+
+  linker:
+    - for-compiler: AC6
+      script: RTE/Device/$Dname$/ac6_linker_script.sct
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: GCC
+      script: RTE/Device/$Dname$/gcc_linker_script.ld
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: CLANG
+      script: RTE/Device/$Dname$/clang_linker_script.ld
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: IAR
+      script: RTE/Device/$Dname$/iar_linker_script.icf
+      regions: RTE/Device/$Dname$/regions_$Dname$.h

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35PS/model_config.txt
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM35PS/model_config.txt
@@ -1,0 +1,32 @@
+# Parameters:
+# instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+#----------------------------------------------------------------------------------------------
+fvp_mps2.mps2_visualisation.disable-visualisation=1   # (bool  , init-time) default = '0'      : Enable/disable visualisation
+cpu0.FPU=1                                            # (bool  , init-time) default = '1'      : Set whether the model has VFP support
+cpu0.DSP=1                                            # (bool  , init-time) default = '1'      : Set whether the model has the DSP extension
+cpu0.semihosting-enable=1                             # (bool  , init-time) default = '1'      : Enable semihosting SVC traps. Applications that do not use semihosting must set this parameter to false.
+cpu0.semihosting-Thumb_SVC=0xAB                       # (int   , init-time) default = '0xAB'   : T32 SVC number for semihosting : [0x0..0xFF]
+cpu0.semihosting-cmd_line=""                          # (string, init-time) default = ''       : Command line available to semihosting SVC calls
+cpu0.semihosting-heap_base=0x0                        # (int   , init-time) default = '0x0'    : Virtual address of heap base : [0x0..0xFFFFFFFF]
+cpu0.semihosting-heap_limit=0x0                       # (int   , init-time) default = '0x10700000' : Virtual address of top of heap : [0x0..0xFFFFFFFF]
+cpu0.semihosting-stack_base=0x0                       # (int   , init-time) default = '0x10700000' : Virtual address of base of descending stack : [0x0..0xFFFFFFFF]
+cpu0.semihosting-stack_limit=0x0                      # (int   , init-time) default = '0x10800000' : Virtual address of stack limit : [0x0..0xFFFFFFFF]
+cpu0.semihosting-cwd=""                               # (string, init-time) default = ''       : Base directory for semihosting file access.
+cpu0.MPU_S=0x8                                        # (int   , init-time) default = '0x8'    : Number of regions in the Secure MPU. If Security Extentions are absent, this is ignored : [0x0..0x10]
+cpu0.MPU_NS=0x8                                       # (int   , init-time) default = '0x8'    : Number of regions in the Non-Secure MPU. If Security Extentions are absent, this is the total number of MPU regions : [0x0..0x10]
+cpu0.ITM=0                                            # (bool  , init-time) default = '1'      : Level of instrumentation trace supported. false : No ITM trace included, true: ITM trace included
+cpu0.IRQLVL=0x3                                       # (int   , init-time) default = '0x3'    : Number of bits of interrupt priority : [0x3..0x8]
+cpu0.BIGENDINIT=0                                     # (bool  , init-time) default = '0'      : Initialize processor to big endian mode
+cpu0.INITSVTOR=0x00000000                             # (int   , init-time) default = '0x10000000' : Secure vector-table offset at reset : [0x0..0xFFFFFF80]
+cpu0.INITNSVTOR=0x0                                   # (int   , init-time) default = '0x0'    : Non-Secure vector-table offset at reset : [0x0..0xFFFFFF80]
+cpu0.SAU=0x8                                          # (int   , init-time) default = '0x4'    : Number of SAU regions (0 => no SAU) : [0x0..0x8]
+cpu0.SAU_CTRL.ENABLE=0                                # (bool  , init-time) default = '0'      : Enable SAU at reset
+cpu0.SAU_CTRL.ALLNS=0                                 # (bool  , init-time) default = '0'      : At reset, the SAU treats entire memory space as NS when the SAU is disabled if this is set
+idau.NUM_IDAU_REGION=0x0                              # (int   , init-time) default = '0xA'    : 
+cpu0.LOCK_SAU=0                                       # (bool  , init-time) default = '0'      : Lock down of SAU registers write
+cpu0.LOCK_S_MPU=0                                     # (bool  , init-time) default = '0'      : Lock down of Secure MPU registers write
+cpu0.LOCK_NS_MPU=0                                    # (bool  , init-time) default = '0'      : Lock down of Non-Secure MPU registers write
+cpu0.CPIF=1                                           # (bool  , init-time) default = '1'      : Specifies whether the external coprocessor interface is included
+cpu0.SECEXT=1                                         # (bool  , init-time) default = '1'      : Whether the ARMv8-M Security Extensions are included
+fvp_mps2.DISABLE_GATING=1                             # (bool  , init-time) default = '0'      : Disable Memory gating logic
+#----------------------------------------------------------------------------------------------

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM4/RTE/Device/ARMCM4/ac6_linker_script.sct
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM4/RTE/Device/ARMCM4/ac6_linker_script.sct
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE 8
+#else
+#define __STACKSEAL_SIZE 0
+#endif
+
+/*----------------------------------------------------------------------------
+  Scatter File Definitions definition
+ *----------------------------------------------------------------------------*/
+
+LR_ROM0 __ROM0_BASE __ROM0_SIZE  {
+
+  ER_ROM0 __ROM0_BASE __ROM0_SIZE {
+    *.o (RESET, +First)
+    *(InRoot$$Sections)
+    *(+RO +XO)
+  }
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  ER_CMSE_VENEER AlignExpr(+0, 32) (__ROM0_SIZE - AlignExpr(ImageLength(ER_ROM0), 32)) {
+    *(Veneer$$CMSE)
+  }
+#endif
+
+  RW_NOINIT __RAM0_BASE UNINIT (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE) {
+    *(.bss.noinit)
+  }
+
+  RW_RAM0 AlignExpr(+0, 8) (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE - AlignExpr(ImageLength(RW_NOINIT), 8)) {
+    *(+RW +ZI)
+  }
+
+#if __HEAP_SIZE > 0
+  ARM_LIB_HEAP  (AlignExpr(+0, 8)) EMPTY __HEAP_SIZE  {   ; Reserve empty region for heap
+  }
+#endif
+
+  ARM_LIB_STACK (__RAM0_BASE + __RAM0_SIZE - __STACKSEAL_SIZE) EMPTY -__STACK_SIZE {   ; Reserve empty region for stack
+  }
+
+#if __STACKSEAL_SIZE > 0
+  STACKSEAL +0 EMPTY __STACKSEAL_SIZE {             ; Reserve empty region for stack seal immediately after stack
+  }
+#endif
+
+#if __RAM1_SIZE > 0
+  RW_RAM1 __RAM1_BASE __RAM1_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+
+#if __RAM2_SIZE > 0
+  RW_RAM2 __RAM2_BASE __RAM2_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+
+#if __RAM3_SIZE > 0
+  RW_RAM3 __RAM3_BASE __RAM3_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+}
+
+#if __ROM1_SIZE > 0
+LR_ROM1 __ROM1_BASE __ROM1_SIZE  {
+  ER_ROM1 +0 __ROM1_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif
+
+#if __ROM2_SIZE > 0
+LR_ROM2 __ROM2_BASE __ROM2_SIZE  {
+  ER_ROM2 +0 __ROM2_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif
+
+#if __ROM3_SIZE > 0
+LR_ROM3 __ROM3_BASE __ROM3_SIZE  {
+  ER_ROM3 +0 __ROM3_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM4/RTE/Device/ARMCM4/clang_linker_script.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM4/RTE/Device/ARMCM4/clang_linker_script.ld
@@ -1,0 +1,361 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2019 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+/* ----------------------------------------------------------------------------
+  Memory definition
+ *----------------------------------------------------------------------------*/
+MEMORY
+{
+  ROM0  (rx!w)  : ORIGIN = __ROM0_BASE, LENGTH = __ROM0_SIZE
+#if __ROM1_SIZE > 0
+  ROM1  (rx!w)  : ORIGIN = __ROM1_BASE, LENGTH = __ROM1_SIZE
+#endif
+#if __ROM2_SIZE > 0
+  ROM2  (rx!w)  : ORIGIN = __ROM2_BASE, LENGTH = __ROM2_SIZE
+#endif
+#if __ROM3_SIZE > 0
+  ROM3  (rx!w)  : ORIGIN = __ROM3_BASE, LENGTH = __ROM3_SIZE
+#endif
+
+  RAM0  (w!rx) : ORIGIN = __RAM0_BASE, LENGTH = __RAM0_SIZE
+#if __RAM1_SIZE > 0
+  RAM1  (w!rx) : ORIGIN = __RAM1_BASE, LENGTH = __RAM1_SIZE
+#endif
+#if __RAM2_SIZE > 0
+  RAM2  (w!rx) : ORIGIN = __RAM2_BASE, LENGTH = __RAM2_SIZE
+#endif
+#if __RAM3_SIZE > 0
+  RAM3  (w!rx) : ORIGIN = __RAM3_BASE, LENGTH = __RAM3_SIZE
+#endif
+}
+
+ENTRY(Reset_Handler)
+
+PHDRS
+{
+	text PT_LOAD;
+	ram PT_LOAD;
+	ram_init PT_LOAD;
+	tls PT_TLS;
+}
+
+SECTIONS
+{
+	.init : {
+		KEEP (*(.vectors))
+		KEEP (*(.text.init.enter))
+		KEEP (*(.data.init.enter))
+		KEEP (*(SORT_BY_NAME(.init) SORT_BY_NAME(.init.*)))
+	} >ROM0 AT>ROM0 :text
+
+	.text : {
+
+		/* code */
+		*(.text.unlikely .text.unlikely.*)
+		*(.text.startup .text.startup.*)
+		*(.text .text.* .opd .opd.*)
+		*(.gnu.linkonce.t.*)
+		KEEP (*(.fini .fini.*))
+		__text_end = .;
+
+		PROVIDE (__etext = __text_end);
+		PROVIDE (_etext = __text_end);
+		PROVIDE (etext = __text_end);
+
+		/* read-only data */
+		*(.rdata)
+		*(.rodata .rodata.*)
+		*(.gnu.linkonce.r.*)
+
+		*(.srodata.cst16)
+		*(.srodata.cst8)
+		*(.srodata.cst4)
+		*(.srodata.cst2)
+		*(.srodata .srodata.*)
+		*(.data.rel.ro .data.rel.ro.*)
+		*(.got .got.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		/* lists of constructors and destructors */
+		PROVIDE_HIDDEN ( __preinit_array_start = . );
+		KEEP (*(.preinit_array))
+		PROVIDE_HIDDEN ( __preinit_array_end = . );
+
+		PROVIDE_HIDDEN ( __init_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+		KEEP (*(.init_array .ctors))
+		PROVIDE_HIDDEN ( __init_array_end = . );
+
+		PROVIDE_HIDDEN ( __fini_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
+		KEEP (*(.fini_array .dtors))
+		PROVIDE_HIDDEN ( __fini_array_end = . );
+
+	} >ROM0 AT>ROM0 :text
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+	.veneers :
+	{
+		. = ALIGN(32);
+		KEEP(*(.gnu.sgstubs))
+	} > ROM0 AT>ROM0 :text
+#endif
+
+	.toc : {
+		*(.toc .toc.*)
+	} >ROM0 AT>ROM0 :text
+
+	/* additional sections when compiling with C++ exception support */
+	
+	.except_ordered : {
+		*(.gcc_except_table *.gcc_except_table.*)
+		KEEP (*(.eh_frame .eh_frame.*))
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+	} >ROM0 AT>ROM0 :text
+
+	.except_unordered : {
+		. = ALIGN(8);
+
+		PROVIDE(__exidx_start = .);
+		*(.ARM.exidx*)
+		PROVIDE(__exidx_end = .);
+	} >ROM0 AT>ROM0 :text
+	
+
+	/*
+	 * Data values which are preserved across reset
+	 */
+	.preserve (NOLOAD) : {
+		PROVIDE(__preserve_start__ = .);
+		KEEP(*(SORT_BY_NAME(.preserve.*)))
+		KEEP(*(.preserve))
+		PROVIDE(__preserve_end__ = .);
+	} >RAM0 AT>RAM0 :ram
+
+	.data :  {
+		*(.data .data.*)
+		*(.gnu.linkonce.d.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		PROVIDE( __global_pointer$ = . + 0x800 );
+		*(.sdata .sdata.* .sdata2.*)
+		*(.gnu.linkonce.s.*)
+	} >RAM0 AT>ROM0 :ram_init
+	PROVIDE(__data_start = ADDR(.data));
+	PROVIDE(__data_source = LOADADDR(.data));
+
+	/* Thread local initialized data. This gets
+	 * space allocated as it is expected to be placed
+	 * in ram to be used as a template for TLS data blocks
+	 * allocated at runtime. We're slightly abusing that
+	 * by placing the data in flash where it will be copied
+	 * into the allocate ram addresses by the existing
+	 * data initialization code in crt0
+	 */
+	.tdata :  {
+		*(.tdata .tdata.* .gnu.linkonce.td.*)
+		PROVIDE(__data_end = .);
+		PROVIDE(__tdata_end = .);
+	} >RAM0 AT>ROM0 :tls :ram_init
+	PROVIDE( __tls_base = ADDR(.tdata));
+	PROVIDE( __tdata_start = ADDR(.tdata));
+	PROVIDE( __tdata_source = LOADADDR(.tdata) );
+	PROVIDE( __tdata_source_end = LOADADDR(.tdata) + SIZEOF(.tdata) );
+	PROVIDE( __data_source_end = __tdata_source_end );
+	PROVIDE( __tdata_size = SIZEOF(.tdata) );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata),ALIGNOF(.tbss)) );
+
+	PROVIDE( __edata = __data_end );
+	PROVIDE( _edata = __data_end );
+	PROVIDE( edata = __data_end );
+	PROVIDE( __data_size = __data_end - __data_start );
+	PROVIDE( __data_source_size = __data_source_end - __data_source );
+
+	.tbss (NOLOAD) : {
+		*(.tbss .tbss.* .gnu.linkonce.tb.*)
+		*(.tcommon)
+		PROVIDE( __tls_end = . );
+		PROVIDE( __tbss_end = . );
+	} >RAM0 AT>RAM0 :tls :ram
+	PROVIDE( __bss_start = ADDR(.tbss));
+	PROVIDE( __tbss_start = ADDR(.tbss));
+	PROVIDE( __tbss_offset = ADDR(.tbss) - ADDR(.tdata) );
+	PROVIDE( __tbss_size = SIZEOF(.tbss) );
+	PROVIDE( __tls_size = __tls_end - __tls_base );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
+	PROVIDE( __arm32_tls_tcb_offset = MAX(8, __tls_align) );
+	PROVIDE( __arm64_tls_tcb_offset = MAX(16, __tls_align) );
+
+	/*
+	 * The linker special cases .tbss segments which are
+	 * identified as segments which are not loaded and are
+	 * thread_local.
+	 *
+	 * For these segments, the linker does not advance 'dot'
+	 * across them.  We actually need memory allocated for tbss,
+	 * so we create a special segment here just to make room
+	 */
+	/*
+	.tbss_space (NOLOAD) : {
+		. = ADDR(.tbss);
+		. = . + SIZEOF(.tbss);
+	} >RAM0 AT>RAM0 :ram
+	*/
+
+	.bss (NOLOAD) : {
+		*(.sbss*)
+		*(.gnu.linkonce.sb.*)
+		*(.bss .bss.*)
+		*(.gnu.linkonce.b.*)
+		*(COMMON)
+
+		/* Align the heap */
+		. = ALIGN(8);
+		__bss_end = .;
+	} >RAM0 AT>RAM0 :ram
+	PROVIDE( __non_tls_bss_start = ADDR(.bss) );
+	PROVIDE( __end = __bss_end );
+	PROVIDE( _end = __bss_end );
+	PROVIDE( end = __bss_end );
+	PROVIDE( __bss_size = __bss_end - __bss_start );
+
+	/* Make the rest of memory available for heap storage */
+	PROVIDE (__heap_start = __end);
+#ifdef __HEAP_SIZE
+	PROVIDE (__heap_end = __heap_start + __HEAP_SIZE);
+	PROVIDE (__heap_size = __HEAP_SIZE);
+#else
+	PROVIDE (__heap_end = __stack - __STACK_SIZE);
+	PROVIDE (__heap_size = __heap_end - __heap_start);
+#endif
+	.heap (NOLOAD) : {
+		. += __heap_size;
+	} >RAM0 :ram
+
+	/* Define a stack region to make sure it fits in memory */
+	PROVIDE(__stack = ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE);
+	PROVIDE(__stack_limit = __stack - __STACK_SIZE);
+	.stack (__stack_limit) (NOLOAD) : {
+		. += __STACK_SIZE;
+	} >RAM0 :ram
+
+#if __STACKSEAL_SIZE > 0
+	PROVIDE(__stack_seal = __stack);
+  	.stackseal (__stack) (NOLOAD) :
+  	{
+    	. += __STACKSEAL_SIZE;
+  	} >RAM0 :ram
+#endif
+
+	/* Throw away C++ exception handling information */
+
+	/*
+
+	/DISCARD/ : {
+		*(.note .note.*)
+		*(.eh_frame .eh_frame.*)
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+		*(.ARM.exidx*)
+	}
+
+	*/
+
+	/* Stabs debugging sections.  */
+	.stab          0 : { *(.stab) }
+	.stabstr       0 : { *(.stabstr) }
+	.stab.excl     0 : { *(.stab.excl) }
+	.stab.exclstr  0 : { *(.stab.exclstr) }
+	.stab.index    0 : { *(.stab.index) }
+	.stab.indexstr 0 : { *(.stab.indexstr) }
+	.comment       0 : { *(.comment) }
+	.gnu.build.attributes : { *(.gnu.build.attributes .gnu.build.attributes.*) }
+	/* DWARF debug sections.
+	   Symbols in the DWARF debugging sections are relative to the beginning
+	   of the section so we begin them at 0.  */
+	/* DWARF 1.  */
+	.debug          0 : { *(.debug) }
+	.line           0 : { *(.line) }
+	/* GNU DWARF 1 extensions.  */
+	.debug_srcinfo  0 : { *(.debug_srcinfo) }
+	.debug_sfnames  0 : { *(.debug_sfnames) }
+	/* DWARF 1.1 and DWARF 2.  */
+	.debug_aranges  0 : { *(.debug_aranges) }
+	.debug_pubnames 0 : { *(.debug_pubnames) }
+	/* DWARF 2.  */
+	.debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+	.debug_abbrev   0 : { *(.debug_abbrev) }
+	.debug_line     0 : { *(.debug_line .debug_line.* .debug_line_end) }
+	.debug_frame    0 : { *(.debug_frame) }
+	.debug_str      0 : { *(.debug_str) }
+	.debug_loc      0 : { *(.debug_loc) }
+	.debug_macinfo  0 : { *(.debug_macinfo) }
+	/* SGI/MIPS DWARF 2 extensions.  */
+	.debug_weaknames 0 : { *(.debug_weaknames) }
+	.debug_funcnames 0 : { *(.debug_funcnames) }
+	.debug_typenames 0 : { *(.debug_typenames) }
+	.debug_varnames  0 : { *(.debug_varnames) }
+	/* DWARF 3.  */
+	.debug_pubtypes 0 : { *(.debug_pubtypes) }
+	.debug_ranges   0 : { *(.debug_ranges) }
+	/* DWARF 5.  */
+	.debug_addr     0 : { *(.debug_addr) }
+	.debug_line_str 0 : { *(.debug_line_str) }
+	.debug_loclists 0 : { *(.debug_loclists) }
+	.debug_macro    0 : { *(.debug_macro) }
+	.debug_names    0 : { *(.debug_names) }
+	.debug_rnglists 0 : { *(.debug_rnglists) }
+	.debug_str_offsets 0 : { *(.debug_str_offsets) }
+	.debug_sup      0 : { *(.debug_sup) }
+	.gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }
+}
+/*
+ * Check that sections that are copied from flash to RAM have matching
+ * padding, so that a single memcpy() of __data_size copies the correct bytes.
+ */
+ASSERT( __data_size == __data_source_size,
+	"ERROR: .data/.tdata flash size does not match RAM size");

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM4/RTE/Device/ARMCM4/gcc_linker_script.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM4/RTE/Device/ARMCM4/gcc_linker_script.ld
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+/* ----------------------------------------------------------------------------
+  Memory definition
+ *----------------------------------------------------------------------------*/
+MEMORY
+{
+  ROM0  (rx)  : ORIGIN = __ROM0_BASE, LENGTH = __ROM0_SIZE
+#if __ROM1_SIZE > 0
+  ROM1  (rx)  : ORIGIN = __ROM1_BASE, LENGTH = __ROM1_SIZE
+#endif
+#if __ROM2_SIZE > 0
+  ROM2  (rx)  : ORIGIN = __ROM2_BASE, LENGTH = __ROM2_SIZE
+#endif
+#if __ROM3_SIZE > 0
+  ROM3  (rx)  : ORIGIN = __ROM3_BASE, LENGTH = __ROM3_SIZE
+#endif
+
+  RAM0  (rwx) : ORIGIN = __RAM0_BASE, LENGTH = __RAM0_SIZE
+#if __RAM1_SIZE > 0
+  RAM1  (rwx) : ORIGIN = __RAM1_BASE, LENGTH = __RAM1_SIZE
+#endif
+#if __RAM2_SIZE > 0
+  RAM2  (rwx) : ORIGIN = __RAM2_BASE, LENGTH = __RAM2_SIZE
+#endif
+#if __RAM3_SIZE > 0
+  RAM3  (rwx) : ORIGIN = __RAM3_BASE, LENGTH = __RAM3_SIZE
+#endif
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __copy_table_start__
+ *   __copy_table_end__
+ *   __zero_table_start__
+ *   __zero_table_end__
+ *   __etext          (deprecated)
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+  .text :
+  {
+    KEEP(*(.vectors))
+    *(.text*)
+
+    KEEP(*(.init))
+    KEEP(*(.fini))
+
+    /* .ctors */
+    *crtbegin.o(.ctors)
+    *crtbegin?.o(.ctors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+    *(SORT(.ctors.*))
+    *(.ctors)
+
+    /* .dtors */
+    *crtbegin.o(.dtors)
+    *crtbegin?.o(.dtors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+    *(SORT(.dtors.*))
+    *(.dtors)
+
+    *(.rodata*)
+
+    KEEP(*(.eh_frame*))
+  } > ROM0
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  .gnu.sgstubs :
+  {
+    . = ALIGN(32);
+  } > ROM0
+#endif
+
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > ROM0
+
+  __exidx_start = .;
+  .ARM.exidx :
+  {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+  } > ROM0
+  __exidx_end = .;
+
+  .copy.table :
+  {
+    . = ALIGN(4);
+    __copy_table_start__ = .;
+
+    LONG (LOADADDR(.data))
+    LONG (ADDR(.data))
+    LONG (SIZEOF(.data) / 4)
+
+    /* Add each additional data section here */
+/*
+    LONG (LOADADDR(.data2))
+    LONG (ADDR(.data2))
+    LONG (SIZEOF(.data2) / 4)
+*/
+    __copy_table_end__ = .;
+  } > ROM0
+
+  .zero.table :
+  {
+    . = ALIGN(4);
+    __zero_table_start__ = .;
+
+/*  .bss initialization to zero is already done during C Run-Time Startup.
+    LONG (ADDR(.bss))
+    LONG (SIZEOF(.bss) / 4)
+*/
+
+    /* Add each additional bss section here */
+/*
+    LONG (ADDR(.bss2))
+    LONG (SIZEOF(.bss2) / 4)
+*/
+    __zero_table_end__ = .;
+  } > ROM0
+
+  /*
+   * This __etext variable is kept for backward compatibility with older,
+   * ASM based startup files.
+   */
+  PROVIDE(__etext = LOADADDR(.data));
+
+  .data : ALIGN(4)
+  {
+    __data_start__ = .;
+    *(vtable)
+    *(.data)
+    *(.data.*)
+
+    . = ALIGN(4);
+    /* preinit data */
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP(*(.preinit_array))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+
+    . = ALIGN(4);
+    /* init data */
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP(*(SORT(.init_array.*)))
+    KEEP(*(.init_array))
+    PROVIDE_HIDDEN (__init_array_end = .);
+
+    . = ALIGN(4);
+    /* finit data */
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP(*(SORT(.fini_array.*)))
+    KEEP(*(.fini_array))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    /* All data end */
+    __data_end__ = .;
+
+  } > RAM0 AT > ROM0
+
+  /*
+   * Secondary data section, optional
+   *
+   * Remember to add each additional data section
+   * to the .copy.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .data2 : ALIGN(4)
+  {
+    . = ALIGN(4);
+    __data2_start__ = .;
+    *(.data2)
+    *(.data2.*)
+    . = ALIGN(4);
+    __data2_end__ = .;
+
+  } > RAM1 AT > ROM0 
+*/
+
+  .bss :
+  {
+    . = ALIGN(4);
+    __bss_start__ = .;
+    *(.bss)
+    *(.bss.*)
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+  } > RAM0 AT > RAM0
+
+  /*
+   * Secondary bss section, optional
+   *
+   * Remember to add each additional bss section
+   * to the .zero.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .bss2 :
+  {
+    . = ALIGN(4);
+    __bss2_start__ = .;
+    *(.bss2)
+    *(.bss2.*)
+    . = ALIGN(4);
+    __bss2_end__ = .;
+  } > RAM1 AT > RAM1
+*/
+
+  .heap (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE(end = .);
+    . = . + __HEAP_SIZE;
+    . = ALIGN(8);
+    __HeapLimit = .;
+  } > RAM0
+
+  .stack (ORIGIN(RAM0) + LENGTH(RAM0) - __STACK_SIZE - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackLimit = .;
+    . = . + __STACK_SIZE;
+    . = ALIGN(8);
+    __StackTop = .;
+  } > RAM0
+  PROVIDE(__stack = __StackTop);
+
+#if __STACKSEAL_SIZE > 0
+  .stackseal (ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackSeal = .;
+    . = . + 8;
+    . = ALIGN(8);
+  } > RAM0
+#endif
+
+  /* Check if data + heap + stack exceeds RAM limit */
+  ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM4/RTE/Device/ARMCM4/iar_linker_script.icf
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM4/RTE/Device/ARMCM4/iar_linker_script.icf
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+define memory mem with size = 4G;
+
+#if __ROM0_SIZE > 0
+  define region ROM0_region = mem:[from __ROM0_BASE to (__ROM0_BASE+__ROM0_SIZE-1)];
+#else
+  define region ROM0_region = [];
+#endif
+
+#if __ROM1_SIZE > 0
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+#else
+  define region ROM1_region = [];
+#endif
+
+#if __ROM2_SIZE > 0
+  define region ROM2_region = mem:[from __ROM2_BASE to (__ROM2_BASE+__ROM2_SIZE-1)];
+#else
+  define region ROM2_region = [];
+#endif
+
+#if __ROM3_SIZE > 0
+  define region ROM3_region = mem:[from __ROM3_BASE to (__ROM3_BASE+__ROM3_SIZE-1)];
+#else
+  define region ROM3_region = [];
+#endif
+
+define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_region;
+
+#if __RAM0_SIZE > 0
+  define region RAM0_region = mem:[from __RAM0_BASE to (__RAM0_BASE+__RAM0_SIZE-1)];
+#else
+  define region RAM0_region = [];
+#endif
+
+#if __RAM1_SIZE > 0
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+#else
+  define region RAM1_region = [];
+#endif
+
+#if __RAM2_SIZE > 0
+  define region RAM2_region = mem:[from __RAM2_BASE to (__RAM2_BASE+__RAM2_SIZE-1)];
+#else
+  define region RAM2_region = [];
+#endif
+
+#if __RAM3_SIZE > 0
+  define region RAM3_region = mem:[from __RAM3_BASE to (__RAM3_BASE+__RAM3_SIZE-1)];
+#else
+  define region RAM3_region = [];
+#endif
+
+define region RAM_region = RAM0_region | RAM1_region | RAM2_region | RAM3_region;
+
+do not initialize  { section .noinit };
+initialize by copy { readwrite };
+if (isdefinedsymbol(__USE_DLIB_PERTHREAD))
+{
+  // Required in a multi-threaded application
+  initialize by copy with packing = none { section __DLIB_PERTHREAD };
+}
+
+place at address mem:__ROM0_BASE { readonly section .intvec };
+
+if (!isempty(ROM_region))
+{
+  place in ROM_region  { readonly };
+}
+
+if (!isempty(RAM_region))
+{
+  define block CSTACK     with alignment = 8, size = __STACK_SIZE     { };
+  define block PROC_STACK with alignment = 8, size = 0 { };
+  define block HEAP       with alignment = 8, size = __HEAP_SIZE       { };
+  place in RAM_region  { readwrite, block CSTACK, block PROC_STACK, block HEAP };
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM4/RTE/Device/ARMCM4/regions_ARMCM4.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM4/RTE/Device/ARMCM4/regions_ARMCM4.h
@@ -1,0 +1,60 @@
+#ifndef REGIONS_ARMCM4_H
+#define REGIONS_ARMCM4_H
+
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+// <n>Device pack:   ARM::Cortex_DFP@1.0.0-dev16
+// <i>Device pack used to generate this file
+
+// <h>ROM Configuration
+// =======================
+// <h> ROM=<__ROM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x00000000
+#define __ROM0_BASE 0x00000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00040000
+#define __ROM0_SIZE 0x00040000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __ROM0_DEFAULT 1
+//   <q>Startup
+//   <i> Selects region to be used for startup code.
+#define __ROM0_STARTUP 1
+// </h>
+
+// </h>
+
+// <h>RAM Configuration
+// =======================
+// <h> RAM=<__RAM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x20000000
+#define __RAM0_BASE 0x20000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00020000
+#define __RAM0_SIZE 0x00020000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __RAM0_DEFAULT 1
+//   <q>No zero initialize
+//   <i> Excludes region from zero initialization.
+#define __RAM0_NOINIT 0
+// </h>
+
+// </h>
+
+// <h>Stack / Heap Configuration
+//   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+#define __STACK_SIZE 0x00000400
+#define __HEAP_SIZE 0x00000C00
+// </h>
+
+
+#endif /* REGIONS_ARMCM4_H */

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM4/RTE/Device/ARMCM4/startup_ARMCM4.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM4/RTE/Device/ARMCM4/startup_ARMCM4.c
@@ -1,0 +1,150 @@
+/******************************************************************************
+ * @file     startup_ARMCM4.c
+ * @brief    CMSIS-Core(M) Device Startup File for a Cortex-M4 Device
+ * @version  V3.0.0
+ * @date     06. April 2023
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (ARMCM4)
+  #include "ARMCM4.h"
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  External References
+ *----------------------------------------------------------------------------*/
+extern uint32_t __INITIAL_SP;
+
+extern __NO_RETURN void __PROGRAM_START(void);
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler  (void);
+            void Default_Handler(void);
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+/* Exceptions */
+void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void HardFault_Handler      (void) __attribute__ ((weak));
+void MemManage_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
+void BusFault_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void UsageFault_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void DebugMon_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+
+void Interrupt0_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt1_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt2_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt3_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt4_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt5_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt6_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt7_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt8_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt9_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[240];
+       const VECTOR_TABLE_Type __VECTOR_TABLE[240] __VECTOR_TABLE_ATTRIBUTE = {
+  (VECTOR_TABLE_Type)(&__INITIAL_SP),       /*     Initial Stack Pointer */
+  Reset_Handler,                            /*     Reset Handler */
+  NMI_Handler,                              /* -14 NMI Handler */
+  HardFault_Handler,                        /* -13 Hard Fault Handler */
+  MemManage_Handler,                        /* -12 MPU Fault Handler */
+  BusFault_Handler,                         /* -11 Bus Fault Handler */
+  UsageFault_Handler,                       /* -10 Usage Fault Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  SVC_Handler,                              /*  -5 SVC Handler */
+  DebugMon_Handler,                         /*  -4 Debug Monitor Handler */
+  0,                                        /*     Reserved */
+  PendSV_Handler,                           /*  -2 PendSV Handler */
+  SysTick_Handler,                          /*  -1 SysTick Handler */
+
+  /* Interrupts */
+  Interrupt0_Handler,                       /*   0 Interrupt 0 */
+  Interrupt1_Handler,                       /*   1 Interrupt 1 */
+  Interrupt2_Handler,                       /*   2 Interrupt 2 */
+  Interrupt3_Handler,                       /*   3 Interrupt 3 */
+  Interrupt4_Handler,                       /*   4 Interrupt 4 */
+  Interrupt5_Handler,                       /*   5 Interrupt 5 */
+  Interrupt6_Handler,                       /*   6 Interrupt 6 */
+  Interrupt7_Handler,                       /*   7 Interrupt 7 */
+  Interrupt8_Handler,                       /*   8 Interrupt 8 */
+  Interrupt9_Handler                        /*   9 Interrupt 9 */
+                                            /* Interrupts 10 .. 223 are left out */
+};
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler(void)
+{
+  SystemInit();                             /* CMSIS System Initialization */
+  __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
+}
+
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wmissing-noreturn"
+#endif
+
+/*----------------------------------------------------------------------------
+  Hard Fault Handler
+ *----------------------------------------------------------------------------*/
+void HardFault_Handler(void)
+{
+  while(1);
+}
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+void Default_Handler(void)
+{
+  while(1);
+}
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic pop
+#endif
+

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM4/RTE/Device/ARMCM4/system_ARMCM4.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM4/RTE/Device/ARMCM4/system_ARMCM4.c
@@ -1,0 +1,79 @@
+/**************************************************************************//**
+ * @file     system_ARMCM4.c
+ * @brief    CMSIS Device System Source File for
+ *           ARMCM4 Device
+ * @version  V2.0.0
+ * @date     06. April 2023
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (ARMCM4)
+  #include "ARMCM4.h"
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  Define clocks
+ *----------------------------------------------------------------------------*/
+#define  XTAL            (50000000UL)     /* Oscillator frequency */
+
+#define  SYSTEM_CLOCK    (XTAL / 2U)
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[240];
+
+
+/*----------------------------------------------------------------------------
+  System Core Clock Variable
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = SYSTEM_CLOCK;  /* System Core Clock Frequency */
+
+
+/*----------------------------------------------------------------------------
+  System Core Clock update function
+ *----------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)
+{
+  SystemCoreClock = SYSTEM_CLOCK;
+}
+
+/*----------------------------------------------------------------------------
+  System initialization function
+ *----------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t) &(__VECTOR_TABLE[0]);
+#endif
+
+#if defined (__FPU_USED) && (__FPU_USED == 1U)
+  SCB->CPACR |= ((3U << 10U*2U) |           /* enable CP10 Full Access */
+                 (3U << 11U*2U)  );         /* enable CP11 Full Access */
+#endif
+
+#ifdef UNALIGNED_SUPPORT_DISABLE
+  SCB->CCR |= SCB_CCR_UNALIGN_TRP_Msk;
+#endif
+
+  SystemCoreClock = SYSTEM_CLOCK;
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM4/RTE/Device/ARMCM4/tiac_arm.cmd
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM4/RTE/Device/ARMCM4/tiac_arm.cmd
@@ -1,0 +1,41 @@
+/****************************************************************************/
+/* tiac_arm.cmd - COMMAND FILE FOR LINKING ARM C PROGRAMS                   */
+/*                                                                          */
+/*   Description: This file is a sample command file that can be used       */
+/*                for linking programs built with the TI Arm Clang          */
+/*                Compiler.   Use it as a guideline; you may want to change */
+/*                the allocation scheme according to the size of your       */
+/*                program and the memory layout of your target system.      */
+/*                                                                          */
+/****************************************************************************/
+-c                                         /* LINK USING C CONVENTIONS      */
+-stack  0x4000                             /* SOFTWARE STACK SIZE           */
+-heap   0x4000                             /* HEAP AREA SIZE                */
+--args 0x1000
+
+/* SPECIFY THE SYSTEM MEMORY MAP */
+MEMORY
+{
+    V_MEM    : org = 0x00000000   len = 0x00001000  /* INT VECTOR */
+    P_MEM    : org = 0x00001000   len = 0x20000000  /* PROGRAM MEMORY (ROM) */
+    D_MEM    : org = 0x20001000   len = 0x20000000  /* DATA MEMORY    (RAM) */
+}
+
+/* SPECIFY THE SECTIONS ALLOCATION INTO MEMORY */
+SECTIONS
+{
+    .intvecs    : {} > 0x0             /* INTERRUPT VECTORS                 */
+    .bss        : {} > D_MEM           /* GLOBAL & STATIC VARS              */
+    .data       : {} > D_MEM
+    .sysmem     : {} > D_MEM           /* DYNAMIC MEMORY ALLOCATION AREA    */
+    .stack      : {} > D_MEM           /* SOFTWARE SYSTEM STACK             */
+
+    .text       : {} > P_MEM           /* CODE                              */
+    .cinit      : {} > P_MEM           /* INITIALIZATION TABLES             */
+    .const      : {} > P_MEM           /* CONSTANT DATA                     */
+    .rodata     : {} > P_MEM, palign(4)
+    .init_array : {} > P_MEM           /* C++ CONSTRUCTOR TABLES            */
+
+
+    .TI.ramfunc : {} load=P_MEM, run=D_MEM, table(BINIT)
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM4/Target.clayer.yml
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM4/Target.clayer.yml
@@ -1,0 +1,32 @@
+layer:
+  type: Target
+  description: CM4 target components and files
+
+  packs:
+    - pack: ARM::Cortex_DFP
+
+  device: ARMCM4
+
+  components:
+    # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
+    - component: ARM::CMSIS:CORE
+    - component: Device:Startup&C Startup
+
+  groups:
+    - group: FVP
+      files:
+        - file: ./model_config.txt
+
+  linker:
+    - for-compiler: AC6
+      script: RTE/Device/$Dname$/ac6_linker_script.sct
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: GCC
+      script: RTE/Device/$Dname$/gcc_linker_script.ld
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: CLANG
+      script: RTE/Device/$Dname$/clang_linker_script.ld
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: IAR
+      script: RTE/Device/$Dname$/iar_linker_script.icf
+      regions: RTE/Device/$Dname$/regions_$Dname$.h

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM4/model_config.txt
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM4/model_config.txt
@@ -1,0 +1,14 @@
+# Parameters:
+# instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+#----------------------------------------------------------------------------------------------
+fvp_mps2.mps2_visualisation.disable-visualisation=1   # (bool  , init-time) default = '0'      : Enable/disable visualisation
+armcortexm4ct.vfp-present=1                           # (bool  , init-time) default = '1'      : Set whether the model has VFP support
+armcortexm4ct.semihosting-enable=1                    # (bool  , init-time) default = '1'      : Enable semihosting SVC traps. Applications that do not use semihosting must set this parameter to false.
+armcortexm4ct.semihosting-Thumb_SVC=0xAB              # (int   , init-time) default = '0xAB'   : T32 SVC number for semihosting : [0x0..0xFF]
+armcortexm4ct.semihosting-cmd_line=""                 # (string, init-time) default = ''       : Command line available to semihosting SVC calls
+armcortexm4ct.semihosting-heap_base=0x0               # (int   , init-time) default = '0x0'    : Virtual address of heap base : [0x0..0xFFFFFFFF]
+armcortexm4ct.semihosting-heap_limit=0x0              # (int   , init-time) default = '0x10700000' : Virtual address of top of heap : [0x0..0xFFFFFFFF]
+armcortexm4ct.semihosting-stack_base=0x0              # (int   , init-time) default = '0x10700000' : Virtual address of base of descending stack : [0x0..0xFFFFFFFF]
+armcortexm4ct.semihosting-stack_limit=0x0             # (int   , init-time) default = '0x10800000' : Virtual address of stack limit : [0x0..0xFFFFFFFF]
+armcortexm4ct.semihosting-cwd=""                      # (string, init-time) default = ''       : Base directory for semihosting file access.
+#----------------------------------------------------------------------------------------------

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55/RTE/Device/ARMCM55/ARMCM55_ac6.sct
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55/RTE/Device/ARMCM55/ARMCM55_ac6.sct
@@ -1,0 +1,123 @@
+#! armclang -E --target=arm-arm-none-eabi -mcpu=cortex-m55 -xc
+; command above MUST be in first line (no comment above!)
+
+;Note: Add '-mcmse' to first line if your software model is "Secure Mode".
+;      #! armclang -E --target=arm-arm-none-eabi -mcpu=cortex-m55 -xc -mcmse
+
+
+/*
+;-------- <<< Use Configuration Wizard in Context Menu >>> -------------------
+*/
+
+/*--------------------- Flash Configuration ----------------------------------
+; <h> Flash Configuration
+;   <o0> Flash Base Address <0x0-0xFFFFFFFF:8>
+;   <o1> Flash Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __ROM_BASE      0x00000000
+#define __ROM_SIZE      0x00080000
+
+/*--------------------- Embedded RAM Configuration ---------------------------
+; <h> RAM Configuration
+;   <o0> RAM Base Address    <0x0-0xFFFFFFFF:8>
+;   <o1> RAM Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __RAM_BASE      0x20000000
+#define __RAM_SIZE      0x00040000
+
+/*--------------------- Stack / Heap Configuration ---------------------------
+; <h> Stack / Heap Configuration
+;   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+;   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __STACK_SIZE    0x00000200
+#define __HEAP_SIZE     0x00000C00
+
+/*--------------------- CMSE Veneer Configuration ---------------------------
+; <h> CMSE Veneer Configuration
+;   <o0>  CMSE Veneer Size (in Bytes) <0x0-0xFFFFFFFF:32>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __CMSEVENEER_SIZE    0x200
+
+/*
+;------------- <<< end of configuration section >>> ---------------------------
+*/
+
+
+/*----------------------------------------------------------------------------
+  User Stack & Heap boundary definition
+ *----------------------------------------------------------------------------*/
+#define __STACK_TOP    (__RAM_BASE + __RAM_SIZE - __STACKSEAL_SIZE) /* starts at end of RAM - 8 byte stack seal */
+#define __HEAP_BASE    (AlignExpr(+0, 8))                           /* starts after RW_RAM section, 8 byte aligned */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+
+/*----------------------------------------------------------------------------
+  Region base & size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __CV_BASE          ( __ROM_BASE + __ROM_SIZE - __CMSEVENEER_SIZE )
+#define __CV_SIZE          ( __CMSEVENEER_SIZE )
+#else
+#define __CV_SIZE          ( 0 )
+#endif
+
+#define __RO_BASE          ( __ROM_BASE )
+#define __RO_SIZE          ( __ROM_SIZE - __CV_SIZE )
+
+#define __RW_BASE          ( __RAM_BASE )
+#define __RW_SIZE      (__RAM_SIZE - __STACK_SIZE - __HEAP_SIZE - __STACKSEAL_SIZE )
+
+
+/*----------------------------------------------------------------------------
+  Scatter Region definition
+ *----------------------------------------------------------------------------*/
+LR_ROM __RO_BASE __RO_SIZE  {                       ; load region size_region
+  ER_ROM __RO_BASE __RO_SIZE  {                     ; load address = execution address
+   *.o (RESET, +First)
+   *(InRoot$$Sections)
+   .ANY (+RO)
+   .ANY (+XO)
+  }
+
+  RW_NOINIT __RW_BASE UNINIT __RW_SIZE {
+    *(.bss.noinit)
+  }
+
+  RW_RAM AlignExpr(+0, 8) (__RW_SIZE - AlignExpr(ImageLength(RW_NOINIT), 8)) {
+    *(+RW +ZI)
+  }
+
+#if __HEAP_SIZE > 0
+  ARM_LIB_HEAP  __HEAP_BASE EMPTY  __HEAP_SIZE  {   ; Reserve empty region for heap
+  }
+#endif
+
+  ARM_LIB_STACK __STACK_TOP EMPTY -__STACK_SIZE {   ; Reserve empty region for stack
+  }
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  STACKSEAL +0 EMPTY __STACKSEAL_SIZE {             ; Reserve empty region for stack seal immediately after stack
+  }
+#endif
+}
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+LR_CMSE_VENEER __CV_BASE ALIGN 32 __CV_SIZE  {      ; own load/execution region for CMSE Veneers
+  ER_CMSE_VENEER __CV_BASE __CV_SIZE  {
+   *(Veneer$$CMSE)
+  }
+}
+#endif

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55/RTE/Device/ARMCM55/ac6_linker_script.sct
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55/RTE/Device/ARMCM55/ac6_linker_script.sct
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE 8
+#else
+#define __STACKSEAL_SIZE 0
+#endif
+
+/*----------------------------------------------------------------------------
+  Scatter File Definitions definition
+ *----------------------------------------------------------------------------*/
+
+LR_ROM0 __ROM0_BASE __ROM0_SIZE  {
+
+  ER_ROM0 __ROM0_BASE __ROM0_SIZE {
+    *.o (RESET, +First)
+    *(InRoot$$Sections)
+    *(+RO +XO)
+  }
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  ER_CMSE_VENEER AlignExpr(+0, 32) (__ROM0_SIZE - AlignExpr(ImageLength(ER_ROM0), 32)) {
+    *(Veneer$$CMSE)
+  }
+#endif
+
+  RW_NOINIT __RAM0_BASE UNINIT (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE) {
+    *(.bss.noinit)
+  }
+
+  RW_RAM0 AlignExpr(+0, 8) (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE - AlignExpr(ImageLength(RW_NOINIT), 8)) {
+    *(+RW +ZI)
+  }
+
+#if __HEAP_SIZE > 0
+  ARM_LIB_HEAP  (AlignExpr(+0, 8)) EMPTY __HEAP_SIZE  {   ; Reserve empty region for heap
+  }
+#endif
+
+  ARM_LIB_STACK (__RAM0_BASE + __RAM0_SIZE - __STACKSEAL_SIZE) EMPTY -__STACK_SIZE {   ; Reserve empty region for stack
+  }
+
+#if __STACKSEAL_SIZE > 0
+  STACKSEAL +0 EMPTY __STACKSEAL_SIZE {             ; Reserve empty region for stack seal immediately after stack
+  }
+#endif
+
+#if __RAM1_SIZE > 0
+  RW_RAM1 __RAM1_BASE __RAM1_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+
+#if __RAM2_SIZE > 0
+  RW_RAM2 __RAM2_BASE __RAM2_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+
+#if __RAM3_SIZE > 0
+  RW_RAM3 __RAM3_BASE __RAM3_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+}
+
+#if __ROM1_SIZE > 0
+LR_ROM1 __ROM1_BASE __ROM1_SIZE  {
+  ER_ROM1 +0 __ROM1_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif
+
+#if __ROM2_SIZE > 0
+LR_ROM2 __ROM2_BASE __ROM2_SIZE  {
+  ER_ROM2 +0 __ROM2_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif
+
+#if __ROM3_SIZE > 0
+LR_ROM3 __ROM3_BASE __ROM3_SIZE  {
+  ER_ROM3 +0 __ROM3_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55/RTE/Device/ARMCM55/clang_linker_script.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55/RTE/Device/ARMCM55/clang_linker_script.ld
@@ -1,0 +1,361 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2019 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+/* ----------------------------------------------------------------------------
+  Memory definition
+ *----------------------------------------------------------------------------*/
+MEMORY
+{
+  ROM0  (rx!w)  : ORIGIN = __ROM0_BASE, LENGTH = __ROM0_SIZE
+#if __ROM1_SIZE > 0
+  ROM1  (rx!w)  : ORIGIN = __ROM1_BASE, LENGTH = __ROM1_SIZE
+#endif
+#if __ROM2_SIZE > 0
+  ROM2  (rx!w)  : ORIGIN = __ROM2_BASE, LENGTH = __ROM2_SIZE
+#endif
+#if __ROM3_SIZE > 0
+  ROM3  (rx!w)  : ORIGIN = __ROM3_BASE, LENGTH = __ROM3_SIZE
+#endif
+
+  RAM0  (w!rx) : ORIGIN = __RAM0_BASE, LENGTH = __RAM0_SIZE
+#if __RAM1_SIZE > 0
+  RAM1  (w!rx) : ORIGIN = __RAM1_BASE, LENGTH = __RAM1_SIZE
+#endif
+#if __RAM2_SIZE > 0
+  RAM2  (w!rx) : ORIGIN = __RAM2_BASE, LENGTH = __RAM2_SIZE
+#endif
+#if __RAM3_SIZE > 0
+  RAM3  (w!rx) : ORIGIN = __RAM3_BASE, LENGTH = __RAM3_SIZE
+#endif
+}
+
+ENTRY(Reset_Handler)
+
+PHDRS
+{
+	text PT_LOAD;
+	ram PT_LOAD;
+	ram_init PT_LOAD;
+	tls PT_TLS;
+}
+
+SECTIONS
+{
+	.init : {
+		KEEP (*(.vectors))
+		KEEP (*(.text.init.enter))
+		KEEP (*(.data.init.enter))
+		KEEP (*(SORT_BY_NAME(.init) SORT_BY_NAME(.init.*)))
+	} >ROM0 AT>ROM0 :text
+
+	.text : {
+
+		/* code */
+		*(.text.unlikely .text.unlikely.*)
+		*(.text.startup .text.startup.*)
+		*(.text .text.* .opd .opd.*)
+		*(.gnu.linkonce.t.*)
+		KEEP (*(.fini .fini.*))
+		__text_end = .;
+
+		PROVIDE (__etext = __text_end);
+		PROVIDE (_etext = __text_end);
+		PROVIDE (etext = __text_end);
+
+		/* read-only data */
+		*(.rdata)
+		*(.rodata .rodata.*)
+		*(.gnu.linkonce.r.*)
+
+		*(.srodata.cst16)
+		*(.srodata.cst8)
+		*(.srodata.cst4)
+		*(.srodata.cst2)
+		*(.srodata .srodata.*)
+		*(.data.rel.ro .data.rel.ro.*)
+		*(.got .got.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		/* lists of constructors and destructors */
+		PROVIDE_HIDDEN ( __preinit_array_start = . );
+		KEEP (*(.preinit_array))
+		PROVIDE_HIDDEN ( __preinit_array_end = . );
+
+		PROVIDE_HIDDEN ( __init_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+		KEEP (*(.init_array .ctors))
+		PROVIDE_HIDDEN ( __init_array_end = . );
+
+		PROVIDE_HIDDEN ( __fini_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
+		KEEP (*(.fini_array .dtors))
+		PROVIDE_HIDDEN ( __fini_array_end = . );
+
+	} >ROM0 AT>ROM0 :text
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+	.veneers :
+	{
+		. = ALIGN(32);
+		KEEP(*(.gnu.sgstubs))
+	} > ROM0 AT>ROM0 :text
+#endif
+
+	.toc : {
+		*(.toc .toc.*)
+	} >ROM0 AT>ROM0 :text
+
+	/* additional sections when compiling with C++ exception support */
+	
+	.except_ordered : {
+		*(.gcc_except_table *.gcc_except_table.*)
+		KEEP (*(.eh_frame .eh_frame.*))
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+	} >ROM0 AT>ROM0 :text
+
+	.except_unordered : {
+		. = ALIGN(8);
+
+		PROVIDE(__exidx_start = .);
+		*(.ARM.exidx*)
+		PROVIDE(__exidx_end = .);
+	} >ROM0 AT>ROM0 :text
+	
+
+	/*
+	 * Data values which are preserved across reset
+	 */
+	.preserve (NOLOAD) : {
+		PROVIDE(__preserve_start__ = .);
+		KEEP(*(SORT_BY_NAME(.preserve.*)))
+		KEEP(*(.preserve))
+		PROVIDE(__preserve_end__ = .);
+	} >RAM0 AT>RAM0 :ram
+
+	.data :  {
+		*(.data .data.*)
+		*(.gnu.linkonce.d.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		PROVIDE( __global_pointer$ = . + 0x800 );
+		*(.sdata .sdata.* .sdata2.*)
+		*(.gnu.linkonce.s.*)
+	} >RAM0 AT>ROM0 :ram_init
+	PROVIDE(__data_start = ADDR(.data));
+	PROVIDE(__data_source = LOADADDR(.data));
+
+	/* Thread local initialized data. This gets
+	 * space allocated as it is expected to be placed
+	 * in ram to be used as a template for TLS data blocks
+	 * allocated at runtime. We're slightly abusing that
+	 * by placing the data in flash where it will be copied
+	 * into the allocate ram addresses by the existing
+	 * data initialization code in crt0
+	 */
+	.tdata :  {
+		*(.tdata .tdata.* .gnu.linkonce.td.*)
+		PROVIDE(__data_end = .);
+		PROVIDE(__tdata_end = .);
+	} >RAM0 AT>ROM0 :tls :ram_init
+	PROVIDE( __tls_base = ADDR(.tdata));
+	PROVIDE( __tdata_start = ADDR(.tdata));
+	PROVIDE( __tdata_source = LOADADDR(.tdata) );
+	PROVIDE( __tdata_source_end = LOADADDR(.tdata) + SIZEOF(.tdata) );
+	PROVIDE( __data_source_end = __tdata_source_end );
+	PROVIDE( __tdata_size = SIZEOF(.tdata) );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata),ALIGNOF(.tbss)) );
+
+	PROVIDE( __edata = __data_end );
+	PROVIDE( _edata = __data_end );
+	PROVIDE( edata = __data_end );
+	PROVIDE( __data_size = __data_end - __data_start );
+	PROVIDE( __data_source_size = __data_source_end - __data_source );
+
+	.tbss (NOLOAD) : {
+		*(.tbss .tbss.* .gnu.linkonce.tb.*)
+		*(.tcommon)
+		PROVIDE( __tls_end = . );
+		PROVIDE( __tbss_end = . );
+	} >RAM0 AT>RAM0 :tls :ram
+	PROVIDE( __bss_start = ADDR(.tbss));
+	PROVIDE( __tbss_start = ADDR(.tbss));
+	PROVIDE( __tbss_offset = ADDR(.tbss) - ADDR(.tdata) );
+	PROVIDE( __tbss_size = SIZEOF(.tbss) );
+	PROVIDE( __tls_size = __tls_end - __tls_base );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
+	PROVIDE( __arm32_tls_tcb_offset = MAX(8, __tls_align) );
+	PROVIDE( __arm64_tls_tcb_offset = MAX(16, __tls_align) );
+
+	/*
+	 * The linker special cases .tbss segments which are
+	 * identified as segments which are not loaded and are
+	 * thread_local.
+	 *
+	 * For these segments, the linker does not advance 'dot'
+	 * across them.  We actually need memory allocated for tbss,
+	 * so we create a special segment here just to make room
+	 */
+	/*
+	.tbss_space (NOLOAD) : {
+		. = ADDR(.tbss);
+		. = . + SIZEOF(.tbss);
+	} >RAM0 AT>RAM0 :ram
+	*/
+
+	.bss (NOLOAD) : {
+		*(.sbss*)
+		*(.gnu.linkonce.sb.*)
+		*(.bss .bss.*)
+		*(.gnu.linkonce.b.*)
+		*(COMMON)
+
+		/* Align the heap */
+		. = ALIGN(8);
+		__bss_end = .;
+	} >RAM0 AT>RAM0 :ram
+	PROVIDE( __non_tls_bss_start = ADDR(.bss) );
+	PROVIDE( __end = __bss_end );
+	PROVIDE( _end = __bss_end );
+	PROVIDE( end = __bss_end );
+	PROVIDE( __bss_size = __bss_end - __bss_start );
+
+	/* Make the rest of memory available for heap storage */
+	PROVIDE (__heap_start = __end);
+#ifdef __HEAP_SIZE
+	PROVIDE (__heap_end = __heap_start + __HEAP_SIZE);
+	PROVIDE (__heap_size = __HEAP_SIZE);
+#else
+	PROVIDE (__heap_end = __stack - __STACK_SIZE);
+	PROVIDE (__heap_size = __heap_end - __heap_start);
+#endif
+	.heap (NOLOAD) : {
+		. += __heap_size;
+	} >RAM0 :ram
+
+	/* Define a stack region to make sure it fits in memory */
+	PROVIDE(__stack = ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE);
+	PROVIDE(__stack_limit = __stack - __STACK_SIZE);
+	.stack (__stack_limit) (NOLOAD) : {
+		. += __STACK_SIZE;
+	} >RAM0 :ram
+
+#if __STACKSEAL_SIZE > 0
+	PROVIDE(__stack_seal = __stack);
+  	.stackseal (__stack) (NOLOAD) :
+  	{
+    	. += __STACKSEAL_SIZE;
+  	} >RAM0 :ram
+#endif
+
+	/* Throw away C++ exception handling information */
+
+	/*
+
+	/DISCARD/ : {
+		*(.note .note.*)
+		*(.eh_frame .eh_frame.*)
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+		*(.ARM.exidx*)
+	}
+
+	*/
+
+	/* Stabs debugging sections.  */
+	.stab          0 : { *(.stab) }
+	.stabstr       0 : { *(.stabstr) }
+	.stab.excl     0 : { *(.stab.excl) }
+	.stab.exclstr  0 : { *(.stab.exclstr) }
+	.stab.index    0 : { *(.stab.index) }
+	.stab.indexstr 0 : { *(.stab.indexstr) }
+	.comment       0 : { *(.comment) }
+	.gnu.build.attributes : { *(.gnu.build.attributes .gnu.build.attributes.*) }
+	/* DWARF debug sections.
+	   Symbols in the DWARF debugging sections are relative to the beginning
+	   of the section so we begin them at 0.  */
+	/* DWARF 1.  */
+	.debug          0 : { *(.debug) }
+	.line           0 : { *(.line) }
+	/* GNU DWARF 1 extensions.  */
+	.debug_srcinfo  0 : { *(.debug_srcinfo) }
+	.debug_sfnames  0 : { *(.debug_sfnames) }
+	/* DWARF 1.1 and DWARF 2.  */
+	.debug_aranges  0 : { *(.debug_aranges) }
+	.debug_pubnames 0 : { *(.debug_pubnames) }
+	/* DWARF 2.  */
+	.debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+	.debug_abbrev   0 : { *(.debug_abbrev) }
+	.debug_line     0 : { *(.debug_line .debug_line.* .debug_line_end) }
+	.debug_frame    0 : { *(.debug_frame) }
+	.debug_str      0 : { *(.debug_str) }
+	.debug_loc      0 : { *(.debug_loc) }
+	.debug_macinfo  0 : { *(.debug_macinfo) }
+	/* SGI/MIPS DWARF 2 extensions.  */
+	.debug_weaknames 0 : { *(.debug_weaknames) }
+	.debug_funcnames 0 : { *(.debug_funcnames) }
+	.debug_typenames 0 : { *(.debug_typenames) }
+	.debug_varnames  0 : { *(.debug_varnames) }
+	/* DWARF 3.  */
+	.debug_pubtypes 0 : { *(.debug_pubtypes) }
+	.debug_ranges   0 : { *(.debug_ranges) }
+	/* DWARF 5.  */
+	.debug_addr     0 : { *(.debug_addr) }
+	.debug_line_str 0 : { *(.debug_line_str) }
+	.debug_loclists 0 : { *(.debug_loclists) }
+	.debug_macro    0 : { *(.debug_macro) }
+	.debug_names    0 : { *(.debug_names) }
+	.debug_rnglists 0 : { *(.debug_rnglists) }
+	.debug_str_offsets 0 : { *(.debug_str_offsets) }
+	.debug_sup      0 : { *(.debug_sup) }
+	.gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }
+}
+/*
+ * Check that sections that are copied from flash to RAM have matching
+ * padding, so that a single memcpy() of __data_size copies the correct bytes.
+ */
+ASSERT( __data_size == __data_source_size,
+	"ERROR: .data/.tdata flash size does not match RAM size");

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55/RTE/Device/ARMCM55/gcc_linker_script.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55/RTE/Device/ARMCM55/gcc_linker_script.ld
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+/* ----------------------------------------------------------------------------
+  Memory definition
+ *----------------------------------------------------------------------------*/
+MEMORY
+{
+  ROM0  (rx)  : ORIGIN = __ROM0_BASE, LENGTH = __ROM0_SIZE
+#if __ROM1_SIZE > 0
+  ROM1  (rx)  : ORIGIN = __ROM1_BASE, LENGTH = __ROM1_SIZE
+#endif
+#if __ROM2_SIZE > 0
+  ROM2  (rx)  : ORIGIN = __ROM2_BASE, LENGTH = __ROM2_SIZE
+#endif
+#if __ROM3_SIZE > 0
+  ROM3  (rx)  : ORIGIN = __ROM3_BASE, LENGTH = __ROM3_SIZE
+#endif
+
+  RAM0  (rwx) : ORIGIN = __RAM0_BASE, LENGTH = __RAM0_SIZE
+#if __RAM1_SIZE > 0
+  RAM1  (rwx) : ORIGIN = __RAM1_BASE, LENGTH = __RAM1_SIZE
+#endif
+#if __RAM2_SIZE > 0
+  RAM2  (rwx) : ORIGIN = __RAM2_BASE, LENGTH = __RAM2_SIZE
+#endif
+#if __RAM3_SIZE > 0
+  RAM3  (rwx) : ORIGIN = __RAM3_BASE, LENGTH = __RAM3_SIZE
+#endif
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __copy_table_start__
+ *   __copy_table_end__
+ *   __zero_table_start__
+ *   __zero_table_end__
+ *   __etext          (deprecated)
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+  .text :
+  {
+    KEEP(*(.vectors))
+    *(.text*)
+
+    KEEP(*(.init))
+    KEEP(*(.fini))
+
+    /* .ctors */
+    *crtbegin.o(.ctors)
+    *crtbegin?.o(.ctors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+    *(SORT(.ctors.*))
+    *(.ctors)
+
+    /* .dtors */
+    *crtbegin.o(.dtors)
+    *crtbegin?.o(.dtors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+    *(SORT(.dtors.*))
+    *(.dtors)
+
+    *(.rodata*)
+
+    KEEP(*(.eh_frame*))
+  } > ROM0
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  .gnu.sgstubs :
+  {
+    . = ALIGN(32);
+  } > ROM0
+#endif
+
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > ROM0
+
+  __exidx_start = .;
+  .ARM.exidx :
+  {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+  } > ROM0
+  __exidx_end = .;
+
+  .copy.table :
+  {
+    . = ALIGN(4);
+    __copy_table_start__ = .;
+
+    LONG (LOADADDR(.data))
+    LONG (ADDR(.data))
+    LONG (SIZEOF(.data) / 4)
+
+    /* Add each additional data section here */
+/*
+    LONG (LOADADDR(.data2))
+    LONG (ADDR(.data2))
+    LONG (SIZEOF(.data2) / 4)
+*/
+    __copy_table_end__ = .;
+  } > ROM0
+
+  .zero.table :
+  {
+    . = ALIGN(4);
+    __zero_table_start__ = .;
+
+/*  .bss initialization to zero is already done during C Run-Time Startup.
+    LONG (ADDR(.bss))
+    LONG (SIZEOF(.bss) / 4)
+*/
+
+    /* Add each additional bss section here */
+/*
+    LONG (ADDR(.bss2))
+    LONG (SIZEOF(.bss2) / 4)
+*/
+    __zero_table_end__ = .;
+  } > ROM0
+
+  /*
+   * This __etext variable is kept for backward compatibility with older,
+   * ASM based startup files.
+   */
+  PROVIDE(__etext = LOADADDR(.data));
+
+  .data : ALIGN(4)
+  {
+    __data_start__ = .;
+    *(vtable)
+    *(.data)
+    *(.data.*)
+
+    . = ALIGN(4);
+    /* preinit data */
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP(*(.preinit_array))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+
+    . = ALIGN(4);
+    /* init data */
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP(*(SORT(.init_array.*)))
+    KEEP(*(.init_array))
+    PROVIDE_HIDDEN (__init_array_end = .);
+
+    . = ALIGN(4);
+    /* finit data */
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP(*(SORT(.fini_array.*)))
+    KEEP(*(.fini_array))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    /* All data end */
+    __data_end__ = .;
+
+  } > RAM0 AT > ROM0
+
+  /*
+   * Secondary data section, optional
+   *
+   * Remember to add each additional data section
+   * to the .copy.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .data2 : ALIGN(4)
+  {
+    . = ALIGN(4);
+    __data2_start__ = .;
+    *(.data2)
+    *(.data2.*)
+    . = ALIGN(4);
+    __data2_end__ = .;
+
+  } > RAM1 AT > ROM0 
+*/
+
+  .bss :
+  {
+    . = ALIGN(4);
+    __bss_start__ = .;
+    *(.bss)
+    *(.bss.*)
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+  } > RAM0 AT > RAM0
+
+  /*
+   * Secondary bss section, optional
+   *
+   * Remember to add each additional bss section
+   * to the .zero.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .bss2 :
+  {
+    . = ALIGN(4);
+    __bss2_start__ = .;
+    *(.bss2)
+    *(.bss2.*)
+    . = ALIGN(4);
+    __bss2_end__ = .;
+  } > RAM1 AT > RAM1
+*/
+
+  .heap (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE(end = .);
+    . = . + __HEAP_SIZE;
+    . = ALIGN(8);
+    __HeapLimit = .;
+  } > RAM0
+
+  .stack (ORIGIN(RAM0) + LENGTH(RAM0) - __STACK_SIZE - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackLimit = .;
+    . = . + __STACK_SIZE;
+    . = ALIGN(8);
+    __StackTop = .;
+  } > RAM0
+  PROVIDE(__stack = __StackTop);
+
+#if __STACKSEAL_SIZE > 0
+  .stackseal (ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackSeal = .;
+    . = . + 8;
+    . = ALIGN(8);
+  } > RAM0
+#endif
+
+  /* Check if data + heap + stack exceeds RAM limit */
+  ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55/RTE/Device/ARMCM55/iar_linker_script.icf
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55/RTE/Device/ARMCM55/iar_linker_script.icf
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+define memory mem with size = 4G;
+
+#if __ROM0_SIZE > 0
+  define region ROM0_region = mem:[from __ROM0_BASE to (__ROM0_BASE+__ROM0_SIZE-1)];
+#else
+  define region ROM0_region = [];
+#endif
+
+#if __ROM1_SIZE > 0
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+#else
+  define region ROM1_region = [];
+#endif
+
+#if __ROM2_SIZE > 0
+  define region ROM2_region = mem:[from __ROM2_BASE to (__ROM2_BASE+__ROM2_SIZE-1)];
+#else
+  define region ROM2_region = [];
+#endif
+
+#if __ROM3_SIZE > 0
+  define region ROM3_region = mem:[from __ROM3_BASE to (__ROM3_BASE+__ROM3_SIZE-1)];
+#else
+  define region ROM3_region = [];
+#endif
+
+define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_region;
+
+#if __RAM0_SIZE > 0
+  define region RAM0_region = mem:[from __RAM0_BASE to (__RAM0_BASE+__RAM0_SIZE-1)];
+#else
+  define region RAM0_region = [];
+#endif
+
+#if __RAM1_SIZE > 0
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+#else
+  define region RAM1_region = [];
+#endif
+
+#if __RAM2_SIZE > 0
+  define region RAM2_region = mem:[from __RAM2_BASE to (__RAM2_BASE+__RAM2_SIZE-1)];
+#else
+  define region RAM2_region = [];
+#endif
+
+#if __RAM3_SIZE > 0
+  define region RAM3_region = mem:[from __RAM3_BASE to (__RAM3_BASE+__RAM3_SIZE-1)];
+#else
+  define region RAM3_region = [];
+#endif
+
+define region RAM_region = RAM0_region | RAM1_region | RAM2_region | RAM3_region;
+
+do not initialize  { section .noinit };
+initialize by copy { readwrite };
+if (isdefinedsymbol(__USE_DLIB_PERTHREAD))
+{
+  // Required in a multi-threaded application
+  initialize by copy with packing = none { section __DLIB_PERTHREAD };
+}
+
+place at address mem:__ROM0_BASE { readonly section .intvec };
+
+if (!isempty(ROM_region))
+{
+  place in ROM_region  { readonly };
+}
+
+if (!isempty(RAM_region))
+{
+  define block CSTACK     with alignment = 8, size = __STACK_SIZE     { };
+  define block PROC_STACK with alignment = 8, size = 0 { };
+  define block HEAP       with alignment = 8, size = __HEAP_SIZE       { };
+  place in RAM_region  { readwrite, block CSTACK, block PROC_STACK, block HEAP };
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55/RTE/Device/ARMCM55/regions_ARMCM55.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55/RTE/Device/ARMCM55/regions_ARMCM55.h
@@ -1,0 +1,94 @@
+#ifndef REGIONS_ARMCM55_H
+#define REGIONS_ARMCM55_H
+
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+// <n>Device pack:   ARM::Cortex_DFP@1.0.0-dev16
+// <i>Device pack used to generate this file
+
+// <h>ROM Configuration
+// =======================
+// <h> ROM_S=<__ROM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x00000000
+#define __ROM0_BASE 0x00000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00200000
+#define __ROM0_SIZE 0x00200000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __ROM0_DEFAULT 1
+//   <q>Startup
+//   <i> Selects region to be used for startup code.
+#define __ROM0_STARTUP 1
+// </h>
+
+// <h> ROM_NS=<__ROM1>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x00200000
+#define __ROM1_BASE 0x00200000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00200000
+#define __ROM1_SIZE 0x00200000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __ROM1_DEFAULT 1
+//   <q>Startup
+//   <i> Selects region to be used for startup code.
+#define __ROM1_STARTUP 1
+// </h>
+
+// </h>
+
+// <h>RAM Configuration
+// =======================
+// <h> RAM_S=<__RAM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x20000000
+#define __RAM0_BASE 0x20000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00020000
+#define __RAM0_SIZE 0x00020000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __RAM0_DEFAULT 1
+//   <q>No zero initialize
+//   <i> Excludes region from zero initialization.
+#define __RAM0_NOINIT 0
+// </h>
+
+// <h> RAM_NS=<__RAM1>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x20200000
+#define __RAM1_BASE 0x20200000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00020000
+#define __RAM1_SIZE 0x00020000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __RAM1_DEFAULT 1
+//   <q>No zero initialize
+//   <i> Excludes region from zero initialization.
+#define __RAM1_NOINIT 0
+// </h>
+
+// </h>
+
+// <h>Stack / Heap Configuration
+//   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+#define __STACK_SIZE 0x00000400
+#define __HEAP_SIZE 0x00000C00
+// </h>
+
+
+#endif /* REGIONS_ARMCM55_H */

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55/RTE/Device/ARMCM55/startup_ARMCM55.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55/RTE/Device/ARMCM55/startup_ARMCM55.c
@@ -1,0 +1,164 @@
+/******************************************************************************
+ * @file     startup_ARMCM55.c
+ * @brief    CMSIS-Core Device Startup File for Cortex-M55 Device
+ * @version  V1.1.0
+ * @date     16. December 2020
+ ******************************************************************************/
+/*
+ * Copyright (c) 2020 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (ARMCM55)
+  #include "ARMCM55.h"
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  External References
+ *----------------------------------------------------------------------------*/
+extern uint32_t __INITIAL_SP;
+extern uint32_t __STACK_LIMIT;
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+extern uint32_t __STACK_SEAL;
+#endif
+
+extern __NO_RETURN void __PROGRAM_START(void);
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler  (void);
+            void Default_Handler(void);
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+/* Exceptions */
+void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void HardFault_Handler      (void) __attribute__ ((weak));
+void MemManage_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
+void BusFault_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void UsageFault_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void SecureFault_Handler    (void) __attribute__ ((weak, alias("Default_Handler")));
+void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void DebugMon_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+
+void Interrupt0_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt1_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt2_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt3_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt4_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt5_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt6_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt7_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt8_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt9_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[496];
+       const VECTOR_TABLE_Type __VECTOR_TABLE[496] __VECTOR_TABLE_ATTRIBUTE = {
+  (VECTOR_TABLE_Type)(&__INITIAL_SP),       /*     Initial Stack Pointer */
+  Reset_Handler,                            /*     Reset Handler */
+  NMI_Handler,                              /* -14 NMI Handler */
+  HardFault_Handler,                        /* -13 Hard Fault Handler */
+  MemManage_Handler,                        /* -12 MPU Fault Handler */
+  BusFault_Handler,                         /* -11 Bus Fault Handler */
+  UsageFault_Handler,                       /* -10 Usage Fault Handler */
+  SecureFault_Handler,                      /*  -9 Secure Fault Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  SVC_Handler,                              /*  -5 SVC Handler */
+  DebugMon_Handler,                         /*  -4 Debug Monitor Handler */
+  0,                                        /*     Reserved */
+  PendSV_Handler,                           /*  -2 PendSV Handler */
+  SysTick_Handler,                          /*  -1 SysTick Handler */
+
+  /* Interrupts */
+  Interrupt0_Handler,                       /*   0 Interrupt 0 */
+  Interrupt1_Handler,                       /*   1 Interrupt 1 */
+  Interrupt2_Handler,                       /*   2 Interrupt 2 */
+  Interrupt3_Handler,                       /*   3 Interrupt 3 */
+  Interrupt4_Handler,                       /*   4 Interrupt 4 */
+  Interrupt5_Handler,                       /*   5 Interrupt 5 */
+  Interrupt6_Handler,                       /*   6 Interrupt 6 */
+  Interrupt7_Handler,                       /*   7 Interrupt 7 */
+  Interrupt8_Handler,                       /*   8 Interrupt 8 */
+  Interrupt9_Handler                        /*   9 Interrupt 9 */
+                                            /* Interrupts 10 .. 480 are left out */
+};
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler(void)
+{
+  __set_PSP((uint32_t)(&__INITIAL_SP));
+
+  __set_MSPLIM((uint32_t)(&__STACK_LIMIT));
+  __set_PSPLIM((uint32_t)(&__STACK_LIMIT));
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  __TZ_set_STACKSEAL_S((uint32_t *)(&__STACK_SEAL));
+#endif
+
+  SystemInit();                             /* CMSIS System Initialization */
+  __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
+}
+
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wmissing-noreturn"
+#endif
+
+/*----------------------------------------------------------------------------
+  Hard Fault Handler
+ *----------------------------------------------------------------------------*/
+void HardFault_Handler(void)
+{
+  while(1);
+}
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+void Default_Handler(void)
+{
+  while(1);
+}
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic pop
+#endif
+

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55/RTE/Device/ARMCM55/system_ARMCM55.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55/RTE/Device/ARMCM55/system_ARMCM55.c
@@ -1,0 +1,107 @@
+/**************************************************************************//**
+ * @file     system_ARMCM55.c
+ * @brief    CMSIS Device System Source File for
+ *           ARMCM55 Device
+ * @version  V1.1.0
+ * @date     28. March 2022
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2022 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (ARMCM55)
+  #include "ARMCM55.h"
+#else
+  #error device not specified!
+#endif
+
+#if defined (__ARM_FEATURE_CMSE) &&  (__ARM_FEATURE_CMSE == 3U)
+  #include "partition_ARMCM55.h"
+#endif
+
+/*----------------------------------------------------------------------------
+  Define clocks
+ *----------------------------------------------------------------------------*/
+#define  XTAL            ( 5000000UL)      /* Oscillator frequency */
+
+#define  SYSTEM_CLOCK    (5U * XTAL)
+
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[496];
+
+
+/*----------------------------------------------------------------------------
+  System Core Clock Variable
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = SYSTEM_CLOCK;
+
+
+/*----------------------------------------------------------------------------
+  System Core Clock update function
+ *----------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)
+{
+  SystemCoreClock = SYSTEM_CLOCK;
+}
+
+/*----------------------------------------------------------------------------
+  System initialization function
+ *----------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t)(&__VECTOR_TABLE[0]);
+#endif
+
+#if (defined (__FPU_USED) && (__FPU_USED == 1U)) || \
+    (defined (__ARM_FEATURE_MVE) && (__ARM_FEATURE_MVE > 0U))
+  SCB->CPACR |= ((3U << 10U*2U) |           /* enable CP10 Full Access */
+                 (3U << 11U*2U)  );         /* enable CP11 Full Access */
+
+  /* Set low-power state for PDEPU                */
+  /*  0b00  | ON, PDEPU is not in low-power state */
+  /*  0b01  | ON, but the clock is off            */
+  /*  0b10  | RET(ention)                         */
+  /*  0b11  | OFF                                 */
+
+  /* Clear ELPSTATE, value is 0b11 on Cold reset */
+  PWRMODCTL->CPDLPSTATE &= ~(PWRMODCTL_CPDLPSTATE_ELPSTATE_Msk);
+
+  /* Favor best FP/MVE performance by default, avoid EPU switch-ON delays */
+  /* PDEPU ON, Clock OFF */
+  PWRMODCTL->CPDLPSTATE |= 0x1 << PWRMODCTL_CPDLPSTATE_ELPSTATE_Pos;
+#endif
+
+#ifdef UNALIGNED_SUPPORT_DISABLE
+  SCB->CCR |= SCB_CCR_UNALIGN_TRP_Msk;
+#endif
+
+  /* Enable Loop and branch info cache */
+  SCB->CCR |= SCB_CCR_LOB_Msk;
+  __DSB();
+  __ISB();
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  TZ_SAU_Setup();
+#endif
+
+  SystemCoreClock = SYSTEM_CLOCK;
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55/Target.clayer.yml
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55/Target.clayer.yml
@@ -1,0 +1,35 @@
+layer:
+  type: Target
+  description: CM55 target components and files
+
+  packs:
+    - pack: ARM::Cortex_DFP
+
+  device: ARMCM55
+
+  processor:
+    trustzone: off
+
+  components:
+    # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
+    - component: ARM::CMSIS:CORE
+    - component: Device:Startup&C Startup
+
+  groups:
+    - group: FVP
+      files:
+        - file: ./model_config.txt
+
+  linker:
+    - for-compiler: AC6
+      script: RTE/Device/$Dname$/ac6_linker_script.sct
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: GCC
+      script: RTE/Device/$Dname$/gcc_linker_script.ld
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: CLANG
+      script: RTE/Device/$Dname$/clang_linker_script.ld
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: IAR
+      script: RTE/Device/$Dname$/iar_linker_script.icf
+      regions: RTE/Device/$Dname$/regions_$Dname$.h

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55/model_config.txt
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55/model_config.txt
@@ -1,0 +1,29 @@
+# Parameters:
+# instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+#----------------------------------------------------------------------------------------------
+fvp_mps2.mps2_visualisation.disable-visualisation=1   # (bool  , init-time) default = '0'      : Enable/disable visualisation
+fvp_mps2.DISABLE_GATING=1                             # (bool  , init-time) default = '0'      : Disable Memory gating logic
+cpu0.FPU=1                                            # (bool  , init-time) default = '1'      : Set whether the model has VFP support
+cpu0.MVE=2                                            # (int   , init-time) default = '0x1'    : Set whether the model has MVE support. If FPU = 0: 0=MVE not included, 1=Integer subset of MVE included. If FPU = 1: 0=MVE not included, 1=Integer subset of MVE included, 2=Integer and half and single precision floating point MVE included
+cpu0.semihosting-enable=1                             # (bool  , init-time) default = '1'      : Enable semihosting SVC traps. Applications that do not use semihosting must set this parameter to false.
+cpu0.semihosting-Thumb_SVC=0xAB                       # (int   , init-time) default = '0xAB'   : T32 SVC number for semihosting : [0x0..0xFF]
+cpu0.semihosting-cmd_line=""                          # (string, init-time) default = ''       : Command line available to semihosting SVC calls
+cpu0.semihosting-heap_base=0x0                        # (int   , init-time) default = '0x0'    : Virtual address of heap base : [0x0..0xFFFFFFFF]
+cpu0.semihosting-heap_limit=0x0                       # (int   , init-time) default = '0x10700000' : Virtual address of top of heap : [0x0..0xFFFFFFFF]
+cpu0.semihosting-stack_base=0x0                       # (int   , init-time) default = '0x10700000' : Virtual address of base of descending stack : [0x0..0xFFFFFFFF]
+cpu0.semihosting-stack_limit=0x0                      # (int   , init-time) default = '0x10800000' : Virtual address of stack limit : [0x0..0xFFFFFFFF]
+cpu0.semihosting-cwd=""                               # (string, init-time) default = ''       : Base directory for semihosting file access.
+cpu0.MPU_S=0x8                                        # (int   , init-time) default = '0x8'    : Number of regions in the Secure MPU. If Security Extentions are absent, this is ignored : [0x0..0x10]
+cpu0.MPU_NS=0x8                                       # (int   , init-time) default = '0x8'    : Number of regions in the Non-Secure MPU. If Security Extentions are absent, this is the total number of MPU regions : [0x0..0x10]
+cpu0.ITM=0                                            # (bool  , init-time) default = '1'      : Level of instrumentation trace supported. false : No ITM trace included, true: ITM trace included
+cpu0.IRQLVL=0x3                                       # (int   , init-time) default = '0x3'    : Number of bits of interrupt priority : [0x3..0x8]
+cpu0.INITSVTOR=0x00000000                             # (int   , init-time) default = '0x10000000' : Secure vector-table offset at reset : [0x0..0xFFFFFF80]
+cpu0.INITNSVTOR=0x0                                   # (int   , init-time) default = '0x0'    : Non-Secure vector-table offset at reset : [0x0..0xFFFFFF80]
+cpu0.SAU=0x8                                          # (int   , init-time) default = '0x4'    : Number of SAU regions (0 => no SAU) : [0x0..0x8]
+idau.NUM_IDAU_REGION=0x0                              # (int   , init-time) default = '0xA'    : 
+cpu0.LOCK_SAU=0                                       # (bool  , init-time) default = '0'      : Lock down of SAU registers write
+cpu0.LOCK_S_MPU=0                                     # (bool  , init-time) default = '0'      : Lock down of Secure MPU registers write
+cpu0.LOCK_NS_MPU=0                                    # (bool  , init-time) default = '0'      : Lock down of Non-Secure MPU registers write
+cpu0.CPIF=1                                           # (bool  , init-time) default = '1'      : Specifies whether the external coprocessor interface is included
+cpu0.SECEXT=0                                         # (bool  , init-time) default = '1'      : Whether the ARMv8-M Security Extensions are included
+#----------------------------------------------------------------------------------------------

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55NS/RTE/Device/ARMCM55/ac6_linker_script.sct
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55NS/RTE/Device/ARMCM55/ac6_linker_script.sct
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE 8
+#else
+#define __STACKSEAL_SIZE 0
+#endif
+
+/*----------------------------------------------------------------------------
+  Scatter File Definitions definition
+ *----------------------------------------------------------------------------*/
+
+LR_ROM0 __ROM0_BASE __ROM0_SIZE  {
+
+  ER_ROM0 __ROM0_BASE __ROM0_SIZE {
+    *.o (RESET, +First)
+    *(InRoot$$Sections)
+    *(+RO +XO)
+  }
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  ER_CMSE_VENEER AlignExpr(+0, 32) (__ROM0_SIZE - AlignExpr(ImageLength(ER_ROM0), 32)) {
+    *(Veneer$$CMSE)
+  }
+#endif
+
+  RW_NOINIT __RAM0_BASE UNINIT (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE) {
+    *(.bss.noinit)
+  }
+
+  RW_RAM0 AlignExpr(+0, 8) (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE - AlignExpr(ImageLength(RW_NOINIT), 8)) {
+    *(+RW +ZI)
+  }
+
+#if __HEAP_SIZE > 0
+  ARM_LIB_HEAP  (AlignExpr(+0, 8)) EMPTY __HEAP_SIZE  {   ; Reserve empty region for heap
+  }
+#endif
+
+  ARM_LIB_STACK (__RAM0_BASE + __RAM0_SIZE - __STACKSEAL_SIZE) EMPTY -__STACK_SIZE {   ; Reserve empty region for stack
+  }
+
+#if __STACKSEAL_SIZE > 0
+  STACKSEAL +0 EMPTY __STACKSEAL_SIZE {             ; Reserve empty region for stack seal immediately after stack
+  }
+#endif
+
+#if __RAM1_SIZE > 0
+  RW_RAM1 __RAM1_BASE __RAM1_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+
+#if __RAM2_SIZE > 0
+  RW_RAM2 __RAM2_BASE __RAM2_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+
+#if __RAM3_SIZE > 0
+  RW_RAM3 __RAM3_BASE __RAM3_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+}
+
+#if __ROM1_SIZE > 0
+LR_ROM1 __ROM1_BASE __ROM1_SIZE  {
+  ER_ROM1 +0 __ROM1_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif
+
+#if __ROM2_SIZE > 0
+LR_ROM2 __ROM2_BASE __ROM2_SIZE  {
+  ER_ROM2 +0 __ROM2_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif
+
+#if __ROM3_SIZE > 0
+LR_ROM3 __ROM3_BASE __ROM3_SIZE  {
+  ER_ROM3 +0 __ROM3_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55NS/RTE/Device/ARMCM55/clang_linker_script.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55NS/RTE/Device/ARMCM55/clang_linker_script.ld
@@ -1,0 +1,361 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2019 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+/* ----------------------------------------------------------------------------
+  Memory definition
+ *----------------------------------------------------------------------------*/
+MEMORY
+{
+  ROM0  (rx!w)  : ORIGIN = __ROM0_BASE, LENGTH = __ROM0_SIZE
+#if __ROM1_SIZE > 0
+  ROM1  (rx!w)  : ORIGIN = __ROM1_BASE, LENGTH = __ROM1_SIZE
+#endif
+#if __ROM2_SIZE > 0
+  ROM2  (rx!w)  : ORIGIN = __ROM2_BASE, LENGTH = __ROM2_SIZE
+#endif
+#if __ROM3_SIZE > 0
+  ROM3  (rx!w)  : ORIGIN = __ROM3_BASE, LENGTH = __ROM3_SIZE
+#endif
+
+  RAM0  (w!rx) : ORIGIN = __RAM0_BASE, LENGTH = __RAM0_SIZE
+#if __RAM1_SIZE > 0
+  RAM1  (w!rx) : ORIGIN = __RAM1_BASE, LENGTH = __RAM1_SIZE
+#endif
+#if __RAM2_SIZE > 0
+  RAM2  (w!rx) : ORIGIN = __RAM2_BASE, LENGTH = __RAM2_SIZE
+#endif
+#if __RAM3_SIZE > 0
+  RAM3  (w!rx) : ORIGIN = __RAM3_BASE, LENGTH = __RAM3_SIZE
+#endif
+}
+
+ENTRY(Reset_Handler)
+
+PHDRS
+{
+	text PT_LOAD;
+	ram PT_LOAD;
+	ram_init PT_LOAD;
+	tls PT_TLS;
+}
+
+SECTIONS
+{
+	.init : {
+		KEEP (*(.vectors))
+		KEEP (*(.text.init.enter))
+		KEEP (*(.data.init.enter))
+		KEEP (*(SORT_BY_NAME(.init) SORT_BY_NAME(.init.*)))
+	} >ROM0 AT>ROM0 :text
+
+	.text : {
+
+		/* code */
+		*(.text.unlikely .text.unlikely.*)
+		*(.text.startup .text.startup.*)
+		*(.text .text.* .opd .opd.*)
+		*(.gnu.linkonce.t.*)
+		KEEP (*(.fini .fini.*))
+		__text_end = .;
+
+		PROVIDE (__etext = __text_end);
+		PROVIDE (_etext = __text_end);
+		PROVIDE (etext = __text_end);
+
+		/* read-only data */
+		*(.rdata)
+		*(.rodata .rodata.*)
+		*(.gnu.linkonce.r.*)
+
+		*(.srodata.cst16)
+		*(.srodata.cst8)
+		*(.srodata.cst4)
+		*(.srodata.cst2)
+		*(.srodata .srodata.*)
+		*(.data.rel.ro .data.rel.ro.*)
+		*(.got .got.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		/* lists of constructors and destructors */
+		PROVIDE_HIDDEN ( __preinit_array_start = . );
+		KEEP (*(.preinit_array))
+		PROVIDE_HIDDEN ( __preinit_array_end = . );
+
+		PROVIDE_HIDDEN ( __init_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+		KEEP (*(.init_array .ctors))
+		PROVIDE_HIDDEN ( __init_array_end = . );
+
+		PROVIDE_HIDDEN ( __fini_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
+		KEEP (*(.fini_array .dtors))
+		PROVIDE_HIDDEN ( __fini_array_end = . );
+
+	} >ROM0 AT>ROM0 :text
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+	.veneers :
+	{
+		. = ALIGN(32);
+		KEEP(*(.gnu.sgstubs))
+	} > ROM0 AT>ROM0 :text
+#endif
+
+	.toc : {
+		*(.toc .toc.*)
+	} >ROM0 AT>ROM0 :text
+
+	/* additional sections when compiling with C++ exception support */
+	
+	.except_ordered : {
+		*(.gcc_except_table *.gcc_except_table.*)
+		KEEP (*(.eh_frame .eh_frame.*))
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+	} >ROM0 AT>ROM0 :text
+
+	.except_unordered : {
+		. = ALIGN(8);
+
+		PROVIDE(__exidx_start = .);
+		*(.ARM.exidx*)
+		PROVIDE(__exidx_end = .);
+	} >ROM0 AT>ROM0 :text
+	
+
+	/*
+	 * Data values which are preserved across reset
+	 */
+	.preserve (NOLOAD) : {
+		PROVIDE(__preserve_start__ = .);
+		KEEP(*(SORT_BY_NAME(.preserve.*)))
+		KEEP(*(.preserve))
+		PROVIDE(__preserve_end__ = .);
+	} >RAM0 AT>RAM0 :ram
+
+	.data :  {
+		*(.data .data.*)
+		*(.gnu.linkonce.d.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		PROVIDE( __global_pointer$ = . + 0x800 );
+		*(.sdata .sdata.* .sdata2.*)
+		*(.gnu.linkonce.s.*)
+	} >RAM0 AT>ROM0 :ram_init
+	PROVIDE(__data_start = ADDR(.data));
+	PROVIDE(__data_source = LOADADDR(.data));
+
+	/* Thread local initialized data. This gets
+	 * space allocated as it is expected to be placed
+	 * in ram to be used as a template for TLS data blocks
+	 * allocated at runtime. We're slightly abusing that
+	 * by placing the data in flash where it will be copied
+	 * into the allocate ram addresses by the existing
+	 * data initialization code in crt0
+	 */
+	.tdata :  {
+		*(.tdata .tdata.* .gnu.linkonce.td.*)
+		PROVIDE(__data_end = .);
+		PROVIDE(__tdata_end = .);
+	} >RAM0 AT>ROM0 :tls :ram_init
+	PROVIDE( __tls_base = ADDR(.tdata));
+	PROVIDE( __tdata_start = ADDR(.tdata));
+	PROVIDE( __tdata_source = LOADADDR(.tdata) );
+	PROVIDE( __tdata_source_end = LOADADDR(.tdata) + SIZEOF(.tdata) );
+	PROVIDE( __data_source_end = __tdata_source_end );
+	PROVIDE( __tdata_size = SIZEOF(.tdata) );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata),ALIGNOF(.tbss)) );
+
+	PROVIDE( __edata = __data_end );
+	PROVIDE( _edata = __data_end );
+	PROVIDE( edata = __data_end );
+	PROVIDE( __data_size = __data_end - __data_start );
+	PROVIDE( __data_source_size = __data_source_end - __data_source );
+
+	.tbss (NOLOAD) : {
+		*(.tbss .tbss.* .gnu.linkonce.tb.*)
+		*(.tcommon)
+		PROVIDE( __tls_end = . );
+		PROVIDE( __tbss_end = . );
+	} >RAM0 AT>RAM0 :tls :ram
+	PROVIDE( __bss_start = ADDR(.tbss));
+	PROVIDE( __tbss_start = ADDR(.tbss));
+	PROVIDE( __tbss_offset = ADDR(.tbss) - ADDR(.tdata) );
+	PROVIDE( __tbss_size = SIZEOF(.tbss) );
+	PROVIDE( __tls_size = __tls_end - __tls_base );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
+	PROVIDE( __arm32_tls_tcb_offset = MAX(8, __tls_align) );
+	PROVIDE( __arm64_tls_tcb_offset = MAX(16, __tls_align) );
+
+	/*
+	 * The linker special cases .tbss segments which are
+	 * identified as segments which are not loaded and are
+	 * thread_local.
+	 *
+	 * For these segments, the linker does not advance 'dot'
+	 * across them.  We actually need memory allocated for tbss,
+	 * so we create a special segment here just to make room
+	 */
+	/*
+	.tbss_space (NOLOAD) : {
+		. = ADDR(.tbss);
+		. = . + SIZEOF(.tbss);
+	} >RAM0 AT>RAM0 :ram
+	*/
+
+	.bss (NOLOAD) : {
+		*(.sbss*)
+		*(.gnu.linkonce.sb.*)
+		*(.bss .bss.*)
+		*(.gnu.linkonce.b.*)
+		*(COMMON)
+
+		/* Align the heap */
+		. = ALIGN(8);
+		__bss_end = .;
+	} >RAM0 AT>RAM0 :ram
+	PROVIDE( __non_tls_bss_start = ADDR(.bss) );
+	PROVIDE( __end = __bss_end );
+	PROVIDE( _end = __bss_end );
+	PROVIDE( end = __bss_end );
+	PROVIDE( __bss_size = __bss_end - __bss_start );
+
+	/* Make the rest of memory available for heap storage */
+	PROVIDE (__heap_start = __end);
+#ifdef __HEAP_SIZE
+	PROVIDE (__heap_end = __heap_start + __HEAP_SIZE);
+	PROVIDE (__heap_size = __HEAP_SIZE);
+#else
+	PROVIDE (__heap_end = __stack - __STACK_SIZE);
+	PROVIDE (__heap_size = __heap_end - __heap_start);
+#endif
+	.heap (NOLOAD) : {
+		. += __heap_size;
+	} >RAM0 :ram
+
+	/* Define a stack region to make sure it fits in memory */
+	PROVIDE(__stack = ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE);
+	PROVIDE(__stack_limit = __stack - __STACK_SIZE);
+	.stack (__stack_limit) (NOLOAD) : {
+		. += __STACK_SIZE;
+	} >RAM0 :ram
+
+#if __STACKSEAL_SIZE > 0
+	PROVIDE(__stack_seal = __stack);
+  	.stackseal (__stack) (NOLOAD) :
+  	{
+    	. += __STACKSEAL_SIZE;
+  	} >RAM0 :ram
+#endif
+
+	/* Throw away C++ exception handling information */
+
+	/*
+
+	/DISCARD/ : {
+		*(.note .note.*)
+		*(.eh_frame .eh_frame.*)
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+		*(.ARM.exidx*)
+	}
+
+	*/
+
+	/* Stabs debugging sections.  */
+	.stab          0 : { *(.stab) }
+	.stabstr       0 : { *(.stabstr) }
+	.stab.excl     0 : { *(.stab.excl) }
+	.stab.exclstr  0 : { *(.stab.exclstr) }
+	.stab.index    0 : { *(.stab.index) }
+	.stab.indexstr 0 : { *(.stab.indexstr) }
+	.comment       0 : { *(.comment) }
+	.gnu.build.attributes : { *(.gnu.build.attributes .gnu.build.attributes.*) }
+	/* DWARF debug sections.
+	   Symbols in the DWARF debugging sections are relative to the beginning
+	   of the section so we begin them at 0.  */
+	/* DWARF 1.  */
+	.debug          0 : { *(.debug) }
+	.line           0 : { *(.line) }
+	/* GNU DWARF 1 extensions.  */
+	.debug_srcinfo  0 : { *(.debug_srcinfo) }
+	.debug_sfnames  0 : { *(.debug_sfnames) }
+	/* DWARF 1.1 and DWARF 2.  */
+	.debug_aranges  0 : { *(.debug_aranges) }
+	.debug_pubnames 0 : { *(.debug_pubnames) }
+	/* DWARF 2.  */
+	.debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+	.debug_abbrev   0 : { *(.debug_abbrev) }
+	.debug_line     0 : { *(.debug_line .debug_line.* .debug_line_end) }
+	.debug_frame    0 : { *(.debug_frame) }
+	.debug_str      0 : { *(.debug_str) }
+	.debug_loc      0 : { *(.debug_loc) }
+	.debug_macinfo  0 : { *(.debug_macinfo) }
+	/* SGI/MIPS DWARF 2 extensions.  */
+	.debug_weaknames 0 : { *(.debug_weaknames) }
+	.debug_funcnames 0 : { *(.debug_funcnames) }
+	.debug_typenames 0 : { *(.debug_typenames) }
+	.debug_varnames  0 : { *(.debug_varnames) }
+	/* DWARF 3.  */
+	.debug_pubtypes 0 : { *(.debug_pubtypes) }
+	.debug_ranges   0 : { *(.debug_ranges) }
+	/* DWARF 5.  */
+	.debug_addr     0 : { *(.debug_addr) }
+	.debug_line_str 0 : { *(.debug_line_str) }
+	.debug_loclists 0 : { *(.debug_loclists) }
+	.debug_macro    0 : { *(.debug_macro) }
+	.debug_names    0 : { *(.debug_names) }
+	.debug_rnglists 0 : { *(.debug_rnglists) }
+	.debug_str_offsets 0 : { *(.debug_str_offsets) }
+	.debug_sup      0 : { *(.debug_sup) }
+	.gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }
+}
+/*
+ * Check that sections that are copied from flash to RAM have matching
+ * padding, so that a single memcpy() of __data_size copies the correct bytes.
+ */
+ASSERT( __data_size == __data_source_size,
+	"ERROR: .data/.tdata flash size does not match RAM size");

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55NS/RTE/Device/ARMCM55/gcc_linker_script.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55NS/RTE/Device/ARMCM55/gcc_linker_script.ld
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+/* ----------------------------------------------------------------------------
+  Memory definition
+ *----------------------------------------------------------------------------*/
+MEMORY
+{
+  ROM0  (rx)  : ORIGIN = __ROM0_BASE, LENGTH = __ROM0_SIZE
+#if __ROM1_SIZE > 0
+  ROM1  (rx)  : ORIGIN = __ROM1_BASE, LENGTH = __ROM1_SIZE
+#endif
+#if __ROM2_SIZE > 0
+  ROM2  (rx)  : ORIGIN = __ROM2_BASE, LENGTH = __ROM2_SIZE
+#endif
+#if __ROM3_SIZE > 0
+  ROM3  (rx)  : ORIGIN = __ROM3_BASE, LENGTH = __ROM3_SIZE
+#endif
+
+  RAM0  (rwx) : ORIGIN = __RAM0_BASE, LENGTH = __RAM0_SIZE
+#if __RAM1_SIZE > 0
+  RAM1  (rwx) : ORIGIN = __RAM1_BASE, LENGTH = __RAM1_SIZE
+#endif
+#if __RAM2_SIZE > 0
+  RAM2  (rwx) : ORIGIN = __RAM2_BASE, LENGTH = __RAM2_SIZE
+#endif
+#if __RAM3_SIZE > 0
+  RAM3  (rwx) : ORIGIN = __RAM3_BASE, LENGTH = __RAM3_SIZE
+#endif
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __copy_table_start__
+ *   __copy_table_end__
+ *   __zero_table_start__
+ *   __zero_table_end__
+ *   __etext          (deprecated)
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+  .text :
+  {
+    KEEP(*(.vectors))
+    *(.text*)
+
+    KEEP(*(.init))
+    KEEP(*(.fini))
+
+    /* .ctors */
+    *crtbegin.o(.ctors)
+    *crtbegin?.o(.ctors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+    *(SORT(.ctors.*))
+    *(.ctors)
+
+    /* .dtors */
+    *crtbegin.o(.dtors)
+    *crtbegin?.o(.dtors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+    *(SORT(.dtors.*))
+    *(.dtors)
+
+    *(.rodata*)
+
+    KEEP(*(.eh_frame*))
+  } > ROM0
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  .gnu.sgstubs :
+  {
+    . = ALIGN(32);
+  } > ROM0
+#endif
+
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > ROM0
+
+  __exidx_start = .;
+  .ARM.exidx :
+  {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+  } > ROM0
+  __exidx_end = .;
+
+  .copy.table :
+  {
+    . = ALIGN(4);
+    __copy_table_start__ = .;
+
+    LONG (LOADADDR(.data))
+    LONG (ADDR(.data))
+    LONG (SIZEOF(.data) / 4)
+
+    /* Add each additional data section here */
+/*
+    LONG (LOADADDR(.data2))
+    LONG (ADDR(.data2))
+    LONG (SIZEOF(.data2) / 4)
+*/
+    __copy_table_end__ = .;
+  } > ROM0
+
+  .zero.table :
+  {
+    . = ALIGN(4);
+    __zero_table_start__ = .;
+
+/*  .bss initialization to zero is already done during C Run-Time Startup.
+    LONG (ADDR(.bss))
+    LONG (SIZEOF(.bss) / 4)
+*/
+
+    /* Add each additional bss section here */
+/*
+    LONG (ADDR(.bss2))
+    LONG (SIZEOF(.bss2) / 4)
+*/
+    __zero_table_end__ = .;
+  } > ROM0
+
+  /*
+   * This __etext variable is kept for backward compatibility with older,
+   * ASM based startup files.
+   */
+  PROVIDE(__etext = LOADADDR(.data));
+
+  .data : ALIGN(4)
+  {
+    __data_start__ = .;
+    *(vtable)
+    *(.data)
+    *(.data.*)
+
+    . = ALIGN(4);
+    /* preinit data */
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP(*(.preinit_array))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+
+    . = ALIGN(4);
+    /* init data */
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP(*(SORT(.init_array.*)))
+    KEEP(*(.init_array))
+    PROVIDE_HIDDEN (__init_array_end = .);
+
+    . = ALIGN(4);
+    /* finit data */
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP(*(SORT(.fini_array.*)))
+    KEEP(*(.fini_array))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    /* All data end */
+    __data_end__ = .;
+
+  } > RAM0 AT > ROM0
+
+  /*
+   * Secondary data section, optional
+   *
+   * Remember to add each additional data section
+   * to the .copy.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .data2 : ALIGN(4)
+  {
+    . = ALIGN(4);
+    __data2_start__ = .;
+    *(.data2)
+    *(.data2.*)
+    . = ALIGN(4);
+    __data2_end__ = .;
+
+  } > RAM1 AT > ROM0 
+*/
+
+  .bss :
+  {
+    . = ALIGN(4);
+    __bss_start__ = .;
+    *(.bss)
+    *(.bss.*)
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+  } > RAM0 AT > RAM0
+
+  /*
+   * Secondary bss section, optional
+   *
+   * Remember to add each additional bss section
+   * to the .zero.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .bss2 :
+  {
+    . = ALIGN(4);
+    __bss2_start__ = .;
+    *(.bss2)
+    *(.bss2.*)
+    . = ALIGN(4);
+    __bss2_end__ = .;
+  } > RAM1 AT > RAM1
+*/
+
+  .heap (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE(end = .);
+    . = . + __HEAP_SIZE;
+    . = ALIGN(8);
+    __HeapLimit = .;
+  } > RAM0
+
+  .stack (ORIGIN(RAM0) + LENGTH(RAM0) - __STACK_SIZE - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackLimit = .;
+    . = . + __STACK_SIZE;
+    . = ALIGN(8);
+    __StackTop = .;
+  } > RAM0
+  PROVIDE(__stack = __StackTop);
+
+#if __STACKSEAL_SIZE > 0
+  .stackseal (ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackSeal = .;
+    . = . + 8;
+    . = ALIGN(8);
+  } > RAM0
+#endif
+
+  /* Check if data + heap + stack exceeds RAM limit */
+  ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55NS/RTE/Device/ARMCM55/iar_linker_script.icf
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55NS/RTE/Device/ARMCM55/iar_linker_script.icf
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+define memory mem with size = 4G;
+
+#if __ROM0_SIZE > 0
+  define region ROM0_region = mem:[from __ROM0_BASE to (__ROM0_BASE+__ROM0_SIZE-1)];
+#else
+  define region ROM0_region = [];
+#endif
+
+#if __ROM1_SIZE > 0
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+#else
+  define region ROM1_region = [];
+#endif
+
+#if __ROM2_SIZE > 0
+  define region ROM2_region = mem:[from __ROM2_BASE to (__ROM2_BASE+__ROM2_SIZE-1)];
+#else
+  define region ROM2_region = [];
+#endif
+
+#if __ROM3_SIZE > 0
+  define region ROM3_region = mem:[from __ROM3_BASE to (__ROM3_BASE+__ROM3_SIZE-1)];
+#else
+  define region ROM3_region = [];
+#endif
+
+define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_region;
+
+#if __RAM0_SIZE > 0
+  define region RAM0_region = mem:[from __RAM0_BASE to (__RAM0_BASE+__RAM0_SIZE-1)];
+#else
+  define region RAM0_region = [];
+#endif
+
+#if __RAM1_SIZE > 0
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+#else
+  define region RAM1_region = [];
+#endif
+
+#if __RAM2_SIZE > 0
+  define region RAM2_region = mem:[from __RAM2_BASE to (__RAM2_BASE+__RAM2_SIZE-1)];
+#else
+  define region RAM2_region = [];
+#endif
+
+#if __RAM3_SIZE > 0
+  define region RAM3_region = mem:[from __RAM3_BASE to (__RAM3_BASE+__RAM3_SIZE-1)];
+#else
+  define region RAM3_region = [];
+#endif
+
+define region RAM_region = RAM0_region | RAM1_region | RAM2_region | RAM3_region;
+
+do not initialize  { section .noinit };
+initialize by copy { readwrite };
+if (isdefinedsymbol(__USE_DLIB_PERTHREAD))
+{
+  // Required in a multi-threaded application
+  initialize by copy with packing = none { section __DLIB_PERTHREAD };
+}
+
+place at address mem:__ROM0_BASE { readonly section .intvec };
+
+if (!isempty(ROM_region))
+{
+  place in ROM_region  { readonly };
+}
+
+if (!isempty(RAM_region))
+{
+  define block CSTACK     with alignment = 8, size = __STACK_SIZE     { };
+  define block PROC_STACK with alignment = 8, size = 0 { };
+  define block HEAP       with alignment = 8, size = __HEAP_SIZE       { };
+  place in RAM_region  { readwrite, block CSTACK, block PROC_STACK, block HEAP };
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55NS/RTE/Device/ARMCM55/regions_ARMCM55.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55NS/RTE/Device/ARMCM55/regions_ARMCM55.h
@@ -1,0 +1,94 @@
+#ifndef REGIONS_ARMCM55_H
+#define REGIONS_ARMCM55_H
+
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+// <n>Device pack:   ARM::Cortex_DFP@1.0.0-dev16
+// <i>Device pack used to generate this file
+
+// <h>ROM Configuration
+// =======================
+// <h> ROM_S=<__ROM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x00000000
+#define __ROM0_BASE 0x00200000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00200000
+#define __ROM0_SIZE 0x00200000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __ROM0_DEFAULT 1
+//   <q>Startup
+//   <i> Selects region to be used for startup code.
+#define __ROM0_STARTUP 1
+// </h>
+
+// <h> ROM_NS=<__ROM1>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x00200000
+#define __ROM1_BASE 0x00000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00200000
+#define __ROM1_SIZE 0x00200000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __ROM1_DEFAULT 0
+//   <q>Startup
+//   <i> Selects region to be used for startup code.
+#define __ROM1_STARTUP 0
+// </h>
+
+// </h>
+
+// <h>RAM Configuration
+// =======================
+// <h> RAM_S=<__RAM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x20000000
+#define __RAM0_BASE 0x20200000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00020000
+#define __RAM0_SIZE 0x00020000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __RAM0_DEFAULT 1
+//   <q>No zero initialize
+//   <i> Excludes region from zero initialization.
+#define __RAM0_NOINIT 0
+// </h>
+
+// <h> RAM_NS=<__RAM1>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x20200000
+#define __RAM1_BASE 0x20000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00020000
+#define __RAM1_SIZE 0x00020000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __RAM1_DEFAULT 0
+//   <q>No zero initialize
+//   <i> Excludes region from zero initialization.
+#define __RAM1_NOINIT 0
+// </h>
+
+// </h>
+
+// <h>Stack / Heap Configuration
+//   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+#define __STACK_SIZE 0x00000400
+#define __HEAP_SIZE 0x00000C00
+// </h>
+
+
+#endif /* REGIONS_ARMCM55_H */

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55NS/RTE/Device/ARMCM55/startup_ARMCM55.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55NS/RTE/Device/ARMCM55/startup_ARMCM55.c
@@ -1,0 +1,164 @@
+/******************************************************************************
+ * @file     startup_ARMCM55.c
+ * @brief    CMSIS-Core Device Startup File for Cortex-M55 Device
+ * @version  V1.1.0
+ * @date     16. December 2020
+ ******************************************************************************/
+/*
+ * Copyright (c) 2020 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (ARMCM55)
+  #include "ARMCM55.h"
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  External References
+ *----------------------------------------------------------------------------*/
+extern uint32_t __INITIAL_SP;
+extern uint32_t __STACK_LIMIT;
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+extern uint32_t __STACK_SEAL;
+#endif
+
+extern __NO_RETURN void __PROGRAM_START(void);
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler  (void);
+            void Default_Handler(void);
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+/* Exceptions */
+void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void HardFault_Handler      (void) __attribute__ ((weak));
+void MemManage_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
+void BusFault_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void UsageFault_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void SecureFault_Handler    (void) __attribute__ ((weak, alias("Default_Handler")));
+void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void DebugMon_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+
+void Interrupt0_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt1_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt2_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt3_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt4_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt5_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt6_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt7_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt8_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt9_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[496];
+       const VECTOR_TABLE_Type __VECTOR_TABLE[496] __VECTOR_TABLE_ATTRIBUTE = {
+  (VECTOR_TABLE_Type)(&__INITIAL_SP),       /*     Initial Stack Pointer */
+  Reset_Handler,                            /*     Reset Handler */
+  NMI_Handler,                              /* -14 NMI Handler */
+  HardFault_Handler,                        /* -13 Hard Fault Handler */
+  MemManage_Handler,                        /* -12 MPU Fault Handler */
+  BusFault_Handler,                         /* -11 Bus Fault Handler */
+  UsageFault_Handler,                       /* -10 Usage Fault Handler */
+  SecureFault_Handler,                      /*  -9 Secure Fault Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  SVC_Handler,                              /*  -5 SVC Handler */
+  DebugMon_Handler,                         /*  -4 Debug Monitor Handler */
+  0,                                        /*     Reserved */
+  PendSV_Handler,                           /*  -2 PendSV Handler */
+  SysTick_Handler,                          /*  -1 SysTick Handler */
+
+  /* Interrupts */
+  Interrupt0_Handler,                       /*   0 Interrupt 0 */
+  Interrupt1_Handler,                       /*   1 Interrupt 1 */
+  Interrupt2_Handler,                       /*   2 Interrupt 2 */
+  Interrupt3_Handler,                       /*   3 Interrupt 3 */
+  Interrupt4_Handler,                       /*   4 Interrupt 4 */
+  Interrupt5_Handler,                       /*   5 Interrupt 5 */
+  Interrupt6_Handler,                       /*   6 Interrupt 6 */
+  Interrupt7_Handler,                       /*   7 Interrupt 7 */
+  Interrupt8_Handler,                       /*   8 Interrupt 8 */
+  Interrupt9_Handler                        /*   9 Interrupt 9 */
+                                            /* Interrupts 10 .. 480 are left out */
+};
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler(void)
+{
+  __set_PSP((uint32_t)(&__INITIAL_SP));
+
+  __set_MSPLIM((uint32_t)(&__STACK_LIMIT));
+  __set_PSPLIM((uint32_t)(&__STACK_LIMIT));
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  __TZ_set_STACKSEAL_S((uint32_t *)(&__STACK_SEAL));
+#endif
+
+  SystemInit();                             /* CMSIS System Initialization */
+  __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
+}
+
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wmissing-noreturn"
+#endif
+
+/*----------------------------------------------------------------------------
+  Hard Fault Handler
+ *----------------------------------------------------------------------------*/
+void HardFault_Handler(void)
+{
+  while(1);
+}
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+void Default_Handler(void)
+{
+  while(1);
+}
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic pop
+#endif
+

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55NS/RTE/Device/ARMCM55/system_ARMCM55.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55NS/RTE/Device/ARMCM55/system_ARMCM55.c
@@ -1,0 +1,107 @@
+/**************************************************************************//**
+ * @file     system_ARMCM55.c
+ * @brief    CMSIS Device System Source File for
+ *           ARMCM55 Device
+ * @version  V1.1.0
+ * @date     28. March 2022
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2022 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (ARMCM55)
+  #include "ARMCM55.h"
+#else
+  #error device not specified!
+#endif
+
+#if defined (__ARM_FEATURE_CMSE) &&  (__ARM_FEATURE_CMSE == 3U)
+  #include "partition_ARMCM55.h"
+#endif
+
+/*----------------------------------------------------------------------------
+  Define clocks
+ *----------------------------------------------------------------------------*/
+#define  XTAL            ( 5000000UL)      /* Oscillator frequency */
+
+#define  SYSTEM_CLOCK    (5U * XTAL)
+
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[496];
+
+
+/*----------------------------------------------------------------------------
+  System Core Clock Variable
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = SYSTEM_CLOCK;
+
+
+/*----------------------------------------------------------------------------
+  System Core Clock update function
+ *----------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)
+{
+  SystemCoreClock = SYSTEM_CLOCK;
+}
+
+/*----------------------------------------------------------------------------
+  System initialization function
+ *----------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t)(&__VECTOR_TABLE[0]);
+#endif
+
+#if (defined (__FPU_USED) && (__FPU_USED == 1U)) || \
+    (defined (__ARM_FEATURE_MVE) && (__ARM_FEATURE_MVE > 0U))
+  SCB->CPACR |= ((3U << 10U*2U) |           /* enable CP10 Full Access */
+                 (3U << 11U*2U)  );         /* enable CP11 Full Access */
+
+  /* Set low-power state for PDEPU                */
+  /*  0b00  | ON, PDEPU is not in low-power state */
+  /*  0b01  | ON, but the clock is off            */
+  /*  0b10  | RET(ention)                         */
+  /*  0b11  | OFF                                 */
+
+  /* Clear ELPSTATE, value is 0b11 on Cold reset */
+  PWRMODCTL->CPDLPSTATE &= ~(PWRMODCTL_CPDLPSTATE_ELPSTATE_Msk);
+
+  /* Favor best FP/MVE performance by default, avoid EPU switch-ON delays */
+  /* PDEPU ON, Clock OFF */
+  PWRMODCTL->CPDLPSTATE |= 0x1 << PWRMODCTL_CPDLPSTATE_ELPSTATE_Pos;
+#endif
+
+#ifdef UNALIGNED_SUPPORT_DISABLE
+  SCB->CCR |= SCB_CCR_UNALIGN_TRP_Msk;
+#endif
+
+  /* Enable Loop and branch info cache */
+  SCB->CCR |= SCB_CCR_LOB_Msk;
+  __DSB();
+  __ISB();
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  TZ_SAU_Setup();
+#endif
+
+  SystemCoreClock = SYSTEM_CLOCK;
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55NS/Target.clayer.yml
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55NS/Target.clayer.yml
@@ -1,0 +1,35 @@
+layer:
+  type: Target
+  description: CM55NS target components and files
+
+  packs:
+    - pack: ARM::Cortex_DFP
+
+  device: ARMCM55
+
+  processor:
+    trustzone: non-secure
+
+  components:
+    # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
+    - component: ARM::CMSIS:CORE
+    - component: Device:Startup&C Startup
+
+  groups:
+    - group: FVP
+      files:
+        - file: ./model_config.txt
+
+  linker:
+    - for-compiler: AC6
+      script: RTE/Device/$Dname$/ac6_linker_script.sct
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: GCC
+      script: RTE/Device/$Dname$/gcc_linker_script.ld
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: CLANG
+      script: RTE/Device/$Dname$/clang_linker_script.ld
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: IAR
+      script: RTE/Device/$Dname$/iar_linker_script.icf
+      regions: RTE/Device/$Dname$/regions_$Dname$.h

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55NS/model_config.txt
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55NS/model_config.txt
@@ -1,0 +1,29 @@
+# Parameters:
+# instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+#----------------------------------------------------------------------------------------------
+fvp_mps2.mps2_visualisation.disable-visualisation=1   # (bool  , init-time) default = '0'      : Enable/disable visualisation
+fvp_mps2.DISABLE_GATING=1                             # (bool  , init-time) default = '0'      : Disable Memory gating logic
+cpu0.FPU=1                                            # (bool  , init-time) default = '1'      : Set whether the model has VFP support
+cpu0.MVE=2                                            # (int   , init-time) default = '0x1'    : Set whether the model has MVE support. If FPU = 0: 0=MVE not included, 1=Integer subset of MVE included. If FPU = 1: 0=MVE not included, 1=Integer subset of MVE included, 2=Integer and half and single precision floating point MVE included
+cpu0.semihosting-enable=1                             # (bool  , init-time) default = '1'      : Enable semihosting SVC traps. Applications that do not use semihosting must set this parameter to false.
+cpu0.semihosting-Thumb_SVC=0xAB                       # (int   , init-time) default = '0xAB'   : T32 SVC number for semihosting : [0x0..0xFF]
+cpu0.semihosting-cmd_line=""                          # (string, init-time) default = ''       : Command line available to semihosting SVC calls
+cpu0.semihosting-heap_base=0x0                        # (int   , init-time) default = '0x0'    : Virtual address of heap base : [0x0..0xFFFFFFFF]
+cpu0.semihosting-heap_limit=0x0                       # (int   , init-time) default = '0x10700000' : Virtual address of top of heap : [0x0..0xFFFFFFFF]
+cpu0.semihosting-stack_base=0x0                       # (int   , init-time) default = '0x10700000' : Virtual address of base of descending stack : [0x0..0xFFFFFFFF]
+cpu0.semihosting-stack_limit=0x0                      # (int   , init-time) default = '0x10800000' : Virtual address of stack limit : [0x0..0xFFFFFFFF]
+cpu0.semihosting-cwd=""                               # (string, init-time) default = ''       : Base directory for semihosting file access.
+cpu0.MPU_S=0x8                                        # (int   , init-time) default = '0x8'    : Number of regions in the Secure MPU. If Security Extentions are absent, this is ignored : [0x0..0x10]
+cpu0.MPU_NS=0x8                                       # (int   , init-time) default = '0x8'    : Number of regions in the Non-Secure MPU. If Security Extentions are absent, this is the total number of MPU regions : [0x0..0x10]
+cpu0.ITM=0                                            # (bool  , init-time) default = '1'      : Level of instrumentation trace supported. false : No ITM trace included, true: ITM trace included
+cpu0.IRQLVL=0x3                                       # (int   , init-time) default = '0x3'    : Number of bits of interrupt priority : [0x3..0x8]
+cpu0.INITSVTOR=0x00000000                             # (int   , init-time) default = '0x10000000' : Secure vector-table offset at reset : [0x0..0xFFFFFF80]
+cpu0.INITNSVTOR=0x0                                   # (int   , init-time) default = '0x0'    : Non-Secure vector-table offset at reset : [0x0..0xFFFFFF80]
+cpu0.SAU=0x8                                          # (int   , init-time) default = '0x4'    : Number of SAU regions (0 => no SAU) : [0x0..0x8]
+idau.NUM_IDAU_REGION=0x0                              # (int   , init-time) default = '0xA'    : 
+cpu0.LOCK_SAU=0                                       # (bool  , init-time) default = '0'      : Lock down of SAU registers write
+cpu0.LOCK_S_MPU=0                                     # (bool  , init-time) default = '0'      : Lock down of Secure MPU registers write
+cpu0.LOCK_NS_MPU=0                                    # (bool  , init-time) default = '0'      : Lock down of Non-Secure MPU registers write
+cpu0.CPIF=1                                           # (bool  , init-time) default = '1'      : Specifies whether the external coprocessor interface is included
+cpu0.SECEXT=1                                         # (bool  , init-time) default = '1'      : Whether the ARMv8-M Security Extensions are included
+#----------------------------------------------------------------------------------------------

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55S/RTE/Device/ARMCM55/ac6_linker_script.sct
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55S/RTE/Device/ARMCM55/ac6_linker_script.sct
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE 8
+#else
+#define __STACKSEAL_SIZE 0
+#endif
+
+/*----------------------------------------------------------------------------
+  Scatter File Definitions definition
+ *----------------------------------------------------------------------------*/
+
+LR_ROM0 __ROM0_BASE __ROM0_SIZE  {
+
+  ER_ROM0 __ROM0_BASE __ROM0_SIZE {
+    *.o (RESET, +First)
+    *(InRoot$$Sections)
+    *(+RO +XO)
+  }
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  ER_CMSE_VENEER AlignExpr(+0, 32) (__ROM0_SIZE - AlignExpr(ImageLength(ER_ROM0), 32)) {
+    *(Veneer$$CMSE)
+  }
+#endif
+
+  RW_NOINIT __RAM0_BASE UNINIT (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE) {
+    *(.bss.noinit)
+  }
+
+  RW_RAM0 AlignExpr(+0, 8) (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE - AlignExpr(ImageLength(RW_NOINIT), 8)) {
+    *(+RW +ZI)
+  }
+
+#if __HEAP_SIZE > 0
+  ARM_LIB_HEAP  (AlignExpr(+0, 8)) EMPTY __HEAP_SIZE  {   ; Reserve empty region for heap
+  }
+#endif
+
+  ARM_LIB_STACK (__RAM0_BASE + __RAM0_SIZE - __STACKSEAL_SIZE) EMPTY -__STACK_SIZE {   ; Reserve empty region for stack
+  }
+
+#if __STACKSEAL_SIZE > 0
+  STACKSEAL +0 EMPTY __STACKSEAL_SIZE {             ; Reserve empty region for stack seal immediately after stack
+  }
+#endif
+
+#if __RAM1_SIZE > 0
+  RW_RAM1 __RAM1_BASE __RAM1_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+
+#if __RAM2_SIZE > 0
+  RW_RAM2 __RAM2_BASE __RAM2_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+
+#if __RAM3_SIZE > 0
+  RW_RAM3 __RAM3_BASE __RAM3_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+}
+
+#if __ROM1_SIZE > 0
+LR_ROM1 __ROM1_BASE __ROM1_SIZE  {
+  ER_ROM1 +0 __ROM1_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif
+
+#if __ROM2_SIZE > 0
+LR_ROM2 __ROM2_BASE __ROM2_SIZE  {
+  ER_ROM2 +0 __ROM2_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif
+
+#if __ROM3_SIZE > 0
+LR_ROM3 __ROM3_BASE __ROM3_SIZE  {
+  ER_ROM3 +0 __ROM3_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55S/RTE/Device/ARMCM55/clang_linker_script.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55S/RTE/Device/ARMCM55/clang_linker_script.ld
@@ -1,0 +1,361 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2019 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+/* ----------------------------------------------------------------------------
+  Memory definition
+ *----------------------------------------------------------------------------*/
+MEMORY
+{
+  ROM0  (rx!w)  : ORIGIN = __ROM0_BASE, LENGTH = __ROM0_SIZE
+#if __ROM1_SIZE > 0
+  ROM1  (rx!w)  : ORIGIN = __ROM1_BASE, LENGTH = __ROM1_SIZE
+#endif
+#if __ROM2_SIZE > 0
+  ROM2  (rx!w)  : ORIGIN = __ROM2_BASE, LENGTH = __ROM2_SIZE
+#endif
+#if __ROM3_SIZE > 0
+  ROM3  (rx!w)  : ORIGIN = __ROM3_BASE, LENGTH = __ROM3_SIZE
+#endif
+
+  RAM0  (w!rx) : ORIGIN = __RAM0_BASE, LENGTH = __RAM0_SIZE
+#if __RAM1_SIZE > 0
+  RAM1  (w!rx) : ORIGIN = __RAM1_BASE, LENGTH = __RAM1_SIZE
+#endif
+#if __RAM2_SIZE > 0
+  RAM2  (w!rx) : ORIGIN = __RAM2_BASE, LENGTH = __RAM2_SIZE
+#endif
+#if __RAM3_SIZE > 0
+  RAM3  (w!rx) : ORIGIN = __RAM3_BASE, LENGTH = __RAM3_SIZE
+#endif
+}
+
+ENTRY(Reset_Handler)
+
+PHDRS
+{
+	text PT_LOAD;
+	ram PT_LOAD;
+	ram_init PT_LOAD;
+	tls PT_TLS;
+}
+
+SECTIONS
+{
+	.init : {
+		KEEP (*(.vectors))
+		KEEP (*(.text.init.enter))
+		KEEP (*(.data.init.enter))
+		KEEP (*(SORT_BY_NAME(.init) SORT_BY_NAME(.init.*)))
+	} >ROM0 AT>ROM0 :text
+
+	.text : {
+
+		/* code */
+		*(.text.unlikely .text.unlikely.*)
+		*(.text.startup .text.startup.*)
+		*(.text .text.* .opd .opd.*)
+		*(.gnu.linkonce.t.*)
+		KEEP (*(.fini .fini.*))
+		__text_end = .;
+
+		PROVIDE (__etext = __text_end);
+		PROVIDE (_etext = __text_end);
+		PROVIDE (etext = __text_end);
+
+		/* read-only data */
+		*(.rdata)
+		*(.rodata .rodata.*)
+		*(.gnu.linkonce.r.*)
+
+		*(.srodata.cst16)
+		*(.srodata.cst8)
+		*(.srodata.cst4)
+		*(.srodata.cst2)
+		*(.srodata .srodata.*)
+		*(.data.rel.ro .data.rel.ro.*)
+		*(.got .got.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		/* lists of constructors and destructors */
+		PROVIDE_HIDDEN ( __preinit_array_start = . );
+		KEEP (*(.preinit_array))
+		PROVIDE_HIDDEN ( __preinit_array_end = . );
+
+		PROVIDE_HIDDEN ( __init_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+		KEEP (*(.init_array .ctors))
+		PROVIDE_HIDDEN ( __init_array_end = . );
+
+		PROVIDE_HIDDEN ( __fini_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
+		KEEP (*(.fini_array .dtors))
+		PROVIDE_HIDDEN ( __fini_array_end = . );
+
+	} >ROM0 AT>ROM0 :text
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+	.veneers :
+	{
+		. = ALIGN(32);
+		KEEP(*(.gnu.sgstubs))
+	} > ROM0 AT>ROM0 :text
+#endif
+
+	.toc : {
+		*(.toc .toc.*)
+	} >ROM0 AT>ROM0 :text
+
+	/* additional sections when compiling with C++ exception support */
+	
+	.except_ordered : {
+		*(.gcc_except_table *.gcc_except_table.*)
+		KEEP (*(.eh_frame .eh_frame.*))
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+	} >ROM0 AT>ROM0 :text
+
+	.except_unordered : {
+		. = ALIGN(8);
+
+		PROVIDE(__exidx_start = .);
+		*(.ARM.exidx*)
+		PROVIDE(__exidx_end = .);
+	} >ROM0 AT>ROM0 :text
+	
+
+	/*
+	 * Data values which are preserved across reset
+	 */
+	.preserve (NOLOAD) : {
+		PROVIDE(__preserve_start__ = .);
+		KEEP(*(SORT_BY_NAME(.preserve.*)))
+		KEEP(*(.preserve))
+		PROVIDE(__preserve_end__ = .);
+	} >RAM0 AT>RAM0 :ram
+
+	.data :  {
+		*(.data .data.*)
+		*(.gnu.linkonce.d.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		PROVIDE( __global_pointer$ = . + 0x800 );
+		*(.sdata .sdata.* .sdata2.*)
+		*(.gnu.linkonce.s.*)
+	} >RAM0 AT>ROM0 :ram_init
+	PROVIDE(__data_start = ADDR(.data));
+	PROVIDE(__data_source = LOADADDR(.data));
+
+	/* Thread local initialized data. This gets
+	 * space allocated as it is expected to be placed
+	 * in ram to be used as a template for TLS data blocks
+	 * allocated at runtime. We're slightly abusing that
+	 * by placing the data in flash where it will be copied
+	 * into the allocate ram addresses by the existing
+	 * data initialization code in crt0
+	 */
+	.tdata :  {
+		*(.tdata .tdata.* .gnu.linkonce.td.*)
+		PROVIDE(__data_end = .);
+		PROVIDE(__tdata_end = .);
+	} >RAM0 AT>ROM0 :tls :ram_init
+	PROVIDE( __tls_base = ADDR(.tdata));
+	PROVIDE( __tdata_start = ADDR(.tdata));
+	PROVIDE( __tdata_source = LOADADDR(.tdata) );
+	PROVIDE( __tdata_source_end = LOADADDR(.tdata) + SIZEOF(.tdata) );
+	PROVIDE( __data_source_end = __tdata_source_end );
+	PROVIDE( __tdata_size = SIZEOF(.tdata) );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata),ALIGNOF(.tbss)) );
+
+	PROVIDE( __edata = __data_end );
+	PROVIDE( _edata = __data_end );
+	PROVIDE( edata = __data_end );
+	PROVIDE( __data_size = __data_end - __data_start );
+	PROVIDE( __data_source_size = __data_source_end - __data_source );
+
+	.tbss (NOLOAD) : {
+		*(.tbss .tbss.* .gnu.linkonce.tb.*)
+		*(.tcommon)
+		PROVIDE( __tls_end = . );
+		PROVIDE( __tbss_end = . );
+	} >RAM0 AT>RAM0 :tls :ram
+	PROVIDE( __bss_start = ADDR(.tbss));
+	PROVIDE( __tbss_start = ADDR(.tbss));
+	PROVIDE( __tbss_offset = ADDR(.tbss) - ADDR(.tdata) );
+	PROVIDE( __tbss_size = SIZEOF(.tbss) );
+	PROVIDE( __tls_size = __tls_end - __tls_base );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
+	PROVIDE( __arm32_tls_tcb_offset = MAX(8, __tls_align) );
+	PROVIDE( __arm64_tls_tcb_offset = MAX(16, __tls_align) );
+
+	/*
+	 * The linker special cases .tbss segments which are
+	 * identified as segments which are not loaded and are
+	 * thread_local.
+	 *
+	 * For these segments, the linker does not advance 'dot'
+	 * across them.  We actually need memory allocated for tbss,
+	 * so we create a special segment here just to make room
+	 */
+	/*
+	.tbss_space (NOLOAD) : {
+		. = ADDR(.tbss);
+		. = . + SIZEOF(.tbss);
+	} >RAM0 AT>RAM0 :ram
+	*/
+
+	.bss (NOLOAD) : {
+		*(.sbss*)
+		*(.gnu.linkonce.sb.*)
+		*(.bss .bss.*)
+		*(.gnu.linkonce.b.*)
+		*(COMMON)
+
+		/* Align the heap */
+		. = ALIGN(8);
+		__bss_end = .;
+	} >RAM0 AT>RAM0 :ram
+	PROVIDE( __non_tls_bss_start = ADDR(.bss) );
+	PROVIDE( __end = __bss_end );
+	PROVIDE( _end = __bss_end );
+	PROVIDE( end = __bss_end );
+	PROVIDE( __bss_size = __bss_end - __bss_start );
+
+	/* Make the rest of memory available for heap storage */
+	PROVIDE (__heap_start = __end);
+#ifdef __HEAP_SIZE
+	PROVIDE (__heap_end = __heap_start + __HEAP_SIZE);
+	PROVIDE (__heap_size = __HEAP_SIZE);
+#else
+	PROVIDE (__heap_end = __stack - __STACK_SIZE);
+	PROVIDE (__heap_size = __heap_end - __heap_start);
+#endif
+	.heap (NOLOAD) : {
+		. += __heap_size;
+	} >RAM0 :ram
+
+	/* Define a stack region to make sure it fits in memory */
+	PROVIDE(__stack = ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE);
+	PROVIDE(__stack_limit = __stack - __STACK_SIZE);
+	.stack (__stack_limit) (NOLOAD) : {
+		. += __STACK_SIZE;
+	} >RAM0 :ram
+
+#if __STACKSEAL_SIZE > 0
+	PROVIDE(__stack_seal = __stack);
+  	.stackseal (__stack) (NOLOAD) :
+  	{
+    	. += __STACKSEAL_SIZE;
+  	} >RAM0 :ram
+#endif
+
+	/* Throw away C++ exception handling information */
+
+	/*
+
+	/DISCARD/ : {
+		*(.note .note.*)
+		*(.eh_frame .eh_frame.*)
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+		*(.ARM.exidx*)
+	}
+
+	*/
+
+	/* Stabs debugging sections.  */
+	.stab          0 : { *(.stab) }
+	.stabstr       0 : { *(.stabstr) }
+	.stab.excl     0 : { *(.stab.excl) }
+	.stab.exclstr  0 : { *(.stab.exclstr) }
+	.stab.index    0 : { *(.stab.index) }
+	.stab.indexstr 0 : { *(.stab.indexstr) }
+	.comment       0 : { *(.comment) }
+	.gnu.build.attributes : { *(.gnu.build.attributes .gnu.build.attributes.*) }
+	/* DWARF debug sections.
+	   Symbols in the DWARF debugging sections are relative to the beginning
+	   of the section so we begin them at 0.  */
+	/* DWARF 1.  */
+	.debug          0 : { *(.debug) }
+	.line           0 : { *(.line) }
+	/* GNU DWARF 1 extensions.  */
+	.debug_srcinfo  0 : { *(.debug_srcinfo) }
+	.debug_sfnames  0 : { *(.debug_sfnames) }
+	/* DWARF 1.1 and DWARF 2.  */
+	.debug_aranges  0 : { *(.debug_aranges) }
+	.debug_pubnames 0 : { *(.debug_pubnames) }
+	/* DWARF 2.  */
+	.debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+	.debug_abbrev   0 : { *(.debug_abbrev) }
+	.debug_line     0 : { *(.debug_line .debug_line.* .debug_line_end) }
+	.debug_frame    0 : { *(.debug_frame) }
+	.debug_str      0 : { *(.debug_str) }
+	.debug_loc      0 : { *(.debug_loc) }
+	.debug_macinfo  0 : { *(.debug_macinfo) }
+	/* SGI/MIPS DWARF 2 extensions.  */
+	.debug_weaknames 0 : { *(.debug_weaknames) }
+	.debug_funcnames 0 : { *(.debug_funcnames) }
+	.debug_typenames 0 : { *(.debug_typenames) }
+	.debug_varnames  0 : { *(.debug_varnames) }
+	/* DWARF 3.  */
+	.debug_pubtypes 0 : { *(.debug_pubtypes) }
+	.debug_ranges   0 : { *(.debug_ranges) }
+	/* DWARF 5.  */
+	.debug_addr     0 : { *(.debug_addr) }
+	.debug_line_str 0 : { *(.debug_line_str) }
+	.debug_loclists 0 : { *(.debug_loclists) }
+	.debug_macro    0 : { *(.debug_macro) }
+	.debug_names    0 : { *(.debug_names) }
+	.debug_rnglists 0 : { *(.debug_rnglists) }
+	.debug_str_offsets 0 : { *(.debug_str_offsets) }
+	.debug_sup      0 : { *(.debug_sup) }
+	.gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }
+}
+/*
+ * Check that sections that are copied from flash to RAM have matching
+ * padding, so that a single memcpy() of __data_size copies the correct bytes.
+ */
+ASSERT( __data_size == __data_source_size,
+	"ERROR: .data/.tdata flash size does not match RAM size");

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55S/RTE/Device/ARMCM55/gcc_linker_script.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55S/RTE/Device/ARMCM55/gcc_linker_script.ld
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+/* ----------------------------------------------------------------------------
+  Memory definition
+ *----------------------------------------------------------------------------*/
+MEMORY
+{
+  ROM0  (rx)  : ORIGIN = __ROM0_BASE, LENGTH = __ROM0_SIZE
+#if __ROM1_SIZE > 0
+  ROM1  (rx)  : ORIGIN = __ROM1_BASE, LENGTH = __ROM1_SIZE
+#endif
+#if __ROM2_SIZE > 0
+  ROM2  (rx)  : ORIGIN = __ROM2_BASE, LENGTH = __ROM2_SIZE
+#endif
+#if __ROM3_SIZE > 0
+  ROM3  (rx)  : ORIGIN = __ROM3_BASE, LENGTH = __ROM3_SIZE
+#endif
+
+  RAM0  (rwx) : ORIGIN = __RAM0_BASE, LENGTH = __RAM0_SIZE
+#if __RAM1_SIZE > 0
+  RAM1  (rwx) : ORIGIN = __RAM1_BASE, LENGTH = __RAM1_SIZE
+#endif
+#if __RAM2_SIZE > 0
+  RAM2  (rwx) : ORIGIN = __RAM2_BASE, LENGTH = __RAM2_SIZE
+#endif
+#if __RAM3_SIZE > 0
+  RAM3  (rwx) : ORIGIN = __RAM3_BASE, LENGTH = __RAM3_SIZE
+#endif
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __copy_table_start__
+ *   __copy_table_end__
+ *   __zero_table_start__
+ *   __zero_table_end__
+ *   __etext          (deprecated)
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+  .text :
+  {
+    KEEP(*(.vectors))
+    *(.text*)
+
+    KEEP(*(.init))
+    KEEP(*(.fini))
+
+    /* .ctors */
+    *crtbegin.o(.ctors)
+    *crtbegin?.o(.ctors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+    *(SORT(.ctors.*))
+    *(.ctors)
+
+    /* .dtors */
+    *crtbegin.o(.dtors)
+    *crtbegin?.o(.dtors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+    *(SORT(.dtors.*))
+    *(.dtors)
+
+    *(.rodata*)
+
+    KEEP(*(.eh_frame*))
+  } > ROM0
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  .gnu.sgstubs :
+  {
+    . = ALIGN(32);
+  } > ROM0
+#endif
+
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > ROM0
+
+  __exidx_start = .;
+  .ARM.exidx :
+  {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+  } > ROM0
+  __exidx_end = .;
+
+  .copy.table :
+  {
+    . = ALIGN(4);
+    __copy_table_start__ = .;
+
+    LONG (LOADADDR(.data))
+    LONG (ADDR(.data))
+    LONG (SIZEOF(.data) / 4)
+
+    /* Add each additional data section here */
+/*
+    LONG (LOADADDR(.data2))
+    LONG (ADDR(.data2))
+    LONG (SIZEOF(.data2) / 4)
+*/
+    __copy_table_end__ = .;
+  } > ROM0
+
+  .zero.table :
+  {
+    . = ALIGN(4);
+    __zero_table_start__ = .;
+
+/*  .bss initialization to zero is already done during C Run-Time Startup.
+    LONG (ADDR(.bss))
+    LONG (SIZEOF(.bss) / 4)
+*/
+
+    /* Add each additional bss section here */
+/*
+    LONG (ADDR(.bss2))
+    LONG (SIZEOF(.bss2) / 4)
+*/
+    __zero_table_end__ = .;
+  } > ROM0
+
+  /*
+   * This __etext variable is kept for backward compatibility with older,
+   * ASM based startup files.
+   */
+  PROVIDE(__etext = LOADADDR(.data));
+
+  .data : ALIGN(4)
+  {
+    __data_start__ = .;
+    *(vtable)
+    *(.data)
+    *(.data.*)
+
+    . = ALIGN(4);
+    /* preinit data */
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP(*(.preinit_array))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+
+    . = ALIGN(4);
+    /* init data */
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP(*(SORT(.init_array.*)))
+    KEEP(*(.init_array))
+    PROVIDE_HIDDEN (__init_array_end = .);
+
+    . = ALIGN(4);
+    /* finit data */
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP(*(SORT(.fini_array.*)))
+    KEEP(*(.fini_array))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    /* All data end */
+    __data_end__ = .;
+
+  } > RAM0 AT > ROM0
+
+  /*
+   * Secondary data section, optional
+   *
+   * Remember to add each additional data section
+   * to the .copy.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .data2 : ALIGN(4)
+  {
+    . = ALIGN(4);
+    __data2_start__ = .;
+    *(.data2)
+    *(.data2.*)
+    . = ALIGN(4);
+    __data2_end__ = .;
+
+  } > RAM1 AT > ROM0 
+*/
+
+  .bss :
+  {
+    . = ALIGN(4);
+    __bss_start__ = .;
+    *(.bss)
+    *(.bss.*)
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+  } > RAM0 AT > RAM0
+
+  /*
+   * Secondary bss section, optional
+   *
+   * Remember to add each additional bss section
+   * to the .zero.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .bss2 :
+  {
+    . = ALIGN(4);
+    __bss2_start__ = .;
+    *(.bss2)
+    *(.bss2.*)
+    . = ALIGN(4);
+    __bss2_end__ = .;
+  } > RAM1 AT > RAM1
+*/
+
+  .heap (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE(end = .);
+    . = . + __HEAP_SIZE;
+    . = ALIGN(8);
+    __HeapLimit = .;
+  } > RAM0
+
+  .stack (ORIGIN(RAM0) + LENGTH(RAM0) - __STACK_SIZE - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackLimit = .;
+    . = . + __STACK_SIZE;
+    . = ALIGN(8);
+    __StackTop = .;
+  } > RAM0
+  PROVIDE(__stack = __StackTop);
+
+#if __STACKSEAL_SIZE > 0
+  .stackseal (ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackSeal = .;
+    . = . + 8;
+    . = ALIGN(8);
+  } > RAM0
+#endif
+
+  /* Check if data + heap + stack exceeds RAM limit */
+  ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55S/RTE/Device/ARMCM55/iar_linker_script.icf
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55S/RTE/Device/ARMCM55/iar_linker_script.icf
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+define memory mem with size = 4G;
+
+#if __ROM0_SIZE > 0
+  define region ROM0_region = mem:[from __ROM0_BASE to (__ROM0_BASE+__ROM0_SIZE-1)];
+#else
+  define region ROM0_region = [];
+#endif
+
+#if __ROM1_SIZE > 0
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+#else
+  define region ROM1_region = [];
+#endif
+
+#if __ROM2_SIZE > 0
+  define region ROM2_region = mem:[from __ROM2_BASE to (__ROM2_BASE+__ROM2_SIZE-1)];
+#else
+  define region ROM2_region = [];
+#endif
+
+#if __ROM3_SIZE > 0
+  define region ROM3_region = mem:[from __ROM3_BASE to (__ROM3_BASE+__ROM3_SIZE-1)];
+#else
+  define region ROM3_region = [];
+#endif
+
+define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_region;
+
+#if __RAM0_SIZE > 0
+  define region RAM0_region = mem:[from __RAM0_BASE to (__RAM0_BASE+__RAM0_SIZE-1)];
+#else
+  define region RAM0_region = [];
+#endif
+
+#if __RAM1_SIZE > 0
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+#else
+  define region RAM1_region = [];
+#endif
+
+#if __RAM2_SIZE > 0
+  define region RAM2_region = mem:[from __RAM2_BASE to (__RAM2_BASE+__RAM2_SIZE-1)];
+#else
+  define region RAM2_region = [];
+#endif
+
+#if __RAM3_SIZE > 0
+  define region RAM3_region = mem:[from __RAM3_BASE to (__RAM3_BASE+__RAM3_SIZE-1)];
+#else
+  define region RAM3_region = [];
+#endif
+
+define region RAM_region = RAM0_region | RAM1_region | RAM2_region | RAM3_region;
+
+do not initialize  { section .noinit };
+initialize by copy { readwrite };
+if (isdefinedsymbol(__USE_DLIB_PERTHREAD))
+{
+  // Required in a multi-threaded application
+  initialize by copy with packing = none { section __DLIB_PERTHREAD };
+}
+
+place at address mem:__ROM0_BASE { readonly section .intvec };
+
+if (!isempty(ROM_region))
+{
+  place in ROM_region  { readonly };
+}
+
+if (!isempty(RAM_region))
+{
+  define block CSTACK     with alignment = 8, size = __STACK_SIZE     { };
+  define block PROC_STACK with alignment = 8, size = 0 { };
+  define block HEAP       with alignment = 8, size = __HEAP_SIZE       { };
+  place in RAM_region  { readwrite, block CSTACK, block PROC_STACK, block HEAP };
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55S/RTE/Device/ARMCM55/partition_ARMCM55.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55S/RTE/Device/ARMCM55/partition_ARMCM55.h
@@ -1,0 +1,1261 @@
+/**************************************************************************//**
+ * @file     partition_ARMCM55.h
+ * @brief    CMSIS-CORE Initial Setup for Secure / Non-Secure Zones for Armv8.1-M Mainline
+ * @version  V1.0.0
+ * @date     20. March 2020
+ ******************************************************************************/
+/*
+ * Copyright (c) 2020 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PARTITION_ARMCM55_H
+#define PARTITION_ARMCM55_H
+
+/*
+//-------- <<< Use Configuration Wizard in Context Menu >>> -----------------
+*/
+
+/*
+// <e>Initialize Security Attribution Unit (SAU) CTRL register
+*/
+#define SAU_INIT_CTRL          1
+
+/*
+//   <q> Enable SAU
+//   <i> Value for SAU->CTRL register bit ENABLE
+*/
+#define SAU_INIT_CTRL_ENABLE   1
+
+/*
+//   <o> When SAU is disabled
+//     <0=> All Memory is Secure
+//     <1=> All Memory is Non-Secure
+//   <i> Value for SAU->CTRL register bit ALLNS
+//   <i> When all Memory is Non-Secure (ALLNS is 1), IDAU can override memory map configuration.
+*/
+#define SAU_INIT_CTRL_ALLNS  0
+
+/*
+// </e>
+*/
+
+/*
+// <h>Initialize Security Attribution Unit (SAU) Address Regions
+// <i>SAU configuration specifies regions to be one of:
+// <i> - Secure and Non-Secure Callable
+// <i> - Non-Secure
+// <i>Note: All memory regions not configured by SAU are Secure
+*/
+#define SAU_REGIONS_MAX   8                 /* Max. number of SAU regions */
+
+/*
+//   <e>Initialize SAU Region 0
+//   <i> Setup SAU Region 0 memory attributes
+*/
+#define SAU_INIT_REGION0    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START0     0x00000000      /* start address of SAU region 0 */
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END0       0x001FFFFF      /* end address of SAU region 0 */
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC0       1
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 1
+//   <i> Setup SAU Region 1 memory attributes
+*/
+#define SAU_INIT_REGION1    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START1     0x00200000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END1       0x003FFFFF
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC1       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 2
+//   <i> Setup SAU Region 2 memory attributes
+*/
+#define SAU_INIT_REGION2    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START2     0x20200000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END2       0x203FFFFF
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC2       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 3
+//   <i> Setup SAU Region 3 memory attributes
+*/
+#define SAU_INIT_REGION3    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START3     0x40000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END3       0x40040000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC3       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 4
+//   <i> Setup SAU Region 4 memory attributes
+*/
+#define SAU_INIT_REGION4    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START4     0x00000000      /* start address of SAU region 4 */
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END4       0x00000000      /* end address of SAU region 4 */
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC4       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 5
+//   <i> Setup SAU Region 5 memory attributes
+*/
+#define SAU_INIT_REGION5    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START5     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END5       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC5       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 6
+//   <i> Setup SAU Region 6 memory attributes
+*/
+#define SAU_INIT_REGION6    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START6     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END6       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC6       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 7
+//   <i> Setup SAU Region 7 memory attributes
+*/
+#define SAU_INIT_REGION7    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START7     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END7       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC7       0
+/*
+//   </e>
+*/
+
+/*
+// </h>
+*/
+
+/*
+// <e>Setup behaviour of Sleep and Exception Handling
+*/
+#define SCB_CSR_AIRCR_INIT  1
+
+/*
+//   <o> Deep Sleep can be enabled by
+//     <0=>Secure and Non-Secure state
+//     <1=>Secure state only
+//   <i> Value for SCB->CSR register bit DEEPSLEEPS
+*/
+#define SCB_CSR_DEEPSLEEPS_VAL  1
+
+/*
+//   <o>System reset request accessible from
+//     <0=> Secure and Non-Secure state
+//     <1=> Secure state only
+//   <i> Value for SCB->AIRCR register bit SYSRESETREQS
+*/
+#define SCB_AIRCR_SYSRESETREQS_VAL  1
+
+/*
+//   <o>Priority of Non-Secure exceptions is
+//     <0=> Not altered
+//     <1=> Lowered to 0x80-0xFF
+//   <i> Value for SCB->AIRCR register bit PRIS
+*/
+#define SCB_AIRCR_PRIS_VAL      1
+
+/*
+//   <o>BusFault, HardFault, and NMI target
+//     <0=> Secure state
+//     <1=> Non-Secure state
+//   <i> Value for SCB->AIRCR register bit BFHFNMINS
+*/
+#define SCB_AIRCR_BFHFNMINS_VAL 0
+
+/*
+// </e>
+*/
+
+/*
+// <e>Setup behaviour of Floating Point and Vector Unit (FPU/MVE)
+*/
+#define TZ_FPU_NS_USAGE 1
+
+/*
+// <o>Floating Point and Vector Unit usage
+//     <0=> Secure state only
+//     <3=> Secure and Non-Secure state
+//   <i> Value for SCB->NSACR register bits CP10, CP11
+*/
+#define SCB_NSACR_CP10_11_VAL       3
+
+/*
+// <o>Treat floating-point registers as Secure
+//     <0=> Disabled
+//     <1=> Enabled
+//   <i> Value for FPU->FPCCR register bit TS
+*/
+#define FPU_FPCCR_TS_VAL            0
+
+/*
+// <o>Clear on return (CLRONRET) accessibility
+//     <0=> Secure and Non-Secure state
+//     <1=> Secure state only
+//   <i> Value for FPU->FPCCR register bit CLRONRETS
+*/
+#define FPU_FPCCR_CLRONRETS_VAL     0
+
+/*
+// <o>Clear floating-point caller saved registers on exception return
+//     <0=> Disabled
+//     <1=> Enabled
+//   <i> Value for FPU->FPCCR register bit CLRONRET
+*/
+#define FPU_FPCCR_CLRONRET_VAL      1
+
+/*
+// </e>
+*/
+
+/*
+// <h>Setup Interrupt Target
+*/
+
+/*
+//   <e>Initialize ITNS 0 (Interrupts 0..31)
+*/
+#define NVIC_INIT_ITNS0    0
+
+/*
+// Interrupts 0..31
+//   <o.0>  Interrupt 0   <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 1   <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 2   <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 3   <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 4   <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 5   <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 6   <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 7   <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 8   <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 9   <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 10  <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 11  <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 12  <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 13  <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 14  <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 15  <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 16  <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 17  <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 18  <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 19  <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 20  <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 21  <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 22  <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 23  <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 24  <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 25  <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 26  <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 27  <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 28  <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 29  <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 30  <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 31  <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS0_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 1 (Interrupts 32..63)
+*/
+#define NVIC_INIT_ITNS1    0
+
+/*
+// Interrupts 32..63
+//   <o.0>  Interrupt 32  <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 33  <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 34  <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 35  <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 36  <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 37  <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 38  <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 39  <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 40  <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 41  <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 42  <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 43  <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 44  <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 45  <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 46  <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 47  <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 48  <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 49  <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 50  <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 51  <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 52  <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 53  <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 54  <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 55  <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 56  <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 57  <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 58  <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 59  <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 60  <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 61  <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 62  <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 63  <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS1_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 2 (Interrupts 64..95)
+*/
+#define NVIC_INIT_ITNS2    0
+
+/*
+// Interrupts 64..95
+//   <o.0>  Interrupt 64  <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 65  <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 66  <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 67  <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 68  <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 69  <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 70  <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 71  <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 72  <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 73  <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 74  <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 75  <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 76  <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 77  <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 78  <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 79  <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 80  <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 81  <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 82  <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 83  <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 84  <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 85  <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 86  <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 87  <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 88  <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 89  <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 90  <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 91  <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 92  <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 93  <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 94  <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 95  <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS2_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 3 (Interrupts 96..127)
+*/
+#define NVIC_INIT_ITNS3    0
+
+/*
+// Interrupts 96..127
+//   <o.0>  Interrupt 96  <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 97  <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 98  <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 99  <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 100 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 101 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 102 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 103 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 104 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 105 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 106 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 107 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 108 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 109 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 110 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 111 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 112 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 113 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 114 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 115 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 116 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 117 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 118 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 119 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 120 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 121 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 122 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 123 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 124 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 125 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 126 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 127 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS3_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 4 (Interrupts 128..159)
+*/
+#define NVIC_INIT_ITNS4    0
+
+/*
+// Interrupts 128..159
+//   <o.0>  Interrupt 128 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 129 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 130 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 131 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 132 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 133 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 134 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 135 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 136 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 137 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 138 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 139 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 140 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 141 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 142 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 143 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 144 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 145 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 146 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 147 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 148 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 149 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 150 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 151 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 152 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 153 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 154 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 155 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 156 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 157 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 158 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 159 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS4_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 5 (Interrupts 160..191)
+*/
+#define NVIC_INIT_ITNS5    0
+
+/*
+// Interrupts 160..191
+//   <o.0>  Interrupt 160 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 161 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 162 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 163 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 164 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 165 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 166 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 167 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 168 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 169 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 170 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 171 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 172 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 173 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 174 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 175 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 176 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 177 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 178 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 179 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 180 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 181 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 182 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 183 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 184 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 185 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 186 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 187 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 188 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 189 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 190 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 191 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS5_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 6 (Interrupts 192..223)
+*/
+#define NVIC_INIT_ITNS6    0
+
+/*
+// Interrupts 192..223
+//   <o.0>  Interrupt 192 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 193 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 194 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 195 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 196 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 197 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 198 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 199 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 200 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 201 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 202 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 203 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 204 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 205 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 206 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 207 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 208 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 209 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 210 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 211 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 212 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 213 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 214 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 215 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 216 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 217 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 218 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 219 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 220 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 221 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 222 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 223 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS6_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 7 (Interrupts 224..255)
+*/
+#define NVIC_INIT_ITNS7    0
+
+/*
+// Interrupts 224..255
+//   <o.0>  Interrupt 224 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 225 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 226 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 227 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 228 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 229 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 230 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 231 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 232 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 233 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 234 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 235 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 236 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 237 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 238 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 239 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 240 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 241 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 242 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 243 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 244 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 245 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 246 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 247 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 248 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 249 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 250 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 251 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 252 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 253 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 254 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 255 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS7_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 8 (Interrupts 256..287)
+*/
+#define NVIC_INIT_ITNS8    0
+
+/*
+// Interrupts 256..287
+//   <o.0>  Interrupt 256 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 257 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 258 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 259 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 260 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 261 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 262 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 263 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 264 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 265 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 266 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 267 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 268 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 269 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 270 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 271 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 272 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 273 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 274 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 275 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 276 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 277 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 278 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 279 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 280 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 281 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 282 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 283 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 284 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 285 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 286 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 287 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS8_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 9 (Interrupts 288..319)
+*/
+#define NVIC_INIT_ITNS9    0
+
+/*
+// Interrupts 288..319
+//   <o.0>  Interrupt 288 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 289 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 290 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 291 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 292 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 293 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 294 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 295 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 296 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 297 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 298 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 299 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 300 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 301 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 302 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 303 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 304 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 305 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 306 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 307 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 308 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 309 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 310 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 311 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 312 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 313 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 314 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 315 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 316 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 317 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 318 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 319 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS9_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 10 (Interrupts 320..351)
+*/
+#define NVIC_INIT_ITNS10   0
+
+/*
+// Interrupts 320..351
+//   <o.0>  Interrupt 320 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 321 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 322 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 323 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 324 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 325 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 326 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 327 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 328 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 329 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 330 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 331 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 332 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 333 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 334 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 335 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 336 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 337 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 338 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 339 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 340 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 341 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 342 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 343 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 344 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 345 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 346 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 347 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 348 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 349 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 350 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 351 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS10_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 11 (Interrupts 352..383)
+*/
+#define NVIC_INIT_ITNS11   0
+
+/*
+// Interrupts 352..383
+//   <o.0>  Interrupt 352 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 353 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 354 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 355 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 356 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 357 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 358 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 359 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 360 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 361 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 362 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 363 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 364 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 365 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 366 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 367 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 368 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 369 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 370 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 371 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 372 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 373 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 374 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 375 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 376 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 377 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 378 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 379 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 380 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 381 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 382 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 383 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS11_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 12 (Interrupts 384..415)
+*/
+#define NVIC_INIT_ITNS12   0
+
+/*
+// Interrupts 384..415
+//   <o.0>  Interrupt 384 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 385 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 386 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 387 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 388 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 389 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 390 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 391 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 392 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 393 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 394 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 395 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 396 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 397 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 398 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 399 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 400 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 401 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 402 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 403 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 404 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 405 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 406 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 407 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 408 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 409 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 410 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 411 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 412 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 413 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 414 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 415 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS12_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 13 (Interrupts 416..447)
+*/
+#define NVIC_INIT_ITNS13   0
+
+/*
+// Interrupts 416..447
+//   <o.0>  Interrupt 416 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 417 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 418 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 419 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 420 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 421 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 422 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 423 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 424 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 425 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 426 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 427 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 428 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 429 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 430 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 431 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 432 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 433 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 434 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 435 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 436 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 437 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 438 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 439 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 440 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 441 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 442 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 443 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 444 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 445 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 446 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 447 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS13_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 14 (Interrupts 448..479)
+*/
+#define NVIC_INIT_ITNS14   0
+
+/*
+// Interrupts 448..479
+//   <o.0>  Interrupt 448 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 449 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 450 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 451 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 452 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 453 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 454 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 455 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 456 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 457 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 458 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 459 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 460 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 461 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 462 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 463 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 464 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 465 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 466 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 467 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 468 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 469 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 470 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 471 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 472 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 473 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 474 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 475 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 476 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 477 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 478 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 479 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS14_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 15 (Interrupts 480..511)
+*/
+#define NVIC_INIT_ITNS15   0
+
+/*
+// Interrupts 480..511
+//   <o.0>  Interrupt 480 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 481 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 482 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 483 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 484 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 485 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 486 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 487 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 488 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 489 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 490 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 491 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 492 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 493 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 494 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 495 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 496 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 497 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 498 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 499 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 500 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 501 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 502 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 503 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 504 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 505 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 506 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 507 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 508 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 509 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 510 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 511 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS15_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+// </h>
+*/
+
+
+
+/*
+    max 128 SAU regions.
+    SAU regions are defined in partition.h
+ */
+
+#define SAU_INIT_REGION(n) \
+    SAU->RNR  =  (n                                     & SAU_RNR_REGION_Msk); \
+    SAU->RBAR =  (SAU_INIT_START##n                     & SAU_RBAR_BADDR_Msk); \
+    SAU->RLAR =  (SAU_INIT_END##n                       & SAU_RLAR_LADDR_Msk) | \
+                ((SAU_INIT_NSC##n << SAU_RLAR_NSC_Pos)  & SAU_RLAR_NSC_Msk)   | 1U
+
+/**
+  \brief   Setup a SAU Region
+  \details Writes the region information contained in SAU_Region to the
+           registers SAU_RNR, SAU_RBAR, and SAU_RLAR
+ */
+__STATIC_INLINE void TZ_SAU_Setup (void)
+{
+
+#if defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U)
+
+  #if defined (SAU_INIT_REGION0) && (SAU_INIT_REGION0 == 1U)
+    SAU_INIT_REGION(0);
+  #endif
+
+  #if defined (SAU_INIT_REGION1) && (SAU_INIT_REGION1 == 1U)
+    SAU_INIT_REGION(1);
+  #endif
+
+  #if defined (SAU_INIT_REGION2) && (SAU_INIT_REGION2 == 1U)
+    SAU_INIT_REGION(2);
+  #endif
+
+  #if defined (SAU_INIT_REGION3) && (SAU_INIT_REGION3 == 1U)
+    SAU_INIT_REGION(3);
+  #endif
+
+  #if defined (SAU_INIT_REGION4) && (SAU_INIT_REGION4 == 1U)
+    SAU_INIT_REGION(4);
+  #endif
+
+  #if defined (SAU_INIT_REGION5) && (SAU_INIT_REGION5 == 1U)
+    SAU_INIT_REGION(5);
+  #endif
+
+  #if defined (SAU_INIT_REGION6) && (SAU_INIT_REGION6 == 1U)
+    SAU_INIT_REGION(6);
+  #endif
+
+  #if defined (SAU_INIT_REGION7) && (SAU_INIT_REGION7 == 1U)
+    SAU_INIT_REGION(7);
+  #endif
+
+  /* repeat this for all possible SAU regions */
+
+#endif /* defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U) */
+
+
+  #if defined (SAU_INIT_CTRL) && (SAU_INIT_CTRL == 1U)
+    SAU->CTRL = ((SAU_INIT_CTRL_ENABLE << SAU_CTRL_ENABLE_Pos) & SAU_CTRL_ENABLE_Msk) |
+                ((SAU_INIT_CTRL_ALLNS  << SAU_CTRL_ALLNS_Pos)  & SAU_CTRL_ALLNS_Msk)   ;
+  #endif
+
+  #if defined (SCB_CSR_AIRCR_INIT) && (SCB_CSR_AIRCR_INIT == 1U)
+    SCB->SCR   = (SCB->SCR   & ~(SCB_SCR_SLEEPDEEPS_Msk    )) |
+                   ((SCB_CSR_DEEPSLEEPS_VAL     << SCB_SCR_SLEEPDEEPS_Pos)     & SCB_SCR_SLEEPDEEPS_Msk);
+
+    SCB->AIRCR = (SCB->AIRCR & ~(SCB_AIRCR_VECTKEY_Msk   | SCB_AIRCR_SYSRESETREQS_Msk |
+                                 SCB_AIRCR_BFHFNMINS_Msk | SCB_AIRCR_PRIS_Msk          ))                    |
+                   ((0x05FAU                    << SCB_AIRCR_VECTKEY_Pos)      & SCB_AIRCR_VECTKEY_Msk)      |
+                   ((SCB_AIRCR_SYSRESETREQS_VAL << SCB_AIRCR_SYSRESETREQS_Pos) & SCB_AIRCR_SYSRESETREQS_Msk) |
+                   ((SCB_AIRCR_PRIS_VAL         << SCB_AIRCR_PRIS_Pos)         & SCB_AIRCR_PRIS_Msk)         |
+                   ((SCB_AIRCR_BFHFNMINS_VAL    << SCB_AIRCR_BFHFNMINS_Pos)    & SCB_AIRCR_BFHFNMINS_Msk);
+  #endif /* defined (SCB_CSR_AIRCR_INIT) && (SCB_CSR_AIRCR_INIT == 1U) */
+
+  #if (((defined (__FPU_USED) && (__FPU_USED == 1U))              || \
+        (defined (__ARM_FEATURE_MVE) && (__ARM_FEATURE_MVE > 0))) && \
+       (defined (TZ_FPU_NS_USAGE) && (TZ_FPU_NS_USAGE == 1U)))
+
+    SCB->NSACR = (SCB->NSACR & ~(SCB_NSACR_CP10_Msk | SCB_NSACR_CP11_Msk)) |
+                   ((SCB_NSACR_CP10_11_VAL << SCB_NSACR_CP10_Pos) & (SCB_NSACR_CP10_Msk | SCB_NSACR_CP11_Msk));
+
+    FPU->FPCCR = (FPU->FPCCR & ~(FPU_FPCCR_TS_Msk | FPU_FPCCR_CLRONRETS_Msk | FPU_FPCCR_CLRONRET_Msk)) |
+                   ((FPU_FPCCR_TS_VAL        << FPU_FPCCR_TS_Pos       ) & FPU_FPCCR_TS_Msk       ) |
+                   ((FPU_FPCCR_CLRONRETS_VAL << FPU_FPCCR_CLRONRETS_Pos) & FPU_FPCCR_CLRONRETS_Msk) |
+                   ((FPU_FPCCR_CLRONRET_VAL  << FPU_FPCCR_CLRONRET_Pos ) & FPU_FPCCR_CLRONRET_Msk );
+  #endif
+
+  #if defined (NVIC_INIT_ITNS0) && (NVIC_INIT_ITNS0 == 1U)
+    NVIC->ITNS[0] = NVIC_INIT_ITNS0_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS1) && (NVIC_INIT_ITNS1 == 1U)
+    NVIC->ITNS[1] = NVIC_INIT_ITNS1_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS2) && (NVIC_INIT_ITNS2 == 1U)
+    NVIC->ITNS[2] = NVIC_INIT_ITNS2_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS3) && (NVIC_INIT_ITNS3 == 1U)
+    NVIC->ITNS[3] = NVIC_INIT_ITNS3_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS4) && (NVIC_INIT_ITNS4 == 1U)
+    NVIC->ITNS[4] = NVIC_INIT_ITNS4_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS5) && (NVIC_INIT_ITNS5 == 1U)
+    NVIC->ITNS[5] = NVIC_INIT_ITNS5_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS6) && (NVIC_INIT_ITNS6 == 1U)
+    NVIC->ITNS[6] = NVIC_INIT_ITNS6_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS7) && (NVIC_INIT_ITNS7 == 1U)
+    NVIC->ITNS[7] = NVIC_INIT_ITNS7_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS8) && (NVIC_INIT_ITNS8 == 1U)
+    NVIC->ITNS[8] = NVIC_INIT_ITNS8_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS9) && (NVIC_INIT_ITNS9 == 1U)
+    NVIC->ITNS[9] = NVIC_INIT_ITNS9_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS10) && (NVIC_INIT_ITNS10 == 1U)
+    NVIC->ITNS[10] = NVIC_INIT_ITNS10_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS11) && (NVIC_INIT_ITNS11 == 1U)
+    NVIC->ITNS[11] = NVIC_INIT_ITNS11_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS12) && (NVIC_INIT_ITNS12 == 1U)
+    NVIC->ITNS[12] = NVIC_INIT_ITNS12_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS13) && (NVIC_INIT_ITNS13 == 1U)
+    NVIC->ITNS[13] = NVIC_INIT_ITNS13_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS14) && (NVIC_INIT_ITNS14 == 1U)
+    NVIC->ITNS[14] = NVIC_INIT_ITNS14_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS15) && (NVIC_INIT_ITNS15 == 1U)
+    NVIC->ITNS[15] = NVIC_INIT_ITNS15_VAL;
+  #endif
+
+  /* repeat this for all possible ITNS elements */
+
+}
+
+#endif  /* PARTITION_ARMCM55_H */

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55S/RTE/Device/ARMCM55/regions_ARMCM55.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55S/RTE/Device/ARMCM55/regions_ARMCM55.h
@@ -1,0 +1,94 @@
+#ifndef REGIONS_ARMCM55_H
+#define REGIONS_ARMCM55_H
+
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+// <n>Device pack:   ARM::Cortex_DFP@1.0.0-dev16
+// <i>Device pack used to generate this file
+
+// <h>ROM Configuration
+// =======================
+// <h> ROM_S=<__ROM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x00000000
+#define __ROM0_BASE 0x00000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00200000
+#define __ROM0_SIZE 0x00200000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __ROM0_DEFAULT 1
+//   <q>Startup
+//   <i> Selects region to be used for startup code.
+#define __ROM0_STARTUP 1
+// </h>
+
+// <h> ROM_NS=<__ROM1>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x00200000
+#define __ROM1_BASE 0x00200000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00200000
+#define __ROM1_SIZE 0x00200000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __ROM1_DEFAULT 0
+//   <q>Startup
+//   <i> Selects region to be used for startup code.
+#define __ROM1_STARTUP 0
+// </h>
+
+// </h>
+
+// <h>RAM Configuration
+// =======================
+// <h> RAM_S=<__RAM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x20000000
+#define __RAM0_BASE 0x20000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00020000
+#define __RAM0_SIZE 0x00020000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __RAM0_DEFAULT 1
+//   <q>No zero initialize
+//   <i> Excludes region from zero initialization.
+#define __RAM0_NOINIT 0
+// </h>
+
+// <h> RAM_NS=<__RAM1>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x20200000
+#define __RAM1_BASE 0x20200000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00020000
+#define __RAM1_SIZE 0x00020000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __RAM1_DEFAULT 0
+//   <q>No zero initialize
+//   <i> Excludes region from zero initialization.
+#define __RAM1_NOINIT 0
+// </h>
+
+// </h>
+
+// <h>Stack / Heap Configuration
+//   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+#define __STACK_SIZE 0x00000400
+#define __HEAP_SIZE 0x00000C00
+// </h>
+
+
+#endif /* REGIONS_ARMCM55_H */

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55S/RTE/Device/ARMCM55/startup_ARMCM55.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55S/RTE/Device/ARMCM55/startup_ARMCM55.c
@@ -1,0 +1,164 @@
+/******************************************************************************
+ * @file     startup_ARMCM55.c
+ * @brief    CMSIS-Core Device Startup File for Cortex-M55 Device
+ * @version  V1.1.0
+ * @date     16. December 2020
+ ******************************************************************************/
+/*
+ * Copyright (c) 2020 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (ARMCM55)
+  #include "ARMCM55.h"
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  External References
+ *----------------------------------------------------------------------------*/
+extern uint32_t __INITIAL_SP;
+extern uint32_t __STACK_LIMIT;
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+extern uint32_t __STACK_SEAL;
+#endif
+
+extern __NO_RETURN void __PROGRAM_START(void);
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler  (void);
+            void Default_Handler(void);
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+/* Exceptions */
+void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void HardFault_Handler      (void) __attribute__ ((weak));
+void MemManage_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
+void BusFault_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void UsageFault_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void SecureFault_Handler    (void) __attribute__ ((weak, alias("Default_Handler")));
+void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void DebugMon_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+
+void Interrupt0_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt1_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt2_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt3_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt4_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt5_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt6_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt7_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt8_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt9_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[496];
+       const VECTOR_TABLE_Type __VECTOR_TABLE[496] __VECTOR_TABLE_ATTRIBUTE = {
+  (VECTOR_TABLE_Type)(&__INITIAL_SP),       /*     Initial Stack Pointer */
+  Reset_Handler,                            /*     Reset Handler */
+  NMI_Handler,                              /* -14 NMI Handler */
+  HardFault_Handler,                        /* -13 Hard Fault Handler */
+  MemManage_Handler,                        /* -12 MPU Fault Handler */
+  BusFault_Handler,                         /* -11 Bus Fault Handler */
+  UsageFault_Handler,                       /* -10 Usage Fault Handler */
+  SecureFault_Handler,                      /*  -9 Secure Fault Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  SVC_Handler,                              /*  -5 SVC Handler */
+  DebugMon_Handler,                         /*  -4 Debug Monitor Handler */
+  0,                                        /*     Reserved */
+  PendSV_Handler,                           /*  -2 PendSV Handler */
+  SysTick_Handler,                          /*  -1 SysTick Handler */
+
+  /* Interrupts */
+  Interrupt0_Handler,                       /*   0 Interrupt 0 */
+  Interrupt1_Handler,                       /*   1 Interrupt 1 */
+  Interrupt2_Handler,                       /*   2 Interrupt 2 */
+  Interrupt3_Handler,                       /*   3 Interrupt 3 */
+  Interrupt4_Handler,                       /*   4 Interrupt 4 */
+  Interrupt5_Handler,                       /*   5 Interrupt 5 */
+  Interrupt6_Handler,                       /*   6 Interrupt 6 */
+  Interrupt7_Handler,                       /*   7 Interrupt 7 */
+  Interrupt8_Handler,                       /*   8 Interrupt 8 */
+  Interrupt9_Handler                        /*   9 Interrupt 9 */
+                                            /* Interrupts 10 .. 480 are left out */
+};
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler(void)
+{
+  __set_PSP((uint32_t)(&__INITIAL_SP));
+
+  __set_MSPLIM((uint32_t)(&__STACK_LIMIT));
+  __set_PSPLIM((uint32_t)(&__STACK_LIMIT));
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  __TZ_set_STACKSEAL_S((uint32_t *)(&__STACK_SEAL));
+#endif
+
+  SystemInit();                             /* CMSIS System Initialization */
+  __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
+}
+
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wmissing-noreturn"
+#endif
+
+/*----------------------------------------------------------------------------
+  Hard Fault Handler
+ *----------------------------------------------------------------------------*/
+void HardFault_Handler(void)
+{
+  while(1);
+}
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+void Default_Handler(void)
+{
+  while(1);
+}
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic pop
+#endif
+

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55S/RTE/Device/ARMCM55/system_ARMCM55.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55S/RTE/Device/ARMCM55/system_ARMCM55.c
@@ -1,0 +1,107 @@
+/**************************************************************************//**
+ * @file     system_ARMCM55.c
+ * @brief    CMSIS Device System Source File for
+ *           ARMCM55 Device
+ * @version  V1.1.0
+ * @date     28. March 2022
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2022 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (ARMCM55)
+  #include "ARMCM55.h"
+#else
+  #error device not specified!
+#endif
+
+#if defined (__ARM_FEATURE_CMSE) &&  (__ARM_FEATURE_CMSE == 3U)
+  #include "partition_ARMCM55.h"
+#endif
+
+/*----------------------------------------------------------------------------
+  Define clocks
+ *----------------------------------------------------------------------------*/
+#define  XTAL            ( 5000000UL)      /* Oscillator frequency */
+
+#define  SYSTEM_CLOCK    (5U * XTAL)
+
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[496];
+
+
+/*----------------------------------------------------------------------------
+  System Core Clock Variable
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = SYSTEM_CLOCK;
+
+
+/*----------------------------------------------------------------------------
+  System Core Clock update function
+ *----------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)
+{
+  SystemCoreClock = SYSTEM_CLOCK;
+}
+
+/*----------------------------------------------------------------------------
+  System initialization function
+ *----------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t)(&__VECTOR_TABLE[0]);
+#endif
+
+#if (defined (__FPU_USED) && (__FPU_USED == 1U)) || \
+    (defined (__ARM_FEATURE_MVE) && (__ARM_FEATURE_MVE > 0U))
+  SCB->CPACR |= ((3U << 10U*2U) |           /* enable CP10 Full Access */
+                 (3U << 11U*2U)  );         /* enable CP11 Full Access */
+
+  /* Set low-power state for PDEPU                */
+  /*  0b00  | ON, PDEPU is not in low-power state */
+  /*  0b01  | ON, but the clock is off            */
+  /*  0b10  | RET(ention)                         */
+  /*  0b11  | OFF                                 */
+
+  /* Clear ELPSTATE, value is 0b11 on Cold reset */
+  PWRMODCTL->CPDLPSTATE &= ~(PWRMODCTL_CPDLPSTATE_ELPSTATE_Msk);
+
+  /* Favor best FP/MVE performance by default, avoid EPU switch-ON delays */
+  /* PDEPU ON, Clock OFF */
+  PWRMODCTL->CPDLPSTATE |= 0x1 << PWRMODCTL_CPDLPSTATE_ELPSTATE_Pos;
+#endif
+
+#ifdef UNALIGNED_SUPPORT_DISABLE
+  SCB->CCR |= SCB_CCR_UNALIGN_TRP_Msk;
+#endif
+
+  /* Enable Loop and branch info cache */
+  SCB->CCR |= SCB_CCR_LOB_Msk;
+  __DSB();
+  __ISB();
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  TZ_SAU_Setup();
+#endif
+
+  SystemCoreClock = SYSTEM_CLOCK;
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55S/Target.clayer.yml
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55S/Target.clayer.yml
@@ -1,0 +1,35 @@
+layer:
+  type: Target
+  description: CM55S target components and files
+
+  packs:
+    - pack: ARM::Cortex_DFP
+
+  device: ARMCM55
+
+  processor:
+    trustzone: secure
+
+  components:
+    # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
+    - component: ARM::CMSIS:CORE
+    - component: Device:Startup&C Startup
+
+  groups:
+    - group: FVP
+      files:
+        - file: ./model_config.txt
+
+  linker:
+    - for-compiler: AC6
+      script: RTE/Device/$Dname$/ac6_linker_script.sct
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: GCC
+      script: RTE/Device/$Dname$/gcc_linker_script.ld
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: CLANG
+      script: RTE/Device/$Dname$/clang_linker_script.ld
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: IAR
+      script: RTE/Device/$Dname$/iar_linker_script.icf
+      regions: RTE/Device/$Dname$/regions_$Dname$.h

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55S/model_config.txt
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM55S/model_config.txt
@@ -1,0 +1,29 @@
+# Parameters:
+# instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+#----------------------------------------------------------------------------------------------
+fvp_mps2.mps2_visualisation.disable-visualisation=1   # (bool  , init-time) default = '0'      : Enable/disable visualisation
+fvp_mps2.DISABLE_GATING=1                             # (bool  , init-time) default = '0'      : Disable Memory gating logic
+cpu0.FPU=1                                            # (bool  , init-time) default = '1'      : Set whether the model has VFP support
+cpu0.MVE=2                                            # (int   , init-time) default = '0x1'    : Set whether the model has MVE support. If FPU = 0: 0=MVE not included, 1=Integer subset of MVE included. If FPU = 1: 0=MVE not included, 1=Integer subset of MVE included, 2=Integer and half and single precision floating point MVE included
+cpu0.semihosting-enable=1                             # (bool  , init-time) default = '1'      : Enable semihosting SVC traps. Applications that do not use semihosting must set this parameter to false.
+cpu0.semihosting-Thumb_SVC=0xAB                       # (int   , init-time) default = '0xAB'   : T32 SVC number for semihosting : [0x0..0xFF]
+cpu0.semihosting-cmd_line=""                          # (string, init-time) default = ''       : Command line available to semihosting SVC calls
+cpu0.semihosting-heap_base=0x0                        # (int   , init-time) default = '0x0'    : Virtual address of heap base : [0x0..0xFFFFFFFF]
+cpu0.semihosting-heap_limit=0x0                       # (int   , init-time) default = '0x10700000' : Virtual address of top of heap : [0x0..0xFFFFFFFF]
+cpu0.semihosting-stack_base=0x0                       # (int   , init-time) default = '0x10700000' : Virtual address of base of descending stack : [0x0..0xFFFFFFFF]
+cpu0.semihosting-stack_limit=0x0                      # (int   , init-time) default = '0x10800000' : Virtual address of stack limit : [0x0..0xFFFFFFFF]
+cpu0.semihosting-cwd=""                               # (string, init-time) default = ''       : Base directory for semihosting file access.
+cpu0.MPU_S=0x8                                        # (int   , init-time) default = '0x8'    : Number of regions in the Secure MPU. If Security Extentions are absent, this is ignored : [0x0..0x10]
+cpu0.MPU_NS=0x8                                       # (int   , init-time) default = '0x8'    : Number of regions in the Non-Secure MPU. If Security Extentions are absent, this is the total number of MPU regions : [0x0..0x10]
+cpu0.ITM=0                                            # (bool  , init-time) default = '1'      : Level of instrumentation trace supported. false : No ITM trace included, true: ITM trace included
+cpu0.IRQLVL=0x3                                       # (int   , init-time) default = '0x3'    : Number of bits of interrupt priority : [0x3..0x8]
+cpu0.INITSVTOR=0x00000000                             # (int   , init-time) default = '0x10000000' : Secure vector-table offset at reset : [0x0..0xFFFFFF80]
+cpu0.INITNSVTOR=0x0                                   # (int   , init-time) default = '0x0'    : Non-Secure vector-table offset at reset : [0x0..0xFFFFFF80]
+cpu0.SAU=0x8                                          # (int   , init-time) default = '0x4'    : Number of SAU regions (0 => no SAU) : [0x0..0x8]
+idau.NUM_IDAU_REGION=0x0                              # (int   , init-time) default = '0xA'    : 
+cpu0.LOCK_SAU=0                                       # (bool  , init-time) default = '0'      : Lock down of SAU registers write
+cpu0.LOCK_S_MPU=0                                     # (bool  , init-time) default = '0'      : Lock down of Secure MPU registers write
+cpu0.LOCK_NS_MPU=0                                    # (bool  , init-time) default = '0'      : Lock down of Non-Secure MPU registers write
+cpu0.CPIF=1                                           # (bool  , init-time) default = '1'      : Specifies whether the external coprocessor interface is included
+cpu0.SECEXT=1                                         # (bool  , init-time) default = '1'      : Whether the ARMv8-M Security Extensions are included
+#----------------------------------------------------------------------------------------------

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM7/RTE/Device/ARMCM7/ac6_linker_script.sct
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM7/RTE/Device/ARMCM7/ac6_linker_script.sct
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE 8
+#else
+#define __STACKSEAL_SIZE 0
+#endif
+
+/*----------------------------------------------------------------------------
+  Scatter File Definitions definition
+ *----------------------------------------------------------------------------*/
+
+LR_ROM0 __ROM0_BASE __ROM0_SIZE  {
+
+  ER_ROM0 __ROM0_BASE __ROM0_SIZE {
+    *.o (RESET, +First)
+    *(InRoot$$Sections)
+    *(+RO +XO)
+  }
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  ER_CMSE_VENEER AlignExpr(+0, 32) (__ROM0_SIZE - AlignExpr(ImageLength(ER_ROM0), 32)) {
+    *(Veneer$$CMSE)
+  }
+#endif
+
+  RW_NOINIT __RAM0_BASE UNINIT (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE) {
+    *(.bss.noinit)
+  }
+
+  RW_RAM0 AlignExpr(+0, 8) (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE - AlignExpr(ImageLength(RW_NOINIT), 8)) {
+    *(+RW +ZI)
+  }
+
+#if __HEAP_SIZE > 0
+  ARM_LIB_HEAP  (AlignExpr(+0, 8)) EMPTY __HEAP_SIZE  {   ; Reserve empty region for heap
+  }
+#endif
+
+  ARM_LIB_STACK (__RAM0_BASE + __RAM0_SIZE - __STACKSEAL_SIZE) EMPTY -__STACK_SIZE {   ; Reserve empty region for stack
+  }
+
+#if __STACKSEAL_SIZE > 0
+  STACKSEAL +0 EMPTY __STACKSEAL_SIZE {             ; Reserve empty region for stack seal immediately after stack
+  }
+#endif
+
+#if __RAM1_SIZE > 0
+  RW_RAM1 __RAM1_BASE __RAM1_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+
+#if __RAM2_SIZE > 0
+  RW_RAM2 __RAM2_BASE __RAM2_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+
+#if __RAM3_SIZE > 0
+  RW_RAM3 __RAM3_BASE __RAM3_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+}
+
+#if __ROM1_SIZE > 0
+LR_ROM1 __ROM1_BASE __ROM1_SIZE  {
+  ER_ROM1 +0 __ROM1_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif
+
+#if __ROM2_SIZE > 0
+LR_ROM2 __ROM2_BASE __ROM2_SIZE  {
+  ER_ROM2 +0 __ROM2_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif
+
+#if __ROM3_SIZE > 0
+LR_ROM3 __ROM3_BASE __ROM3_SIZE  {
+  ER_ROM3 +0 __ROM3_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM7/RTE/Device/ARMCM7/clang_linker_script.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM7/RTE/Device/ARMCM7/clang_linker_script.ld
@@ -1,0 +1,361 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2019 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+/* ----------------------------------------------------------------------------
+  Memory definition
+ *----------------------------------------------------------------------------*/
+MEMORY
+{
+  ROM0  (rx!w)  : ORIGIN = __ROM0_BASE, LENGTH = __ROM0_SIZE
+#if __ROM1_SIZE > 0
+  ROM1  (rx!w)  : ORIGIN = __ROM1_BASE, LENGTH = __ROM1_SIZE
+#endif
+#if __ROM2_SIZE > 0
+  ROM2  (rx!w)  : ORIGIN = __ROM2_BASE, LENGTH = __ROM2_SIZE
+#endif
+#if __ROM3_SIZE > 0
+  ROM3  (rx!w)  : ORIGIN = __ROM3_BASE, LENGTH = __ROM3_SIZE
+#endif
+
+  RAM0  (w!rx) : ORIGIN = __RAM0_BASE, LENGTH = __RAM0_SIZE
+#if __RAM1_SIZE > 0
+  RAM1  (w!rx) : ORIGIN = __RAM1_BASE, LENGTH = __RAM1_SIZE
+#endif
+#if __RAM2_SIZE > 0
+  RAM2  (w!rx) : ORIGIN = __RAM2_BASE, LENGTH = __RAM2_SIZE
+#endif
+#if __RAM3_SIZE > 0
+  RAM3  (w!rx) : ORIGIN = __RAM3_BASE, LENGTH = __RAM3_SIZE
+#endif
+}
+
+ENTRY(Reset_Handler)
+
+PHDRS
+{
+	text PT_LOAD;
+	ram PT_LOAD;
+	ram_init PT_LOAD;
+	tls PT_TLS;
+}
+
+SECTIONS
+{
+	.init : {
+		KEEP (*(.vectors))
+		KEEP (*(.text.init.enter))
+		KEEP (*(.data.init.enter))
+		KEEP (*(SORT_BY_NAME(.init) SORT_BY_NAME(.init.*)))
+	} >ROM0 AT>ROM0 :text
+
+	.text : {
+
+		/* code */
+		*(.text.unlikely .text.unlikely.*)
+		*(.text.startup .text.startup.*)
+		*(.text .text.* .opd .opd.*)
+		*(.gnu.linkonce.t.*)
+		KEEP (*(.fini .fini.*))
+		__text_end = .;
+
+		PROVIDE (__etext = __text_end);
+		PROVIDE (_etext = __text_end);
+		PROVIDE (etext = __text_end);
+
+		/* read-only data */
+		*(.rdata)
+		*(.rodata .rodata.*)
+		*(.gnu.linkonce.r.*)
+
+		*(.srodata.cst16)
+		*(.srodata.cst8)
+		*(.srodata.cst4)
+		*(.srodata.cst2)
+		*(.srodata .srodata.*)
+		*(.data.rel.ro .data.rel.ro.*)
+		*(.got .got.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		/* lists of constructors and destructors */
+		PROVIDE_HIDDEN ( __preinit_array_start = . );
+		KEEP (*(.preinit_array))
+		PROVIDE_HIDDEN ( __preinit_array_end = . );
+
+		PROVIDE_HIDDEN ( __init_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+		KEEP (*(.init_array .ctors))
+		PROVIDE_HIDDEN ( __init_array_end = . );
+
+		PROVIDE_HIDDEN ( __fini_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
+		KEEP (*(.fini_array .dtors))
+		PROVIDE_HIDDEN ( __fini_array_end = . );
+
+	} >ROM0 AT>ROM0 :text
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+	.veneers :
+	{
+		. = ALIGN(32);
+		KEEP(*(.gnu.sgstubs))
+	} > ROM0 AT>ROM0 :text
+#endif
+
+	.toc : {
+		*(.toc .toc.*)
+	} >ROM0 AT>ROM0 :text
+
+	/* additional sections when compiling with C++ exception support */
+	
+	.except_ordered : {
+		*(.gcc_except_table *.gcc_except_table.*)
+		KEEP (*(.eh_frame .eh_frame.*))
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+	} >ROM0 AT>ROM0 :text
+
+	.except_unordered : {
+		. = ALIGN(8);
+
+		PROVIDE(__exidx_start = .);
+		*(.ARM.exidx*)
+		PROVIDE(__exidx_end = .);
+	} >ROM0 AT>ROM0 :text
+	
+
+	/*
+	 * Data values which are preserved across reset
+	 */
+	.preserve (NOLOAD) : {
+		PROVIDE(__preserve_start__ = .);
+		KEEP(*(SORT_BY_NAME(.preserve.*)))
+		KEEP(*(.preserve))
+		PROVIDE(__preserve_end__ = .);
+	} >RAM0 AT>RAM0 :ram
+
+	.data :  {
+		*(.data .data.*)
+		*(.gnu.linkonce.d.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		PROVIDE( __global_pointer$ = . + 0x800 );
+		*(.sdata .sdata.* .sdata2.*)
+		*(.gnu.linkonce.s.*)
+	} >RAM0 AT>ROM0 :ram_init
+	PROVIDE(__data_start = ADDR(.data));
+	PROVIDE(__data_source = LOADADDR(.data));
+
+	/* Thread local initialized data. This gets
+	 * space allocated as it is expected to be placed
+	 * in ram to be used as a template for TLS data blocks
+	 * allocated at runtime. We're slightly abusing that
+	 * by placing the data in flash where it will be copied
+	 * into the allocate ram addresses by the existing
+	 * data initialization code in crt0
+	 */
+	.tdata :  {
+		*(.tdata .tdata.* .gnu.linkonce.td.*)
+		PROVIDE(__data_end = .);
+		PROVIDE(__tdata_end = .);
+	} >RAM0 AT>ROM0 :tls :ram_init
+	PROVIDE( __tls_base = ADDR(.tdata));
+	PROVIDE( __tdata_start = ADDR(.tdata));
+	PROVIDE( __tdata_source = LOADADDR(.tdata) );
+	PROVIDE( __tdata_source_end = LOADADDR(.tdata) + SIZEOF(.tdata) );
+	PROVIDE( __data_source_end = __tdata_source_end );
+	PROVIDE( __tdata_size = SIZEOF(.tdata) );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata),ALIGNOF(.tbss)) );
+
+	PROVIDE( __edata = __data_end );
+	PROVIDE( _edata = __data_end );
+	PROVIDE( edata = __data_end );
+	PROVIDE( __data_size = __data_end - __data_start );
+	PROVIDE( __data_source_size = __data_source_end - __data_source );
+
+	.tbss (NOLOAD) : {
+		*(.tbss .tbss.* .gnu.linkonce.tb.*)
+		*(.tcommon)
+		PROVIDE( __tls_end = . );
+		PROVIDE( __tbss_end = . );
+	} >RAM0 AT>RAM0 :tls :ram
+	PROVIDE( __bss_start = ADDR(.tbss));
+	PROVIDE( __tbss_start = ADDR(.tbss));
+	PROVIDE( __tbss_offset = ADDR(.tbss) - ADDR(.tdata) );
+	PROVIDE( __tbss_size = SIZEOF(.tbss) );
+	PROVIDE( __tls_size = __tls_end - __tls_base );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
+	PROVIDE( __arm32_tls_tcb_offset = MAX(8, __tls_align) );
+	PROVIDE( __arm64_tls_tcb_offset = MAX(16, __tls_align) );
+
+	/*
+	 * The linker special cases .tbss segments which are
+	 * identified as segments which are not loaded and are
+	 * thread_local.
+	 *
+	 * For these segments, the linker does not advance 'dot'
+	 * across them.  We actually need memory allocated for tbss,
+	 * so we create a special segment here just to make room
+	 */
+	/*
+	.tbss_space (NOLOAD) : {
+		. = ADDR(.tbss);
+		. = . + SIZEOF(.tbss);
+	} >RAM0 AT>RAM0 :ram
+	*/
+
+	.bss (NOLOAD) : {
+		*(.sbss*)
+		*(.gnu.linkonce.sb.*)
+		*(.bss .bss.*)
+		*(.gnu.linkonce.b.*)
+		*(COMMON)
+
+		/* Align the heap */
+		. = ALIGN(8);
+		__bss_end = .;
+	} >RAM0 AT>RAM0 :ram
+	PROVIDE( __non_tls_bss_start = ADDR(.bss) );
+	PROVIDE( __end = __bss_end );
+	PROVIDE( _end = __bss_end );
+	PROVIDE( end = __bss_end );
+	PROVIDE( __bss_size = __bss_end - __bss_start );
+
+	/* Make the rest of memory available for heap storage */
+	PROVIDE (__heap_start = __end);
+#ifdef __HEAP_SIZE
+	PROVIDE (__heap_end = __heap_start + __HEAP_SIZE);
+	PROVIDE (__heap_size = __HEAP_SIZE);
+#else
+	PROVIDE (__heap_end = __stack - __STACK_SIZE);
+	PROVIDE (__heap_size = __heap_end - __heap_start);
+#endif
+	.heap (NOLOAD) : {
+		. += __heap_size;
+	} >RAM0 :ram
+
+	/* Define a stack region to make sure it fits in memory */
+	PROVIDE(__stack = ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE);
+	PROVIDE(__stack_limit = __stack - __STACK_SIZE);
+	.stack (__stack_limit) (NOLOAD) : {
+		. += __STACK_SIZE;
+	} >RAM0 :ram
+
+#if __STACKSEAL_SIZE > 0
+	PROVIDE(__stack_seal = __stack);
+  	.stackseal (__stack) (NOLOAD) :
+  	{
+    	. += __STACKSEAL_SIZE;
+  	} >RAM0 :ram
+#endif
+
+	/* Throw away C++ exception handling information */
+
+	/*
+
+	/DISCARD/ : {
+		*(.note .note.*)
+		*(.eh_frame .eh_frame.*)
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+		*(.ARM.exidx*)
+	}
+
+	*/
+
+	/* Stabs debugging sections.  */
+	.stab          0 : { *(.stab) }
+	.stabstr       0 : { *(.stabstr) }
+	.stab.excl     0 : { *(.stab.excl) }
+	.stab.exclstr  0 : { *(.stab.exclstr) }
+	.stab.index    0 : { *(.stab.index) }
+	.stab.indexstr 0 : { *(.stab.indexstr) }
+	.comment       0 : { *(.comment) }
+	.gnu.build.attributes : { *(.gnu.build.attributes .gnu.build.attributes.*) }
+	/* DWARF debug sections.
+	   Symbols in the DWARF debugging sections are relative to the beginning
+	   of the section so we begin them at 0.  */
+	/* DWARF 1.  */
+	.debug          0 : { *(.debug) }
+	.line           0 : { *(.line) }
+	/* GNU DWARF 1 extensions.  */
+	.debug_srcinfo  0 : { *(.debug_srcinfo) }
+	.debug_sfnames  0 : { *(.debug_sfnames) }
+	/* DWARF 1.1 and DWARF 2.  */
+	.debug_aranges  0 : { *(.debug_aranges) }
+	.debug_pubnames 0 : { *(.debug_pubnames) }
+	/* DWARF 2.  */
+	.debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+	.debug_abbrev   0 : { *(.debug_abbrev) }
+	.debug_line     0 : { *(.debug_line .debug_line.* .debug_line_end) }
+	.debug_frame    0 : { *(.debug_frame) }
+	.debug_str      0 : { *(.debug_str) }
+	.debug_loc      0 : { *(.debug_loc) }
+	.debug_macinfo  0 : { *(.debug_macinfo) }
+	/* SGI/MIPS DWARF 2 extensions.  */
+	.debug_weaknames 0 : { *(.debug_weaknames) }
+	.debug_funcnames 0 : { *(.debug_funcnames) }
+	.debug_typenames 0 : { *(.debug_typenames) }
+	.debug_varnames  0 : { *(.debug_varnames) }
+	/* DWARF 3.  */
+	.debug_pubtypes 0 : { *(.debug_pubtypes) }
+	.debug_ranges   0 : { *(.debug_ranges) }
+	/* DWARF 5.  */
+	.debug_addr     0 : { *(.debug_addr) }
+	.debug_line_str 0 : { *(.debug_line_str) }
+	.debug_loclists 0 : { *(.debug_loclists) }
+	.debug_macro    0 : { *(.debug_macro) }
+	.debug_names    0 : { *(.debug_names) }
+	.debug_rnglists 0 : { *(.debug_rnglists) }
+	.debug_str_offsets 0 : { *(.debug_str_offsets) }
+	.debug_sup      0 : { *(.debug_sup) }
+	.gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }
+}
+/*
+ * Check that sections that are copied from flash to RAM have matching
+ * padding, so that a single memcpy() of __data_size copies the correct bytes.
+ */
+ASSERT( __data_size == __data_source_size,
+	"ERROR: .data/.tdata flash size does not match RAM size");

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM7/RTE/Device/ARMCM7/gcc_linker_script.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM7/RTE/Device/ARMCM7/gcc_linker_script.ld
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+/* ----------------------------------------------------------------------------
+  Memory definition
+ *----------------------------------------------------------------------------*/
+MEMORY
+{
+  ROM0  (rx)  : ORIGIN = __ROM0_BASE, LENGTH = __ROM0_SIZE
+#if __ROM1_SIZE > 0
+  ROM1  (rx)  : ORIGIN = __ROM1_BASE, LENGTH = __ROM1_SIZE
+#endif
+#if __ROM2_SIZE > 0
+  ROM2  (rx)  : ORIGIN = __ROM2_BASE, LENGTH = __ROM2_SIZE
+#endif
+#if __ROM3_SIZE > 0
+  ROM3  (rx)  : ORIGIN = __ROM3_BASE, LENGTH = __ROM3_SIZE
+#endif
+
+  RAM0  (rwx) : ORIGIN = __RAM0_BASE, LENGTH = __RAM0_SIZE
+#if __RAM1_SIZE > 0
+  RAM1  (rwx) : ORIGIN = __RAM1_BASE, LENGTH = __RAM1_SIZE
+#endif
+#if __RAM2_SIZE > 0
+  RAM2  (rwx) : ORIGIN = __RAM2_BASE, LENGTH = __RAM2_SIZE
+#endif
+#if __RAM3_SIZE > 0
+  RAM3  (rwx) : ORIGIN = __RAM3_BASE, LENGTH = __RAM3_SIZE
+#endif
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __copy_table_start__
+ *   __copy_table_end__
+ *   __zero_table_start__
+ *   __zero_table_end__
+ *   __etext          (deprecated)
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+  .text :
+  {
+    KEEP(*(.vectors))
+    *(.text*)
+
+    KEEP(*(.init))
+    KEEP(*(.fini))
+
+    /* .ctors */
+    *crtbegin.o(.ctors)
+    *crtbegin?.o(.ctors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+    *(SORT(.ctors.*))
+    *(.ctors)
+
+    /* .dtors */
+    *crtbegin.o(.dtors)
+    *crtbegin?.o(.dtors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+    *(SORT(.dtors.*))
+    *(.dtors)
+
+    *(.rodata*)
+
+    KEEP(*(.eh_frame*))
+  } > ROM0
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  .gnu.sgstubs :
+  {
+    . = ALIGN(32);
+  } > ROM0
+#endif
+
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > ROM0
+
+  __exidx_start = .;
+  .ARM.exidx :
+  {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+  } > ROM0
+  __exidx_end = .;
+
+  .copy.table :
+  {
+    . = ALIGN(4);
+    __copy_table_start__ = .;
+
+    LONG (LOADADDR(.data))
+    LONG (ADDR(.data))
+    LONG (SIZEOF(.data) / 4)
+
+    /* Add each additional data section here */
+/*
+    LONG (LOADADDR(.data2))
+    LONG (ADDR(.data2))
+    LONG (SIZEOF(.data2) / 4)
+*/
+    __copy_table_end__ = .;
+  } > ROM0
+
+  .zero.table :
+  {
+    . = ALIGN(4);
+    __zero_table_start__ = .;
+
+/*  .bss initialization to zero is already done during C Run-Time Startup.
+    LONG (ADDR(.bss))
+    LONG (SIZEOF(.bss) / 4)
+*/
+
+    /* Add each additional bss section here */
+/*
+    LONG (ADDR(.bss2))
+    LONG (SIZEOF(.bss2) / 4)
+*/
+    __zero_table_end__ = .;
+  } > ROM0
+
+  /*
+   * This __etext variable is kept for backward compatibility with older,
+   * ASM based startup files.
+   */
+  PROVIDE(__etext = LOADADDR(.data));
+
+  .data : ALIGN(4)
+  {
+    __data_start__ = .;
+    *(vtable)
+    *(.data)
+    *(.data.*)
+
+    . = ALIGN(4);
+    /* preinit data */
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP(*(.preinit_array))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+
+    . = ALIGN(4);
+    /* init data */
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP(*(SORT(.init_array.*)))
+    KEEP(*(.init_array))
+    PROVIDE_HIDDEN (__init_array_end = .);
+
+    . = ALIGN(4);
+    /* finit data */
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP(*(SORT(.fini_array.*)))
+    KEEP(*(.fini_array))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    /* All data end */
+    __data_end__ = .;
+
+  } > RAM0 AT > ROM0
+
+  /*
+   * Secondary data section, optional
+   *
+   * Remember to add each additional data section
+   * to the .copy.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .data2 : ALIGN(4)
+  {
+    . = ALIGN(4);
+    __data2_start__ = .;
+    *(.data2)
+    *(.data2.*)
+    . = ALIGN(4);
+    __data2_end__ = .;
+
+  } > RAM1 AT > ROM0 
+*/
+
+  .bss :
+  {
+    . = ALIGN(4);
+    __bss_start__ = .;
+    *(.bss)
+    *(.bss.*)
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+  } > RAM0 AT > RAM0
+
+  /*
+   * Secondary bss section, optional
+   *
+   * Remember to add each additional bss section
+   * to the .zero.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .bss2 :
+  {
+    . = ALIGN(4);
+    __bss2_start__ = .;
+    *(.bss2)
+    *(.bss2.*)
+    . = ALIGN(4);
+    __bss2_end__ = .;
+  } > RAM1 AT > RAM1
+*/
+
+  .heap (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE(end = .);
+    . = . + __HEAP_SIZE;
+    . = ALIGN(8);
+    __HeapLimit = .;
+  } > RAM0
+
+  .stack (ORIGIN(RAM0) + LENGTH(RAM0) - __STACK_SIZE - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackLimit = .;
+    . = . + __STACK_SIZE;
+    . = ALIGN(8);
+    __StackTop = .;
+  } > RAM0
+  PROVIDE(__stack = __StackTop);
+
+#if __STACKSEAL_SIZE > 0
+  .stackseal (ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackSeal = .;
+    . = . + 8;
+    . = ALIGN(8);
+  } > RAM0
+#endif
+
+  /* Check if data + heap + stack exceeds RAM limit */
+  ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM7/RTE/Device/ARMCM7/iar_linker_script.icf
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM7/RTE/Device/ARMCM7/iar_linker_script.icf
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+define memory mem with size = 4G;
+
+#if __ROM0_SIZE > 0
+  define region ROM0_region = mem:[from __ROM0_BASE to (__ROM0_BASE+__ROM0_SIZE-1)];
+#else
+  define region ROM0_region = [];
+#endif
+
+#if __ROM1_SIZE > 0
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+#else
+  define region ROM1_region = [];
+#endif
+
+#if __ROM2_SIZE > 0
+  define region ROM2_region = mem:[from __ROM2_BASE to (__ROM2_BASE+__ROM2_SIZE-1)];
+#else
+  define region ROM2_region = [];
+#endif
+
+#if __ROM3_SIZE > 0
+  define region ROM3_region = mem:[from __ROM3_BASE to (__ROM3_BASE+__ROM3_SIZE-1)];
+#else
+  define region ROM3_region = [];
+#endif
+
+define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_region;
+
+#if __RAM0_SIZE > 0
+  define region RAM0_region = mem:[from __RAM0_BASE to (__RAM0_BASE+__RAM0_SIZE-1)];
+#else
+  define region RAM0_region = [];
+#endif
+
+#if __RAM1_SIZE > 0
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+#else
+  define region RAM1_region = [];
+#endif
+
+#if __RAM2_SIZE > 0
+  define region RAM2_region = mem:[from __RAM2_BASE to (__RAM2_BASE+__RAM2_SIZE-1)];
+#else
+  define region RAM2_region = [];
+#endif
+
+#if __RAM3_SIZE > 0
+  define region RAM3_region = mem:[from __RAM3_BASE to (__RAM3_BASE+__RAM3_SIZE-1)];
+#else
+  define region RAM3_region = [];
+#endif
+
+define region RAM_region = RAM0_region | RAM1_region | RAM2_region | RAM3_region;
+
+do not initialize  { section .noinit };
+initialize by copy { readwrite };
+if (isdefinedsymbol(__USE_DLIB_PERTHREAD))
+{
+  // Required in a multi-threaded application
+  initialize by copy with packing = none { section __DLIB_PERTHREAD };
+}
+
+place at address mem:__ROM0_BASE { readonly section .intvec };
+
+if (!isempty(ROM_region))
+{
+  place in ROM_region  { readonly };
+}
+
+if (!isempty(RAM_region))
+{
+  define block CSTACK     with alignment = 8, size = __STACK_SIZE     { };
+  define block PROC_STACK with alignment = 8, size = 0 { };
+  define block HEAP       with alignment = 8, size = __HEAP_SIZE       { };
+  place in RAM_region  { readwrite, block CSTACK, block PROC_STACK, block HEAP };
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM7/RTE/Device/ARMCM7/regions_ARMCM7.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM7/RTE/Device/ARMCM7/regions_ARMCM7.h
@@ -1,0 +1,60 @@
+#ifndef REGIONS_ARMCM7_H
+#define REGIONS_ARMCM7_H
+
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+// <n>Device pack:   ARM::Cortex_DFP@1.0.0-dev16
+// <i>Device pack used to generate this file
+
+// <h>ROM Configuration
+// =======================
+// <h> ROM=<__ROM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x00000000
+#define __ROM0_BASE 0x00000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00040000
+#define __ROM0_SIZE 0x00040000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __ROM0_DEFAULT 1
+//   <q>Startup
+//   <i> Selects region to be used for startup code.
+#define __ROM0_STARTUP 1
+// </h>
+
+// </h>
+
+// <h>RAM Configuration
+// =======================
+// <h> RAM=<__RAM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x20000000
+#define __RAM0_BASE 0x20000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00020000
+#define __RAM0_SIZE 0x00020000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __RAM0_DEFAULT 1
+//   <q>No zero initialize
+//   <i> Excludes region from zero initialization.
+#define __RAM0_NOINIT 0
+// </h>
+
+// </h>
+
+// <h>Stack / Heap Configuration
+//   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+#define __STACK_SIZE 0x00000400
+#define __HEAP_SIZE 0x00000C00
+// </h>
+
+
+#endif /* REGIONS_ARMCM7_H */

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM7/RTE/Device/ARMCM7/startup_ARMCM7.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM7/RTE/Device/ARMCM7/startup_ARMCM7.c
@@ -1,0 +1,150 @@
+/******************************************************************************
+ * @file     startup_ARMCM7.c
+ * @brief    CMSIS-Core(M) Device Startup File for a Cortex-M7 Device
+ * @version  V3.0.0
+ * @date     06. April 2023
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (ARMCM7)
+  #include "ARMCM7.h"
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  External References
+ *----------------------------------------------------------------------------*/
+extern uint32_t __INITIAL_SP;
+
+extern __NO_RETURN void __PROGRAM_START(void);
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler  (void);
+            void Default_Handler(void);
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+/* Exceptions */
+void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void HardFault_Handler      (void) __attribute__ ((weak));
+void MemManage_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
+void BusFault_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void UsageFault_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void DebugMon_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+
+void Interrupt0_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt1_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt2_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt3_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt4_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt5_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt6_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt7_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt8_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt9_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[240];
+       const VECTOR_TABLE_Type __VECTOR_TABLE[240] __VECTOR_TABLE_ATTRIBUTE = {
+  (VECTOR_TABLE_Type)(&__INITIAL_SP),       /*     Initial Stack Pointer */
+  Reset_Handler,                            /*     Reset Handler */
+  NMI_Handler,                              /* -14 NMI Handler */
+  HardFault_Handler,                        /* -13 Hard Fault Handler */
+  MemManage_Handler,                        /* -12 MPU Fault Handler */
+  BusFault_Handler,                         /* -11 Bus Fault Handler */
+  UsageFault_Handler,                       /* -10 Usage Fault Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  SVC_Handler,                              /*  -5 SVC Handler */
+  DebugMon_Handler,                         /*  -4 Debug Monitor Handler */
+  0,                                        /*     Reserved */
+  PendSV_Handler,                           /*  -2 PendSV Handler */
+  SysTick_Handler,                          /*  -1 SysTick Handler */
+
+  /* Interrupts */
+  Interrupt0_Handler,                       /*   0 Interrupt 0 */
+  Interrupt1_Handler,                       /*   1 Interrupt 1 */
+  Interrupt2_Handler,                       /*   2 Interrupt 2 */
+  Interrupt3_Handler,                       /*   3 Interrupt 3 */
+  Interrupt4_Handler,                       /*   4 Interrupt 4 */
+  Interrupt5_Handler,                       /*   5 Interrupt 5 */
+  Interrupt6_Handler,                       /*   6 Interrupt 6 */
+  Interrupt7_Handler,                       /*   7 Interrupt 7 */
+  Interrupt8_Handler,                       /*   8 Interrupt 8 */
+  Interrupt9_Handler                        /*   9 Interrupt 9 */
+                                            /* Interrupts 10 .. 223 are left out */
+};
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler(void)
+{
+  SystemInit();                             /* CMSIS System Initialization */
+  __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
+}
+
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wmissing-noreturn"
+#endif
+
+/*----------------------------------------------------------------------------
+  Hard Fault Handler
+ *----------------------------------------------------------------------------*/
+void HardFault_Handler(void)
+{
+  while(1);
+}
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+void Default_Handler(void)
+{
+  while(1);
+}
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic pop
+#endif
+

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM7/RTE/Device/ARMCM7/system_ARMCM7.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM7/RTE/Device/ARMCM7/system_ARMCM7.c
@@ -1,0 +1,79 @@
+/**************************************************************************//**
+ * @file     system_ARMCM7.c
+ * @brief    CMSIS Device System Source File for
+ *           ARMCM7 Device
+ * @version  V2.0.0
+ * @date     06. April 2023
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (ARMCM7)
+  #include "ARMCM7.h"
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  Define clocks
+ *----------------------------------------------------------------------------*/
+#define  XTAL            (50000000UL)     /* Oscillator frequency */
+
+#define  SYSTEM_CLOCK    (XTAL / 2U)
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[240];
+
+
+/*----------------------------------------------------------------------------
+  System Core Clock Variable
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = SYSTEM_CLOCK;  /* System Core Clock Frequency */
+
+
+/*----------------------------------------------------------------------------
+  System Core Clock update function
+ *----------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)
+{
+  SystemCoreClock = SYSTEM_CLOCK;
+}
+
+/*----------------------------------------------------------------------------
+  System initialization function
+ *----------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t) &(__VECTOR_TABLE[0]);
+#endif
+
+#if defined (__FPU_USED) && (__FPU_USED == 1U)
+  SCB->CPACR |= ((3U << 10U*2U) |           /* enable CP10 Full Access */
+                 (3U << 11U*2U)  );         /* enable CP11 Full Access */
+#endif
+
+#ifdef UNALIGNED_SUPPORT_DISABLE
+  SCB->CCR |= SCB_CCR_UNALIGN_TRP_Msk;
+#endif
+
+  SystemCoreClock = SYSTEM_CLOCK;
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM7/Target.clayer.yml
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM7/Target.clayer.yml
@@ -1,0 +1,32 @@
+layer:
+  type: Target
+  description: CM7 target components and files
+
+  packs:
+    - pack: ARM::Cortex_DFP
+
+  device: ARMCM7
+
+  components:
+    # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
+    - component: ARM::CMSIS:CORE
+    - component: Device:Startup&C Startup
+
+  groups:
+    - group: FVP
+      files:
+        - file: ./model_config.txt
+
+  linker:
+    - for-compiler: AC6
+      script: RTE/Device/$Dname$/ac6_linker_script.sct
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: GCC
+      script: RTE/Device/$Dname$/gcc_linker_script.ld
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: CLANG
+      script: RTE/Device/$Dname$/clang_linker_script.ld
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: IAR
+      script: RTE/Device/$Dname$/iar_linker_script.icf
+      regions: RTE/Device/$Dname$/regions_$Dname$.h

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM7/model_config.txt
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM7/model_config.txt
@@ -1,0 +1,15 @@
+# Parameters:
+# instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+#----------------------------------------------------------------------------------------------
+fvp_mps2.mps2_visualisation.disable-visualisation=1   # (bool  , init-time) default = '0'      : Enable/disable visualisation
+armcortexm7ct.vfp-present=1                           # (bool  , init-time) default = '1'      : Set whether the model has VFP support
+armcortexm7ct.semihosting-enable=1                    # (bool  , init-time) default = '1'      : Enable semihosting SVC traps. Applications that do not use semihosting must set this parameter to false.
+armcortexm7ct.semihosting-Thumb_SVC=0xAB              # (int   , init-time) default = '0xAB'   : T32 SVC number for semihosting : [0x0..0xFF]
+armcortexm7ct.semihosting-cmd_line=""                 # (string, init-time) default = ''       : Command line available to semihosting SVC calls
+armcortexm7ct.semihosting-heap_base=0x0               # (int   , init-time) default = '0x0'    : Virtual address of heap base : [0x0..0xFFFFFFFF]
+armcortexm7ct.semihosting-heap_limit=0x0              # (int   , init-time) default = '0x10700000' : Virtual address of top of heap : [0x0..0xFFFFFFFF]
+armcortexm7ct.semihosting-stack_base=0x0              # (int   , init-time) default = '0x10700000' : Virtual address of base of descending stack : [0x0..0xFFFFFFFF]
+armcortexm7ct.semihosting-stack_limit=0x0             # (int   , init-time) default = '0x10800000' : Virtual address of stack limit : [0x0..0xFFFFFFFF]
+armcortexm7ct.semihosting-cwd=""                      # (string, init-time) default = ''       : Base directory for semihosting file access.
+armcortexm7ct.DP_FLOAT=1                              # (bool  , init-time) default = '1'      : Support 8-byte floats
+#----------------------------------------------------------------------------------------------

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85/RTE/Device/ARMCM85/ARMCM85_ac6.sct
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85/RTE/Device/ARMCM85/ARMCM85_ac6.sct
@@ -1,0 +1,130 @@
+#! armclang -E --target=arm-arm-none-eabi -mcpu=cortex-m85 -xc
+; command above MUST be in first line (no comment above!)
+
+;Note: Add '-mcmse' to first line if your software model is "Secure Mode".
+;      #! armclang -E --target=arm-arm-none-eabi -mcpu=cortex-m85 -xc -mcmse
+
+
+/*
+;-------- <<< Use Configuration Wizard in Context Menu >>> -------------------
+*/
+
+/*--------------------- Flash Configuration ----------------------------------
+; <h> Flash Configuration
+;   <o0> Flash Base Address <0x0-0xFFFFFFFF:8>
+;   <o1> Flash Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __ROM_BASE      0x00000000
+#define __ROM_SIZE      0x00080000
+
+/*--------------------- Embedded RAM Configuration ---------------------------
+; <h> RAM Configuration
+;   <o0> RAM Base Address    <0x0-0xFFFFFFFF:8>
+;   <o1> RAM Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __RAM_BASE      0x20000000
+#define __RAM_SIZE      0x00040000
+
+/*--------------------- Stack / Heap Configuration ---------------------------
+; <h> Stack / Heap Configuration
+;   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+;   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __STACK_SIZE    0x00000400
+#define __HEAP_SIZE     0x00000C00
+
+/*--------------------- CMSE Veneer Configuration ---------------------------
+; <h> CMSE Veneer Configuration
+;   <o0> CMSE VeneerBase Address     <0x0-0xFFFFFFFF:8>
+;     <i> 0xFFFFFFFF: Place Veneers at the end of Flash (default)
+;   <o1> CMSE Veneer Size (in Bytes) <0x0-0xFFFFFFFF:32>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __CMSEVENEER_BASE    0xFFFFFFFF
+#define __CMSEVENEER_SIZE    0x00000400
+
+/*
+;------------- <<< end of configuration section >>> ---------------------------
+*/
+
+
+/*----------------------------------------------------------------------------
+  User Stack & Heap boundary definition
+ *----------------------------------------------------------------------------*/
+#define __STACK_TOP    (__RAM_BASE + __RAM_SIZE - __STACKSEAL_SIZE) /* starts at end of RAM - 8 byte stack seal */
+#define __HEAP_BASE    (AlignExpr(+0, 8))                           /* starts after RW_RAM section, 8 byte aligned */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+
+/*----------------------------------------------------------------------------
+  Region base & size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#if defined (__CMSEVENEER_BASE) && (__CMSEVENEER_BASE == 0xFFFFFFFF)
+#define __CV_BASE          ( __ROM_BASE + __ROM_SIZE - __CMSEVENEER_SIZE )
+#else
+#define __CV_BASE          ( __CMSEVENEER_BASE )
+#endif
+#define __CV_SIZE          ( __CMSEVENEER_SIZE )
+#else
+#define __CV_SIZE          ( 0 )
+#endif
+
+#define __RO_BASE          ( __ROM_BASE )
+#define __RO_SIZE          ( __ROM_SIZE - __CV_SIZE )
+
+#define __RW_BASE          ( __RAM_BASE )
+#define __RW_SIZE      (__RAM_SIZE - __STACK_SIZE - __HEAP_SIZE - __STACKSEAL_SIZE )
+
+
+/*----------------------------------------------------------------------------
+  Scatter Region definition
+ *----------------------------------------------------------------------------*/
+LR_ROM __RO_BASE __RO_SIZE  {                       ; load region size_region
+  ER_ROM __RO_BASE __RO_SIZE  {                     ; load address = execution address
+   *.o (RESET, +First)
+   *(InRoot$$Sections)
+   .ANY (+RO)
+   .ANY (+XO)
+  }
+
+  RW_NOINIT __RW_BASE UNINIT __RW_SIZE {
+    *(.bss.noinit)
+  }
+
+  RW_RAM AlignExpr(+0, 8) (__RW_SIZE - AlignExpr(ImageLength(RW_NOINIT), 8)) {
+    *(+RW +ZI)
+  }
+
+#if __HEAP_SIZE > 0
+  ARM_LIB_HEAP  __HEAP_BASE EMPTY  __HEAP_SIZE  {   ; Reserve empty region for heap
+  }
+#endif
+
+  ARM_LIB_STACK __STACK_TOP EMPTY -__STACK_SIZE {   ; Reserve empty region for stack
+  }
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  STACKSEAL +0 EMPTY __STACKSEAL_SIZE {             ; Reserve empty region for stack seal immediately after stack
+  }
+#endif
+}
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+LR_CMSE_VENEER __CV_BASE ALIGN 32 __CV_SIZE  {      ; own load/execution region for CMSE Veneers
+  ER_CMSE_VENEER __CV_BASE __CV_SIZE  {
+   *(Veneer$$CMSE)
+  }
+}
+#endif

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85/RTE/Device/ARMCM85/ac6_linker_script.sct
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85/RTE/Device/ARMCM85/ac6_linker_script.sct
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE 8
+#else
+#define __STACKSEAL_SIZE 0
+#endif
+
+/*----------------------------------------------------------------------------
+  Scatter File Definitions definition
+ *----------------------------------------------------------------------------*/
+
+LR_ROM0 __ROM0_BASE __ROM0_SIZE  {
+
+  ER_ROM0 __ROM0_BASE __ROM0_SIZE {
+    *.o (RESET, +First)
+    *(InRoot$$Sections)
+    *(+RO +XO)
+  }
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  ER_CMSE_VENEER AlignExpr(+0, 32) (__ROM0_SIZE - AlignExpr(ImageLength(ER_ROM0), 32)) {
+    *(Veneer$$CMSE)
+  }
+#endif
+
+  RW_NOINIT __RAM0_BASE UNINIT (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE) {
+    *(.bss.noinit)
+  }
+
+  RW_RAM0 AlignExpr(+0, 8) (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE - AlignExpr(ImageLength(RW_NOINIT), 8)) {
+    *(+RW +ZI)
+  }
+
+#if __HEAP_SIZE > 0
+  ARM_LIB_HEAP  (AlignExpr(+0, 8)) EMPTY __HEAP_SIZE  {   ; Reserve empty region for heap
+  }
+#endif
+
+  ARM_LIB_STACK (__RAM0_BASE + __RAM0_SIZE - __STACKSEAL_SIZE) EMPTY -__STACK_SIZE {   ; Reserve empty region for stack
+  }
+
+#if __STACKSEAL_SIZE > 0
+  STACKSEAL +0 EMPTY __STACKSEAL_SIZE {             ; Reserve empty region for stack seal immediately after stack
+  }
+#endif
+
+#if __RAM1_SIZE > 0
+  RW_RAM1 __RAM1_BASE __RAM1_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+
+#if __RAM2_SIZE > 0
+  RW_RAM2 __RAM2_BASE __RAM2_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+
+#if __RAM3_SIZE > 0
+  RW_RAM3 __RAM3_BASE __RAM3_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+}
+
+#if __ROM1_SIZE > 0
+LR_ROM1 __ROM1_BASE __ROM1_SIZE  {
+  ER_ROM1 +0 __ROM1_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif
+
+#if __ROM2_SIZE > 0
+LR_ROM2 __ROM2_BASE __ROM2_SIZE  {
+  ER_ROM2 +0 __ROM2_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif
+
+#if __ROM3_SIZE > 0
+LR_ROM3 __ROM3_BASE __ROM3_SIZE  {
+  ER_ROM3 +0 __ROM3_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85/RTE/Device/ARMCM85/clang_linker_script.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85/RTE/Device/ARMCM85/clang_linker_script.ld
@@ -1,0 +1,361 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2019 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+/* ----------------------------------------------------------------------------
+  Memory definition
+ *----------------------------------------------------------------------------*/
+MEMORY
+{
+  ROM0  (rx!w)  : ORIGIN = __ROM0_BASE, LENGTH = __ROM0_SIZE
+#if __ROM1_SIZE > 0
+  ROM1  (rx!w)  : ORIGIN = __ROM1_BASE, LENGTH = __ROM1_SIZE
+#endif
+#if __ROM2_SIZE > 0
+  ROM2  (rx!w)  : ORIGIN = __ROM2_BASE, LENGTH = __ROM2_SIZE
+#endif
+#if __ROM3_SIZE > 0
+  ROM3  (rx!w)  : ORIGIN = __ROM3_BASE, LENGTH = __ROM3_SIZE
+#endif
+
+  RAM0  (w!rx) : ORIGIN = __RAM0_BASE, LENGTH = __RAM0_SIZE
+#if __RAM1_SIZE > 0
+  RAM1  (w!rx) : ORIGIN = __RAM1_BASE, LENGTH = __RAM1_SIZE
+#endif
+#if __RAM2_SIZE > 0
+  RAM2  (w!rx) : ORIGIN = __RAM2_BASE, LENGTH = __RAM2_SIZE
+#endif
+#if __RAM3_SIZE > 0
+  RAM3  (w!rx) : ORIGIN = __RAM3_BASE, LENGTH = __RAM3_SIZE
+#endif
+}
+
+ENTRY(Reset_Handler)
+
+PHDRS
+{
+	text PT_LOAD;
+	ram PT_LOAD;
+	ram_init PT_LOAD;
+	tls PT_TLS;
+}
+
+SECTIONS
+{
+	.init : {
+		KEEP (*(.vectors))
+		KEEP (*(.text.init.enter))
+		KEEP (*(.data.init.enter))
+		KEEP (*(SORT_BY_NAME(.init) SORT_BY_NAME(.init.*)))
+	} >ROM0 AT>ROM0 :text
+
+	.text : {
+
+		/* code */
+		*(.text.unlikely .text.unlikely.*)
+		*(.text.startup .text.startup.*)
+		*(.text .text.* .opd .opd.*)
+		*(.gnu.linkonce.t.*)
+		KEEP (*(.fini .fini.*))
+		__text_end = .;
+
+		PROVIDE (__etext = __text_end);
+		PROVIDE (_etext = __text_end);
+		PROVIDE (etext = __text_end);
+
+		/* read-only data */
+		*(.rdata)
+		*(.rodata .rodata.*)
+		*(.gnu.linkonce.r.*)
+
+		*(.srodata.cst16)
+		*(.srodata.cst8)
+		*(.srodata.cst4)
+		*(.srodata.cst2)
+		*(.srodata .srodata.*)
+		*(.data.rel.ro .data.rel.ro.*)
+		*(.got .got.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		/* lists of constructors and destructors */
+		PROVIDE_HIDDEN ( __preinit_array_start = . );
+		KEEP (*(.preinit_array))
+		PROVIDE_HIDDEN ( __preinit_array_end = . );
+
+		PROVIDE_HIDDEN ( __init_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+		KEEP (*(.init_array .ctors))
+		PROVIDE_HIDDEN ( __init_array_end = . );
+
+		PROVIDE_HIDDEN ( __fini_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
+		KEEP (*(.fini_array .dtors))
+		PROVIDE_HIDDEN ( __fini_array_end = . );
+
+	} >ROM0 AT>ROM0 :text
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+	.veneers :
+	{
+		. = ALIGN(32);
+		KEEP(*(.gnu.sgstubs))
+	} > ROM0 AT>ROM0 :text
+#endif
+
+	.toc : {
+		*(.toc .toc.*)
+	} >ROM0 AT>ROM0 :text
+
+	/* additional sections when compiling with C++ exception support */
+	
+	.except_ordered : {
+		*(.gcc_except_table *.gcc_except_table.*)
+		KEEP (*(.eh_frame .eh_frame.*))
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+	} >ROM0 AT>ROM0 :text
+
+	.except_unordered : {
+		. = ALIGN(8);
+
+		PROVIDE(__exidx_start = .);
+		*(.ARM.exidx*)
+		PROVIDE(__exidx_end = .);
+	} >ROM0 AT>ROM0 :text
+	
+
+	/*
+	 * Data values which are preserved across reset
+	 */
+	.preserve (NOLOAD) : {
+		PROVIDE(__preserve_start__ = .);
+		KEEP(*(SORT_BY_NAME(.preserve.*)))
+		KEEP(*(.preserve))
+		PROVIDE(__preserve_end__ = .);
+	} >RAM0 AT>RAM0 :ram
+
+	.data :  {
+		*(.data .data.*)
+		*(.gnu.linkonce.d.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		PROVIDE( __global_pointer$ = . + 0x800 );
+		*(.sdata .sdata.* .sdata2.*)
+		*(.gnu.linkonce.s.*)
+	} >RAM0 AT>ROM0 :ram_init
+	PROVIDE(__data_start = ADDR(.data));
+	PROVIDE(__data_source = LOADADDR(.data));
+
+	/* Thread local initialized data. This gets
+	 * space allocated as it is expected to be placed
+	 * in ram to be used as a template for TLS data blocks
+	 * allocated at runtime. We're slightly abusing that
+	 * by placing the data in flash where it will be copied
+	 * into the allocate ram addresses by the existing
+	 * data initialization code in crt0
+	 */
+	.tdata :  {
+		*(.tdata .tdata.* .gnu.linkonce.td.*)
+		PROVIDE(__data_end = .);
+		PROVIDE(__tdata_end = .);
+	} >RAM0 AT>ROM0 :tls :ram_init
+	PROVIDE( __tls_base = ADDR(.tdata));
+	PROVIDE( __tdata_start = ADDR(.tdata));
+	PROVIDE( __tdata_source = LOADADDR(.tdata) );
+	PROVIDE( __tdata_source_end = LOADADDR(.tdata) + SIZEOF(.tdata) );
+	PROVIDE( __data_source_end = __tdata_source_end );
+	PROVIDE( __tdata_size = SIZEOF(.tdata) );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata),ALIGNOF(.tbss)) );
+
+	PROVIDE( __edata = __data_end );
+	PROVIDE( _edata = __data_end );
+	PROVIDE( edata = __data_end );
+	PROVIDE( __data_size = __data_end - __data_start );
+	PROVIDE( __data_source_size = __data_source_end - __data_source );
+
+	.tbss (NOLOAD) : {
+		*(.tbss .tbss.* .gnu.linkonce.tb.*)
+		*(.tcommon)
+		PROVIDE( __tls_end = . );
+		PROVIDE( __tbss_end = . );
+	} >RAM0 AT>RAM0 :tls :ram
+	PROVIDE( __bss_start = ADDR(.tbss));
+	PROVIDE( __tbss_start = ADDR(.tbss));
+	PROVIDE( __tbss_offset = ADDR(.tbss) - ADDR(.tdata) );
+	PROVIDE( __tbss_size = SIZEOF(.tbss) );
+	PROVIDE( __tls_size = __tls_end - __tls_base );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
+	PROVIDE( __arm32_tls_tcb_offset = MAX(8, __tls_align) );
+	PROVIDE( __arm64_tls_tcb_offset = MAX(16, __tls_align) );
+
+	/*
+	 * The linker special cases .tbss segments which are
+	 * identified as segments which are not loaded and are
+	 * thread_local.
+	 *
+	 * For these segments, the linker does not advance 'dot'
+	 * across them.  We actually need memory allocated for tbss,
+	 * so we create a special segment here just to make room
+	 */
+	/*
+	.tbss_space (NOLOAD) : {
+		. = ADDR(.tbss);
+		. = . + SIZEOF(.tbss);
+	} >RAM0 AT>RAM0 :ram
+	*/
+
+	.bss (NOLOAD) : {
+		*(.sbss*)
+		*(.gnu.linkonce.sb.*)
+		*(.bss .bss.*)
+		*(.gnu.linkonce.b.*)
+		*(COMMON)
+
+		/* Align the heap */
+		. = ALIGN(8);
+		__bss_end = .;
+	} >RAM0 AT>RAM0 :ram
+	PROVIDE( __non_tls_bss_start = ADDR(.bss) );
+	PROVIDE( __end = __bss_end );
+	PROVIDE( _end = __bss_end );
+	PROVIDE( end = __bss_end );
+	PROVIDE( __bss_size = __bss_end - __bss_start );
+
+	/* Make the rest of memory available for heap storage */
+	PROVIDE (__heap_start = __end);
+#ifdef __HEAP_SIZE
+	PROVIDE (__heap_end = __heap_start + __HEAP_SIZE);
+	PROVIDE (__heap_size = __HEAP_SIZE);
+#else
+	PROVIDE (__heap_end = __stack - __STACK_SIZE);
+	PROVIDE (__heap_size = __heap_end - __heap_start);
+#endif
+	.heap (NOLOAD) : {
+		. += __heap_size;
+	} >RAM0 :ram
+
+	/* Define a stack region to make sure it fits in memory */
+	PROVIDE(__stack = ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE);
+	PROVIDE(__stack_limit = __stack - __STACK_SIZE);
+	.stack (__stack_limit) (NOLOAD) : {
+		. += __STACK_SIZE;
+	} >RAM0 :ram
+
+#if __STACKSEAL_SIZE > 0
+	PROVIDE(__stack_seal = __stack);
+  	.stackseal (__stack) (NOLOAD) :
+  	{
+    	. += __STACKSEAL_SIZE;
+  	} >RAM0 :ram
+#endif
+
+	/* Throw away C++ exception handling information */
+
+	/*
+
+	/DISCARD/ : {
+		*(.note .note.*)
+		*(.eh_frame .eh_frame.*)
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+		*(.ARM.exidx*)
+	}
+
+	*/
+
+	/* Stabs debugging sections.  */
+	.stab          0 : { *(.stab) }
+	.stabstr       0 : { *(.stabstr) }
+	.stab.excl     0 : { *(.stab.excl) }
+	.stab.exclstr  0 : { *(.stab.exclstr) }
+	.stab.index    0 : { *(.stab.index) }
+	.stab.indexstr 0 : { *(.stab.indexstr) }
+	.comment       0 : { *(.comment) }
+	.gnu.build.attributes : { *(.gnu.build.attributes .gnu.build.attributes.*) }
+	/* DWARF debug sections.
+	   Symbols in the DWARF debugging sections are relative to the beginning
+	   of the section so we begin them at 0.  */
+	/* DWARF 1.  */
+	.debug          0 : { *(.debug) }
+	.line           0 : { *(.line) }
+	/* GNU DWARF 1 extensions.  */
+	.debug_srcinfo  0 : { *(.debug_srcinfo) }
+	.debug_sfnames  0 : { *(.debug_sfnames) }
+	/* DWARF 1.1 and DWARF 2.  */
+	.debug_aranges  0 : { *(.debug_aranges) }
+	.debug_pubnames 0 : { *(.debug_pubnames) }
+	/* DWARF 2.  */
+	.debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+	.debug_abbrev   0 : { *(.debug_abbrev) }
+	.debug_line     0 : { *(.debug_line .debug_line.* .debug_line_end) }
+	.debug_frame    0 : { *(.debug_frame) }
+	.debug_str      0 : { *(.debug_str) }
+	.debug_loc      0 : { *(.debug_loc) }
+	.debug_macinfo  0 : { *(.debug_macinfo) }
+	/* SGI/MIPS DWARF 2 extensions.  */
+	.debug_weaknames 0 : { *(.debug_weaknames) }
+	.debug_funcnames 0 : { *(.debug_funcnames) }
+	.debug_typenames 0 : { *(.debug_typenames) }
+	.debug_varnames  0 : { *(.debug_varnames) }
+	/* DWARF 3.  */
+	.debug_pubtypes 0 : { *(.debug_pubtypes) }
+	.debug_ranges   0 : { *(.debug_ranges) }
+	/* DWARF 5.  */
+	.debug_addr     0 : { *(.debug_addr) }
+	.debug_line_str 0 : { *(.debug_line_str) }
+	.debug_loclists 0 : { *(.debug_loclists) }
+	.debug_macro    0 : { *(.debug_macro) }
+	.debug_names    0 : { *(.debug_names) }
+	.debug_rnglists 0 : { *(.debug_rnglists) }
+	.debug_str_offsets 0 : { *(.debug_str_offsets) }
+	.debug_sup      0 : { *(.debug_sup) }
+	.gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }
+}
+/*
+ * Check that sections that are copied from flash to RAM have matching
+ * padding, so that a single memcpy() of __data_size copies the correct bytes.
+ */
+ASSERT( __data_size == __data_source_size,
+	"ERROR: .data/.tdata flash size does not match RAM size");

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85/RTE/Device/ARMCM85/gcc_linker_script.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85/RTE/Device/ARMCM85/gcc_linker_script.ld
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+/* ----------------------------------------------------------------------------
+  Memory definition
+ *----------------------------------------------------------------------------*/
+MEMORY
+{
+  ROM0  (rx)  : ORIGIN = __ROM0_BASE, LENGTH = __ROM0_SIZE
+#if __ROM1_SIZE > 0
+  ROM1  (rx)  : ORIGIN = __ROM1_BASE, LENGTH = __ROM1_SIZE
+#endif
+#if __ROM2_SIZE > 0
+  ROM2  (rx)  : ORIGIN = __ROM2_BASE, LENGTH = __ROM2_SIZE
+#endif
+#if __ROM3_SIZE > 0
+  ROM3  (rx)  : ORIGIN = __ROM3_BASE, LENGTH = __ROM3_SIZE
+#endif
+
+  RAM0  (rwx) : ORIGIN = __RAM0_BASE, LENGTH = __RAM0_SIZE
+#if __RAM1_SIZE > 0
+  RAM1  (rwx) : ORIGIN = __RAM1_BASE, LENGTH = __RAM1_SIZE
+#endif
+#if __RAM2_SIZE > 0
+  RAM2  (rwx) : ORIGIN = __RAM2_BASE, LENGTH = __RAM2_SIZE
+#endif
+#if __RAM3_SIZE > 0
+  RAM3  (rwx) : ORIGIN = __RAM3_BASE, LENGTH = __RAM3_SIZE
+#endif
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __copy_table_start__
+ *   __copy_table_end__
+ *   __zero_table_start__
+ *   __zero_table_end__
+ *   __etext          (deprecated)
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+  .text :
+  {
+    KEEP(*(.vectors))
+    *(.text*)
+
+    KEEP(*(.init))
+    KEEP(*(.fini))
+
+    /* .ctors */
+    *crtbegin.o(.ctors)
+    *crtbegin?.o(.ctors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+    *(SORT(.ctors.*))
+    *(.ctors)
+
+    /* .dtors */
+    *crtbegin.o(.dtors)
+    *crtbegin?.o(.dtors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+    *(SORT(.dtors.*))
+    *(.dtors)
+
+    *(.rodata*)
+
+    KEEP(*(.eh_frame*))
+  } > ROM0
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  .gnu.sgstubs :
+  {
+    . = ALIGN(32);
+  } > ROM0
+#endif
+
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > ROM0
+
+  __exidx_start = .;
+  .ARM.exidx :
+  {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+  } > ROM0
+  __exidx_end = .;
+
+  .copy.table :
+  {
+    . = ALIGN(4);
+    __copy_table_start__ = .;
+
+    LONG (LOADADDR(.data))
+    LONG (ADDR(.data))
+    LONG (SIZEOF(.data) / 4)
+
+    /* Add each additional data section here */
+/*
+    LONG (LOADADDR(.data2))
+    LONG (ADDR(.data2))
+    LONG (SIZEOF(.data2) / 4)
+*/
+    __copy_table_end__ = .;
+  } > ROM0
+
+  .zero.table :
+  {
+    . = ALIGN(4);
+    __zero_table_start__ = .;
+
+/*  .bss initialization to zero is already done during C Run-Time Startup.
+    LONG (ADDR(.bss))
+    LONG (SIZEOF(.bss) / 4)
+*/
+
+    /* Add each additional bss section here */
+/*
+    LONG (ADDR(.bss2))
+    LONG (SIZEOF(.bss2) / 4)
+*/
+    __zero_table_end__ = .;
+  } > ROM0
+
+  /*
+   * This __etext variable is kept for backward compatibility with older,
+   * ASM based startup files.
+   */
+  PROVIDE(__etext = LOADADDR(.data));
+
+  .data : ALIGN(4)
+  {
+    __data_start__ = .;
+    *(vtable)
+    *(.data)
+    *(.data.*)
+
+    . = ALIGN(4);
+    /* preinit data */
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP(*(.preinit_array))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+
+    . = ALIGN(4);
+    /* init data */
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP(*(SORT(.init_array.*)))
+    KEEP(*(.init_array))
+    PROVIDE_HIDDEN (__init_array_end = .);
+
+    . = ALIGN(4);
+    /* finit data */
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP(*(SORT(.fini_array.*)))
+    KEEP(*(.fini_array))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    /* All data end */
+    __data_end__ = .;
+
+  } > RAM0 AT > ROM0
+
+  /*
+   * Secondary data section, optional
+   *
+   * Remember to add each additional data section
+   * to the .copy.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .data2 : ALIGN(4)
+  {
+    . = ALIGN(4);
+    __data2_start__ = .;
+    *(.data2)
+    *(.data2.*)
+    . = ALIGN(4);
+    __data2_end__ = .;
+
+  } > RAM1 AT > ROM0 
+*/
+
+  .bss :
+  {
+    . = ALIGN(4);
+    __bss_start__ = .;
+    *(.bss)
+    *(.bss.*)
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+  } > RAM0 AT > RAM0
+
+  /*
+   * Secondary bss section, optional
+   *
+   * Remember to add each additional bss section
+   * to the .zero.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .bss2 :
+  {
+    . = ALIGN(4);
+    __bss2_start__ = .;
+    *(.bss2)
+    *(.bss2.*)
+    . = ALIGN(4);
+    __bss2_end__ = .;
+  } > RAM1 AT > RAM1
+*/
+
+  .heap (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE(end = .);
+    . = . + __HEAP_SIZE;
+    . = ALIGN(8);
+    __HeapLimit = .;
+  } > RAM0
+
+  .stack (ORIGIN(RAM0) + LENGTH(RAM0) - __STACK_SIZE - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackLimit = .;
+    . = . + __STACK_SIZE;
+    . = ALIGN(8);
+    __StackTop = .;
+  } > RAM0
+  PROVIDE(__stack = __StackTop);
+
+#if __STACKSEAL_SIZE > 0
+  .stackseal (ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackSeal = .;
+    . = . + 8;
+    . = ALIGN(8);
+  } > RAM0
+#endif
+
+  /* Check if data + heap + stack exceeds RAM limit */
+  ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85/RTE/Device/ARMCM85/iar_linker_script.icf
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85/RTE/Device/ARMCM85/iar_linker_script.icf
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+define memory mem with size = 4G;
+
+#if __ROM0_SIZE > 0
+  define region ROM0_region = mem:[from __ROM0_BASE to (__ROM0_BASE+__ROM0_SIZE-1)];
+#else
+  define region ROM0_region = [];
+#endif
+
+#if __ROM1_SIZE > 0
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+#else
+  define region ROM1_region = [];
+#endif
+
+#if __ROM2_SIZE > 0
+  define region ROM2_region = mem:[from __ROM2_BASE to (__ROM2_BASE+__ROM2_SIZE-1)];
+#else
+  define region ROM2_region = [];
+#endif
+
+#if __ROM3_SIZE > 0
+  define region ROM3_region = mem:[from __ROM3_BASE to (__ROM3_BASE+__ROM3_SIZE-1)];
+#else
+  define region ROM3_region = [];
+#endif
+
+define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_region;
+
+#if __RAM0_SIZE > 0
+  define region RAM0_region = mem:[from __RAM0_BASE to (__RAM0_BASE+__RAM0_SIZE-1)];
+#else
+  define region RAM0_region = [];
+#endif
+
+#if __RAM1_SIZE > 0
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+#else
+  define region RAM1_region = [];
+#endif
+
+#if __RAM2_SIZE > 0
+  define region RAM2_region = mem:[from __RAM2_BASE to (__RAM2_BASE+__RAM2_SIZE-1)];
+#else
+  define region RAM2_region = [];
+#endif
+
+#if __RAM3_SIZE > 0
+  define region RAM3_region = mem:[from __RAM3_BASE to (__RAM3_BASE+__RAM3_SIZE-1)];
+#else
+  define region RAM3_region = [];
+#endif
+
+define region RAM_region = RAM0_region | RAM1_region | RAM2_region | RAM3_region;
+
+do not initialize  { section .noinit };
+initialize by copy { readwrite };
+if (isdefinedsymbol(__USE_DLIB_PERTHREAD))
+{
+  // Required in a multi-threaded application
+  initialize by copy with packing = none { section __DLIB_PERTHREAD };
+}
+
+place at address mem:__ROM0_BASE { readonly section .intvec };
+
+if (!isempty(ROM_region))
+{
+  place in ROM_region  { readonly };
+}
+
+if (!isempty(RAM_region))
+{
+  define block CSTACK     with alignment = 8, size = __STACK_SIZE     { };
+  define block PROC_STACK with alignment = 8, size = 0 { };
+  define block HEAP       with alignment = 8, size = __HEAP_SIZE       { };
+  place in RAM_region  { readwrite, block CSTACK, block PROC_STACK, block HEAP };
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85/RTE/Device/ARMCM85/regions_ARMCM85.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85/RTE/Device/ARMCM85/regions_ARMCM85.h
@@ -1,0 +1,94 @@
+#ifndef REGIONS_ARMCM85_H
+#define REGIONS_ARMCM85_H
+
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+// <n>Device pack:   ARM::Cortex_DFP@1.0.0-dev16
+// <i>Device pack used to generate this file
+
+// <h>ROM Configuration
+// =======================
+// <h> ROM_S=<__ROM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x00000000
+#define __ROM0_BASE 0x00000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00200000
+#define __ROM0_SIZE 0x00200000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __ROM0_DEFAULT 1
+//   <q>Startup
+//   <i> Selects region to be used for startup code.
+#define __ROM0_STARTUP 1
+// </h>
+
+// <h> ROM_NS=<__ROM1>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x00200000
+#define __ROM1_BASE 0x00200000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00200000
+#define __ROM1_SIZE 0x00200000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __ROM1_DEFAULT 1
+//   <q>Startup
+//   <i> Selects region to be used for startup code.
+#define __ROM1_STARTUP 1
+// </h>
+
+// </h>
+
+// <h>RAM Configuration
+// =======================
+// <h> RAM_S=<__RAM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x20000000
+#define __RAM0_BASE 0x20000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00020000
+#define __RAM0_SIZE 0x00020000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __RAM0_DEFAULT 1
+//   <q>No zero initialize
+//   <i> Excludes region from zero initialization.
+#define __RAM0_NOINIT 0
+// </h>
+
+// <h> RAM_NS=<__RAM1>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x20200000
+#define __RAM1_BASE 0x20200000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00020000
+#define __RAM1_SIZE 0x00020000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __RAM1_DEFAULT 1
+//   <q>No zero initialize
+//   <i> Excludes region from zero initialization.
+#define __RAM1_NOINIT 0
+// </h>
+
+// </h>
+
+// <h>Stack / Heap Configuration
+//   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+#define __STACK_SIZE 0x00000400
+#define __HEAP_SIZE 0x00000C00
+// </h>
+
+
+#endif /* REGIONS_ARMCM85_H */

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85/RTE/Device/ARMCM85/startup_ARMCM85.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85/RTE/Device/ARMCM85/startup_ARMCM85.c
@@ -1,0 +1,164 @@
+/******************************************************************************
+ * @file     startup_ARMCM85.c
+ * @brief    CMSIS Device Startup File for ARMCM85 Device
+ * @version  V1.0.0
+ * @date     07. February 2022
+ ******************************************************************************/
+/*
+ * Copyright (c) 2022 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (ARMCM85)
+  #include "ARMCM85.h"
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  External References
+ *----------------------------------------------------------------------------*/
+extern uint32_t __INITIAL_SP;
+extern uint32_t __STACK_LIMIT;
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+extern uint32_t __STACK_SEAL;
+#endif
+
+extern __NO_RETURN void __PROGRAM_START(void);
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler  (void);
+            void Default_Handler(void);
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+/* Exceptions */
+void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void HardFault_Handler      (void) __attribute__ ((weak));
+void MemManage_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
+void BusFault_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void UsageFault_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void SecureFault_Handler    (void) __attribute__ ((weak, alias("Default_Handler")));
+void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void DebugMon_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+
+void Interrupt0_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt1_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt2_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt3_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt4_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt5_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt6_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt7_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt8_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt9_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[496];
+       const VECTOR_TABLE_Type __VECTOR_TABLE[496] __VECTOR_TABLE_ATTRIBUTE = {
+  (VECTOR_TABLE_Type)(&__INITIAL_SP),       /*     Initial Stack Pointer */
+  Reset_Handler,                            /*     Reset Handler */
+  NMI_Handler,                              /* -14 NMI Handler */
+  HardFault_Handler,                        /* -13 Hard Fault Handler */
+  MemManage_Handler,                        /* -12 MPU Fault Handler */
+  BusFault_Handler,                         /* -11 Bus Fault Handler */
+  UsageFault_Handler,                       /* -10 Usage Fault Handler */
+  SecureFault_Handler,                      /*  -9 Secure Fault Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  SVC_Handler,                              /*  -5 SVC Handler */
+  DebugMon_Handler,                         /*  -4 Debug Monitor Handler */
+  0,                                        /*     Reserved */
+  PendSV_Handler,                           /*  -2 PendSV Handler */
+  SysTick_Handler,                          /*  -1 SysTick Handler */
+
+  /* Interrupts */
+  Interrupt0_Handler,                       /*   0 Interrupt 0 */
+  Interrupt1_Handler,                       /*   1 Interrupt 1 */
+  Interrupt2_Handler,                       /*   2 Interrupt 2 */
+  Interrupt3_Handler,                       /*   3 Interrupt 3 */
+  Interrupt4_Handler,                       /*   4 Interrupt 4 */
+  Interrupt5_Handler,                       /*   5 Interrupt 5 */
+  Interrupt6_Handler,                       /*   6 Interrupt 6 */
+  Interrupt7_Handler,                       /*   7 Interrupt 7 */
+  Interrupt8_Handler,                       /*   8 Interrupt 8 */
+  Interrupt9_Handler                        /*   9 Interrupt 9 */
+                                            /* Interrupts 10 .. 480 are left out */
+};
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler(void)
+{
+  __set_PSP((uint32_t)(&__INITIAL_SP));
+
+  __set_MSPLIM((uint32_t)(&__STACK_LIMIT));
+  __set_PSPLIM((uint32_t)(&__STACK_LIMIT));
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  __TZ_set_STACKSEAL_S((uint32_t *)(&__STACK_SEAL));
+#endif
+
+  SystemInit();                             /* CMSIS System Initialization */
+  __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
+}
+
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wmissing-noreturn"
+#endif
+
+/*----------------------------------------------------------------------------
+  Hard Fault Handler
+ *----------------------------------------------------------------------------*/
+void HardFault_Handler(void)
+{
+  while(1);
+}
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+void Default_Handler(void)
+{
+  while(1);
+}
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic pop
+#endif
+

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85/RTE/Device/ARMCM85/system_ARMCM85.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85/RTE/Device/ARMCM85/system_ARMCM85.c
@@ -1,0 +1,106 @@
+/**************************************************************************//**
+ * @file     system_ARMCM85.c
+ * @brief    CMSIS Device System Source File for ARMCM85 Device
+ * @version  V1.0.0
+ * @date     30. March 2022
+ ******************************************************************************/
+/*
+ * Copyright (c) 2022 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (ARMCM85)
+  #include "ARMCM85.h"
+
+  #if defined (__ARM_FEATURE_CMSE) &&  (__ARM_FEATURE_CMSE == 3U)
+    #include "partition_ARMCM85.h"
+  #endif
+#else
+  #error device not specified!
+#endif
+
+
+/*----------------------------------------------------------------------------
+  Define clocks
+ *----------------------------------------------------------------------------*/
+#define  XTAL            (50000000UL)     /* Oscillator frequency */
+
+#define  SYSTEM_CLOCK    (XTAL / 2U)
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[496];
+
+/*----------------------------------------------------------------------------
+  System Core Clock Variable
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = SYSTEM_CLOCK;  /* System Core Clock Frequency */
+
+/*----------------------------------------------------------------------------
+  System Core Clock update function
+ *----------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)
+{
+  SystemCoreClock = SYSTEM_CLOCK;
+}
+
+/*----------------------------------------------------------------------------
+  System initialization function
+ *----------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t)(&__VECTOR_TABLE[0]);
+#endif
+
+  /* Set CPDLPSTATE.RLPSTATE to 0
+     Set CPDLPSTATE.ELPSTATE to 0, to stop the processor from trying to switch the EPU into retention state.
+     Set CPDLPSTATE.CLPSTATE to 0, so PDCORE will not enter low-power state. */
+  PWRMODCTL->CPDLPSTATE &= ~(PWRMODCTL_CPDLPSTATE_RLPSTATE_Msk |
+                             PWRMODCTL_CPDLPSTATE_ELPSTATE_Msk |
+                             PWRMODCTL_CPDLPSTATE_CLPSTATE_Msk  );
+
+#if (defined (__FPU_USED) && (__FPU_USED == 1U)) || \
+    (defined (__ARM_FEATURE_MVE) && (__ARM_FEATURE_MVE > 0U))
+  SCB->CPACR |= ((3U << 10U*2U) |           /* enable CP10 Full Access */
+                 (3U << 11U*2U)  );         /* enable CP11 Full Access */
+
+  /* Favor best FP/MVE performance by default, avoid EPU switch-ON delays */
+  /* PDEPU ON, Clock OFF */
+  PWRMODCTL->CPDLPSTATE |= 0x1 << PWRMODCTL_CPDLPSTATE_ELPSTATE_Pos;
+#endif
+
+#ifdef UNALIGNED_SUPPORT_DISABLE
+  SCB->CCR |= SCB_CCR_UNALIGN_TRP_Msk;
+#endif
+
+  /* Enable Loop and branch info cache */
+  SCB->CCR |= SCB_CCR_LOB_Msk;
+
+  /* Enable Branch Prediction */
+  SCB->CCR |= SCB_CCR_BP_Msk;
+
+  __DSB();
+  __ISB();
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  TZ_SAU_Setup();
+#endif
+
+  SystemCoreClock = SYSTEM_CLOCK;
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85/Target.clayer.yml
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85/Target.clayer.yml
@@ -1,0 +1,35 @@
+layer:
+  type: Target
+  description: CM85 target components and files
+
+  packs:
+    - pack: ARM::Cortex_DFP
+
+  device: ARMCM85
+
+  processor:
+    trustzone: off
+
+  components:
+    # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
+    - component: ARM::CMSIS:CORE
+    - component: Device:Startup&C Startup
+
+  groups:
+    - group: FVP
+      files:
+        - file: ./model_config.txt
+
+  linker:
+    - for-compiler: AC6
+      script: RTE/Device/$Dname$/ac6_linker_script.sct
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: GCC
+      script: RTE/Device/$Dname$/gcc_linker_script.ld
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: CLANG
+      script: RTE/Device/$Dname$/clang_linker_script.ld
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: IAR
+      script: RTE/Device/$Dname$/iar_linker_script.icf
+      regions: RTE/Device/$Dname$/regions_$Dname$.h

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85/model_config.txt
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85/model_config.txt
@@ -1,0 +1,30 @@
+# Parameters:
+# instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+#----------------------------------------------------------------------------------------------
+fvp_mps2.mps2_visualisation.disable-visualisation=1   # (bool  , init-time) default = '0'      : Enable/disable visualisation
+fvp_mps2.DISABLE_GATING=1                             # (bool  , init-time) default = '0'      : Disable Memory gating logic
+cpu0.FPU=1                                            # (bool  , init-time) default = '1'      : Set whether the model has VFP support
+cpu0.MVE=1                                            # (int   , init-time) default = '0x1'    : Set whether the model has MVE support. If FPU = 0: 0=MVE not included, 1=Integer subset of MVE included. If FPU = 1: 0=MVE not included, 1=Integer subset of MVE included, 2=Integer and half and single precision floating point MVE included
+cpu0.ID_ISAR5.PACBTI=1                                # (int   , init-time) default = '0x0'    : 0: PAC/BTI not implemented, 1: PAC implemented using the QARMA5 algorithm with BTI, 2: PAC implemented using an IMP DEF algorithm with BTI, 4: PAC implemented using the QARMA3 algorithm with BTI
+cpu0.semihosting-enable=1                             # (bool  , init-time) default = '1'      : Enable semihosting SVC traps. Applications that do not use semihosting must set this parameter to false.
+cpu0.semihosting-Thumb_SVC=0xAB                       # (int   , init-time) default = '0xAB'   : T32 SVC number for semihosting : [0x0..0xFF]
+cpu0.semihosting-cmd_line=""                          # (string, init-time) default = ''       : Command line available to semihosting SVC calls
+cpu0.semihosting-heap_base=0x0                        # (int   , init-time) default = '0x0'    : Virtual address of heap base : [0x0..0xFFFFFFFF]
+cpu0.semihosting-heap_limit=0x0                       # (int   , init-time) default = '0x10700000' : Virtual address of top of heap : [0x0..0xFFFFFFFF]
+cpu0.semihosting-stack_base=0x0                       # (int   , init-time) default = '0x10700000' : Virtual address of base of descending stack : [0x0..0xFFFFFFFF]
+cpu0.semihosting-stack_limit=0x0                      # (int   , init-time) default = '0x10800000' : Virtual address of stack limit : [0x0..0xFFFFFFFF]
+cpu0.semihosting-cwd=""                               # (string, init-time) default = ''       : Base directory for semihosting file access.
+cpu0.MPU_S=0x8                                        # (int   , init-time) default = '0x8'    : Number of regions in the Secure MPU. If Security Extentions are absent, this is ignored : [0x0..0x10]
+cpu0.MPU_NS=0x8                                       # (int   , init-time) default = '0x8'    : Number of regions in the Non-Secure MPU. If Security Extentions are absent, this is the total number of MPU regions : [0x0..0x10]
+cpu0.ITM=0                                            # (bool  , init-time) default = '1'      : Level of instrumentation trace supported. false : No ITM trace included, true: ITM trace included
+cpu0.IRQLVL=0x3                                       # (int   , init-time) default = '0x3'    : Number of bits of interrupt priority : [0x3..0x8]
+cpu0.INITSVTOR=0x00000000                             # (int   , init-time) default = '0x10000000' : Secure vector-table offset at reset : [0x0..0xFFFFFF80]
+cpu0.INITNSVTOR=0x0                                   # (int   , init-time) default = '0x0'    : Non-Secure vector-table offset at reset : [0x0..0xFFFFFF80]
+cpu0.SAU=0x8                                          # (int   , init-time) default = '0x4'    : Number of SAU regions (0 => no SAU) : [0x0..0x8]
+idau.NUM_IDAU_REGION=0x0                              # (int   , init-time) default = '0xA'    : 
+cpu0.LOCK_SAU=0                                       # (bool  , init-time) default = '0'      : Lock down of SAU registers write
+cpu0.LOCK_S_MPU=0                                     # (bool  , init-time) default = '0'      : Lock down of Secure MPU registers write
+cpu0.LOCK_NS_MPU=0                                    # (bool  , init-time) default = '0'      : Lock down of Non-Secure MPU registers write
+cpu0.CPIF=1                                           # (bool  , init-time) default = '1'      : Specifies whether the external coprocessor interface is included
+cpu0.SECEXT=0                                         # (bool  , init-time) default = '1'      : Whether the ARMv8-M Security Extensions are included
+#----------------------------------------------------------------------------------------------

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85NS/RTE/Device/ARMCM85/ac6_linker_script.sct
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85NS/RTE/Device/ARMCM85/ac6_linker_script.sct
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE 8
+#else
+#define __STACKSEAL_SIZE 0
+#endif
+
+/*----------------------------------------------------------------------------
+  Scatter File Definitions definition
+ *----------------------------------------------------------------------------*/
+
+LR_ROM0 __ROM0_BASE __ROM0_SIZE  {
+
+  ER_ROM0 __ROM0_BASE __ROM0_SIZE {
+    *.o (RESET, +First)
+    *(InRoot$$Sections)
+    *(+RO +XO)
+  }
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  ER_CMSE_VENEER AlignExpr(+0, 32) (__ROM0_SIZE - AlignExpr(ImageLength(ER_ROM0), 32)) {
+    *(Veneer$$CMSE)
+  }
+#endif
+
+  RW_NOINIT __RAM0_BASE UNINIT (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE) {
+    *(.bss.noinit)
+  }
+
+  RW_RAM0 AlignExpr(+0, 8) (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE - AlignExpr(ImageLength(RW_NOINIT), 8)) {
+    *(+RW +ZI)
+  }
+
+#if __HEAP_SIZE > 0
+  ARM_LIB_HEAP  (AlignExpr(+0, 8)) EMPTY __HEAP_SIZE  {   ; Reserve empty region for heap
+  }
+#endif
+
+  ARM_LIB_STACK (__RAM0_BASE + __RAM0_SIZE - __STACKSEAL_SIZE) EMPTY -__STACK_SIZE {   ; Reserve empty region for stack
+  }
+
+#if __STACKSEAL_SIZE > 0
+  STACKSEAL +0 EMPTY __STACKSEAL_SIZE {             ; Reserve empty region for stack seal immediately after stack
+  }
+#endif
+
+#if __RAM1_SIZE > 0
+  RW_RAM1 __RAM1_BASE __RAM1_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+
+#if __RAM2_SIZE > 0
+  RW_RAM2 __RAM2_BASE __RAM2_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+
+#if __RAM3_SIZE > 0
+  RW_RAM3 __RAM3_BASE __RAM3_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+}
+
+#if __ROM1_SIZE > 0
+LR_ROM1 __ROM1_BASE __ROM1_SIZE  {
+  ER_ROM1 +0 __ROM1_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif
+
+#if __ROM2_SIZE > 0
+LR_ROM2 __ROM2_BASE __ROM2_SIZE  {
+  ER_ROM2 +0 __ROM2_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif
+
+#if __ROM3_SIZE > 0
+LR_ROM3 __ROM3_BASE __ROM3_SIZE  {
+  ER_ROM3 +0 __ROM3_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85NS/RTE/Device/ARMCM85/clang_linker_script.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85NS/RTE/Device/ARMCM85/clang_linker_script.ld
@@ -1,0 +1,361 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2019 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+/* ----------------------------------------------------------------------------
+  Memory definition
+ *----------------------------------------------------------------------------*/
+MEMORY
+{
+  ROM0  (rx!w)  : ORIGIN = __ROM0_BASE, LENGTH = __ROM0_SIZE
+#if __ROM1_SIZE > 0
+  ROM1  (rx!w)  : ORIGIN = __ROM1_BASE, LENGTH = __ROM1_SIZE
+#endif
+#if __ROM2_SIZE > 0
+  ROM2  (rx!w)  : ORIGIN = __ROM2_BASE, LENGTH = __ROM2_SIZE
+#endif
+#if __ROM3_SIZE > 0
+  ROM3  (rx!w)  : ORIGIN = __ROM3_BASE, LENGTH = __ROM3_SIZE
+#endif
+
+  RAM0  (w!rx) : ORIGIN = __RAM0_BASE, LENGTH = __RAM0_SIZE
+#if __RAM1_SIZE > 0
+  RAM1  (w!rx) : ORIGIN = __RAM1_BASE, LENGTH = __RAM1_SIZE
+#endif
+#if __RAM2_SIZE > 0
+  RAM2  (w!rx) : ORIGIN = __RAM2_BASE, LENGTH = __RAM2_SIZE
+#endif
+#if __RAM3_SIZE > 0
+  RAM3  (w!rx) : ORIGIN = __RAM3_BASE, LENGTH = __RAM3_SIZE
+#endif
+}
+
+ENTRY(Reset_Handler)
+
+PHDRS
+{
+	text PT_LOAD;
+	ram PT_LOAD;
+	ram_init PT_LOAD;
+	tls PT_TLS;
+}
+
+SECTIONS
+{
+	.init : {
+		KEEP (*(.vectors))
+		KEEP (*(.text.init.enter))
+		KEEP (*(.data.init.enter))
+		KEEP (*(SORT_BY_NAME(.init) SORT_BY_NAME(.init.*)))
+	} >ROM0 AT>ROM0 :text
+
+	.text : {
+
+		/* code */
+		*(.text.unlikely .text.unlikely.*)
+		*(.text.startup .text.startup.*)
+		*(.text .text.* .opd .opd.*)
+		*(.gnu.linkonce.t.*)
+		KEEP (*(.fini .fini.*))
+		__text_end = .;
+
+		PROVIDE (__etext = __text_end);
+		PROVIDE (_etext = __text_end);
+		PROVIDE (etext = __text_end);
+
+		/* read-only data */
+		*(.rdata)
+		*(.rodata .rodata.*)
+		*(.gnu.linkonce.r.*)
+
+		*(.srodata.cst16)
+		*(.srodata.cst8)
+		*(.srodata.cst4)
+		*(.srodata.cst2)
+		*(.srodata .srodata.*)
+		*(.data.rel.ro .data.rel.ro.*)
+		*(.got .got.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		/* lists of constructors and destructors */
+		PROVIDE_HIDDEN ( __preinit_array_start = . );
+		KEEP (*(.preinit_array))
+		PROVIDE_HIDDEN ( __preinit_array_end = . );
+
+		PROVIDE_HIDDEN ( __init_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+		KEEP (*(.init_array .ctors))
+		PROVIDE_HIDDEN ( __init_array_end = . );
+
+		PROVIDE_HIDDEN ( __fini_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
+		KEEP (*(.fini_array .dtors))
+		PROVIDE_HIDDEN ( __fini_array_end = . );
+
+	} >ROM0 AT>ROM0 :text
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+	.veneers :
+	{
+		. = ALIGN(32);
+		KEEP(*(.gnu.sgstubs))
+	} > ROM0 AT>ROM0 :text
+#endif
+
+	.toc : {
+		*(.toc .toc.*)
+	} >ROM0 AT>ROM0 :text
+
+	/* additional sections when compiling with C++ exception support */
+	
+	.except_ordered : {
+		*(.gcc_except_table *.gcc_except_table.*)
+		KEEP (*(.eh_frame .eh_frame.*))
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+	} >ROM0 AT>ROM0 :text
+
+	.except_unordered : {
+		. = ALIGN(8);
+
+		PROVIDE(__exidx_start = .);
+		*(.ARM.exidx*)
+		PROVIDE(__exidx_end = .);
+	} >ROM0 AT>ROM0 :text
+	
+
+	/*
+	 * Data values which are preserved across reset
+	 */
+	.preserve (NOLOAD) : {
+		PROVIDE(__preserve_start__ = .);
+		KEEP(*(SORT_BY_NAME(.preserve.*)))
+		KEEP(*(.preserve))
+		PROVIDE(__preserve_end__ = .);
+	} >RAM0 AT>RAM0 :ram
+
+	.data :  {
+		*(.data .data.*)
+		*(.gnu.linkonce.d.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		PROVIDE( __global_pointer$ = . + 0x800 );
+		*(.sdata .sdata.* .sdata2.*)
+		*(.gnu.linkonce.s.*)
+	} >RAM0 AT>ROM0 :ram_init
+	PROVIDE(__data_start = ADDR(.data));
+	PROVIDE(__data_source = LOADADDR(.data));
+
+	/* Thread local initialized data. This gets
+	 * space allocated as it is expected to be placed
+	 * in ram to be used as a template for TLS data blocks
+	 * allocated at runtime. We're slightly abusing that
+	 * by placing the data in flash where it will be copied
+	 * into the allocate ram addresses by the existing
+	 * data initialization code in crt0
+	 */
+	.tdata :  {
+		*(.tdata .tdata.* .gnu.linkonce.td.*)
+		PROVIDE(__data_end = .);
+		PROVIDE(__tdata_end = .);
+	} >RAM0 AT>ROM0 :tls :ram_init
+	PROVIDE( __tls_base = ADDR(.tdata));
+	PROVIDE( __tdata_start = ADDR(.tdata));
+	PROVIDE( __tdata_source = LOADADDR(.tdata) );
+	PROVIDE( __tdata_source_end = LOADADDR(.tdata) + SIZEOF(.tdata) );
+	PROVIDE( __data_source_end = __tdata_source_end );
+	PROVIDE( __tdata_size = SIZEOF(.tdata) );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata),ALIGNOF(.tbss)) );
+
+	PROVIDE( __edata = __data_end );
+	PROVIDE( _edata = __data_end );
+	PROVIDE( edata = __data_end );
+	PROVIDE( __data_size = __data_end - __data_start );
+	PROVIDE( __data_source_size = __data_source_end - __data_source );
+
+	.tbss (NOLOAD) : {
+		*(.tbss .tbss.* .gnu.linkonce.tb.*)
+		*(.tcommon)
+		PROVIDE( __tls_end = . );
+		PROVIDE( __tbss_end = . );
+	} >RAM0 AT>RAM0 :tls :ram
+	PROVIDE( __bss_start = ADDR(.tbss));
+	PROVIDE( __tbss_start = ADDR(.tbss));
+	PROVIDE( __tbss_offset = ADDR(.tbss) - ADDR(.tdata) );
+	PROVIDE( __tbss_size = SIZEOF(.tbss) );
+	PROVIDE( __tls_size = __tls_end - __tls_base );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
+	PROVIDE( __arm32_tls_tcb_offset = MAX(8, __tls_align) );
+	PROVIDE( __arm64_tls_tcb_offset = MAX(16, __tls_align) );
+
+	/*
+	 * The linker special cases .tbss segments which are
+	 * identified as segments which are not loaded and are
+	 * thread_local.
+	 *
+	 * For these segments, the linker does not advance 'dot'
+	 * across them.  We actually need memory allocated for tbss,
+	 * so we create a special segment here just to make room
+	 */
+	/*
+	.tbss_space (NOLOAD) : {
+		. = ADDR(.tbss);
+		. = . + SIZEOF(.tbss);
+	} >RAM0 AT>RAM0 :ram
+	*/
+
+	.bss (NOLOAD) : {
+		*(.sbss*)
+		*(.gnu.linkonce.sb.*)
+		*(.bss .bss.*)
+		*(.gnu.linkonce.b.*)
+		*(COMMON)
+
+		/* Align the heap */
+		. = ALIGN(8);
+		__bss_end = .;
+	} >RAM0 AT>RAM0 :ram
+	PROVIDE( __non_tls_bss_start = ADDR(.bss) );
+	PROVIDE( __end = __bss_end );
+	PROVIDE( _end = __bss_end );
+	PROVIDE( end = __bss_end );
+	PROVIDE( __bss_size = __bss_end - __bss_start );
+
+	/* Make the rest of memory available for heap storage */
+	PROVIDE (__heap_start = __end);
+#ifdef __HEAP_SIZE
+	PROVIDE (__heap_end = __heap_start + __HEAP_SIZE);
+	PROVIDE (__heap_size = __HEAP_SIZE);
+#else
+	PROVIDE (__heap_end = __stack - __STACK_SIZE);
+	PROVIDE (__heap_size = __heap_end - __heap_start);
+#endif
+	.heap (NOLOAD) : {
+		. += __heap_size;
+	} >RAM0 :ram
+
+	/* Define a stack region to make sure it fits in memory */
+	PROVIDE(__stack = ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE);
+	PROVIDE(__stack_limit = __stack - __STACK_SIZE);
+	.stack (__stack_limit) (NOLOAD) : {
+		. += __STACK_SIZE;
+	} >RAM0 :ram
+
+#if __STACKSEAL_SIZE > 0
+	PROVIDE(__stack_seal = __stack);
+  	.stackseal (__stack) (NOLOAD) :
+  	{
+    	. += __STACKSEAL_SIZE;
+  	} >RAM0 :ram
+#endif
+
+	/* Throw away C++ exception handling information */
+
+	/*
+
+	/DISCARD/ : {
+		*(.note .note.*)
+		*(.eh_frame .eh_frame.*)
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+		*(.ARM.exidx*)
+	}
+
+	*/
+
+	/* Stabs debugging sections.  */
+	.stab          0 : { *(.stab) }
+	.stabstr       0 : { *(.stabstr) }
+	.stab.excl     0 : { *(.stab.excl) }
+	.stab.exclstr  0 : { *(.stab.exclstr) }
+	.stab.index    0 : { *(.stab.index) }
+	.stab.indexstr 0 : { *(.stab.indexstr) }
+	.comment       0 : { *(.comment) }
+	.gnu.build.attributes : { *(.gnu.build.attributes .gnu.build.attributes.*) }
+	/* DWARF debug sections.
+	   Symbols in the DWARF debugging sections are relative to the beginning
+	   of the section so we begin them at 0.  */
+	/* DWARF 1.  */
+	.debug          0 : { *(.debug) }
+	.line           0 : { *(.line) }
+	/* GNU DWARF 1 extensions.  */
+	.debug_srcinfo  0 : { *(.debug_srcinfo) }
+	.debug_sfnames  0 : { *(.debug_sfnames) }
+	/* DWARF 1.1 and DWARF 2.  */
+	.debug_aranges  0 : { *(.debug_aranges) }
+	.debug_pubnames 0 : { *(.debug_pubnames) }
+	/* DWARF 2.  */
+	.debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+	.debug_abbrev   0 : { *(.debug_abbrev) }
+	.debug_line     0 : { *(.debug_line .debug_line.* .debug_line_end) }
+	.debug_frame    0 : { *(.debug_frame) }
+	.debug_str      0 : { *(.debug_str) }
+	.debug_loc      0 : { *(.debug_loc) }
+	.debug_macinfo  0 : { *(.debug_macinfo) }
+	/* SGI/MIPS DWARF 2 extensions.  */
+	.debug_weaknames 0 : { *(.debug_weaknames) }
+	.debug_funcnames 0 : { *(.debug_funcnames) }
+	.debug_typenames 0 : { *(.debug_typenames) }
+	.debug_varnames  0 : { *(.debug_varnames) }
+	/* DWARF 3.  */
+	.debug_pubtypes 0 : { *(.debug_pubtypes) }
+	.debug_ranges   0 : { *(.debug_ranges) }
+	/* DWARF 5.  */
+	.debug_addr     0 : { *(.debug_addr) }
+	.debug_line_str 0 : { *(.debug_line_str) }
+	.debug_loclists 0 : { *(.debug_loclists) }
+	.debug_macro    0 : { *(.debug_macro) }
+	.debug_names    0 : { *(.debug_names) }
+	.debug_rnglists 0 : { *(.debug_rnglists) }
+	.debug_str_offsets 0 : { *(.debug_str_offsets) }
+	.debug_sup      0 : { *(.debug_sup) }
+	.gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }
+}
+/*
+ * Check that sections that are copied from flash to RAM have matching
+ * padding, so that a single memcpy() of __data_size copies the correct bytes.
+ */
+ASSERT( __data_size == __data_source_size,
+	"ERROR: .data/.tdata flash size does not match RAM size");

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85NS/RTE/Device/ARMCM85/gcc_linker_script.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85NS/RTE/Device/ARMCM85/gcc_linker_script.ld
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+/* ----------------------------------------------------------------------------
+  Memory definition
+ *----------------------------------------------------------------------------*/
+MEMORY
+{
+  ROM0  (rx)  : ORIGIN = __ROM0_BASE, LENGTH = __ROM0_SIZE
+#if __ROM1_SIZE > 0
+  ROM1  (rx)  : ORIGIN = __ROM1_BASE, LENGTH = __ROM1_SIZE
+#endif
+#if __ROM2_SIZE > 0
+  ROM2  (rx)  : ORIGIN = __ROM2_BASE, LENGTH = __ROM2_SIZE
+#endif
+#if __ROM3_SIZE > 0
+  ROM3  (rx)  : ORIGIN = __ROM3_BASE, LENGTH = __ROM3_SIZE
+#endif
+
+  RAM0  (rwx) : ORIGIN = __RAM0_BASE, LENGTH = __RAM0_SIZE
+#if __RAM1_SIZE > 0
+  RAM1  (rwx) : ORIGIN = __RAM1_BASE, LENGTH = __RAM1_SIZE
+#endif
+#if __RAM2_SIZE > 0
+  RAM2  (rwx) : ORIGIN = __RAM2_BASE, LENGTH = __RAM2_SIZE
+#endif
+#if __RAM3_SIZE > 0
+  RAM3  (rwx) : ORIGIN = __RAM3_BASE, LENGTH = __RAM3_SIZE
+#endif
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __copy_table_start__
+ *   __copy_table_end__
+ *   __zero_table_start__
+ *   __zero_table_end__
+ *   __etext          (deprecated)
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+  .text :
+  {
+    KEEP(*(.vectors))
+    *(.text*)
+
+    KEEP(*(.init))
+    KEEP(*(.fini))
+
+    /* .ctors */
+    *crtbegin.o(.ctors)
+    *crtbegin?.o(.ctors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+    *(SORT(.ctors.*))
+    *(.ctors)
+
+    /* .dtors */
+    *crtbegin.o(.dtors)
+    *crtbegin?.o(.dtors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+    *(SORT(.dtors.*))
+    *(.dtors)
+
+    *(.rodata*)
+
+    KEEP(*(.eh_frame*))
+  } > ROM0
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  .gnu.sgstubs :
+  {
+    . = ALIGN(32);
+  } > ROM0
+#endif
+
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > ROM0
+
+  __exidx_start = .;
+  .ARM.exidx :
+  {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+  } > ROM0
+  __exidx_end = .;
+
+  .copy.table :
+  {
+    . = ALIGN(4);
+    __copy_table_start__ = .;
+
+    LONG (LOADADDR(.data))
+    LONG (ADDR(.data))
+    LONG (SIZEOF(.data) / 4)
+
+    /* Add each additional data section here */
+/*
+    LONG (LOADADDR(.data2))
+    LONG (ADDR(.data2))
+    LONG (SIZEOF(.data2) / 4)
+*/
+    __copy_table_end__ = .;
+  } > ROM0
+
+  .zero.table :
+  {
+    . = ALIGN(4);
+    __zero_table_start__ = .;
+
+/*  .bss initialization to zero is already done during C Run-Time Startup.
+    LONG (ADDR(.bss))
+    LONG (SIZEOF(.bss) / 4)
+*/
+
+    /* Add each additional bss section here */
+/*
+    LONG (ADDR(.bss2))
+    LONG (SIZEOF(.bss2) / 4)
+*/
+    __zero_table_end__ = .;
+  } > ROM0
+
+  /*
+   * This __etext variable is kept for backward compatibility with older,
+   * ASM based startup files.
+   */
+  PROVIDE(__etext = LOADADDR(.data));
+
+  .data : ALIGN(4)
+  {
+    __data_start__ = .;
+    *(vtable)
+    *(.data)
+    *(.data.*)
+
+    . = ALIGN(4);
+    /* preinit data */
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP(*(.preinit_array))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+
+    . = ALIGN(4);
+    /* init data */
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP(*(SORT(.init_array.*)))
+    KEEP(*(.init_array))
+    PROVIDE_HIDDEN (__init_array_end = .);
+
+    . = ALIGN(4);
+    /* finit data */
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP(*(SORT(.fini_array.*)))
+    KEEP(*(.fini_array))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    /* All data end */
+    __data_end__ = .;
+
+  } > RAM0 AT > ROM0
+
+  /*
+   * Secondary data section, optional
+   *
+   * Remember to add each additional data section
+   * to the .copy.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .data2 : ALIGN(4)
+  {
+    . = ALIGN(4);
+    __data2_start__ = .;
+    *(.data2)
+    *(.data2.*)
+    . = ALIGN(4);
+    __data2_end__ = .;
+
+  } > RAM1 AT > ROM0 
+*/
+
+  .bss :
+  {
+    . = ALIGN(4);
+    __bss_start__ = .;
+    *(.bss)
+    *(.bss.*)
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+  } > RAM0 AT > RAM0
+
+  /*
+   * Secondary bss section, optional
+   *
+   * Remember to add each additional bss section
+   * to the .zero.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .bss2 :
+  {
+    . = ALIGN(4);
+    __bss2_start__ = .;
+    *(.bss2)
+    *(.bss2.*)
+    . = ALIGN(4);
+    __bss2_end__ = .;
+  } > RAM1 AT > RAM1
+*/
+
+  .heap (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE(end = .);
+    . = . + __HEAP_SIZE;
+    . = ALIGN(8);
+    __HeapLimit = .;
+  } > RAM0
+
+  .stack (ORIGIN(RAM0) + LENGTH(RAM0) - __STACK_SIZE - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackLimit = .;
+    . = . + __STACK_SIZE;
+    . = ALIGN(8);
+    __StackTop = .;
+  } > RAM0
+  PROVIDE(__stack = __StackTop);
+
+#if __STACKSEAL_SIZE > 0
+  .stackseal (ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackSeal = .;
+    . = . + 8;
+    . = ALIGN(8);
+  } > RAM0
+#endif
+
+  /* Check if data + heap + stack exceeds RAM limit */
+  ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85NS/RTE/Device/ARMCM85/iar_linker_script.icf
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85NS/RTE/Device/ARMCM85/iar_linker_script.icf
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+define memory mem with size = 4G;
+
+#if __ROM0_SIZE > 0
+  define region ROM0_region = mem:[from __ROM0_BASE to (__ROM0_BASE+__ROM0_SIZE-1)];
+#else
+  define region ROM0_region = [];
+#endif
+
+#if __ROM1_SIZE > 0
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+#else
+  define region ROM1_region = [];
+#endif
+
+#if __ROM2_SIZE > 0
+  define region ROM2_region = mem:[from __ROM2_BASE to (__ROM2_BASE+__ROM2_SIZE-1)];
+#else
+  define region ROM2_region = [];
+#endif
+
+#if __ROM3_SIZE > 0
+  define region ROM3_region = mem:[from __ROM3_BASE to (__ROM3_BASE+__ROM3_SIZE-1)];
+#else
+  define region ROM3_region = [];
+#endif
+
+define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_region;
+
+#if __RAM0_SIZE > 0
+  define region RAM0_region = mem:[from __RAM0_BASE to (__RAM0_BASE+__RAM0_SIZE-1)];
+#else
+  define region RAM0_region = [];
+#endif
+
+#if __RAM1_SIZE > 0
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+#else
+  define region RAM1_region = [];
+#endif
+
+#if __RAM2_SIZE > 0
+  define region RAM2_region = mem:[from __RAM2_BASE to (__RAM2_BASE+__RAM2_SIZE-1)];
+#else
+  define region RAM2_region = [];
+#endif
+
+#if __RAM3_SIZE > 0
+  define region RAM3_region = mem:[from __RAM3_BASE to (__RAM3_BASE+__RAM3_SIZE-1)];
+#else
+  define region RAM3_region = [];
+#endif
+
+define region RAM_region = RAM0_region | RAM1_region | RAM2_region | RAM3_region;
+
+do not initialize  { section .noinit };
+initialize by copy { readwrite };
+if (isdefinedsymbol(__USE_DLIB_PERTHREAD))
+{
+  // Required in a multi-threaded application
+  initialize by copy with packing = none { section __DLIB_PERTHREAD };
+}
+
+place at address mem:__ROM0_BASE { readonly section .intvec };
+
+if (!isempty(ROM_region))
+{
+  place in ROM_region  { readonly };
+}
+
+if (!isempty(RAM_region))
+{
+  define block CSTACK     with alignment = 8, size = __STACK_SIZE     { };
+  define block PROC_STACK with alignment = 8, size = 0 { };
+  define block HEAP       with alignment = 8, size = __HEAP_SIZE       { };
+  place in RAM_region  { readwrite, block CSTACK, block PROC_STACK, block HEAP };
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85NS/RTE/Device/ARMCM85/regions_ARMCM85.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85NS/RTE/Device/ARMCM85/regions_ARMCM85.h
@@ -1,0 +1,94 @@
+#ifndef REGIONS_ARMCM85_H
+#define REGIONS_ARMCM85_H
+
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+// <n>Device pack:   ARM::Cortex_DFP@1.0.0-dev16
+// <i>Device pack used to generate this file
+
+// <h>ROM Configuration
+// =======================
+// <h> ROM_S=<__ROM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x00000000
+#define __ROM0_BASE 0x00200000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00200000
+#define __ROM0_SIZE 0x00200000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __ROM0_DEFAULT 1
+//   <q>Startup
+//   <i> Selects region to be used for startup code.
+#define __ROM0_STARTUP 1
+// </h>
+
+// <h> ROM_NS=<__ROM1>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x00200000
+#define __ROM1_BASE 0x00000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00200000
+#define __ROM1_SIZE 0x00200000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __ROM1_DEFAULT 0
+//   <q>Startup
+//   <i> Selects region to be used for startup code.
+#define __ROM1_STARTUP 0
+// </h>
+
+// </h>
+
+// <h>RAM Configuration
+// =======================
+// <h> RAM_S=<__RAM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x20000000
+#define __RAM0_BASE 0x20200000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00020000
+#define __RAM0_SIZE 0x00020000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __RAM0_DEFAULT 1
+//   <q>No zero initialize
+//   <i> Excludes region from zero initialization.
+#define __RAM0_NOINIT 0
+// </h>
+
+// <h> RAM_NS=<__RAM1>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x20200000
+#define __RAM1_BASE 0x20000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00020000
+#define __RAM1_SIZE 0x00020000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __RAM1_DEFAULT 0
+//   <q>No zero initialize
+//   <i> Excludes region from zero initialization.
+#define __RAM1_NOINIT 0
+// </h>
+
+// </h>
+
+// <h>Stack / Heap Configuration
+//   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+#define __STACK_SIZE 0x00000400
+#define __HEAP_SIZE 0x00000C00
+// </h>
+
+
+#endif /* REGIONS_ARMCM85_H */

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85NS/RTE/Device/ARMCM85/startup_ARMCM85.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85NS/RTE/Device/ARMCM85/startup_ARMCM85.c
@@ -1,0 +1,164 @@
+/******************************************************************************
+ * @file     startup_ARMCM85.c
+ * @brief    CMSIS Device Startup File for ARMCM85 Device
+ * @version  V1.0.0
+ * @date     07. February 2022
+ ******************************************************************************/
+/*
+ * Copyright (c) 2022 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (ARMCM85)
+  #include "ARMCM85.h"
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  External References
+ *----------------------------------------------------------------------------*/
+extern uint32_t __INITIAL_SP;
+extern uint32_t __STACK_LIMIT;
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+extern uint32_t __STACK_SEAL;
+#endif
+
+extern __NO_RETURN void __PROGRAM_START(void);
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler  (void);
+            void Default_Handler(void);
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+/* Exceptions */
+void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void HardFault_Handler      (void) __attribute__ ((weak));
+void MemManage_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
+void BusFault_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void UsageFault_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void SecureFault_Handler    (void) __attribute__ ((weak, alias("Default_Handler")));
+void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void DebugMon_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+
+void Interrupt0_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt1_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt2_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt3_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt4_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt5_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt6_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt7_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt8_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt9_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[496];
+       const VECTOR_TABLE_Type __VECTOR_TABLE[496] __VECTOR_TABLE_ATTRIBUTE = {
+  (VECTOR_TABLE_Type)(&__INITIAL_SP),       /*     Initial Stack Pointer */
+  Reset_Handler,                            /*     Reset Handler */
+  NMI_Handler,                              /* -14 NMI Handler */
+  HardFault_Handler,                        /* -13 Hard Fault Handler */
+  MemManage_Handler,                        /* -12 MPU Fault Handler */
+  BusFault_Handler,                         /* -11 Bus Fault Handler */
+  UsageFault_Handler,                       /* -10 Usage Fault Handler */
+  SecureFault_Handler,                      /*  -9 Secure Fault Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  SVC_Handler,                              /*  -5 SVC Handler */
+  DebugMon_Handler,                         /*  -4 Debug Monitor Handler */
+  0,                                        /*     Reserved */
+  PendSV_Handler,                           /*  -2 PendSV Handler */
+  SysTick_Handler,                          /*  -1 SysTick Handler */
+
+  /* Interrupts */
+  Interrupt0_Handler,                       /*   0 Interrupt 0 */
+  Interrupt1_Handler,                       /*   1 Interrupt 1 */
+  Interrupt2_Handler,                       /*   2 Interrupt 2 */
+  Interrupt3_Handler,                       /*   3 Interrupt 3 */
+  Interrupt4_Handler,                       /*   4 Interrupt 4 */
+  Interrupt5_Handler,                       /*   5 Interrupt 5 */
+  Interrupt6_Handler,                       /*   6 Interrupt 6 */
+  Interrupt7_Handler,                       /*   7 Interrupt 7 */
+  Interrupt8_Handler,                       /*   8 Interrupt 8 */
+  Interrupt9_Handler                        /*   9 Interrupt 9 */
+                                            /* Interrupts 10 .. 480 are left out */
+};
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler(void)
+{
+  __set_PSP((uint32_t)(&__INITIAL_SP));
+
+  __set_MSPLIM((uint32_t)(&__STACK_LIMIT));
+  __set_PSPLIM((uint32_t)(&__STACK_LIMIT));
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  __TZ_set_STACKSEAL_S((uint32_t *)(&__STACK_SEAL));
+#endif
+
+  SystemInit();                             /* CMSIS System Initialization */
+  __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
+}
+
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wmissing-noreturn"
+#endif
+
+/*----------------------------------------------------------------------------
+  Hard Fault Handler
+ *----------------------------------------------------------------------------*/
+void HardFault_Handler(void)
+{
+  while(1);
+}
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+void Default_Handler(void)
+{
+  while(1);
+}
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic pop
+#endif
+

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85NS/RTE/Device/ARMCM85/system_ARMCM85.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85NS/RTE/Device/ARMCM85/system_ARMCM85.c
@@ -1,0 +1,106 @@
+/**************************************************************************//**
+ * @file     system_ARMCM85.c
+ * @brief    CMSIS Device System Source File for ARMCM85 Device
+ * @version  V1.0.0
+ * @date     30. March 2022
+ ******************************************************************************/
+/*
+ * Copyright (c) 2022 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (ARMCM85)
+  #include "ARMCM85.h"
+
+  #if defined (__ARM_FEATURE_CMSE) &&  (__ARM_FEATURE_CMSE == 3U)
+    #include "partition_ARMCM85.h"
+  #endif
+#else
+  #error device not specified!
+#endif
+
+
+/*----------------------------------------------------------------------------
+  Define clocks
+ *----------------------------------------------------------------------------*/
+#define  XTAL            (50000000UL)     /* Oscillator frequency */
+
+#define  SYSTEM_CLOCK    (XTAL / 2U)
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[496];
+
+/*----------------------------------------------------------------------------
+  System Core Clock Variable
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = SYSTEM_CLOCK;  /* System Core Clock Frequency */
+
+/*----------------------------------------------------------------------------
+  System Core Clock update function
+ *----------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)
+{
+  SystemCoreClock = SYSTEM_CLOCK;
+}
+
+/*----------------------------------------------------------------------------
+  System initialization function
+ *----------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t)(&__VECTOR_TABLE[0]);
+#endif
+
+  /* Set CPDLPSTATE.RLPSTATE to 0
+     Set CPDLPSTATE.ELPSTATE to 0, to stop the processor from trying to switch the EPU into retention state.
+     Set CPDLPSTATE.CLPSTATE to 0, so PDCORE will not enter low-power state. */
+  PWRMODCTL->CPDLPSTATE &= ~(PWRMODCTL_CPDLPSTATE_RLPSTATE_Msk |
+                             PWRMODCTL_CPDLPSTATE_ELPSTATE_Msk |
+                             PWRMODCTL_CPDLPSTATE_CLPSTATE_Msk  );
+
+#if (defined (__FPU_USED) && (__FPU_USED == 1U)) || \
+    (defined (__ARM_FEATURE_MVE) && (__ARM_FEATURE_MVE > 0U))
+  SCB->CPACR |= ((3U << 10U*2U) |           /* enable CP10 Full Access */
+                 (3U << 11U*2U)  );         /* enable CP11 Full Access */
+
+  /* Favor best FP/MVE performance by default, avoid EPU switch-ON delays */
+  /* PDEPU ON, Clock OFF */
+  PWRMODCTL->CPDLPSTATE |= 0x1 << PWRMODCTL_CPDLPSTATE_ELPSTATE_Pos;
+#endif
+
+#ifdef UNALIGNED_SUPPORT_DISABLE
+  SCB->CCR |= SCB_CCR_UNALIGN_TRP_Msk;
+#endif
+
+  /* Enable Loop and branch info cache */
+  SCB->CCR |= SCB_CCR_LOB_Msk;
+
+  /* Enable Branch Prediction */
+  SCB->CCR |= SCB_CCR_BP_Msk;
+
+  __DSB();
+  __ISB();
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  TZ_SAU_Setup();
+#endif
+
+  SystemCoreClock = SYSTEM_CLOCK;
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85NS/Target.clayer.yml
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85NS/Target.clayer.yml
@@ -1,0 +1,35 @@
+layer:
+  type: Target
+  description: CM85NS target components and files
+
+  packs:
+    - pack: ARM::Cortex_DFP
+
+  device: ARMCM85
+
+  processor:
+    trustzone: non-secure
+
+  components:
+    # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
+    - component: ARM::CMSIS:CORE
+    - component: Device:Startup&C Startup
+
+  groups:
+    - group: FVP
+      files:
+        - file: ./model_config.txt
+
+  linker:
+    - for-compiler: AC6
+      script: RTE/Device/$Dname$/ac6_linker_script.sct
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: GCC
+      script: RTE/Device/$Dname$/gcc_linker_script.ld
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: CLANG
+      script: RTE/Device/$Dname$/clang_linker_script.ld
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: IAR
+      script: RTE/Device/$Dname$/iar_linker_script.icf
+      regions: RTE/Device/$Dname$/regions_$Dname$.h

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85NS/model_config.txt
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85NS/model_config.txt
@@ -1,0 +1,30 @@
+# Parameters:
+# instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+#----------------------------------------------------------------------------------------------
+fvp_mps2.mps2_visualisation.disable-visualisation=1   # (bool  , init-time) default = '0'      : Enable/disable visualisation
+fvp_mps2.DISABLE_GATING=1                             # (bool  , init-time) default = '0'      : Disable Memory gating logic
+cpu0.FPU=1                                            # (bool  , init-time) default = '1'      : Set whether the model has VFP support
+cpu0.MVE=1                                            # (int   , init-time) default = '0x1'    : Set whether the model has MVE support. If FPU = 0: 0=MVE not included, 1=Integer subset of MVE included. If FPU = 1: 0=MVE not included, 1=Integer subset of MVE included, 2=Integer and half and single precision floating point MVE included
+cpu0.ID_ISAR5.PACBTI=1                                # (int   , init-time) default = '0x0'    : 0: PAC/BTI not implemented, 1: PAC implemented using the QARMA5 algorithm with BTI, 2: PAC implemented using an IMP DEF algorithm with BTI, 4: PAC implemented using the QARMA3 algorithm with BTI
+cpu0.semihosting-enable=1                             # (bool  , init-time) default = '1'      : Enable semihosting SVC traps. Applications that do not use semihosting must set this parameter to false.
+cpu0.semihosting-Thumb_SVC=0xAB                       # (int   , init-time) default = '0xAB'   : T32 SVC number for semihosting : [0x0..0xFF]
+cpu0.semihosting-cmd_line=""                          # (string, init-time) default = ''       : Command line available to semihosting SVC calls
+cpu0.semihosting-heap_base=0x0                        # (int   , init-time) default = '0x0'    : Virtual address of heap base : [0x0..0xFFFFFFFF]
+cpu0.semihosting-heap_limit=0x0                       # (int   , init-time) default = '0x10700000' : Virtual address of top of heap : [0x0..0xFFFFFFFF]
+cpu0.semihosting-stack_base=0x0                       # (int   , init-time) default = '0x10700000' : Virtual address of base of descending stack : [0x0..0xFFFFFFFF]
+cpu0.semihosting-stack_limit=0x0                      # (int   , init-time) default = '0x10800000' : Virtual address of stack limit : [0x0..0xFFFFFFFF]
+cpu0.semihosting-cwd=""                               # (string, init-time) default = ''       : Base directory for semihosting file access.
+cpu0.MPU_S=0x8                                        # (int   , init-time) default = '0x8'    : Number of regions in the Secure MPU. If Security Extentions are absent, this is ignored : [0x0..0x10]
+cpu0.MPU_NS=0x8                                       # (int   , init-time) default = '0x8'    : Number of regions in the Non-Secure MPU. If Security Extentions are absent, this is the total number of MPU regions : [0x0..0x10]
+cpu0.ITM=0                                            # (bool  , init-time) default = '1'      : Level of instrumentation trace supported. false : No ITM trace included, true: ITM trace included
+cpu0.IRQLVL=0x3                                       # (int   , init-time) default = '0x3'    : Number of bits of interrupt priority : [0x3..0x8]
+cpu0.INITSVTOR=0x00000000                             # (int   , init-time) default = '0x10000000' : Secure vector-table offset at reset : [0x0..0xFFFFFF80]
+cpu0.INITNSVTOR=0x0                                   # (int   , init-time) default = '0x0'    : Non-Secure vector-table offset at reset : [0x0..0xFFFFFF80]
+cpu0.SAU=0x8                                          # (int   , init-time) default = '0x4'    : Number of SAU regions (0 => no SAU) : [0x0..0x8]
+idau.NUM_IDAU_REGION=0x0                              # (int   , init-time) default = '0xA'    : 
+cpu0.LOCK_SAU=0                                       # (bool  , init-time) default = '0'      : Lock down of SAU registers write
+cpu0.LOCK_S_MPU=0                                     # (bool  , init-time) default = '0'      : Lock down of Secure MPU registers write
+cpu0.LOCK_NS_MPU=0                                    # (bool  , init-time) default = '0'      : Lock down of Non-Secure MPU registers write
+cpu0.CPIF=1                                           # (bool  , init-time) default = '1'      : Specifies whether the external coprocessor interface is included
+cpu0.SECEXT=1                                         # (bool  , init-time) default = '1'      : Whether the ARMv8-M Security Extensions are included
+#----------------------------------------------------------------------------------------------

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85S/RTE/Device/ARMCM85/ac6_linker_script.sct
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85S/RTE/Device/ARMCM85/ac6_linker_script.sct
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE 8
+#else
+#define __STACKSEAL_SIZE 0
+#endif
+
+/*----------------------------------------------------------------------------
+  Scatter File Definitions definition
+ *----------------------------------------------------------------------------*/
+
+LR_ROM0 __ROM0_BASE __ROM0_SIZE  {
+
+  ER_ROM0 __ROM0_BASE __ROM0_SIZE {
+    *.o (RESET, +First)
+    *(InRoot$$Sections)
+    *(+RO +XO)
+  }
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  ER_CMSE_VENEER AlignExpr(+0, 32) (__ROM0_SIZE - AlignExpr(ImageLength(ER_ROM0), 32)) {
+    *(Veneer$$CMSE)
+  }
+#endif
+
+  RW_NOINIT __RAM0_BASE UNINIT (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE) {
+    *(.bss.noinit)
+  }
+
+  RW_RAM0 AlignExpr(+0, 8) (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE - AlignExpr(ImageLength(RW_NOINIT), 8)) {
+    *(+RW +ZI)
+  }
+
+#if __HEAP_SIZE > 0
+  ARM_LIB_HEAP  (AlignExpr(+0, 8)) EMPTY __HEAP_SIZE  {   ; Reserve empty region for heap
+  }
+#endif
+
+  ARM_LIB_STACK (__RAM0_BASE + __RAM0_SIZE - __STACKSEAL_SIZE) EMPTY -__STACK_SIZE {   ; Reserve empty region for stack
+  }
+
+#if __STACKSEAL_SIZE > 0
+  STACKSEAL +0 EMPTY __STACKSEAL_SIZE {             ; Reserve empty region for stack seal immediately after stack
+  }
+#endif
+
+#if __RAM1_SIZE > 0
+  RW_RAM1 __RAM1_BASE __RAM1_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+
+#if __RAM2_SIZE > 0
+  RW_RAM2 __RAM2_BASE __RAM2_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+
+#if __RAM3_SIZE > 0
+  RW_RAM3 __RAM3_BASE __RAM3_SIZE  {
+   .ANY (+RW +ZI)
+  }
+#endif
+}
+
+#if __ROM1_SIZE > 0
+LR_ROM1 __ROM1_BASE __ROM1_SIZE  {
+  ER_ROM1 +0 __ROM1_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif
+
+#if __ROM2_SIZE > 0
+LR_ROM2 __ROM2_BASE __ROM2_SIZE  {
+  ER_ROM2 +0 __ROM2_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif
+
+#if __ROM3_SIZE > 0
+LR_ROM3 __ROM3_BASE __ROM3_SIZE  {
+  ER_ROM3 +0 __ROM3_SIZE {
+   .ANY (+RO +XO)
+  }
+}
+#endif

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85S/RTE/Device/ARMCM85/clang_linker_script.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85S/RTE/Device/ARMCM85/clang_linker_script.ld
@@ -1,0 +1,361 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2019 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+/* ----------------------------------------------------------------------------
+  Memory definition
+ *----------------------------------------------------------------------------*/
+MEMORY
+{
+  ROM0  (rx!w)  : ORIGIN = __ROM0_BASE, LENGTH = __ROM0_SIZE
+#if __ROM1_SIZE > 0
+  ROM1  (rx!w)  : ORIGIN = __ROM1_BASE, LENGTH = __ROM1_SIZE
+#endif
+#if __ROM2_SIZE > 0
+  ROM2  (rx!w)  : ORIGIN = __ROM2_BASE, LENGTH = __ROM2_SIZE
+#endif
+#if __ROM3_SIZE > 0
+  ROM3  (rx!w)  : ORIGIN = __ROM3_BASE, LENGTH = __ROM3_SIZE
+#endif
+
+  RAM0  (w!rx) : ORIGIN = __RAM0_BASE, LENGTH = __RAM0_SIZE
+#if __RAM1_SIZE > 0
+  RAM1  (w!rx) : ORIGIN = __RAM1_BASE, LENGTH = __RAM1_SIZE
+#endif
+#if __RAM2_SIZE > 0
+  RAM2  (w!rx) : ORIGIN = __RAM2_BASE, LENGTH = __RAM2_SIZE
+#endif
+#if __RAM3_SIZE > 0
+  RAM3  (w!rx) : ORIGIN = __RAM3_BASE, LENGTH = __RAM3_SIZE
+#endif
+}
+
+ENTRY(Reset_Handler)
+
+PHDRS
+{
+	text PT_LOAD;
+	ram PT_LOAD;
+	ram_init PT_LOAD;
+	tls PT_TLS;
+}
+
+SECTIONS
+{
+	.init : {
+		KEEP (*(.vectors))
+		KEEP (*(.text.init.enter))
+		KEEP (*(.data.init.enter))
+		KEEP (*(SORT_BY_NAME(.init) SORT_BY_NAME(.init.*)))
+	} >ROM0 AT>ROM0 :text
+
+	.text : {
+
+		/* code */
+		*(.text.unlikely .text.unlikely.*)
+		*(.text.startup .text.startup.*)
+		*(.text .text.* .opd .opd.*)
+		*(.gnu.linkonce.t.*)
+		KEEP (*(.fini .fini.*))
+		__text_end = .;
+
+		PROVIDE (__etext = __text_end);
+		PROVIDE (_etext = __text_end);
+		PROVIDE (etext = __text_end);
+
+		/* read-only data */
+		*(.rdata)
+		*(.rodata .rodata.*)
+		*(.gnu.linkonce.r.*)
+
+		*(.srodata.cst16)
+		*(.srodata.cst8)
+		*(.srodata.cst4)
+		*(.srodata.cst2)
+		*(.srodata .srodata.*)
+		*(.data.rel.ro .data.rel.ro.*)
+		*(.got .got.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		/* lists of constructors and destructors */
+		PROVIDE_HIDDEN ( __preinit_array_start = . );
+		KEEP (*(.preinit_array))
+		PROVIDE_HIDDEN ( __preinit_array_end = . );
+
+		PROVIDE_HIDDEN ( __init_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+		KEEP (*(.init_array .ctors))
+		PROVIDE_HIDDEN ( __init_array_end = . );
+
+		PROVIDE_HIDDEN ( __fini_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
+		KEEP (*(.fini_array .dtors))
+		PROVIDE_HIDDEN ( __fini_array_end = . );
+
+	} >ROM0 AT>ROM0 :text
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+	.veneers :
+	{
+		. = ALIGN(32);
+		KEEP(*(.gnu.sgstubs))
+	} > ROM0 AT>ROM0 :text
+#endif
+
+	.toc : {
+		*(.toc .toc.*)
+	} >ROM0 AT>ROM0 :text
+
+	/* additional sections when compiling with C++ exception support */
+	
+	.except_ordered : {
+		*(.gcc_except_table *.gcc_except_table.*)
+		KEEP (*(.eh_frame .eh_frame.*))
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+	} >ROM0 AT>ROM0 :text
+
+	.except_unordered : {
+		. = ALIGN(8);
+
+		PROVIDE(__exidx_start = .);
+		*(.ARM.exidx*)
+		PROVIDE(__exidx_end = .);
+	} >ROM0 AT>ROM0 :text
+	
+
+	/*
+	 * Data values which are preserved across reset
+	 */
+	.preserve (NOLOAD) : {
+		PROVIDE(__preserve_start__ = .);
+		KEEP(*(SORT_BY_NAME(.preserve.*)))
+		KEEP(*(.preserve))
+		PROVIDE(__preserve_end__ = .);
+	} >RAM0 AT>RAM0 :ram
+
+	.data :  {
+		*(.data .data.*)
+		*(.gnu.linkonce.d.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		PROVIDE( __global_pointer$ = . + 0x800 );
+		*(.sdata .sdata.* .sdata2.*)
+		*(.gnu.linkonce.s.*)
+	} >RAM0 AT>ROM0 :ram_init
+	PROVIDE(__data_start = ADDR(.data));
+	PROVIDE(__data_source = LOADADDR(.data));
+
+	/* Thread local initialized data. This gets
+	 * space allocated as it is expected to be placed
+	 * in ram to be used as a template for TLS data blocks
+	 * allocated at runtime. We're slightly abusing that
+	 * by placing the data in flash where it will be copied
+	 * into the allocate ram addresses by the existing
+	 * data initialization code in crt0
+	 */
+	.tdata :  {
+		*(.tdata .tdata.* .gnu.linkonce.td.*)
+		PROVIDE(__data_end = .);
+		PROVIDE(__tdata_end = .);
+	} >RAM0 AT>ROM0 :tls :ram_init
+	PROVIDE( __tls_base = ADDR(.tdata));
+	PROVIDE( __tdata_start = ADDR(.tdata));
+	PROVIDE( __tdata_source = LOADADDR(.tdata) );
+	PROVIDE( __tdata_source_end = LOADADDR(.tdata) + SIZEOF(.tdata) );
+	PROVIDE( __data_source_end = __tdata_source_end );
+	PROVIDE( __tdata_size = SIZEOF(.tdata) );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata),ALIGNOF(.tbss)) );
+
+	PROVIDE( __edata = __data_end );
+	PROVIDE( _edata = __data_end );
+	PROVIDE( edata = __data_end );
+	PROVIDE( __data_size = __data_end - __data_start );
+	PROVIDE( __data_source_size = __data_source_end - __data_source );
+
+	.tbss (NOLOAD) : {
+		*(.tbss .tbss.* .gnu.linkonce.tb.*)
+		*(.tcommon)
+		PROVIDE( __tls_end = . );
+		PROVIDE( __tbss_end = . );
+	} >RAM0 AT>RAM0 :tls :ram
+	PROVIDE( __bss_start = ADDR(.tbss));
+	PROVIDE( __tbss_start = ADDR(.tbss));
+	PROVIDE( __tbss_offset = ADDR(.tbss) - ADDR(.tdata) );
+	PROVIDE( __tbss_size = SIZEOF(.tbss) );
+	PROVIDE( __tls_size = __tls_end - __tls_base );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
+	PROVIDE( __arm32_tls_tcb_offset = MAX(8, __tls_align) );
+	PROVIDE( __arm64_tls_tcb_offset = MAX(16, __tls_align) );
+
+	/*
+	 * The linker special cases .tbss segments which are
+	 * identified as segments which are not loaded and are
+	 * thread_local.
+	 *
+	 * For these segments, the linker does not advance 'dot'
+	 * across them.  We actually need memory allocated for tbss,
+	 * so we create a special segment here just to make room
+	 */
+	/*
+	.tbss_space (NOLOAD) : {
+		. = ADDR(.tbss);
+		. = . + SIZEOF(.tbss);
+	} >RAM0 AT>RAM0 :ram
+	*/
+
+	.bss (NOLOAD) : {
+		*(.sbss*)
+		*(.gnu.linkonce.sb.*)
+		*(.bss .bss.*)
+		*(.gnu.linkonce.b.*)
+		*(COMMON)
+
+		/* Align the heap */
+		. = ALIGN(8);
+		__bss_end = .;
+	} >RAM0 AT>RAM0 :ram
+	PROVIDE( __non_tls_bss_start = ADDR(.bss) );
+	PROVIDE( __end = __bss_end );
+	PROVIDE( _end = __bss_end );
+	PROVIDE( end = __bss_end );
+	PROVIDE( __bss_size = __bss_end - __bss_start );
+
+	/* Make the rest of memory available for heap storage */
+	PROVIDE (__heap_start = __end);
+#ifdef __HEAP_SIZE
+	PROVIDE (__heap_end = __heap_start + __HEAP_SIZE);
+	PROVIDE (__heap_size = __HEAP_SIZE);
+#else
+	PROVIDE (__heap_end = __stack - __STACK_SIZE);
+	PROVIDE (__heap_size = __heap_end - __heap_start);
+#endif
+	.heap (NOLOAD) : {
+		. += __heap_size;
+	} >RAM0 :ram
+
+	/* Define a stack region to make sure it fits in memory */
+	PROVIDE(__stack = ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE);
+	PROVIDE(__stack_limit = __stack - __STACK_SIZE);
+	.stack (__stack_limit) (NOLOAD) : {
+		. += __STACK_SIZE;
+	} >RAM0 :ram
+
+#if __STACKSEAL_SIZE > 0
+	PROVIDE(__stack_seal = __stack);
+  	.stackseal (__stack) (NOLOAD) :
+  	{
+    	. += __STACKSEAL_SIZE;
+  	} >RAM0 :ram
+#endif
+
+	/* Throw away C++ exception handling information */
+
+	/*
+
+	/DISCARD/ : {
+		*(.note .note.*)
+		*(.eh_frame .eh_frame.*)
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+		*(.ARM.exidx*)
+	}
+
+	*/
+
+	/* Stabs debugging sections.  */
+	.stab          0 : { *(.stab) }
+	.stabstr       0 : { *(.stabstr) }
+	.stab.excl     0 : { *(.stab.excl) }
+	.stab.exclstr  0 : { *(.stab.exclstr) }
+	.stab.index    0 : { *(.stab.index) }
+	.stab.indexstr 0 : { *(.stab.indexstr) }
+	.comment       0 : { *(.comment) }
+	.gnu.build.attributes : { *(.gnu.build.attributes .gnu.build.attributes.*) }
+	/* DWARF debug sections.
+	   Symbols in the DWARF debugging sections are relative to the beginning
+	   of the section so we begin them at 0.  */
+	/* DWARF 1.  */
+	.debug          0 : { *(.debug) }
+	.line           0 : { *(.line) }
+	/* GNU DWARF 1 extensions.  */
+	.debug_srcinfo  0 : { *(.debug_srcinfo) }
+	.debug_sfnames  0 : { *(.debug_sfnames) }
+	/* DWARF 1.1 and DWARF 2.  */
+	.debug_aranges  0 : { *(.debug_aranges) }
+	.debug_pubnames 0 : { *(.debug_pubnames) }
+	/* DWARF 2.  */
+	.debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+	.debug_abbrev   0 : { *(.debug_abbrev) }
+	.debug_line     0 : { *(.debug_line .debug_line.* .debug_line_end) }
+	.debug_frame    0 : { *(.debug_frame) }
+	.debug_str      0 : { *(.debug_str) }
+	.debug_loc      0 : { *(.debug_loc) }
+	.debug_macinfo  0 : { *(.debug_macinfo) }
+	/* SGI/MIPS DWARF 2 extensions.  */
+	.debug_weaknames 0 : { *(.debug_weaknames) }
+	.debug_funcnames 0 : { *(.debug_funcnames) }
+	.debug_typenames 0 : { *(.debug_typenames) }
+	.debug_varnames  0 : { *(.debug_varnames) }
+	/* DWARF 3.  */
+	.debug_pubtypes 0 : { *(.debug_pubtypes) }
+	.debug_ranges   0 : { *(.debug_ranges) }
+	/* DWARF 5.  */
+	.debug_addr     0 : { *(.debug_addr) }
+	.debug_line_str 0 : { *(.debug_line_str) }
+	.debug_loclists 0 : { *(.debug_loclists) }
+	.debug_macro    0 : { *(.debug_macro) }
+	.debug_names    0 : { *(.debug_names) }
+	.debug_rnglists 0 : { *(.debug_rnglists) }
+	.debug_str_offsets 0 : { *(.debug_str_offsets) }
+	.debug_sup      0 : { *(.debug_sup) }
+	.gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }
+}
+/*
+ * Check that sections that are copied from flash to RAM have matching
+ * padding, so that a single memcpy() of __data_size copies the correct bytes.
+ */
+ASSERT( __data_size == __data_source_size,
+	"ERROR: .data/.tdata flash size does not match RAM size");

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85S/RTE/Device/ARMCM85/gcc_linker_script.ld
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85S/RTE/Device/ARMCM85/gcc_linker_script.ld
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+/* ----------------------------------------------------------------------------
+  Memory definition
+ *----------------------------------------------------------------------------*/
+MEMORY
+{
+  ROM0  (rx)  : ORIGIN = __ROM0_BASE, LENGTH = __ROM0_SIZE
+#if __ROM1_SIZE > 0
+  ROM1  (rx)  : ORIGIN = __ROM1_BASE, LENGTH = __ROM1_SIZE
+#endif
+#if __ROM2_SIZE > 0
+  ROM2  (rx)  : ORIGIN = __ROM2_BASE, LENGTH = __ROM2_SIZE
+#endif
+#if __ROM3_SIZE > 0
+  ROM3  (rx)  : ORIGIN = __ROM3_BASE, LENGTH = __ROM3_SIZE
+#endif
+
+  RAM0  (rwx) : ORIGIN = __RAM0_BASE, LENGTH = __RAM0_SIZE
+#if __RAM1_SIZE > 0
+  RAM1  (rwx) : ORIGIN = __RAM1_BASE, LENGTH = __RAM1_SIZE
+#endif
+#if __RAM2_SIZE > 0
+  RAM2  (rwx) : ORIGIN = __RAM2_BASE, LENGTH = __RAM2_SIZE
+#endif
+#if __RAM3_SIZE > 0
+  RAM3  (rwx) : ORIGIN = __RAM3_BASE, LENGTH = __RAM3_SIZE
+#endif
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __copy_table_start__
+ *   __copy_table_end__
+ *   __zero_table_start__
+ *   __zero_table_end__
+ *   __etext          (deprecated)
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+  .text :
+  {
+    KEEP(*(.vectors))
+    *(.text*)
+
+    KEEP(*(.init))
+    KEEP(*(.fini))
+
+    /* .ctors */
+    *crtbegin.o(.ctors)
+    *crtbegin?.o(.ctors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+    *(SORT(.ctors.*))
+    *(.ctors)
+
+    /* .dtors */
+    *crtbegin.o(.dtors)
+    *crtbegin?.o(.dtors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+    *(SORT(.dtors.*))
+    *(.dtors)
+
+    *(.rodata*)
+
+    KEEP(*(.eh_frame*))
+  } > ROM0
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  .gnu.sgstubs :
+  {
+    . = ALIGN(32);
+  } > ROM0
+#endif
+
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > ROM0
+
+  __exidx_start = .;
+  .ARM.exidx :
+  {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+  } > ROM0
+  __exidx_end = .;
+
+  .copy.table :
+  {
+    . = ALIGN(4);
+    __copy_table_start__ = .;
+
+    LONG (LOADADDR(.data))
+    LONG (ADDR(.data))
+    LONG (SIZEOF(.data) / 4)
+
+    /* Add each additional data section here */
+/*
+    LONG (LOADADDR(.data2))
+    LONG (ADDR(.data2))
+    LONG (SIZEOF(.data2) / 4)
+*/
+    __copy_table_end__ = .;
+  } > ROM0
+
+  .zero.table :
+  {
+    . = ALIGN(4);
+    __zero_table_start__ = .;
+
+/*  .bss initialization to zero is already done during C Run-Time Startup.
+    LONG (ADDR(.bss))
+    LONG (SIZEOF(.bss) / 4)
+*/
+
+    /* Add each additional bss section here */
+/*
+    LONG (ADDR(.bss2))
+    LONG (SIZEOF(.bss2) / 4)
+*/
+    __zero_table_end__ = .;
+  } > ROM0
+
+  /*
+   * This __etext variable is kept for backward compatibility with older,
+   * ASM based startup files.
+   */
+  PROVIDE(__etext = LOADADDR(.data));
+
+  .data : ALIGN(4)
+  {
+    __data_start__ = .;
+    *(vtable)
+    *(.data)
+    *(.data.*)
+
+    . = ALIGN(4);
+    /* preinit data */
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP(*(.preinit_array))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+
+    . = ALIGN(4);
+    /* init data */
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP(*(SORT(.init_array.*)))
+    KEEP(*(.init_array))
+    PROVIDE_HIDDEN (__init_array_end = .);
+
+    . = ALIGN(4);
+    /* finit data */
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP(*(SORT(.fini_array.*)))
+    KEEP(*(.fini_array))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    /* All data end */
+    __data_end__ = .;
+
+  } > RAM0 AT > ROM0
+
+  /*
+   * Secondary data section, optional
+   *
+   * Remember to add each additional data section
+   * to the .copy.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .data2 : ALIGN(4)
+  {
+    . = ALIGN(4);
+    __data2_start__ = .;
+    *(.data2)
+    *(.data2.*)
+    . = ALIGN(4);
+    __data2_end__ = .;
+
+  } > RAM1 AT > ROM0 
+*/
+
+  .bss :
+  {
+    . = ALIGN(4);
+    __bss_start__ = .;
+    *(.bss)
+    *(.bss.*)
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+  } > RAM0 AT > RAM0
+
+  /*
+   * Secondary bss section, optional
+   *
+   * Remember to add each additional bss section
+   * to the .zero.table above to assure proper
+   * initialization during startup.
+   */
+/*
+  .bss2 :
+  {
+    . = ALIGN(4);
+    __bss2_start__ = .;
+    *(.bss2)
+    *(.bss2.*)
+    . = ALIGN(4);
+    __bss2_end__ = .;
+  } > RAM1 AT > RAM1
+*/
+
+  .heap (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE(end = .);
+    . = . + __HEAP_SIZE;
+    . = ALIGN(8);
+    __HeapLimit = .;
+  } > RAM0
+
+  .stack (ORIGIN(RAM0) + LENGTH(RAM0) - __STACK_SIZE - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackLimit = .;
+    . = . + __STACK_SIZE;
+    . = ALIGN(8);
+    __StackTop = .;
+  } > RAM0
+  PROVIDE(__stack = __StackTop);
+
+#if __STACKSEAL_SIZE > 0
+  .stackseal (ORIGIN(RAM0) + LENGTH(RAM0) - __STACKSEAL_SIZE) (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackSeal = .;
+    . = . + 8;
+    . = ALIGN(8);
+  } > RAM0
+#endif
+
+  /* Check if data + heap + stack exceeds RAM limit */
+  ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85S/RTE/Device/ARMCM85/iar_linker_script.icf
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85S/RTE/Device/ARMCM85/iar_linker_script.icf
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+define memory mem with size = 4G;
+
+#if __ROM0_SIZE > 0
+  define region ROM0_region = mem:[from __ROM0_BASE to (__ROM0_BASE+__ROM0_SIZE-1)];
+#else
+  define region ROM0_region = [];
+#endif
+
+#if __ROM1_SIZE > 0
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+#else
+  define region ROM1_region = [];
+#endif
+
+#if __ROM2_SIZE > 0
+  define region ROM2_region = mem:[from __ROM2_BASE to (__ROM2_BASE+__ROM2_SIZE-1)];
+#else
+  define region ROM2_region = [];
+#endif
+
+#if __ROM3_SIZE > 0
+  define region ROM3_region = mem:[from __ROM3_BASE to (__ROM3_BASE+__ROM3_SIZE-1)];
+#else
+  define region ROM3_region = [];
+#endif
+
+define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_region;
+
+#if __RAM0_SIZE > 0
+  define region RAM0_region = mem:[from __RAM0_BASE to (__RAM0_BASE+__RAM0_SIZE-1)];
+#else
+  define region RAM0_region = [];
+#endif
+
+#if __RAM1_SIZE > 0
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+#else
+  define region RAM1_region = [];
+#endif
+
+#if __RAM2_SIZE > 0
+  define region RAM2_region = mem:[from __RAM2_BASE to (__RAM2_BASE+__RAM2_SIZE-1)];
+#else
+  define region RAM2_region = [];
+#endif
+
+#if __RAM3_SIZE > 0
+  define region RAM3_region = mem:[from __RAM3_BASE to (__RAM3_BASE+__RAM3_SIZE-1)];
+#else
+  define region RAM3_region = [];
+#endif
+
+define region RAM_region = RAM0_region | RAM1_region | RAM2_region | RAM3_region;
+
+do not initialize  { section .noinit };
+initialize by copy { readwrite };
+if (isdefinedsymbol(__USE_DLIB_PERTHREAD))
+{
+  // Required in a multi-threaded application
+  initialize by copy with packing = none { section __DLIB_PERTHREAD };
+}
+
+place at address mem:__ROM0_BASE { readonly section .intvec };
+
+if (!isempty(ROM_region))
+{
+  place in ROM_region  { readonly };
+}
+
+if (!isempty(RAM_region))
+{
+  define block CSTACK     with alignment = 8, size = __STACK_SIZE     { };
+  define block PROC_STACK with alignment = 8, size = 0 { };
+  define block HEAP       with alignment = 8, size = __HEAP_SIZE       { };
+  place in RAM_region  { readwrite, block CSTACK, block PROC_STACK, block HEAP };
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85S/RTE/Device/ARMCM85/partition_ARMCM85.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85S/RTE/Device/ARMCM85/partition_ARMCM85.h
@@ -1,0 +1,1301 @@
+/**************************************************************************//**
+ * @file     partition_ARMCM85.h
+ * @brief    CMSIS-CORE Initial Setup for Secure / Non-Secure Zones for Armv8.1-M Mainline
+ * @version  V1.0.0
+ * @date     07. March 2022
+ ******************************************************************************/
+/*
+ * Copyright (c) 2022 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PARTITION_ARMCM85_H
+#define PARTITION_ARMCM85_H
+
+/*
+//-------- <<< Use Configuration Wizard in Context Menu >>> -----------------
+*/
+
+/*
+// <e>Initialize Security Attribution Unit (SAU) CTRL register
+*/
+#define SAU_INIT_CTRL          1
+
+/*
+//   <q> Enable SAU
+//   <i> Value for SAU->CTRL register bit ENABLE
+*/
+#define SAU_INIT_CTRL_ENABLE   1
+
+/*
+//   <o> When SAU is disabled
+//     <0=> All Memory is Secure
+//     <1=> All Memory is Non-Secure
+//   <i> Value for SAU->CTRL register bit ALLNS
+//   <i> When all Memory is Non-Secure (ALLNS is 1), IDAU can override memory map configuration.
+*/
+#define SAU_INIT_CTRL_ALLNS  0
+
+/*
+// </e>
+*/
+
+/*
+// <h>Initialize Security Attribution Unit (SAU) Address Regions
+// <i>SAU configuration specifies regions to be one of:
+// <i> - Secure and Non-Secure Callable
+// <i> - Non-Secure
+// <i>Note: All memory regions not configured by SAU are Secure
+*/
+#define SAU_REGIONS_MAX   8                 /* Max. number of SAU regions */
+
+/*
+//   <e>Initialize SAU Region 0
+//   <i> Setup SAU Region 0 memory attributes
+*/
+#define SAU_INIT_REGION0    1
+
+/*
+//     <s>Description
+*/
+#define SAU_INIT_DSCR0     "NSC code"   /* description SAU region 0 */
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START0     0x00000000      /* start address of SAU region 0 */
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END0       0x001FFFFF      /* end address of SAU region 0 */
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC0       1
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 1
+//   <i> Setup SAU Region 1 memory attributes
+*/
+#define SAU_INIT_REGION1    1
+
+/*
+//     <s>Description
+*/
+#define SAU_INIT_DSCR1     "NS code"   /* description SAU region 1 */
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START1     0x00200000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END1       0x003FFFFF
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC1       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 2
+//   <i> Setup SAU Region 2 memory attributes
+*/
+#define SAU_INIT_REGION2    1
+
+/*
+//     <s>Description
+*/
+#define SAU_INIT_DSCR2     "NS data"   /* description SAU region 2 */
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START2     0x20200000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END2       0x203FFFFF
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC2       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 3
+//   <i> Setup SAU Region 3 memory attributes
+*/
+#define SAU_INIT_REGION3    1
+
+/*
+//     <s>Description
+*/
+#define SAU_INIT_DSCR3     "NS peripherals"   /* description SAU region 3 */
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START3     0x40000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END3       0x40040000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC3       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 4
+//   <i> Setup SAU Region 4 memory attributes
+*/
+#define SAU_INIT_REGION4    0
+
+/*
+//     <s>Description
+*/
+#define SAU_INIT_DSCR4     "SAU region 4"   /* description SAU region 4 */
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START4     0x00000000      /* start address of SAU region 4 */
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END4       0x00000000      /* end address of SAU region 4 */
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC4       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 5
+//   <i> Setup SAU Region 5 memory attributes
+*/
+#define SAU_INIT_REGION5    0
+
+/*
+//     <s>Description
+*/
+#define SAU_INIT_DSCR5     "SAU region 5"   /* description SAU region 5 */
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START5     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END5       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC5       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 6
+//   <i> Setup SAU Region 6 memory attributes
+*/
+#define SAU_INIT_REGION6    0
+
+/*
+//     <s>Description
+*/
+#define SAU_INIT_DSCR6     "SAU region 6"   /* description SAU region 6 */
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START6     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END6       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC6       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 7
+//   <i> Setup SAU Region 7 memory attributes
+*/
+#define SAU_INIT_REGION7    0
+
+/*
+//     <s>Description
+*/
+#define SAU_INIT_DSCR7     "SAU region 7"   /* description SAU region 7 */
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START7     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END7       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC7       0
+/*
+//   </e>
+*/
+
+/*
+// </h>
+*/
+
+/*
+// <e>Setup behaviour of Sleep and Exception Handling
+*/
+#define SCB_CSR_AIRCR_INIT  1
+
+/*
+//   <o> Deep Sleep can be enabled by
+//     <0=>Secure and Non-Secure state
+//     <1=>Secure state only
+//   <i> Value for SCB->CSR register bit DEEPSLEEPS
+*/
+#define SCB_CSR_DEEPSLEEPS_VAL  1
+
+/*
+//   <o>System reset request accessible from
+//     <0=> Secure and Non-Secure state
+//     <1=> Secure state only
+//   <i> Value for SCB->AIRCR register bit SYSRESETREQS
+*/
+#define SCB_AIRCR_SYSRESETREQS_VAL  1
+
+/*
+//   <o>Priority of Non-Secure exceptions is
+//     <0=> Not altered
+//     <1=> Lowered to 0x80-0xFF
+//   <i> Value for SCB->AIRCR register bit PRIS
+*/
+#define SCB_AIRCR_PRIS_VAL      1
+
+/*
+//   <o>BusFault, HardFault, and NMI target
+//     <0=> Secure state
+//     <1=> Non-Secure state
+//   <i> Value for SCB->AIRCR register bit BFHFNMINS
+*/
+#define SCB_AIRCR_BFHFNMINS_VAL 0
+
+/*
+// </e>
+*/
+
+/*
+// <e>Setup behaviour of Floating Point and Vector Unit (FPU/MVE)
+*/
+#define TZ_FPU_NS_USAGE 1
+
+/*
+// <o>Floating Point and Vector Unit usage
+//     <0=> Secure state only
+//     <3=> Secure and Non-Secure state
+//   <i> Value for SCB->NSACR register bits CP10, CP11
+*/
+#define SCB_NSACR_CP10_11_VAL       3
+
+/*
+// <o>Treat floating-point registers as Secure
+//     <0=> Disabled
+//     <1=> Enabled
+//   <i> Value for FPU->FPCCR register bit TS
+*/
+#define FPU_FPCCR_TS_VAL            0
+
+/*
+// <o>Clear on return (CLRONRET) accessibility
+//     <0=> Secure and Non-Secure state
+//     <1=> Secure state only
+//   <i> Value for FPU->FPCCR register bit CLRONRETS
+*/
+#define FPU_FPCCR_CLRONRETS_VAL     0
+
+/*
+// <o>Clear floating-point caller saved registers on exception return
+//     <0=> Disabled
+//     <1=> Enabled
+//   <i> Value for FPU->FPCCR register bit CLRONRET
+*/
+#define FPU_FPCCR_CLRONRET_VAL      1
+
+/*
+// </e>
+*/
+
+/*
+// <h>Setup Interrupt Target
+*/
+
+/*
+//   <e>Initialize ITNS 0 (Interrupts 0..31)
+*/
+#define NVIC_INIT_ITNS0    0
+
+/*
+// Interrupts 0..31
+//   <o.0>  Interrupt 0   <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 1   <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 2   <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 3   <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 4   <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 5   <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 6   <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 7   <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 8   <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 9   <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 10  <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 11  <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 12  <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 13  <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 14  <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 15  <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 16  <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 17  <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 18  <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 19  <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 20  <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 21  <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 22  <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 23  <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 24  <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 25  <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 26  <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 27  <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 28  <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 29  <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 30  <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 31  <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS0_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 1 (Interrupts 32..63)
+*/
+#define NVIC_INIT_ITNS1    0
+
+/*
+// Interrupts 32..63
+//   <o.0>  Interrupt 32  <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 33  <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 34  <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 35  <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 36  <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 37  <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 38  <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 39  <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 40  <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 41  <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 42  <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 43  <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 44  <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 45  <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 46  <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 47  <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 48  <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 49  <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 50  <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 51  <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 52  <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 53  <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 54  <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 55  <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 56  <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 57  <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 58  <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 59  <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 60  <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 61  <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 62  <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 63  <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS1_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 2 (Interrupts 64..95)
+*/
+#define NVIC_INIT_ITNS2    0
+
+/*
+// Interrupts 64..95
+//   <o.0>  Interrupt 64  <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 65  <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 66  <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 67  <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 68  <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 69  <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 70  <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 71  <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 72  <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 73  <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 74  <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 75  <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 76  <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 77  <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 78  <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 79  <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 80  <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 81  <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 82  <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 83  <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 84  <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 85  <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 86  <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 87  <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 88  <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 89  <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 90  <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 91  <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 92  <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 93  <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 94  <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 95  <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS2_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 3 (Interrupts 96..127)
+*/
+#define NVIC_INIT_ITNS3    0
+
+/*
+// Interrupts 96..127
+//   <o.0>  Interrupt 96  <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 97  <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 98  <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 99  <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 100 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 101 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 102 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 103 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 104 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 105 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 106 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 107 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 108 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 109 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 110 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 111 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 112 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 113 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 114 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 115 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 116 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 117 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 118 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 119 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 120 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 121 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 122 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 123 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 124 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 125 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 126 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 127 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS3_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 4 (Interrupts 128..159)
+*/
+#define NVIC_INIT_ITNS4    0
+
+/*
+// Interrupts 128..159
+//   <o.0>  Interrupt 128 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 129 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 130 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 131 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 132 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 133 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 134 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 135 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 136 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 137 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 138 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 139 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 140 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 141 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 142 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 143 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 144 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 145 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 146 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 147 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 148 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 149 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 150 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 151 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 152 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 153 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 154 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 155 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 156 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 157 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 158 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 159 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS4_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 5 (Interrupts 160..191)
+*/
+#define NVIC_INIT_ITNS5    0
+
+/*
+// Interrupts 160..191
+//   <o.0>  Interrupt 160 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 161 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 162 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 163 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 164 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 165 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 166 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 167 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 168 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 169 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 170 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 171 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 172 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 173 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 174 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 175 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 176 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 177 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 178 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 179 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 180 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 181 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 182 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 183 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 184 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 185 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 186 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 187 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 188 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 189 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 190 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 191 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS5_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 6 (Interrupts 192..223)
+*/
+#define NVIC_INIT_ITNS6    0
+
+/*
+// Interrupts 192..223
+//   <o.0>  Interrupt 192 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 193 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 194 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 195 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 196 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 197 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 198 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 199 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 200 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 201 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 202 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 203 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 204 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 205 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 206 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 207 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 208 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 209 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 210 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 211 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 212 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 213 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 214 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 215 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 216 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 217 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 218 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 219 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 220 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 221 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 222 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 223 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS6_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 7 (Interrupts 224..255)
+*/
+#define NVIC_INIT_ITNS7    0
+
+/*
+// Interrupts 224..255
+//   <o.0>  Interrupt 224 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 225 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 226 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 227 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 228 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 229 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 230 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 231 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 232 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 233 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 234 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 235 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 236 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 237 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 238 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 239 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 240 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 241 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 242 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 243 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 244 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 245 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 246 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 247 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 248 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 249 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 250 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 251 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 252 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 253 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 254 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 255 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS7_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 8 (Interrupts 256..287)
+*/
+#define NVIC_INIT_ITNS8    0
+
+/*
+// Interrupts 256..287
+//   <o.0>  Interrupt 256 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 257 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 258 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 259 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 260 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 261 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 262 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 263 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 264 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 265 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 266 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 267 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 268 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 269 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 270 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 271 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 272 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 273 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 274 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 275 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 276 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 277 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 278 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 279 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 280 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 281 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 282 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 283 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 284 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 285 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 286 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 287 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS8_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 9 (Interrupts 288..319)
+*/
+#define NVIC_INIT_ITNS9    0
+
+/*
+// Interrupts 288..319
+//   <o.0>  Interrupt 288 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 289 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 290 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 291 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 292 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 293 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 294 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 295 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 296 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 297 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 298 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 299 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 300 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 301 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 302 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 303 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 304 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 305 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 306 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 307 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 308 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 309 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 310 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 311 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 312 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 313 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 314 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 315 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 316 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 317 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 318 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 319 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS9_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 10 (Interrupts 320..351)
+*/
+#define NVIC_INIT_ITNS10   0
+
+/*
+// Interrupts 320..351
+//   <o.0>  Interrupt 320 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 321 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 322 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 323 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 324 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 325 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 326 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 327 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 328 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 329 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 330 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 331 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 332 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 333 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 334 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 335 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 336 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 337 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 338 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 339 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 340 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 341 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 342 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 343 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 344 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 345 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 346 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 347 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 348 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 349 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 350 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 351 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS10_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 11 (Interrupts 352..383)
+*/
+#define NVIC_INIT_ITNS11   0
+
+/*
+// Interrupts 352..383
+//   <o.0>  Interrupt 352 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 353 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 354 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 355 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 356 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 357 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 358 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 359 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 360 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 361 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 362 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 363 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 364 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 365 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 366 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 367 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 368 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 369 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 370 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 371 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 372 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 373 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 374 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 375 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 376 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 377 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 378 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 379 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 380 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 381 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 382 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 383 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS11_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 12 (Interrupts 384..415)
+*/
+#define NVIC_INIT_ITNS12   0
+
+/*
+// Interrupts 384..415
+//   <o.0>  Interrupt 384 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 385 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 386 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 387 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 388 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 389 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 390 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 391 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 392 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 393 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 394 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 395 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 396 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 397 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 398 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 399 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 400 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 401 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 402 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 403 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 404 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 405 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 406 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 407 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 408 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 409 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 410 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 411 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 412 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 413 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 414 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 415 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS12_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 13 (Interrupts 416..447)
+*/
+#define NVIC_INIT_ITNS13   0
+
+/*
+// Interrupts 416..447
+//   <o.0>  Interrupt 416 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 417 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 418 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 419 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 420 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 421 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 422 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 423 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 424 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 425 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 426 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 427 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 428 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 429 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 430 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 431 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 432 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 433 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 434 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 435 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 436 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 437 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 438 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 439 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 440 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 441 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 442 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 443 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 444 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 445 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 446 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 447 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS13_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 14 (Interrupts 448..479)
+*/
+#define NVIC_INIT_ITNS14   0
+
+/*
+// Interrupts 448..479
+//   <o.0>  Interrupt 448 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 449 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 450 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 451 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 452 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 453 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 454 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 455 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 456 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 457 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 458 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 459 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 460 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 461 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 462 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 463 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 464 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 465 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 466 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 467 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 468 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 469 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 470 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 471 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 472 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 473 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 474 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 475 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 476 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 477 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 478 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 479 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS14_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 15 (Interrupts 480..511)
+*/
+#define NVIC_INIT_ITNS15   0
+
+/*
+// Interrupts 480..511
+//   <o.0>  Interrupt 480 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 481 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 482 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 483 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 484 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 485 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 486 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 487 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 488 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 489 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 490 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 491 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 492 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 493 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 494 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 495 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 496 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 497 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 498 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 499 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 500 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 501 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 502 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 503 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 504 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 505 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 506 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 507 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 508 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 509 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 510 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 511 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS15_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+// </h>
+*/
+
+
+
+/*
+    max 128 SAU regions.
+    SAU regions are defined in partition.h
+ */
+
+#define SAU_INIT_REGION(n) \
+    SAU->RNR  =  (n                                     & SAU_RNR_REGION_Msk); \
+    SAU->RBAR =  (SAU_INIT_START##n                     & SAU_RBAR_BADDR_Msk); \
+    SAU->RLAR =  (SAU_INIT_END##n                       & SAU_RLAR_LADDR_Msk) | \
+                ((SAU_INIT_NSC##n << SAU_RLAR_NSC_Pos)  & SAU_RLAR_NSC_Msk)   | 1U
+
+/**
+  \brief   Setup a SAU Region
+  \details Writes the region information contained in SAU_Region to the
+           registers SAU_RNR, SAU_RBAR, and SAU_RLAR
+ */
+__STATIC_INLINE void TZ_SAU_Setup (void)
+{
+
+#if defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U)
+
+  #if defined (SAU_INIT_REGION0) && (SAU_INIT_REGION0 == 1U)
+    SAU_INIT_REGION(0);
+  #endif
+
+  #if defined (SAU_INIT_REGION1) && (SAU_INIT_REGION1 == 1U)
+    SAU_INIT_REGION(1);
+  #endif
+
+  #if defined (SAU_INIT_REGION2) && (SAU_INIT_REGION2 == 1U)
+    SAU_INIT_REGION(2);
+  #endif
+
+  #if defined (SAU_INIT_REGION3) && (SAU_INIT_REGION3 == 1U)
+    SAU_INIT_REGION(3);
+  #endif
+
+  #if defined (SAU_INIT_REGION4) && (SAU_INIT_REGION4 == 1U)
+    SAU_INIT_REGION(4);
+  #endif
+
+  #if defined (SAU_INIT_REGION5) && (SAU_INIT_REGION5 == 1U)
+    SAU_INIT_REGION(5);
+  #endif
+
+  #if defined (SAU_INIT_REGION6) && (SAU_INIT_REGION6 == 1U)
+    SAU_INIT_REGION(6);
+  #endif
+
+  #if defined (SAU_INIT_REGION7) && (SAU_INIT_REGION7 == 1U)
+    SAU_INIT_REGION(7);
+  #endif
+
+  /* repeat this for all possible SAU regions */
+
+#endif /* defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U) */
+
+
+  #if defined (SAU_INIT_CTRL) && (SAU_INIT_CTRL == 1U)
+    SAU->CTRL = ((SAU_INIT_CTRL_ENABLE << SAU_CTRL_ENABLE_Pos) & SAU_CTRL_ENABLE_Msk) |
+                ((SAU_INIT_CTRL_ALLNS  << SAU_CTRL_ALLNS_Pos)  & SAU_CTRL_ALLNS_Msk)   ;
+  #endif
+
+  #if defined (SCB_CSR_AIRCR_INIT) && (SCB_CSR_AIRCR_INIT == 1U)
+    SCB->SCR   = (SCB->SCR   & ~(SCB_SCR_SLEEPDEEPS_Msk    )) |
+                   ((SCB_CSR_DEEPSLEEPS_VAL     << SCB_SCR_SLEEPDEEPS_Pos)     & SCB_SCR_SLEEPDEEPS_Msk);
+
+    SCB->AIRCR = (SCB->AIRCR & ~(SCB_AIRCR_VECTKEY_Msk   | SCB_AIRCR_SYSRESETREQS_Msk |
+                                 SCB_AIRCR_BFHFNMINS_Msk | SCB_AIRCR_PRIS_Msk          ))                    |
+                   ((0x05FAU                    << SCB_AIRCR_VECTKEY_Pos)      & SCB_AIRCR_VECTKEY_Msk)      |
+                   ((SCB_AIRCR_SYSRESETREQS_VAL << SCB_AIRCR_SYSRESETREQS_Pos) & SCB_AIRCR_SYSRESETREQS_Msk) |
+                   ((SCB_AIRCR_PRIS_VAL         << SCB_AIRCR_PRIS_Pos)         & SCB_AIRCR_PRIS_Msk)         |
+                   ((SCB_AIRCR_BFHFNMINS_VAL    << SCB_AIRCR_BFHFNMINS_Pos)    & SCB_AIRCR_BFHFNMINS_Msk);
+  #endif /* defined (SCB_CSR_AIRCR_INIT) && (SCB_CSR_AIRCR_INIT == 1U) */
+
+  #if (((defined (__FPU_USED) && (__FPU_USED == 1U))              || \
+        (defined (__ARM_FEATURE_MVE) && (__ARM_FEATURE_MVE > 0))) && \
+       (defined (TZ_FPU_NS_USAGE) && (TZ_FPU_NS_USAGE == 1U)))
+
+    SCB->NSACR = (SCB->NSACR & ~(SCB_NSACR_CP10_Msk | SCB_NSACR_CP11_Msk)) |
+                   ((SCB_NSACR_CP10_11_VAL << SCB_NSACR_CP10_Pos) & (SCB_NSACR_CP10_Msk | SCB_NSACR_CP11_Msk));
+
+    FPU->FPCCR = (FPU->FPCCR & ~(FPU_FPCCR_TS_Msk | FPU_FPCCR_CLRONRETS_Msk | FPU_FPCCR_CLRONRET_Msk)) |
+                   ((FPU_FPCCR_TS_VAL        << FPU_FPCCR_TS_Pos       ) & FPU_FPCCR_TS_Msk       ) |
+                   ((FPU_FPCCR_CLRONRETS_VAL << FPU_FPCCR_CLRONRETS_Pos) & FPU_FPCCR_CLRONRETS_Msk) |
+                   ((FPU_FPCCR_CLRONRET_VAL  << FPU_FPCCR_CLRONRET_Pos ) & FPU_FPCCR_CLRONRET_Msk );
+  #endif
+
+  #if defined (NVIC_INIT_ITNS0) && (NVIC_INIT_ITNS0 == 1U)
+    NVIC->ITNS[0] = NVIC_INIT_ITNS0_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS1) && (NVIC_INIT_ITNS1 == 1U)
+    NVIC->ITNS[1] = NVIC_INIT_ITNS1_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS2) && (NVIC_INIT_ITNS2 == 1U)
+    NVIC->ITNS[2] = NVIC_INIT_ITNS2_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS3) && (NVIC_INIT_ITNS3 == 1U)
+    NVIC->ITNS[3] = NVIC_INIT_ITNS3_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS4) && (NVIC_INIT_ITNS4 == 1U)
+    NVIC->ITNS[4] = NVIC_INIT_ITNS4_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS5) && (NVIC_INIT_ITNS5 == 1U)
+    NVIC->ITNS[5] = NVIC_INIT_ITNS5_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS6) && (NVIC_INIT_ITNS6 == 1U)
+    NVIC->ITNS[6] = NVIC_INIT_ITNS6_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS7) && (NVIC_INIT_ITNS7 == 1U)
+    NVIC->ITNS[7] = NVIC_INIT_ITNS7_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS8) && (NVIC_INIT_ITNS8 == 1U)
+    NVIC->ITNS[8] = NVIC_INIT_ITNS8_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS9) && (NVIC_INIT_ITNS9 == 1U)
+    NVIC->ITNS[9] = NVIC_INIT_ITNS9_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS10) && (NVIC_INIT_ITNS10 == 1U)
+    NVIC->ITNS[10] = NVIC_INIT_ITNS10_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS11) && (NVIC_INIT_ITNS11 == 1U)
+    NVIC->ITNS[11] = NVIC_INIT_ITNS11_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS12) && (NVIC_INIT_ITNS12 == 1U)
+    NVIC->ITNS[12] = NVIC_INIT_ITNS12_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS13) && (NVIC_INIT_ITNS13 == 1U)
+    NVIC->ITNS[13] = NVIC_INIT_ITNS13_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS14) && (NVIC_INIT_ITNS14 == 1U)
+    NVIC->ITNS[14] = NVIC_INIT_ITNS14_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS15) && (NVIC_INIT_ITNS15 == 1U)
+    NVIC->ITNS[15] = NVIC_INIT_ITNS15_VAL;
+  #endif
+
+  /* repeat this for all possible ITNS elements */
+
+}
+
+#endif  /* PARTITION_ARMCM85_H */

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85S/RTE/Device/ARMCM85/regions_ARMCM85.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85S/RTE/Device/ARMCM85/regions_ARMCM85.h
@@ -1,0 +1,94 @@
+#ifndef REGIONS_ARMCM85_H
+#define REGIONS_ARMCM85_H
+
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+// <n>Device pack:   ARM::Cortex_DFP@1.0.0-dev16
+// <i>Device pack used to generate this file
+
+// <h>ROM Configuration
+// =======================
+// <h> ROM_S=<__ROM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x00000000
+#define __ROM0_BASE 0x00000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00200000
+#define __ROM0_SIZE 0x00200000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __ROM0_DEFAULT 1
+//   <q>Startup
+//   <i> Selects region to be used for startup code.
+#define __ROM0_STARTUP 1
+// </h>
+
+// <h> ROM_NS=<__ROM1>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x00200000
+#define __ROM1_BASE 0x00200000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00200000
+#define __ROM1_SIZE 0x00200000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __ROM1_DEFAULT 0
+//   <q>Startup
+//   <i> Selects region to be used for startup code.
+#define __ROM1_STARTUP 0
+// </h>
+
+// </h>
+
+// <h>RAM Configuration
+// =======================
+// <h> RAM_S=<__RAM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x20000000
+#define __RAM0_BASE 0x20000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00020000
+#define __RAM0_SIZE 0x00020000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __RAM0_DEFAULT 1
+//   <q>No zero initialize
+//   <i> Excludes region from zero initialization.
+#define __RAM0_NOINIT 0
+// </h>
+
+// <h> RAM_NS=<__RAM1>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x20200000
+#define __RAM1_BASE 0x20200000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00020000
+#define __RAM1_SIZE 0x00020000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __RAM1_DEFAULT 0
+//   <q>No zero initialize
+//   <i> Excludes region from zero initialization.
+#define __RAM1_NOINIT 0
+// </h>
+
+// </h>
+
+// <h>Stack / Heap Configuration
+//   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+#define __STACK_SIZE 0x00000400
+#define __HEAP_SIZE 0x00000C00
+// </h>
+
+
+#endif /* REGIONS_ARMCM85_H */

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85S/RTE/Device/ARMCM85/startup_ARMCM85.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85S/RTE/Device/ARMCM85/startup_ARMCM85.c
@@ -1,0 +1,164 @@
+/******************************************************************************
+ * @file     startup_ARMCM85.c
+ * @brief    CMSIS Device Startup File for ARMCM85 Device
+ * @version  V1.0.0
+ * @date     07. February 2022
+ ******************************************************************************/
+/*
+ * Copyright (c) 2022 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (ARMCM85)
+  #include "ARMCM85.h"
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  External References
+ *----------------------------------------------------------------------------*/
+extern uint32_t __INITIAL_SP;
+extern uint32_t __STACK_LIMIT;
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+extern uint32_t __STACK_SEAL;
+#endif
+
+extern __NO_RETURN void __PROGRAM_START(void);
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler  (void);
+            void Default_Handler(void);
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+/* Exceptions */
+void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void HardFault_Handler      (void) __attribute__ ((weak));
+void MemManage_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
+void BusFault_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void UsageFault_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void SecureFault_Handler    (void) __attribute__ ((weak, alias("Default_Handler")));
+void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void DebugMon_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+
+void Interrupt0_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt1_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt2_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt3_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt4_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt5_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt6_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt7_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt8_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void Interrupt9_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[496];
+       const VECTOR_TABLE_Type __VECTOR_TABLE[496] __VECTOR_TABLE_ATTRIBUTE = {
+  (VECTOR_TABLE_Type)(&__INITIAL_SP),       /*     Initial Stack Pointer */
+  Reset_Handler,                            /*     Reset Handler */
+  NMI_Handler,                              /* -14 NMI Handler */
+  HardFault_Handler,                        /* -13 Hard Fault Handler */
+  MemManage_Handler,                        /* -12 MPU Fault Handler */
+  BusFault_Handler,                         /* -11 Bus Fault Handler */
+  UsageFault_Handler,                       /* -10 Usage Fault Handler */
+  SecureFault_Handler,                      /*  -9 Secure Fault Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  SVC_Handler,                              /*  -5 SVC Handler */
+  DebugMon_Handler,                         /*  -4 Debug Monitor Handler */
+  0,                                        /*     Reserved */
+  PendSV_Handler,                           /*  -2 PendSV Handler */
+  SysTick_Handler,                          /*  -1 SysTick Handler */
+
+  /* Interrupts */
+  Interrupt0_Handler,                       /*   0 Interrupt 0 */
+  Interrupt1_Handler,                       /*   1 Interrupt 1 */
+  Interrupt2_Handler,                       /*   2 Interrupt 2 */
+  Interrupt3_Handler,                       /*   3 Interrupt 3 */
+  Interrupt4_Handler,                       /*   4 Interrupt 4 */
+  Interrupt5_Handler,                       /*   5 Interrupt 5 */
+  Interrupt6_Handler,                       /*   6 Interrupt 6 */
+  Interrupt7_Handler,                       /*   7 Interrupt 7 */
+  Interrupt8_Handler,                       /*   8 Interrupt 8 */
+  Interrupt9_Handler                        /*   9 Interrupt 9 */
+                                            /* Interrupts 10 .. 480 are left out */
+};
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler(void)
+{
+  __set_PSP((uint32_t)(&__INITIAL_SP));
+
+  __set_MSPLIM((uint32_t)(&__STACK_LIMIT));
+  __set_PSPLIM((uint32_t)(&__STACK_LIMIT));
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  __TZ_set_STACKSEAL_S((uint32_t *)(&__STACK_SEAL));
+#endif
+
+  SystemInit();                             /* CMSIS System Initialization */
+  __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
+}
+
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wmissing-noreturn"
+#endif
+
+/*----------------------------------------------------------------------------
+  Hard Fault Handler
+ *----------------------------------------------------------------------------*/
+void HardFault_Handler(void)
+{
+  while(1);
+}
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+void Default_Handler(void)
+{
+  while(1);
+}
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic pop
+#endif
+

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85S/RTE/Device/ARMCM85/system_ARMCM85.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85S/RTE/Device/ARMCM85/system_ARMCM85.c
@@ -1,0 +1,106 @@
+/**************************************************************************//**
+ * @file     system_ARMCM85.c
+ * @brief    CMSIS Device System Source File for ARMCM85 Device
+ * @version  V1.0.0
+ * @date     30. March 2022
+ ******************************************************************************/
+/*
+ * Copyright (c) 2022 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (ARMCM85)
+  #include "ARMCM85.h"
+
+  #if defined (__ARM_FEATURE_CMSE) &&  (__ARM_FEATURE_CMSE == 3U)
+    #include "partition_ARMCM85.h"
+  #endif
+#else
+  #error device not specified!
+#endif
+
+
+/*----------------------------------------------------------------------------
+  Define clocks
+ *----------------------------------------------------------------------------*/
+#define  XTAL            (50000000UL)     /* Oscillator frequency */
+
+#define  SYSTEM_CLOCK    (XTAL / 2U)
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[496];
+
+/*----------------------------------------------------------------------------
+  System Core Clock Variable
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = SYSTEM_CLOCK;  /* System Core Clock Frequency */
+
+/*----------------------------------------------------------------------------
+  System Core Clock update function
+ *----------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)
+{
+  SystemCoreClock = SYSTEM_CLOCK;
+}
+
+/*----------------------------------------------------------------------------
+  System initialization function
+ *----------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t)(&__VECTOR_TABLE[0]);
+#endif
+
+  /* Set CPDLPSTATE.RLPSTATE to 0
+     Set CPDLPSTATE.ELPSTATE to 0, to stop the processor from trying to switch the EPU into retention state.
+     Set CPDLPSTATE.CLPSTATE to 0, so PDCORE will not enter low-power state. */
+  PWRMODCTL->CPDLPSTATE &= ~(PWRMODCTL_CPDLPSTATE_RLPSTATE_Msk |
+                             PWRMODCTL_CPDLPSTATE_ELPSTATE_Msk |
+                             PWRMODCTL_CPDLPSTATE_CLPSTATE_Msk  );
+
+#if (defined (__FPU_USED) && (__FPU_USED == 1U)) || \
+    (defined (__ARM_FEATURE_MVE) && (__ARM_FEATURE_MVE > 0U))
+  SCB->CPACR |= ((3U << 10U*2U) |           /* enable CP10 Full Access */
+                 (3U << 11U*2U)  );         /* enable CP11 Full Access */
+
+  /* Favor best FP/MVE performance by default, avoid EPU switch-ON delays */
+  /* PDEPU ON, Clock OFF */
+  PWRMODCTL->CPDLPSTATE |= 0x1 << PWRMODCTL_CPDLPSTATE_ELPSTATE_Pos;
+#endif
+
+#ifdef UNALIGNED_SUPPORT_DISABLE
+  SCB->CCR |= SCB_CCR_UNALIGN_TRP_Msk;
+#endif
+
+  /* Enable Loop and branch info cache */
+  SCB->CCR |= SCB_CCR_LOB_Msk;
+
+  /* Enable Branch Prediction */
+  SCB->CCR |= SCB_CCR_BP_Msk;
+
+  __DSB();
+  __ISB();
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  TZ_SAU_Setup();
+#endif
+
+  SystemCoreClock = SYSTEM_CLOCK;
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85S/Target.clayer.yml
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85S/Target.clayer.yml
@@ -1,0 +1,35 @@
+layer:
+  type: Target
+  description: CM85S target components and files
+
+  packs:
+    - pack: ARM::Cortex_DFP
+
+  device: ARMCM85
+
+  processor:
+    trustzone: secure
+
+  components:
+    # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
+    - component: ARM::CMSIS:CORE
+    - component: Device:Startup&C Startup
+
+  groups:
+    - group: FVP
+      files:
+        - file: ./model_config.txt
+
+  linker:
+    - for-compiler: AC6
+      script: RTE/Device/$Dname$/ac6_linker_script.sct
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: GCC
+      script: RTE/Device/$Dname$/gcc_linker_script.ld
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: CLANG
+      script: RTE/Device/$Dname$/clang_linker_script.ld
+      regions: RTE/Device/$Dname$/regions_$Dname$.h
+    - for-compiler: IAR
+      script: RTE/Device/$Dname$/iar_linker_script.icf
+      regions: RTE/Device/$Dname$/regions_$Dname$.h

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85S/model_config.txt
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Layer/Target/CM85S/model_config.txt
@@ -1,0 +1,30 @@
+# Parameters:
+# instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+#----------------------------------------------------------------------------------------------
+fvp_mps2.mps2_visualisation.disable-visualisation=1   # (bool  , init-time) default = '0'      : Enable/disable visualisation
+fvp_mps2.DISABLE_GATING=1                             # (bool  , init-time) default = '0'      : Disable Memory gating logic
+cpu0.FPU=1                                            # (bool  , init-time) default = '1'      : Set whether the model has VFP support
+cpu0.MVE=1                                            # (int   , init-time) default = '0x1'    : Set whether the model has MVE support. If FPU = 0: 0=MVE not included, 1=Integer subset of MVE included. If FPU = 1: 0=MVE not included, 1=Integer subset of MVE included, 2=Integer and half and single precision floating point MVE included
+cpu0.ID_ISAR5.PACBTI=1                                # (int   , init-time) default = '0x0'    : 0: PAC/BTI not implemented, 1: PAC implemented using the QARMA5 algorithm with BTI, 2: PAC implemented using an IMP DEF algorithm with BTI, 4: PAC implemented using the QARMA3 algorithm with BTI
+cpu0.semihosting-enable=1                             # (bool  , init-time) default = '1'      : Enable semihosting SVC traps. Applications that do not use semihosting must set this parameter to false.
+cpu0.semihosting-Thumb_SVC=0xAB                       # (int   , init-time) default = '0xAB'   : T32 SVC number for semihosting : [0x0..0xFF]
+cpu0.semihosting-cmd_line=""                          # (string, init-time) default = ''       : Command line available to semihosting SVC calls
+cpu0.semihosting-heap_base=0x0                        # (int   , init-time) default = '0x0'    : Virtual address of heap base : [0x0..0xFFFFFFFF]
+cpu0.semihosting-heap_limit=0x0                       # (int   , init-time) default = '0x10700000' : Virtual address of top of heap : [0x0..0xFFFFFFFF]
+cpu0.semihosting-stack_base=0x0                       # (int   , init-time) default = '0x10700000' : Virtual address of base of descending stack : [0x0..0xFFFFFFFF]
+cpu0.semihosting-stack_limit=0x0                      # (int   , init-time) default = '0x10800000' : Virtual address of stack limit : [0x0..0xFFFFFFFF]
+cpu0.semihosting-cwd=""                               # (string, init-time) default = ''       : Base directory for semihosting file access.
+cpu0.MPU_S=0x8                                        # (int   , init-time) default = '0x8'    : Number of regions in the Secure MPU. If Security Extentions are absent, this is ignored : [0x0..0x10]
+cpu0.MPU_NS=0x8                                       # (int   , init-time) default = '0x8'    : Number of regions in the Non-Secure MPU. If Security Extentions are absent, this is the total number of MPU regions : [0x0..0x10]
+cpu0.ITM=0                                            # (bool  , init-time) default = '1'      : Level of instrumentation trace supported. false : No ITM trace included, true: ITM trace included
+cpu0.IRQLVL=0x3                                       # (int   , init-time) default = '0x3'    : Number of bits of interrupt priority : [0x3..0x8]
+cpu0.INITSVTOR=0x00000000                             # (int   , init-time) default = '0x10000000' : Secure vector-table offset at reset : [0x0..0xFFFFFF80]
+cpu0.INITNSVTOR=0x0                                   # (int   , init-time) default = '0x0'    : Non-Secure vector-table offset at reset : [0x0..0xFFFFFF80]
+cpu0.SAU=0x8                                          # (int   , init-time) default = '0x4'    : Number of SAU regions (0 => no SAU) : [0x0..0x8]
+idau.NUM_IDAU_REGION=0x0                              # (int   , init-time) default = '0xA'    : 
+cpu0.LOCK_SAU=0                                       # (bool  , init-time) default = '0'      : Lock down of SAU registers write
+cpu0.LOCK_S_MPU=0                                     # (bool  , init-time) default = '0'      : Lock down of Secure MPU registers write
+cpu0.LOCK_NS_MPU=0                                    # (bool  , init-time) default = '0'      : Lock down of Non-Secure MPU registers write
+cpu0.CPIF=1                                           # (bool  , init-time) default = '1'      : Specifies whether the external coprocessor interface is included
+cpu0.SECEXT=1                                         # (bool  , init-time) default = '1'      : Whether the ARMv8-M Security Extensions are included
+#----------------------------------------------------------------------------------------------

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Project/Bootloader.cproject.yml
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Project/Bootloader.cproject.yml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.5.0/tools/projmgr/schemas/cproject.schema.json
+
+project:
+  layers:
+    - layer: ../Layer/App/Bootloader_Cortex-M/App.clayer.yml
+
+    - layer: ../Layer/Target/CM23S/Target.clayer.yml
+      for-context:
+        - +CM23NS
+
+    - layer: ../Layer/Target/CM33S/Target.clayer.yml
+      for-context:
+        - +CM33NS
+
+    - layer: ../Layer/Target/CM35PS/Target.clayer.yml
+      for-context:
+        - +CM35PNS
+
+    - layer: ../Layer/Target/CM55S/Target.clayer.yml
+      for-context:
+        - +CM55NS
+
+    - layer: ../Layer/Target/CM85S/Target.clayer.yml
+      for-context:
+        - +CM85NS

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Project/Validation.cproject.yml
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Project/Validation.cproject.yml
@@ -1,0 +1,147 @@
+project:
+  layers:
+    # App: CMSIS-Core Validation for Cortex-M
+    - layer: ../Layer/App/Validation_Cortex-M/App.clayer.yml
+      for-context:
+        - +CM0
+        - +CM0plus
+        - +CM3
+        - +CM4
+        - +CM7
+        - +CM23
+        - +CM23S
+        - +CM23NS
+        - +CM33
+        - +CM33S
+        - +CM33NS
+        - +CM35P
+        - +CM35PS
+        - +CM35PNS
+        - +CM55
+        - +CM55S
+        - +CM55NS
+        - +CM85
+        - +CM85S
+        - +CM85NS
+
+    # App: CMSIS-Core Validation for Cortex-A
+    - layer: ../Layer/App/Validation_Cortex-A/App.clayer.yml
+      for-context:
+        - +CA5
+        - +CA7
+        - +CA9
+
+    #Target: CM0
+    - layer: ../Layer/Target/CM0/Target.clayer.yml
+      for-context:
+        - +CM0
+
+    #Target: CM0plus
+    - layer: ../Layer/Target/CM0plus/Target.clayer.yml
+      for-context:
+        - +CM0plus
+
+    #Target: CM3
+    - layer: ../Layer/Target/CM3/Target.clayer.yml
+      for-context:
+        - +CM3
+
+    #Target: CM4
+    - layer: ../Layer/Target/CM4/Target.clayer.yml
+      for-context:
+        - +CM4
+
+    #Target: CM7
+    - layer: ../Layer/Target/CM7/Target.clayer.yml
+      for-context:
+        - +CM7
+
+    #Target: CM23
+    - layer: ../Layer/Target/CM23/Target.clayer.yml
+      for-context:
+        - +CM23
+
+    #Target: CM23S
+    - layer: ../Layer/Target/CM23S/Target.clayer.yml
+      for-context:
+        - +CM23S
+
+    #Target: CM23NS
+    - layer: ../Layer/Target/CM23NS/Target.clayer.yml
+      for-context:
+        - +CM23NS
+
+    #Target: CM33
+    - layer: ../Layer/Target/CM33/Target.clayer.yml
+      for-context:
+        - +CM33
+
+    #Target: CM33S
+    - layer: ../Layer/Target/CM33S/Target.clayer.yml
+      for-context:
+        - +CM33S
+
+    #Target: CM33NS
+    - layer: ../Layer/Target/CM33NS/Target.clayer.yml
+      for-context:
+        - +CM33NS
+
+    #Target: CM35P
+    - layer: ../Layer/Target/CM35P/Target.clayer.yml
+      for-context:
+        - +CM35P
+
+    #Target: CM35PS
+    - layer: ../Layer/Target/CM35PS/Target.clayer.yml
+      for-context:
+        - +CM35PS
+
+    #Target: CM35PNS
+    - layer: ../Layer/Target/CM35PNS/Target.clayer.yml
+      for-context:
+        - +CM35PNS
+
+    #Target: CM55
+    - layer: ../Layer/Target/CM55/Target.clayer.yml
+      for-context:
+        - +CM55
+
+    #Target: CM55S
+    - layer: ../Layer/Target/CM55S/Target.clayer.yml
+      for-context:
+        - +CM55S
+
+    #Target: CM55NS
+    - layer: ../Layer/Target/CM55NS/Target.clayer.yml
+      for-context:
+        - +CM55NS
+
+    #Target: CM85
+    - layer: ../Layer/Target/CM85/Target.clayer.yml
+      for-context:
+        - +CM85
+
+    #Target: CM85S
+    - layer: ../Layer/Target/CM85S/Target.clayer.yml
+      for-context:
+        - +CM85S
+
+    #Target: CM85NS
+    - layer: ../Layer/Target/CM85NS/Target.clayer.yml
+      for-context:
+        - +CM85NS
+
+    #Target: CA5
+    - layer: ../Layer/Target/CA5/Target.clayer.yml
+      for-context:
+        - +CA5
+
+    #Target: CA7
+    - layer: ../Layer/Target/CA7/Target.clayer.yml
+      for-context:
+        - +CA7
+
+    #Target: CA9
+    - layer: ../Layer/Target/CA9/Target.clayer.yml
+      for-context:
+        - +CA9

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Project/Validation.csolution.yml
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Project/Validation.csolution.yml
@@ -1,0 +1,115 @@
+solution:
+  created-for: cmsis-toobox@2.1.0
+
+  cdefault:
+
+  misc:
+    - for-compiler: GCC
+      C-CPP:
+        - -masm-syntax-unified
+
+  packs:
+    - pack: ARM::CMSIS
+      path: ../../../
+
+  target-types:
+    #Target: CM0
+    - type: CM0
+
+    #Target: CM0plus
+    - type: CM0plus
+
+    #Target: CM3
+    - type: CM3
+
+    #Target: CM4
+    - type: CM4
+
+    #Target: CM7
+    - type: CM7
+
+    #Target: CM23
+    - type: CM23
+
+    #Target: CM23S
+    - type: CM23S
+
+    #Target: CM23NS
+    - type: CM23NS
+
+    #Target: CM33
+    - type: CM33
+
+    #Target: CM33S
+    - type: CM33S
+
+    #Target: CM33NS
+    - type: CM33NS
+
+    #Target: CM35P
+    - type: CM35P
+
+    #Target: CM35PS
+    - type: CM35PS
+
+    #Target: CM35PNS
+    - type: CM35PNS
+
+    #Target: CM55
+    - type: CM55
+
+    #Target: CM55S
+    - type: CM55S
+
+    #Target: CM55NS
+    - type: CM55NS
+
+    #Target: CM85
+    - type: CM85
+
+    #Target: CM85S
+    - type: CM85S
+
+    #Target: CM85NS
+    - type: CM85NS
+
+    #Target: CA5
+    - type: CA5
+
+    #Target: CA7
+    - type: CA7
+
+    #Target: CA9
+    - type: CA9
+
+  build-types:
+    - type: none
+      optimize: none
+      debug: on
+
+    - type: balanced
+      optimize: balanced
+      debug: on
+
+    - type: size
+      optimize: size
+      debug: on
+
+    - type: speed
+      optimize: speed
+      debug: on
+
+  projects:
+    - project: ./Validation.cproject.yml
+    - project: ./Bootloader.cproject.yml
+      for-context:
+        - +CM23NS
+        - +CM33NS
+        - +CM35PNS
+        - +CM55NS
+        - +CM85NS
+
+  output-dirs:
+    cprjdir: ./build/$TargetType$/$Compiler$/$BuildType$/$Project$
+    intdir:  ./build/$TargetType$/$Compiler$/$BuildType$/$Project$/intdir
+    outdir:  ./build/$TargetType$/$Compiler$/$BuildType$/$Project$/outdir

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Project/build.py
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Project/build.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import logging
+
+from datetime import datetime
+from enum import Enum
+from glob import glob, iglob
+from pathlib import Path
+
+from lxml.etree import XMLSyntaxError
+from zipfile import ZipFile
+
+from matrix_runner import main, matrix_axis, matrix_action, matrix_command, matrix_filter, \
+    ConsoleReport, CropReport, TransformReport, JUnitReport
+
+
+@matrix_axis("device", "d", "Device(s) to be considered.")
+class DeviceAxis(Enum):
+    CM0 = ('Cortex-M0', 'CM0')
+    CM0plus = ('Cortex-M0plus', 'CM0plus')
+    CM3 = ('Cortex-M3', 'CM3')
+    CM4 = ('Cortex-M4', 'CM4')
+    CM7 = ('Cortex-M7', 'CM7')
+    CM23 = ('Cortex-M23', 'CM23')
+    CM23S = ('Cortex-M23S', 'CM23S')
+    CM23NS = ('Cortex-M23NS', 'CM23NS')
+    CM33 = ('Cortex-M33', 'CM33')
+    CM33S = ('Cortex-M33S', 'CM33S')
+    CM33NS = ('Cortex-M33NS', 'CM33NS')
+    CM35P = ('Cortex-M35P', 'CM35P')
+    CM35PS = ('Cortex-M35PS', 'CM35PS')
+    CM35PNS = ('Cortex-M35PNS', 'CM35PNS')
+    CM55 = ('Cortex-M55', 'CM55')
+    CM55S = ('Cortex-M55S', 'CM55S')
+    CM55NS = ('Cortex-M55NS', 'CM55NS')
+    CM85 = ('Cortex-M85', 'CM85')
+    CM85S = ('Cortex-M85S', 'CM85S')
+    CM85NS = ('Cortex-M85NS', 'CM85NS')
+    CA5 = ('Cortex-A5', 'CA5')
+    CA7 = ('Cortex-A7', 'CA7')
+    CA9 = ('Cortex-A9', 'CA9')
+#    CA5NEON = ('Cortex-A5neon', 'CA5neon')
+#    CA7NEON = ('Cortex-A7neon', 'CA7neon')
+#    CA9NEON = ('Cortex-A9neon', 'CA9neon')
+
+    def has_bl(self):
+        return self in [
+            DeviceAxis.CM23NS,
+            DeviceAxis.CM33NS,
+            DeviceAxis.CM35PNS,
+            DeviceAxis.CM55NS,
+            DeviceAxis.CM85NS
+        ]
+
+    @property
+    def bl_device(self):
+        bld = {
+            DeviceAxis.CM23NS: 'CM23S',
+            DeviceAxis.CM33NS: 'CM33S',
+            DeviceAxis.CM35PNS: 'CM35PS',
+            DeviceAxis.CM55NS: 'CM55S',
+            DeviceAxis.CM85NS: 'CM85S'
+        }
+        return bld[self]
+
+
+@matrix_axis("compiler", "c", "Compiler(s) to be considered.")
+class CompilerAxis(Enum):
+    AC6 = ('AC6')
+    GCC = ('GCC')
+    IAR = ('IAR')
+    CLANG = ('Clang')
+
+    @property
+    def image_ext(self):
+        ext = {
+            CompilerAxis.AC6: 'axf',
+            CompilerAxis.GCC: 'elf',
+            CompilerAxis.IAR: 'elf',
+            CompilerAxis.CLANG: 'elf',
+        }
+        return ext[self]
+
+    @property
+    def toolchain(self):
+        ext = {
+            CompilerAxis.AC6: 'AC6',
+            CompilerAxis.GCC: 'GCC',
+            CompilerAxis.IAR: 'IAR',
+            CompilerAxis.CLANG: 'CLANG'
+        }
+        return ext[self]
+
+
+@matrix_axis("optimize", "o", "Optimization level(s) to be considered.")
+class OptimizationAxis(Enum):
+    NONE = ('none')
+    BALANCED = ('balanced')
+    SPEED = ('speed')
+    SIZE = ('size')
+
+
+MODEL_EXECUTABLE = {
+    DeviceAxis.CM0: ("FVP_MPS2_Cortex-M0", []),
+    DeviceAxis.CM0plus: ("FVP_MPS2_Cortex-M0plus", []),
+    DeviceAxis.CM3: ("FVP_MPS2_Cortex-M3", []),
+    DeviceAxis.CM4: ("FVP_MPS2_Cortex-M4", []),
+    DeviceAxis.CM7: ("FVP_MPS2_Cortex-M7", []),
+    DeviceAxis.CM23: ("FVP_MPS2_Cortex-M23", []),
+    DeviceAxis.CM23S: ("FVP_MPS2_Cortex-M23", []),
+    DeviceAxis.CM23NS: ("FVP_MPS2_Cortex-M23", []),
+    DeviceAxis.CM33: ("FVP_MPS2_Cortex-M33", []),
+    DeviceAxis.CM33S: ("FVP_MPS2_Cortex-M33", []),
+    DeviceAxis.CM33NS: ("FVP_MPS2_Cortex-M33", []),
+    DeviceAxis.CM35P: ("FVP_MPS2_Cortex-M35P", []),
+    DeviceAxis.CM35PS: ("FVP_MPS2_Cortex-M35P", []),
+    DeviceAxis.CM35PNS: ("FVP_MPS2_Cortex-M35P", []),
+    DeviceAxis.CM55: ("FVP_MPS2_Cortex-M55", []),
+    DeviceAxis.CM55S: ("FVP_MPS2_Cortex-M55", []),
+    DeviceAxis.CM55NS: ("FVP_MPS2_Cortex-M55", []),
+    DeviceAxis.CM85: ("FVP_MPS2_Cortex-M85", []),
+    DeviceAxis.CM85S: ("FVP_MPS2_Cortex-M85", []),
+    DeviceAxis.CM85NS: ("FVP_MPS2_Cortex-M85", []),
+    DeviceAxis.CA5: ("FVP_VE_Cortex-A5x1", []),
+    DeviceAxis.CA7: ("FVP_VE_Cortex-A7x1", []),
+    DeviceAxis.CA9: ("FVP_VE_Cortex-A9x1", []),
+#    DeviceAxis.CA5NEON: ("_VE_Cortex-A5x1", []),
+#    DeviceAxis.CA7NEON: ("_VE_Cortex-A7x1", []),
+#    DeviceAxis.CA9NEON: ("_VE_Cortex-A9x1", [])
+}
+
+def config_suffix(config, timestamp=True):
+    suffix = f"{config.compiler[0]}-{config.optimize[0]}-{config.device[1]}"
+    if timestamp:
+        suffix += f"-{datetime.now().strftime('%Y%m%d%H%M%S')}"
+    return suffix
+
+
+def project_name(config):
+    return f"Validation.{config.compiler}_{config.optimize}+{config.device[1]}"
+
+
+def bl_project_name(config):
+    return f"Bootloader.{config.compiler}_{config.optimize}+{config.device.bl_device}"
+
+
+def output_dir(config):
+    return f"Validation/outdir"
+
+
+def bl_output_dir(config):
+    return f"Bootloader/outdir"
+
+
+def model_config(config):
+    return f"../Layer/Target/{config.device[1]}/model_config.txt"
+
+
+def build_dir(config):
+    return f"build/{config.device[1]}/{config.compiler.toolchain}/{config.optimize}"
+
+
+@matrix_action
+def clean(config):
+    """Build the selected configurations using CMSIS-Build."""
+    yield cbuild_clean(f"{project_name(config)}/{project_name(config)}.cprj")
+
+
+@matrix_action
+def build(config, results):
+    """Build the selected configurations using CMSIS-Build."""
+
+    logging.info("Compiling Tests...")
+
+    yield cbuild(config)
+
+    if not all(r.success for r in results):
+        return
+
+    file = f"build/CoreValidation-{config_suffix(config)}.zip"
+    logging.info("Archiving build output to %s...", file)
+    with ZipFile(file, "w") as archive:
+        for content in iglob(f"{build_dir(config)}/**/*", recursive=True):
+            if Path(content).is_file():
+                archive.write(content)
+
+
+@matrix_action
+def extract(config):
+    """Extract the latest build archive."""
+    archives = sorted(glob(f"build/CoreValidation-{config_suffix(config, timestamp=False)}-*.zip"), reverse=True)
+    yield unzip(archives[0])
+
+
+@matrix_action
+def run(config, results):
+    """Run the selected configurations."""
+    logging.info("Running Core Validation on Arm model ...")
+    yield model_exec(config)
+
+    try:
+        results[0].test_report.write(f"build/CoreValidation-{config_suffix(config)}.junit")
+    except RuntimeError as ex:
+        if isinstance(ex.__cause__, XMLSyntaxError):
+            logging.error("No valid test report found in model output!")
+        else:
+            logging.exception(ex)
+
+
+@matrix_command()
+def cbuild_clean(project):
+    return ["cbuild", "-c", project]
+
+
+@matrix_command()
+def unzip(archive):
+    return ["bash", "-c", f"unzip {archive}"]
+
+
+@matrix_command()
+def preprocess(infile, outfile):
+    return ["arm-none-eabi-gcc", "-xc", "-E", infile, "-P", "-o", outfile]
+
+
+@matrix_command()
+def cbuild(config):
+    return ["cbuild", "--toolchain", config.compiler.toolchain, "--update-rte", \
+             "--context", f".{config.optimize}+{config.device[1]}", \
+             "Validation.csolution.yml" ]
+
+
+@matrix_command(test_report=ConsoleReport() |
+                            CropReport('<\?xml version="1.0"\?>', '</report>') |
+                            TransformReport('validation.xsl') |
+                            JUnitReport(title=lambda title, result: f"{result.command.config.compiler}."
+                                                                    f"{result.command.config.optimize}."
+                                                                    f"{result.command.config.device}."
+                                                                    f"{title}"))
+def model_exec(config):
+    cmdline = [MODEL_EXECUTABLE[config.device][0], "-q", "--simlimit", 100, "-f", model_config(config)]
+    cmdline += MODEL_EXECUTABLE[config.device][1]
+    cmdline += ["-a", f"{build_dir(config)}/{output_dir(config)}/Validation.{config.compiler.image_ext}"]
+    if config.device.has_bl():
+        cmdline += ["-a", f"{build_dir(config)}/{bl_output_dir(config)}/Bootloader.{config.compiler.image_ext}"]
+    return cmdline
+
+
+@matrix_filter
+def filter_iar(config):
+    return config.compiler == CompilerAxis.IAR
+
+
+if __name__ == "__main__":
+    main()

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Project/requirements.txt
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Project/requirements.txt
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+#
+# Python requirements for build.py script
+#
+python-matrix-runner~=1.0
+lxml~=4.8

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Project/validation.xsl
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Project/validation.xsl
@@ -1,0 +1,42 @@
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <xsl:output method="xml" indent="yes"/>
+    <xsl:template match="/">
+        <testsuites>
+            <xsl:variable name="buildName" select="//report/test/title"/>
+            <xsl:variable name="numberOfTests" select="//report/test/summary/tcnt"/>
+            <xsl:variable name="numberOfExecutes" select="//report/test/summary/exec"/>
+            <xsl:variable name="numberOfPasses" select="//report/test/summary/pass"/>
+            <xsl:variable name="numberOfFailures" select="//report/test/summary/fail"/>
+			<xsl:variable name="numberOfSkips" select="$numberOfTests - $numberOfExecutes"/>
+			<xsl:variable name="numberOfErrors" select="0"/>
+            <testsuite name="{$buildName}"
+                       tests="{$numberOfTests}" time="0"
+                       failures="{$numberOfFailures}" errors="{$numberOfErrors}"
+                       skipped="{$numberOfSkips}">
+                <xsl:for-each select="//report/test/test_cases/tc">
+                    <xsl:variable name="testName" select="func"/>
+                    <xsl:variable name="status" select="res"/>
+                    <testcase name="{$testName}">
+                        <xsl:choose>
+                            <xsl:when test="res='PASSED'"/>
+							<xsl:when test="res='NOT EXECUTED'">
+								<skipped/>
+							</xsl:when>
+                            <xsl:otherwise>
+                                <failure>
+                                    <xsl:for-each select="dbgi/detail">
+                                        <xsl:variable name="file" select="module"/>
+                                        <xsl:variable name="line" select="line"/>
+                                        <xsl:text>&#10;        </xsl:text>
+                                        <xsl:value-of select="$file"/>:<xsl:value-of select="$line"/>
+                                    </xsl:for-each>
+                                    <xsl:text>&#10;      </xsl:text>
+                                 </failure>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </testcase>
+                </xsl:for-each>
+            </testsuite>
+        </testsuites>
+    </xsl:template>
+</xsl:stylesheet>

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Project/vcpkg-configuration.json
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Project/vcpkg-configuration.json
@@ -1,0 +1,25 @@
+{
+    "registries": [
+      {
+        "kind": "artifact",
+        "location": "https://aka.ms/vcpkg-ce-default",
+        "name": "microsoft"
+      },
+      {
+        "kind": "artifact",
+        "location": "https://artifacts.keil.arm.com/vcpkg-ce-registry/registry.zip",
+        "name": "arm"
+      }
+    ],
+    "requires": {
+      "microsoft:tools/kitware/cmake": "^3.25.2",
+      "microsoft:ninja": "^1.10.2",
+      "arm:compilers/arm/armclang":"^6.20.0",
+      "arm:compilers/arm/arm-none-eabi-gcc": "^13.2.1",
+      "arm:compilers/arm/llvm-embedded": "^17.0.1-0",
+      "arm:tools/open-cmsis-pack/cmsis-toolbox": "^2.1.0-0",
+      "arm:models/arm/avh-fvp": "^11.22.39",
+      "arm:debuggers/arm/armdbg": "^6.0.0"
+    }
+  }
+  

--- a/platform/ext/cmsis/CMSIS/CoreValidation/README.md
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/README.md
@@ -1,0 +1,119 @@
+# CMSIS-Core Validation
+
+This folder contains a test suite that validates CMSIS-Core implementations. It uses [**Fixed Virtual Platforms**](https://developer.arm.com/Tools%20and%20Software/Fixed%20Virtual%20Platforms) to run tests to verify correct operation of the CMSIS-Core functionality on various Arm Cortex based processors.
+
+## Folder structure
+
+```txt
+    📂 CoreValidation
+    ┣ 📂 Include        Include files for test cases etc.
+    ┣ 📂 Layer          Layers for creating the projects.
+    ┣ 📂 Project        Solution and project files to build tests for various configurations.
+    ┗ 📂 Source         Test case source code.
+```
+
+## Test matrix
+
+Currently, the following build configurations are provided:
+
+1. Compiler
+   - Arm Compiler 6 (AC6)
+   - GNU Compiler (GCC)
+   - LLVM/Clang (Clang)
+2. Devices
+   - Cortex-M0
+   - Cortex-M0+
+   - Cortex-M3
+   - Cortex-M4 (with FPU)
+   - Cortex-M7 (with DP FPU)
+   - Cortex-M23
+     - w/o security extensions (TrustZone)
+     - in secure mode
+     - in non-secure mode
+   - Cortex-M33 (with FPU and DSP extensions)
+     - w/o security extensions (TrustZone)
+     - in secure mode
+     - in non-secure mode
+   - Cortex-M35P (with FPU and DSP extensions)
+     - w/o security extensions (TrustZone)
+     - in secure mode
+     - in non-secure mode
+   - Cortex-M55 (with FPU and DSP extensions)
+     - w/o security extensions (TrustZone)
+     - in secure mode
+     - in non-secure mode
+   - Cortex-M85 (with FPU and DSP extensions)
+     - w/o security extensions (TrustZone)
+     - in secure mode
+     - in non-secure mode
+   - Cortex-A5
+     - w/o NEON extensions
+   - Cortex-A7
+     - w/o NEON extensions
+   - Cortex-A9
+     - w/o NEON extensions
+3. Optimization Levels
+   - none
+   - balanced
+   - size
+   - speed
+
+## Prerequisites
+
+The following tools are required to build and run the CoreValidation tests:
+
+- [CMSIS-Toolbox 2.1.0](https://artifacts.keil.arm.com/cmsis-toolbox/2.1.0/)*
+- [CMake 3.25.2](https://cmake.org/download/)*
+- [Ninja 1.10.2](https://github.com/ninja-build/ninja/releases)*
+- [Arm Compiler 6.20](https://artifacts.keil.arm.com/arm-compiler/6.20/21/)*
+- [GCC Compiler 13.2.1](https://artifacts.keil.arm.com/arm-none-eabi-gcc/13.2.1/)*
+- [Clang Compiler 17.0.1](https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/releases/tag/release-17.0.1)*
+- [Arm Virtual Hardware for Cortex-M based on FastModels 11.22.39](https://artifacts.keil.arm.com/avh/11.22.39/)*
+- [Python 3.9](https://www.python.org/downloads/)
+
+The executables need to be present on the `PATH`.
+For tools distributed via vcpkg (*) this can be achieved automatically:
+
+```bash
+ ./CMSIS/CoreValidation/Project $ vcpkg activate
+```
+
+Install the Python packages required by `build.py`:
+
+```bash
+ ./CMSIS/CoreValidation/Project $ pip install -r requirements.txt
+```
+
+## Build and run
+
+To build and run the CoreValidation tests for one or more configurations use the following command line.
+Select the `<compiler>`, `<device>`, and `<optimize>` level to `build` and `run` for.
+
+```bash
+ ./CMSIS/CoreValidation/Project $ ./build.py -c <compiler> -d <device> -o <optimize> [build] [run]
+```
+
+For example, build and run the tests using GCC for Cortex-M3 with low optimization, execute:
+
+```bash
+ ./CMSIS/CoreValidation/Project $ ./build.py -c GCC -d CM3 -o none build run
+[GCC][Cortex-M3][none](build:csolution) csolution convert -s Validation.csolution.yml -c Validation.GCC_low+CM3
+[GCC][Cortex-M3][none](build:csolution) csolution succeeded with exit code 0
+[GCC][Cortex-M3][none](build:cbuild) cbuild Validation.GCC_low+CM3/Validation.GCC_low+CM3.cprj
+[GCC][Cortex-M3][none](build:cbuild) cbuild succeeded with exit code 0
+[GCC][Cortex-M3][none](run:model_exec) VHT_MPS2_Cortex-M3 -q --simlimit 100 -f ../Layer/Target/CM3/model_config.txt -a Validation.GCC_low+CM3/Validation.GCC_low+CM3_outdir/Validation.GCC_low+CM3.elf
+[GCC][Cortex-M3][none](run:model_exec) VHT_MPS2_Cortex-M3 succeeded with exit code 0
+
+Matrix Summary
+==============
+
+compiler    device     optimize    build    clean    extract    run
+----------  ---------  ----------  -------  -------  ---------  -----
+GCC         Cortex-M3  none        success  (skip)   (skip)     35/35
+```
+
+The full test report is written to `Core_Validation-GCC-none-CM3-<timestamp>.junit` file.
+
+## License
+
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Source/CV_CAL1Cache.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Source/CV_CAL1Cache.c
@@ -1,0 +1,181 @@
+/*-----------------------------------------------------------------------------
+ *      Name:         CV_CAL1Cache.c 
+ *      Purpose:      CMSIS CORE validation tests implementation
+ *-----------------------------------------------------------------------------
+ *      Copyright (c) 2017 ARM Limited. All rights reserved.
+ *----------------------------------------------------------------------------*/
+
+#include "CV_Framework.h"
+#include "cmsis_cv.h"
+
+/*-----------------------------------------------------------------------------
+ *      Test implementation
+ *----------------------------------------------------------------------------*/
+
+/*-----------------------------------------------------------------------------
+ *      Test cases
+ *----------------------------------------------------------------------------*/
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+void TC_CAL1Cache_EnDisable(void) {
+  
+  uint32_t orig = __get_SCTLR();
+  
+  L1C_EnableCaches();
+  
+  uint32_t sctlr = __get_SCTLR();
+  ASSERT_TRUE((sctlr  & SCTLR_I_Msk) == SCTLR_I_Msk);
+  ASSERT_TRUE((sctlr  & SCTLR_C_Msk) == SCTLR_C_Msk);
+  
+  L1C_CleanDCacheAll();
+  L1C_DisableCaches();
+  
+  sctlr = __get_SCTLR();
+  ASSERT_TRUE((sctlr & SCTLR_I_Msk) == 0U);
+  ASSERT_TRUE((sctlr & SCTLR_C_Msk) == 0U);
+  
+  __set_SCTLR(orig);
+  __ISB();
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+void TC_CAL1Cache_EnDisableBTAC(void) {
+  uint32_t orig = __get_SCTLR();
+  
+  L1C_EnableBTAC();
+  
+  uint32_t sctlr = __get_SCTLR();
+  ASSERT_TRUE((sctlr & SCTLR_Z_Msk) == SCTLR_Z_Msk);
+  
+  L1C_DisableBTAC();
+  
+  sctlr = __get_SCTLR();
+#if __CORTEX_A == 7
+  // On Cortex-A7 SCTLR_Z is RAO/WI.
+  ASSERT_TRUE((sctlr & SCTLR_Z_Msk) == SCTLR_Z_Msk);
+#else
+  ASSERT_TRUE((sctlr & SCTLR_Z_Msk) == 0U);
+#endif
+
+  __set_SCTLR(orig);
+  __ISB();
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+void TC_CAL1Cache_log2_up(void) {
+  uint8_t log2 = __log2_up(0U);
+  ASSERT_TRUE(log2 == 0U);
+  
+  log2 = __log2_up(1U);
+  ASSERT_TRUE(log2 == 0U);
+
+  log2 = __log2_up(2U);
+  ASSERT_TRUE(log2 == 1U);
+
+  log2 = __log2_up(3U);
+  ASSERT_TRUE(log2 == 2U);
+
+  log2 = __log2_up(4U);
+  ASSERT_TRUE(log2 == 2U);
+
+  log2 = __log2_up(0x80000000U);
+  ASSERT_TRUE(log2 == 31U);
+
+  log2 = __log2_up(0x80000001U);
+  ASSERT_TRUE(log2 == 32U);
+  
+  log2 = __log2_up(0xFFFFFFFFU);
+  ASSERT_TRUE(log2 == 32U);
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+void TC_CAL1Cache_InvalidateDCacheAll(void) {
+  
+  /* setup */
+  uint32_t orig = __get_SCTLR();
+  volatile uint32_t value = 0x0815U;
+
+  L1C_EnableCaches();
+
+  L1C_CleanDCacheAll();
+
+  /* test cached value gets lost */
+  
+  // WHEN a value is written
+  value = 0x4711U;
+  
+  // ... and the cache is invalidated
+  L1C_InvalidateDCacheAll();
+
+  // ... and the cache is disabled
+  L1C_DisableCaches();
+
+  // THEN the new value has been lost
+  ASSERT_TRUE(value == 0x0815U);
+  
+  /* tear down */
+  L1C_InvalidateDCacheAll();
+  __set_SCTLR(orig);
+  __ISB();
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+void TC_CAL1Cache_CleanDCacheAll(void) {
+  /* setup */
+  uint32_t orig = __get_SCTLR();
+  uint32_t value = 0x0815U;
+
+  L1C_EnableCaches();
+
+  L1C_CleanDCacheAll();
+  
+  /* test cached value is preserved */
+  
+  // WHEN a value is written
+  value = 0x4711U;
+  
+  // ... and the cache is cleaned
+  L1C_CleanDCacheAll();
+  
+  // ... and the cache is disabled
+  L1C_DisableCaches();
+  
+  // THEN the new value is preserved
+  ASSERT_TRUE(value == 0x4711U);
+  
+  /* tear down */
+  L1C_InvalidateDCacheAll();
+  __set_SCTLR(orig);
+  __ISB();
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+void TC_CAL1Cache_CleanInvalidateDCacheAll(void) {
+  /* setup */
+  uint32_t orig = __get_SCTLR();
+  uint32_t value = 0x0815U;
+
+  L1C_EnableCaches();
+
+  L1C_CleanDCacheAll();
+  
+  /* test cached value is preserved */
+  
+  // WHEN a value is written
+  value = 0x4711U;
+  
+  // ... and the cache is cleaned/invalidated
+  L1C_CleanInvalidateDCacheAll();
+  
+  // ... and the cache is disabled
+  L1C_DisableCaches();
+
+  // THEN the new value is preserved
+  ASSERT_TRUE(value == 0x4711U);
+  
+  /* tear down */
+  L1C_InvalidateDCacheAll();
+  __set_SCTLR(orig);
+  __ISB();
+}
+

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Source/CV_CML1Cache.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Source/CV_CML1Cache.c
@@ -1,0 +1,56 @@
+/*-----------------------------------------------------------------------------
+ *      Name:         CV_CML1Cache.c 
+ *      Purpose:      CMSIS CORE validation tests implementation
+ *-----------------------------------------------------------------------------
+ *      Copyright (c) 2020 - 2021 ARM Limited. All rights reserved.
+ *----------------------------------------------------------------------------*/
+
+#include "CV_Framework.h"
+#include "cmsis_cv.h"
+
+/*-----------------------------------------------------------------------------
+ *      Test implementation
+ *----------------------------------------------------------------------------*/
+
+/*-----------------------------------------------------------------------------
+ *      Test cases
+ *----------------------------------------------------------------------------*/
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+void TC_CML1Cache_EnDisableICache(void) {
+#ifdef __ICACHE_PRESENT
+  SCB_EnableICache();
+  
+  ASSERT_TRUE((SCB->CCR & SCB_CCR_IC_Msk) == SCB_CCR_IC_Msk);
+  
+  SCB_DisableICache();
+
+  ASSERT_TRUE((SCB->CCR & SCB_CCR_IC_Msk) == 0U);
+#endif
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+void TC_CML1Cache_EnDisableDCache(void) {
+#ifdef __DCACHE_PRESENT
+  SCB_EnableDCache();
+
+  ASSERT_TRUE((SCB->CCR & SCB_CCR_DC_Msk) == SCB_CCR_DC_Msk);
+
+  SCB_DisableDCache();
+
+  ASSERT_TRUE((SCB->CCR & SCB_CCR_DC_Msk) == 0U);
+#endif
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+#ifdef __DCACHE_PRESENT
+static uint32_t TC_CML1Cache_CleanDCacheByAddrWhileDisabled_Values[] = { 42U, 0U, 8U, 15U };
+#endif
+
+void TC_CML1Cache_CleanDCacheByAddrWhileDisabled(void) {
+#ifdef __DCACHE_PRESENT
+  SCB_DisableDCache();
+  SCB_CleanDCache_by_Addr(TC_CML1Cache_CleanDCacheByAddrWhileDisabled_Values, sizeof(TC_CML1Cache_CleanDCacheByAddrWhileDisabled_Values)/sizeof(TC_CML1Cache_CleanDCacheByAddrWhileDisabled_Values[0]));
+  ASSERT_TRUE((SCB->CCR & SCB_CCR_DC_Msk) == 0U);
+#endif
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Source/CV_CoreAFunc.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Source/CV_CoreAFunc.c
@@ -1,0 +1,250 @@
+/*-----------------------------------------------------------------------------
+ *      Name:         CV_CoreFunc.c
+ *      Purpose:      CMSIS CORE validation tests implementation
+ *-----------------------------------------------------------------------------
+ *      Copyright (c) 2017 ARM Limited. All rights reserved.
+ *----------------------------------------------------------------------------*/
+
+#include "CV_Framework.h"
+#include "cmsis_cv.h"
+
+/*-----------------------------------------------------------------------------
+ *      Test implementation
+ *----------------------------------------------------------------------------*/
+
+/*-----------------------------------------------------------------------------
+ *      Test cases
+ *----------------------------------------------------------------------------*/
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+void TC_CoreAFunc_IRQ(void) {
+  uint32_t orig = __get_CPSR();
+
+  __enable_irq();
+  uint32_t cpsr = __get_CPSR();
+  ASSERT_TRUE((cpsr & CPSR_I_Msk) == 0U);
+
+  __disable_irq();
+  cpsr = __get_CPSR();
+  ASSERT_TRUE((cpsr & CPSR_I_Msk) == CPSR_I_Msk);
+
+  __set_CPSR(orig);
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+void TC_CoreAFunc_FaultIRQ(void) {
+  uint32_t orig = __get_CPSR();
+
+  __enable_fault_irq();
+  uint32_t cpsr = __get_CPSR();
+  ASSERT_TRUE((cpsr & CPSR_F_Msk) == 0U);
+
+  __disable_fault_irq();
+  cpsr = __get_CPSR();
+  ASSERT_TRUE((cpsr & CPSR_F_Msk) == CPSR_F_Msk);
+
+  __set_CPSR(orig);
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+void TC_CoreAFunc_FPSCR(void) {
+
+  volatile float f1 = 47.11f;
+  volatile float f2 = 8.15f;
+  volatile float f3 = f1 / f2;
+
+  uint32_t fpscr = __get_FPSCR();
+  __set_FPSCR(fpscr);
+
+  ASSERT_TRUE(fpscr == __get_FPSCR());
+  ASSERT_TRUE((f3 < 5.781f) && (f3 > 5.780f));
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+#if defined(__CC_ARM)
+#define __SUBS(Rd, Rm, Rn) __ASM volatile("SUBS " # Rd ", " # Rm ", " # Rn)
+#define __ADDS(Rd, Rm, Rn) __ASM volatile("ADDS " # Rd ", " # Rm ", " # Rn)
+#elif defined( __GNUC__ ) && defined(__thumb__)
+#define __SUBS(Rd, Rm, Rn) __ASM volatile("SUB %0, %1, %2" : "=r"(Rd) : "r"(Rm), "r"(Rn))
+#define __ADDS(Rd, Rm, Rn) __ASM volatile("ADD %0, %1, %2" : "=r"(Rd) : "r"(Rm), "r"(Rn))
+#else
+#define __SUBS(Rd, Rm, Rn) __ASM volatile("SUBS %0, %1, %2" : "=r"(Rd) : "r"(Rm), "r"(Rn))
+#define __ADDS(Rd, Rm, Rn) __ASM volatile("ADDS %0, %1, %2" : "=r"(Rd) : "r"(Rm), "r"(Rn))
+#endif
+
+void TC_CoreAFunc_CPSR(void) {
+  uint32_t result;
+
+  uint32_t cpsr = __get_CPSR();
+  __set_CPSR(cpsr & CPSR_M_Msk);
+
+  // Check negative flag
+  int32_t Rm = 5;
+  int32_t Rn = 7;
+  __SUBS(Rm, Rm, Rn);
+  result  = __get_CPSR();
+  ASSERT_TRUE((result & CPSR_N_Msk) == CPSR_N_Msk);
+
+  // Check zero and compare flag
+  Rm = 5;
+  __SUBS(Rm, Rm, Rm);
+  result  = __get_CPSR();
+  ASSERT_TRUE((result & CPSR_Z_Msk) == CPSR_Z_Msk);
+  ASSERT_TRUE((result & CPSR_C_Msk) == CPSR_C_Msk);
+
+  // Check overflow flag
+  Rm = 5;
+  Rn = INT32_MAX;
+  __ADDS(Rm, Rm, Rn);
+  result  = __get_CPSR();
+  ASSERT_TRUE((result & CPSR_V_Msk) == CPSR_V_Msk);
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+void TC_CoreAFunc_Mode(void) {
+  uint32_t mode = __get_mode();
+  __set_mode(mode);
+
+  ASSERT_TRUE(mode == __get_mode());
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+void TC_CoreAFunc_FPEXC(void) {
+  uint32_t fpexc = __get_FPEXC();
+  __set_FPEXC(fpexc);
+
+  ASSERT_TRUE(fpexc == __get_FPEXC());
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+void TC_CoreAFunc_ACTLR(void) {
+  uint32_t actlr = __get_ACTLR();
+  __set_ACTLR(actlr);
+
+  ASSERT_TRUE(actlr == __get_ACTLR());
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+void TC_CoreAFunc_CPACR(void) {
+  uint32_t cpacr = __get_CPACR();
+  __set_CPACR(cpacr);
+
+  ASSERT_TRUE(cpacr == __get_CPACR());
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+void TC_CoreAFunc_DFSR(void) {
+  uint32_t dfsr = __get_DFSR();
+  __set_DFSR(dfsr);
+
+  ASSERT_TRUE(dfsr == __get_DFSR());
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+void TC_CoreAFunc_IFSR(void) {
+  uint32_t ifsr = __get_IFSR();
+  __set_IFSR(ifsr);
+
+  ASSERT_TRUE(ifsr == __get_IFSR());
+}
+
+/*0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+void TC_CoreAFunc_ISR(void) {
+  uint32_t isr = __get_ISR();
+
+  ASSERT_TRUE(isr == __get_ISR());
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+void TC_CoreAFunc_CBAR(void) {
+  uint32_t cbar = __get_CBAR();
+
+  ASSERT_TRUE(cbar == __get_CBAR());
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+void TC_CoreAFunc_TTBR0(void) {
+  uint32_t ttbr0 = __get_TTBR0();
+  __set_TTBR0(ttbr0);
+
+  ASSERT_TRUE(ttbr0 == __get_TTBR0());
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+void TC_CoreAFunc_DACR(void) {
+  uint32_t dacr = __get_DACR();
+  __set_DACR(dacr);
+
+  ASSERT_TRUE(dacr == __get_DACR());
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+void TC_CoreAFunc_SCTLR(void) {
+  uint32_t sctlr = __get_SCTLR();
+  __set_SCTLR(sctlr);
+
+  ASSERT_TRUE(sctlr == __get_SCTLR());
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+void TC_CoreAFunc_MPIDR(void) {
+  uint32_t mpidr = __get_MPIDR();
+
+  ASSERT_TRUE(mpidr == __get_MPIDR());
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+static uint8_t vectorRAM[32U] __attribute__((aligned(32U)));
+
+void TC_CoreAFunc_VBAR(void) {
+  uint32_t vbar = __get_VBAR();
+
+  memcpy(vectorRAM, (void*)vbar, sizeof(vectorRAM));
+
+  __set_VBAR((uint32_t)vectorRAM);
+  ASSERT_TRUE(((uint32_t)vectorRAM) == __get_VBAR());
+
+  __set_VBAR(vbar);
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+void TC_CoreAFunc_MVBAR(void) {
+  uint32_t mvbar = __get_MVBAR();
+
+  memcpy(vectorRAM, (void*)mvbar, sizeof(vectorRAM));
+
+  __set_MVBAR((uint32_t)vectorRAM);
+  ASSERT_TRUE(((uint32_t)vectorRAM) == __get_MVBAR());
+
+  __set_MVBAR(mvbar);
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+
+#define STRINGIFYx(x) #x
+#define STRINGIFY(x) STRINGIFYx(x)
+
+void TC_CoreAFunc_FPU_Enable(void) {
+  uint32_t fpexc = __get_FPEXC();
+  __set_FPEXC(fpexc & ~0x40000000ul); // disable FPU
+
+  fpexc = __get_FPEXC();
+  ASSERT_TRUE((fpexc & 0x40000000ul) == 0x00000000ul);
+
+  uint32_t cparc;
+  __get_CP(15, 0, cparc, 1, 0, 2);
+
+  cparc &= ~0x00F00000ul;
+  __set_CP(15, 0, cparc, 1, 0, 2); // disable FPU access
+
+  __get_CP(15, 0, cparc, 1, 0, 2);
+  ASSERT_TRUE((cparc & 0x00F00000ul) == 0x00000000ul);
+
+  __FPU_Enable();
+
+  __get_CP(15, 0, cparc, 1, 0, 2);
+  ASSERT_TRUE((cparc & 0x00F00000ul) == 0x00F00000ul);
+
+  fpexc = __get_FPEXC();
+  ASSERT_TRUE((fpexc & 0x40000000ul) == 0x40000000ul);
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Source/CV_CoreFunc.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Source/CV_CoreFunc.c
@@ -1,0 +1,722 @@
+/*-----------------------------------------------------------------------------
+ *      Name:         CV_CoreFunc.c
+ *      Purpose:      CMSIS CORE validation tests implementation
+ *-----------------------------------------------------------------------------
+ *      Copyright (c) 2017 - 2023 Arm Limited. All rights reserved.
+ *----------------------------------------------------------------------------*/
+
+#include "cmsis_compiler.h"
+
+#include "CV_Framework.h"
+#include "cmsis_cv.h"
+
+/*-----------------------------------------------------------------------------
+ *      Test implementation
+ *----------------------------------------------------------------------------*/
+
+static volatile uint32_t irqTaken = 0U;
+#if defined(__CORTEX_M) && (__CORTEX_M > 0)
+static volatile uint32_t irqActive = 0U;
+#endif
+
+static void TC_CoreFunc_EnDisIRQIRQHandler(void) {
+  ++irqTaken;
+#if defined(__CORTEX_M) && (__CORTEX_M > 0)
+  irqActive = NVIC_GetActive(Interrupt0_IRQn);
+#endif
+}
+
+static volatile uint32_t irqIPSR = 0U;
+static volatile uint32_t irqXPSR = 0U;
+
+static void TC_CoreFunc_IPSR_IRQHandler(void) {
+  irqIPSR = __get_IPSR();
+  irqXPSR = __get_xPSR();
+}
+
+/*-----------------------------------------------------------------------------
+ *      Test cases
+ *----------------------------------------------------------------------------*/
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/**
+\brief Test case: TC_CoreFunc_EnDisIRQ
+\details
+Check expected behavior of interrupt related control functions:
+- __disable_irq() and __enable_irq()
+- NVIC_EnableIRQ, NVIC_DisableIRQ,  and NVIC_GetEnableIRQ
+- NVIC_SetPendingIRQ, NVIC_ClearPendingIRQ, and NVIC_GetPendingIRQ
+- NVIC_GetActive (not on Cortex-M0/M0+)
+*/
+void TC_CoreFunc_EnDisIRQ (void)
+{
+  // Globally disable all interrupt servicing
+  __disable_irq();
+
+  // Enable the interrupt
+  NVIC_EnableIRQ(Interrupt0_IRQn);
+  ASSERT_TRUE(NVIC_GetEnableIRQ(Interrupt0_IRQn) != 0U);
+
+  // Clear its pending state
+  NVIC_ClearPendingIRQ(Interrupt0_IRQn);
+  ASSERT_TRUE(NVIC_GetPendingIRQ(Interrupt0_IRQn) == 0U);
+
+  // Register test interrupt handler.
+  TST_IRQHandler = TC_CoreFunc_EnDisIRQIRQHandler;
+  irqTaken = 0U;
+#if defined(__CORTEX_M) && (__CORTEX_M > 0)
+  irqActive = UINT32_MAX;
+#endif
+
+  // Set the interrupt pending state
+  NVIC_SetPendingIRQ(Interrupt0_IRQn);
+  for(uint32_t i = 10U; i > 0U; --i) {__NOP();}
+
+  // Interrupt is not taken
+  ASSERT_TRUE(irqTaken == 0U);
+  ASSERT_TRUE(NVIC_GetPendingIRQ(Interrupt0_IRQn) != 0U);
+#if defined(__CORTEX_M) && (__CORTEX_M > 0)
+  ASSERT_TRUE(NVIC_GetActive(Interrupt0_IRQn) == 0U);
+#endif
+
+  // Globally enable interrupt servicing
+  __enable_irq();
+
+  for(uint32_t i = 10U; i > 0U; --i) {__NOP();}
+
+  // Interrupt was taken
+  ASSERT_TRUE(irqTaken == 1U);
+#if defined(__CORTEX_M) && (__CORTEX_M > 0)
+  ASSERT_TRUE(irqActive != 0U);
+  ASSERT_TRUE(NVIC_GetActive(Interrupt0_IRQn) == 0U);
+#endif
+
+  // Interrupt it not pending anymore.
+  ASSERT_TRUE(NVIC_GetPendingIRQ(Interrupt0_IRQn) == 0U);
+
+  // Disable interrupt
+  NVIC_DisableIRQ(Interrupt0_IRQn);
+  ASSERT_TRUE(NVIC_GetEnableIRQ(Interrupt0_IRQn) == 0U);
+
+  // Set interrupt pending
+  NVIC_SetPendingIRQ(Interrupt0_IRQn);
+  for(uint32_t i = 10U; i > 0U; --i) {__NOP();}
+
+  // Interrupt is not taken again
+  ASSERT_TRUE(irqTaken == 1U);
+  ASSERT_TRUE(NVIC_GetPendingIRQ(Interrupt0_IRQn) != 0U);
+
+  // Clear interrupt pending
+  NVIC_ClearPendingIRQ(Interrupt0_IRQn);
+  for(uint32_t i = 10U; i > 0U; --i) {__NOP();}
+
+  // Interrupt it not pending anymore.
+  ASSERT_TRUE(NVIC_GetPendingIRQ(Interrupt0_IRQn) == 0U);
+
+  // Globally disable interrupt servicing
+  __disable_irq();
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/**
+\brief Test case: TC_CoreFunc_IRQPrio
+\details
+Check expected behavior of interrupt priority control functions:
+- NVIC_SetPriority, NVIC_GetPriority
+*/
+void TC_CoreFunc_IRQPrio (void)
+{
+  /* Test Exception Priority */
+  uint32_t orig = NVIC_GetPriority(SVCall_IRQn);
+
+  NVIC_SetPriority(SVCall_IRQn, orig+1U);
+  uint32_t prio = NVIC_GetPriority(SVCall_IRQn);
+
+  ASSERT_TRUE(prio == orig+1U);
+
+  NVIC_SetPriority(SVCall_IRQn, orig);
+
+  /* Test Interrupt Priority */
+  orig = NVIC_GetPriority(Interrupt0_IRQn);
+
+  NVIC_SetPriority(Interrupt0_IRQn, orig+1U);
+  prio = NVIC_GetPriority(Interrupt0_IRQn);
+
+  ASSERT_TRUE(prio == orig+1U);
+
+  NVIC_SetPriority(Interrupt0_IRQn, orig);
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/** Helper function for TC_CoreFunc_EncDecIRQPrio
+\details
+The helper encodes and decodes the given priority configuration.
+\param[in] prigroup The PRIGROUP setting to be considered for encoding/decoding.
+\param[in] pre The preempt priority value.
+\param[in] sub The subpriority value.
+*/
+static void TC_CoreFunc_EncDecIRQPrio_Step(uint32_t prigroup, uint32_t pre, uint32_t sub) {
+  uint32_t prio = NVIC_EncodePriority(prigroup, pre, sub);
+
+  uint32_t ret_pre = UINT32_MAX;
+  uint32_t ret_sub = UINT32_MAX;
+
+  NVIC_DecodePriority(prio, prigroup, &ret_pre, &ret_sub);
+
+  ASSERT_TRUE(ret_pre == pre);
+  ASSERT_TRUE(ret_sub == sub);
+}
+
+/**
+\brief Test case: TC_CoreFunc_EncDecIRQPrio
+\details
+Check expected behavior of interrupt priority encoding/decoding functions:
+- NVIC_EncodePriority, NVIC_DecodePriority
+*/
+void TC_CoreFunc_EncDecIRQPrio (void)
+{
+  /* Check only the valid range of PRIGROUP and preempt-/sub-priority values. */
+  static const uint32_t priobits = (__NVIC_PRIO_BITS > 7U) ? 7U : __NVIC_PRIO_BITS;
+  for(uint32_t prigroup = 7U-priobits; prigroup<7U; prigroup++) {
+    for(uint32_t pre = 0U; pre<(128U>>prigroup); pre++) {
+      for(uint32_t sub = 0U; sub<(256U>>(8U-__NVIC_PRIO_BITS+7U-prigroup)); sub++) {
+        TC_CoreFunc_EncDecIRQPrio_Step(prigroup, pre, sub);
+      }
+    }
+  }
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/**
+\brief Test case: TC_CoreFunc_IRQVect
+\details
+Check expected behavior of interrupt vector relocation functions:
+- NVIC_SetVector, NVIC_GetVector
+*/
+void TC_CoreFunc_IRQVect(void) {
+#if defined(__VTOR_PRESENT) && __VTOR_PRESENT
+  /* relocate vector table */
+  extern const VECTOR_TABLE_Type __VECTOR_TABLE[48];
+  static VECTOR_TABLE_Type vectors[sizeof(__VECTOR_TABLE)/sizeof(__VECTOR_TABLE[0])] __ALIGNED(1024) __NO_INIT;
+  memcpy(vectors, __VECTOR_TABLE, sizeof(__VECTOR_TABLE));
+
+  const uint32_t orig_vtor = SCB->VTOR;
+  const uint32_t vtor = ((uint32_t)vectors) & SCB_VTOR_TBLOFF_Msk;
+  SCB->VTOR = vtor;
+
+  ASSERT_TRUE(vtor == SCB->VTOR);
+
+  /* check exception vectors */
+  extern void HardFault_Handler(void);
+  extern void SVC_Handler(void);
+  extern void PendSV_Handler(void);
+  extern void SysTick_Handler(void);
+
+  ASSERT_TRUE(NVIC_GetVector(HardFault_IRQn) == (uint32_t)HardFault_Handler);
+  ASSERT_TRUE(NVIC_GetVector(SVCall_IRQn) == (uint32_t)SVC_Handler);
+  ASSERT_TRUE(NVIC_GetVector(PendSV_IRQn) == (uint32_t)PendSV_Handler);
+  ASSERT_TRUE(NVIC_GetVector(SysTick_IRQn) == (uint32_t)SysTick_Handler);
+
+  /* reconfigure WDT IRQ vector */
+  extern void Interrupt0_Handler(void);
+
+  const uint32_t wdtvec = NVIC_GetVector(Interrupt0_IRQn);
+  ASSERT_TRUE(wdtvec == (uint32_t)Interrupt0_Handler);
+
+  NVIC_SetVector(Interrupt0_IRQn, wdtvec + 32U);
+
+  ASSERT_TRUE(NVIC_GetVector(Interrupt0_IRQn) == (wdtvec + 32U));
+
+  /* restore vector table */
+  SCB->VTOR = orig_vtor;
+#endif
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/**
+\brief Test case: TC_CoreFunc_GetCtrl
+\details
+- Check if __set_CONTROL and __get_CONTROL() sets/gets control register
+*/
+void TC_CoreFunc_Control (void) {
+  // don't use stack for this variables
+  static uint32_t orig;
+  static uint32_t ctrl;
+  static uint32_t result;
+
+  orig = __get_CONTROL();
+  ctrl = orig;
+  result = UINT32_MAX;
+
+#ifdef CONTROL_SPSEL_Msk
+  // SPSEL set to 0 (MSP)
+  ASSERT_TRUE((ctrl & CONTROL_SPSEL_Msk) == 0U);
+
+  // SPSEL set to 1 (PSP)
+  ctrl |= CONTROL_SPSEL_Msk;
+
+  // Move MSP to PSP
+  __set_PSP(__get_MSP());
+#endif
+
+  __set_CONTROL(ctrl);
+  __ISB();
+
+  result = __get_CONTROL();
+
+  __set_CONTROL(orig);
+  __ISB();
+
+  ASSERT_TRUE(result == ctrl);
+  ASSERT_TRUE(__get_CONTROL() == orig);
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/**
+\brief Test case: TC_CoreFunc_IPSR
+\details
+- Check if __get_IPSR intrinsic is available
+- Check if __get_xPSR intrinsic is available
+- Result differentiates between thread and exception modes
+*/
+void TC_CoreFunc_IPSR (void) {
+  uint32_t result = __get_IPSR();
+  ASSERT_TRUE(result == 0U); // Thread Mode
+
+  result = __get_xPSR();
+  ASSERT_TRUE((result & xPSR_ISR_Msk) == 0U); // Thread Mode
+
+  TST_IRQHandler = TC_CoreFunc_IPSR_IRQHandler;
+  irqIPSR = 0U;
+  irqXPSR = 0U;
+
+  NVIC_ClearPendingIRQ(Interrupt0_IRQn);
+  NVIC_EnableIRQ(Interrupt0_IRQn);
+  __enable_irq();
+
+  NVIC_SetPendingIRQ(Interrupt0_IRQn);
+  for(uint32_t i = 10U; i > 0U; --i) {__NOP();}
+
+  __disable_irq();
+  NVIC_DisableIRQ(Interrupt0_IRQn);
+
+  ASSERT_TRUE(irqIPSR != 0U); // Exception Mode
+  ASSERT_TRUE((irqXPSR & xPSR_ISR_Msk) != 0U); // Exception Mode
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+
+#if defined(__CC_ARM)
+#define SUBS(Rd, Rm, Rn) __ASM volatile("SUBS " # Rd ", " # Rm ", " # Rn)
+#define ADDS(Rd, Rm, Rn) __ASM volatile("ADDS " # Rd ", " # Rm ", " # Rn)
+#elif defined(_lint)
+//lint -save -e(9026) allow function-like macro
+#define SUBS(Rd, Rm, Rn) ((Rd) = (Rm) - (Rn))
+#define ADDS(Rd, Rm, Rn) ((Rd) = (Rm) + (Rn))
+//lint -restore
+#else
+#define SUBS(Rd, Rm, Rn) __ASM volatile("SUBS %0, %1, %2" : "=r"(Rd) : "r"(Rm), "r"(Rn) : "cc")
+#define ADDS(Rd, Rm, Rn) __ASM volatile("ADDS %0, %1, %2" : "=r"(Rd) : "r"(Rm), "r"(Rn) : "cc")
+#endif
+
+/**
+\brief Test case: TC_CoreFunc_APSR
+\details
+- Check if __get_APSR intrinsic is available
+- Check if __get_xPSR intrinsic is available
+- Check negative, zero and overflow flags
+*/
+void TC_CoreFunc_APSR (void) {
+  volatile uint32_t result;
+  //lint -esym(838, Rm) unused values
+  //lint -esym(438, Rm) unused values
+
+  // Check negative flag
+  volatile int32_t Rm = 5;
+  volatile int32_t Rn = 7;
+  SUBS(Rm, Rm, Rn);
+  result  = __get_APSR();
+  ASSERT_TRUE((result & APSR_N_Msk) == APSR_N_Msk);
+
+  Rm = 5;
+  Rn = 7;
+  SUBS(Rm, Rm, Rn);
+  result  = __get_xPSR();
+  ASSERT_TRUE((result & xPSR_N_Msk) == xPSR_N_Msk);
+
+  // Check zero and compare flag
+  Rm = 5;
+  SUBS(Rm, Rm, Rm);
+  result  = __get_APSR();
+  ASSERT_TRUE((result & APSR_Z_Msk) == APSR_Z_Msk);
+  ASSERT_TRUE((result & APSR_C_Msk) == APSR_C_Msk);
+
+  Rm = 5;
+  SUBS(Rm, Rm, Rm);
+  result  = __get_xPSR();
+  ASSERT_TRUE((result & xPSR_Z_Msk) == xPSR_Z_Msk);
+  ASSERT_TRUE((result & APSR_C_Msk) == APSR_C_Msk);
+
+  // Check overflow flag
+  Rm = 5;
+  Rn = INT32_MAX;
+  ADDS(Rm, Rm, Rn);
+  result  = __get_APSR();
+  ASSERT_TRUE((result & APSR_V_Msk) == APSR_V_Msk);
+
+  Rm = 5;
+  Rn = INT32_MAX;
+  ADDS(Rm, Rm, Rn);
+  result  = __get_xPSR();
+  ASSERT_TRUE((result & xPSR_V_Msk) == xPSR_V_Msk);
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/**
+\brief Test case: TC_CoreFunc_PSP
+\details
+- Check if __get_PSP and __set_PSP intrinsic can be used to manipulate process stack pointer.
+*/
+void TC_CoreFunc_PSP (void) {
+  // don't use stack for this variables
+  static uint32_t orig;
+  static uint32_t psp;
+  static uint32_t result;
+
+  orig = __get_PSP();
+
+  psp = orig + 0x12345678U;
+  __set_PSP(psp);
+
+  result = __get_PSP();
+
+  __set_PSP(orig);
+
+  ASSERT_TRUE(result == psp);
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/**
+\brief Test case: TC_CoreFunc_MSP
+\details
+- Check if __get_MSP and __set_MSP intrinsic can be used to manipulate main stack pointer.
+*/
+void TC_CoreFunc_MSP (void) {
+  // don't use stack for this variables
+  static uint32_t orig;
+  static uint32_t msp;
+  static uint32_t result;
+  static uint32_t ctrl;
+
+  ctrl = __get_CONTROL();
+  orig = __get_MSP();
+
+  __set_PSP(orig);
+  __set_CONTROL(ctrl | CONTROL_SPSEL_Msk); // switch to PSP
+
+  msp = orig + 0x12345678U;
+  __set_MSP(msp);
+
+  result = __get_MSP();
+
+  __set_MSP(orig);
+
+  __set_CONTROL(ctrl);
+
+  ASSERT_TRUE(result == msp);
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/**
+\brief Test case: TC_CoreFunc_PSPLIM
+\details
+- Check if __get_PSPLIM and __set_PSPLIM intrinsic can be used to manipulate process stack pointer limit.
+*/
+void TC_CoreFunc_PSPLIM (void) {
+#if ((defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) || \
+     (defined (__ARM_ARCH_8M_MAIN__   ) && (__ARM_ARCH_8M_MAIN__   == 1)) || \
+     (defined (__ARM_ARCH_8M_BASE__   ) && (__ARM_ARCH_8M_BASE__   == 1))    )
+  // don't use stack for this variables
+  static uint32_t orig;
+  static uint32_t psplim;
+  static uint32_t result;
+
+  orig = __get_PSPLIM();
+
+  psplim = orig + 0x12345678U;
+  __set_PSPLIM(psplim);
+
+  result = __get_PSPLIM();
+
+  __set_PSPLIM(orig);
+
+#if (!(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
+     !(defined (__ARM_ARCH_8M_MAIN__   ) && (__ARM_ARCH_8M_MAIN__   == 1)) && \
+     (!defined (__ARM_FEATURE_CMSE     ) || (__ARM_FEATURE_CMSE      < 3))    )
+  // without main extensions, the non-secure PSPLIM is RAZ/WI
+  ASSERT_TRUE(result == 0U);
+#else
+  ASSERT_TRUE(result == psplim);
+#endif
+
+#endif
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/**
+\brief Test case: TC_CoreFunc_PSPLIM_NS
+\details
+- Check if __TZ_get_PSPLIM_NS and __TZ_set_PSPLIM_NS intrinsic can be used to manipulate process stack pointer limit.
+*/
+void TC_CoreFunc_PSPLIM_NS (void) {
+#if ((defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) || \
+     (defined (__ARM_ARCH_8M_MAIN__   ) && (__ARM_ARCH_8M_MAIN__   == 1)) || \
+     (defined (__ARM_ARCH_8M_BASE__   ) && (__ARM_ARCH_8M_BASE__   == 1))    )
+
+#if (defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3))
+  uint32_t orig;
+  uint32_t psplim;
+  uint32_t result;
+
+  orig = __TZ_get_PSPLIM_NS();
+
+  psplim = orig + 0x12345678U;
+  __TZ_set_PSPLIM_NS(psplim);
+
+  result = __TZ_get_PSPLIM_NS();
+
+  __TZ_set_PSPLIM_NS(orig);
+
+#if (!(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
+     !(defined (__ARM_ARCH_8M_MAIN__   ) && (__ARM_ARCH_8M_MAIN__   == 1))    )
+  // without main extensions, the non-secure PSPLIM is RAZ/WI
+  ASSERT_TRUE(result == 0U);
+#else
+  ASSERT_TRUE(result == psplim);
+#endif
+#endif
+
+#endif
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/**
+\brief Test case: TC_CoreFunc_MSPLIM
+\details
+- Check if __get_MSPLIM and __set_MSPLIM intrinsic can be used to manipulate main stack pointer limit.
+*/
+void TC_CoreFunc_MSPLIM (void) {
+#if ((defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) || \
+     (defined (__ARM_ARCH_8M_MAIN__   ) && (__ARM_ARCH_8M_MAIN__   == 1)) || \
+     (defined (__ARM_ARCH_8M_BASE__   ) && (__ARM_ARCH_8M_BASE__   == 1))    )
+  // don't use stack for this variables
+  static uint32_t orig;
+  static uint32_t msplim;
+  static uint32_t result;
+  static uint32_t ctrl;
+
+  ctrl = __get_CONTROL();
+  __set_CONTROL(ctrl | CONTROL_SPSEL_Msk); // switch to PSP
+
+  orig = __get_MSPLIM();
+
+  msplim = orig + 0x12345678U;
+  __set_MSPLIM(msplim);
+
+  result = __get_MSPLIM();
+
+  __set_MSPLIM(orig);
+
+  __set_CONTROL(ctrl);
+
+#if (!(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
+     !(defined (__ARM_ARCH_8M_MAIN__   ) && (__ARM_ARCH_8M_MAIN__   == 1)) && \
+     (!defined (__ARM_FEATURE_CMSE     ) || (__ARM_FEATURE_CMSE      < 3))    )
+  // without main extensions, the non-secure MSPLIM is RAZ/WI
+  ASSERT_TRUE(result == 0U);
+#else
+  ASSERT_TRUE(result == msplim);
+#endif
+
+#endif
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/**
+\brief Test case: TC_CoreFunc_MSPLIM_NS
+\details
+- Check if __TZ_get_MSPLIM_NS and __TZ_set_MSPLIM_NS intrinsic can be used to manipulate process stack pointer limit.
+*/
+void TC_CoreFunc_MSPLIM_NS (void) {
+#if ((defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) || \
+     (defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) || \
+     (defined (__ARM_ARCH_8M_BASE__ ) && (__ARM_ARCH_8M_BASE__ == 1))    )
+
+#if (defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3))
+  uint32_t orig;
+  uint32_t msplim;
+  uint32_t result;
+
+  orig = __TZ_get_MSPLIM_NS();
+
+  msplim = orig + 0x12345678U;
+  __TZ_set_MSPLIM_NS(msplim);
+
+  result = __TZ_get_MSPLIM_NS();
+
+  __TZ_set_MSPLIM_NS(orig);
+
+#if (!(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
+     !(defined (__ARM_ARCH_8M_MAIN__   ) && (__ARM_ARCH_8M_MAIN__   == 1))    )
+  // without main extensions, the non-secure MSPLIM is RAZ/WI
+  ASSERT_TRUE(result == 0U);
+#else
+  ASSERT_TRUE(result == msplim);
+#endif
+#endif
+
+#endif
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/**
+\brief Test case: TC_CoreFunc_PRIMASK
+\details
+- Check if __get_PRIMASK and __set_PRIMASK intrinsic can be used to manipulate PRIMASK.
+- Check if __enable_irq and __disable_irq are reflected in PRIMASK.
+*/
+void TC_CoreFunc_PRIMASK (void) {
+  uint32_t orig = __get_PRIMASK();
+
+  // toggle primask
+  uint32_t primask = (orig & ~0x01U) | (~orig & 0x01U);
+
+  __set_PRIMASK(primask);
+  uint32_t result = __get_PRIMASK();
+  ASSERT_TRUE(result == primask);
+
+  __disable_irq();
+  result = __get_PRIMASK();
+  ASSERT_TRUE((result & 0x01U) == 1U);
+
+  __enable_irq();
+  result = __get_PRIMASK();
+  ASSERT_TRUE((result & 0x01U) == 0U);
+
+  __disable_irq();
+  result = __get_PRIMASK();
+  ASSERT_TRUE((result & 0x01U) == 1U);
+
+  __set_PRIMASK(orig);
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/**
+\brief Test case: TC_CoreFunc_FAULTMASK
+\details
+- Check if __get_FAULTMASK and __set_FAULTMASK intrinsic can be used to manipulate FAULTMASK.
+- Check if __enable_fault_irq and __disable_fault_irq are reflected in FAULTMASK.
+*/
+void TC_CoreFunc_FAULTMASK (void) {
+#if ((defined (__ARM_ARCH_7M__        ) && (__ARM_ARCH_7M__        == 1)) || \
+     (defined (__ARM_ARCH_7EM__       ) && (__ARM_ARCH_7EM__       == 1)) || \
+     (defined (__ARM_ARCH_8M_MAIN__   ) && (__ARM_ARCH_8M_MAIN__   == 1)) || \
+     (defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1))    )
+
+  uint32_t orig = __get_FAULTMASK();
+
+  // toggle faultmask
+  uint32_t faultmask = (orig & ~0x01U) | (~orig & 0x01U);
+
+  __set_FAULTMASK(faultmask);
+  uint32_t result = __get_FAULTMASK();
+  ASSERT_TRUE(result == faultmask);
+
+  __disable_fault_irq();
+  result = __get_FAULTMASK();
+  ASSERT_TRUE((result & 0x01U) == 1U);
+
+  __enable_fault_irq();
+  result = __get_FAULTMASK();
+  ASSERT_TRUE((result & 0x01U) == 0U);
+
+  __disable_fault_irq();
+  result = __get_FAULTMASK();
+  ASSERT_TRUE((result & 0x01U) == 1U);
+
+  __set_FAULTMASK(orig);
+
+#endif
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/**
+\brief Test case: TC_CoreFunc_BASEPRI
+\details
+- Check if __get_BASEPRI and __set_BASEPRI intrinsic can be used to manipulate BASEPRI.
+- Check if __set_BASEPRI_MAX intrinsic can be used to manipulate BASEPRI.
+*/
+void TC_CoreFunc_BASEPRI(void) {
+#if ((defined (__ARM_ARCH_7M__        ) && (__ARM_ARCH_7M__        == 1)) || \
+     (defined (__ARM_ARCH_7EM__       ) && (__ARM_ARCH_7EM__       == 1)) || \
+     (defined (__ARM_ARCH_8M_MAIN__   ) && (__ARM_ARCH_8M_MAIN__   == 1)) || \
+     (defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1))    )
+
+  uint32_t orig = __get_BASEPRI();
+
+  uint32_t basepri = ~orig & 0x80U;
+  __set_BASEPRI(basepri);
+  uint32_t result = __get_BASEPRI();
+
+  ASSERT_TRUE(result == basepri);
+
+  __set_BASEPRI(orig);
+
+  __set_BASEPRI_MAX(basepri);
+  result = __get_BASEPRI();
+
+  ASSERT_TRUE(result == basepri);
+
+#endif
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/**
+\brief Test case: TC_CoreFunc_FPUType
+\details
+Check SCB_GetFPUType returns information.
+*/
+void TC_CoreFunc_FPUType(void) {
+  uint32_t fpuType = SCB_GetFPUType();
+#if defined(__FPU_PRESENT) && (__FPU_PRESENT != 0)
+  ASSERT_TRUE(fpuType > 0U);
+#else
+  ASSERT_TRUE(fpuType  == 0U);
+#endif
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/**
+\brief Test case: TC_CoreFunc_FPSCR
+\details
+- Check if __get_FPSCR and __set_FPSCR intrinsics can be used
+*/
+void TC_CoreFunc_FPSCR(void) {
+  uint32_t fpscr = __get_FPSCR();
+  __ISB();
+  __DSB();
+
+  __set_FPSCR(~fpscr);
+  __ISB();
+  __DSB();
+
+  uint32_t result = __get_FPSCR();
+
+  __set_FPSCR(fpscr);
+
+#if (defined (__FPU_USED   ) && (__FPU_USED    == 1U))
+  ASSERT_TRUE(result != fpscr);
+#else
+  ASSERT_TRUE(result == 0U);
+#endif
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Source/CV_CoreInstr.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Source/CV_CoreInstr.c
@@ -1,0 +1,821 @@
+/*-----------------------------------------------------------------------------
+ *      Name:         CV_CoreInstr.c
+ *      Purpose:      CMSIS CORE validation tests implementation
+ *-----------------------------------------------------------------------------
+ *      Copyright (c) 2017 - 2021 Arm Limited. All rights reserved.
+ *----------------------------------------------------------------------------*/
+
+#include "CV_Framework.h"
+#include "cmsis_cv.h"
+
+#if defined(__CORTEX_M)
+#elif defined(__CORTEX_A)
+#include "irq_ctrl.h"
+#else
+#error __CORTEX_M or __CORTEX_A must be defined!
+#endif
+
+/*-----------------------------------------------------------------------------
+ *      Test implementation
+ *----------------------------------------------------------------------------*/
+
+/*-----------------------------------------------------------------------------
+ *      Test cases
+ *----------------------------------------------------------------------------*/
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/**
+\brief Test case: TC_CoreInstr_NOP
+\details
+- Check if __NOP instrinsic is available
+- No real assertion is deployed, just a compile time check.
+*/
+void TC_CoreInstr_NOP (void) {
+  __NOP();
+  ASSERT_TRUE(1U == 1U);
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/**
+\brief Test case: TC_CoreInstr_SEV
+\details
+- Check if __SEV instrinsic is available
+- No real assertion is deployed, just a compile time check.
+*/
+void TC_CoreInstr_SEV (void) {
+  __SEV();
+  ASSERT_TRUE(1U == 1U);
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/**
+\brief Test case: TC_CoreInstr_BKPT
+\details
+- Check if __BKPT instrinsic is available
+- No real assertion is deployed, just a compile time check.
+*/
+void TC_CoreInstr_BKPT (void) {
+  __BKPT(0xABU);
+  ASSERT_TRUE(1U == 1U);
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/**
+\brief Test case: TC_CoreInstr_ISB
+\details
+- Check if __ISB instrinsic is available
+- No real assertion is deployed, just a compile time check.
+*/
+void TC_CoreInstr_ISB (void) {
+  __ISB();
+  ASSERT_TRUE(1U == 1U);
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/**
+\brief Test case: TC_CoreInstr_DSB
+\details
+- Check if __DSB instrinsic is available
+- No real assertion is deployed, just a compile time check.
+*/
+void TC_CoreInstr_DSB (void) {
+  __DSB();
+  ASSERT_TRUE(1U == 1U);
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/**
+\brief Test case: TC_CoreInstr_DMB
+\details
+- Check if __DNB instrinsic is available
+- No real assertion is deployed, just a compile time check.
+*/
+void TC_CoreInstr_DMB (void) {
+  __DMB();
+  ASSERT_TRUE(1U == 1U);
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/**
+\brief Test case: TC_CoreInstr_WFI
+\details
+- Check if __WFI instrinsic is available
+- No real assertion is deployed, just a compile time check.
+*/
+void TC_CoreInstr_WFI (void) {
+  __WFI();
+  ASSERT_TRUE(1U == 1U);
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/**
+\brief Test case: TC_CoreInstr_WFE
+\details
+- Check if __WFE instrinsic is available
+- No real assertion is deployed, just a compile time check.
+*/
+void TC_CoreInstr_WFE (void) {
+  __WFE();
+  ASSERT_TRUE(1U == 1U);
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/**
+\brief Test case: TC_CoreInstr_REV
+\details
+- Check if __REV instrinsic swaps all bytes in a word.
+*/
+void TC_CoreInstr_REV (void) {
+  volatile uint32_t op1_u32;
+  volatile uint32_t res_u32;
+
+  op1_u32 = 0x47110815U;
+  res_u32 = __REV(op1_u32);
+  ASSERT_TRUE(res_u32 == 0x15081147U);
+
+  op1_u32 = 0x80000000U;
+  res_u32 = __REV(op1_u32);
+  ASSERT_TRUE(res_u32 == 0x00000080U);
+
+  op1_u32 = 0x00000080U;
+  res_u32 = __REV(op1_u32);
+  ASSERT_TRUE(res_u32 == 0x80000000U);
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/**
+\brief Test case: TC_CoreInstr_REV16
+\details
+- Check if __REV16 instrinsic swaps the bytes in both halfwords independendly.
+*/
+void TC_CoreInstr_REV16(void) {
+  volatile uint32_t op1_u32;
+  volatile uint32_t res_u32;
+
+  op1_u32 = 0x47110815U;
+  res_u32 = __REV16(op1_u32);
+  ASSERT_TRUE(res_u32 == 0x11471508U);
+
+  op1_u32 = 0x00001234U;
+  res_u32 = __REV16(op1_u32);
+  ASSERT_TRUE(res_u32 == 0x00003412U);
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/**
+\brief Test case: TC_CoreInstr_REVSH
+\details
+- Check if __REVSH instrinsic swaps bytes in a signed halfword keeping the sign.
+*/
+void TC_CoreInstr_REVSH(void) {
+  volatile int16_t value  = 0U;
+           int16_t result = 0U;
+
+  value = 0x4711;
+  result = __REVSH(value);
+  ASSERT_TRUE(result == 0x1147);
+
+  value = (int16_t)0x8000;
+  result = __REVSH(value);
+  ASSERT_TRUE(result == 0x0080);
+
+  value = 0x0080;
+  result = __REVSH(value);
+  ASSERT_TRUE(result == (int16_t)0x8000);
+
+  value = -0x1234;
+  result = __REVSH(value);
+  ASSERT_TRUE(result == (int16_t)0xcced);
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/**
+\brief Test case: TC_CoreInstr_RBIT
+\details
+- Check if __RBIT instrinsic revserses the bit order of arbitrary words.
+*/
+void TC_CoreInstr_RBIT (void) {
+  volatile uint32_t value  = 0U;
+           uint32_t result = 0U;
+
+  value = 0xAAAAAAAAU;
+  result = __RBIT(value);
+  ASSERT_TRUE(result == 0x55555555U);
+
+  value = 0x55555555U;
+  result = __RBIT(value);
+  ASSERT_TRUE(result == 0xAAAAAAAAU);
+
+  value = 0x00000001U;
+  result = __RBIT(value);
+  ASSERT_TRUE(result == 0x80000000U);
+
+  value = 0x80000000U;
+  result = __RBIT(value);
+  ASSERT_TRUE(result == 0x00000001U);
+
+  value = 0xDEADBEEFU;
+  result = __RBIT(value);
+  ASSERT_TRUE(result == 0xF77DB57BU);
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/**
+\brief Test case: TC_CoreInstr_ROR
+\details
+- Check if __ROR instrinsic moves all bits as expected.
+*/
+void TC_CoreInstr_ROR(void) {
+  volatile uint32_t value  = 0U;
+           uint32_t result = 0U;
+
+  value = 0x00000001U;
+  result = __ROR(value, 1U);
+  ASSERT_TRUE(result == 0x80000000U);
+
+  value = 0x80000000U;
+  result = __ROR(value, 1U);
+  ASSERT_TRUE(result == 0x40000000U);
+
+  value = 0x40000000U;
+  result = __ROR(value, 30U);
+  ASSERT_TRUE(result == 0x00000001U);
+
+  value = 0x00000001U;
+  result = __ROR(value, 32U);
+  ASSERT_TRUE(result == 0x00000001U);
+
+  value = 0x08154711U;
+  result = __ROR(value, 8U);
+  ASSERT_TRUE(result == 0x11081547U);
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/**
+\brief Test case: TC_CoreInstr_CLZ
+\details
+- Check if __CLZ instrinsic counts leading zeros.
+*/
+void TC_CoreInstr_CLZ (void) {
+  volatile uint32_t value  = 0U;
+           uint32_t result = 0U;
+
+  value = 0x00000000U;
+  result = __CLZ(value);
+  ASSERT_TRUE(result == 32);
+
+  value = 0x00000001U;
+  result = __CLZ(value);
+  ASSERT_TRUE(result == 31);
+
+  value = 0x40000000U;
+  result = __CLZ(value);
+  ASSERT_TRUE(result == 1);
+
+  value = 0x80000000U;
+  result = __CLZ(value);
+  ASSERT_TRUE(result == 0);
+
+  value = 0xFFFFFFFFU;
+  result = __CLZ(value);
+  ASSERT_TRUE(result == 0);
+
+  value = 0x80000001U;
+  result = __CLZ(value);
+  ASSERT_TRUE(result == 0);
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/**
+\brief Test case: TC_CoreInstr_SSAT
+\details
+- Check if __SSAT instrinsic saturates signed integer values.
+*/
+void TC_CoreInstr_SSAT (void) {
+  volatile int32_t value  = 0;
+           int32_t result = 0;
+
+  value = INT32_MAX;
+  result = __SSAT(value, 32U);
+  ASSERT_TRUE(result == INT32_MAX);
+
+  value = INT32_MAX;
+  result = __SSAT(value, 16U);
+  ASSERT_TRUE(result == INT16_MAX);
+
+  value = INT32_MAX;
+  result = __SSAT(value, 8U);
+  ASSERT_TRUE(result == INT8_MAX);
+
+  value = INT32_MAX;
+  result = __SSAT(value, 1U);
+  ASSERT_TRUE(result == 0);
+
+  value = INT32_MIN;
+  result = __SSAT(value, 32U);
+  ASSERT_TRUE(result == INT32_MIN);
+
+  value = INT32_MIN;
+  result = __SSAT(value, 16U);
+  ASSERT_TRUE(result == INT16_MIN);
+
+  value = INT32_MIN;
+  result = __SSAT(value, 8U);
+  ASSERT_TRUE(result == INT8_MIN);
+
+  value = INT32_MIN;
+  result = __SSAT(value, 1U);
+  ASSERT_TRUE(result == -1);
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/**
+\brief Test case: TC_CoreInstr_USAT
+\details
+- Check if __USAT instrinsic saturates unsigned integer values.
+*/
+void TC_CoreInstr_USAT (void) {
+  volatile  int32_t value  = 0U;
+           uint32_t result = 0U;
+
+  value = INT32_MAX;
+  result = __USAT(value, 31U);
+  ASSERT_TRUE(result == (UINT32_MAX >> 1U));
+
+  value = INT32_MAX;
+  result = __USAT(value, 16U);
+  ASSERT_TRUE(result == UINT16_MAX);
+
+  value = INT32_MAX;
+  result = __USAT(value, 8U);
+  ASSERT_TRUE(result == UINT8_MAX);
+
+  value = INT32_MAX;
+  result = __USAT(value, 0U);
+  ASSERT_TRUE(result == 0U);
+
+  value = INT32_MIN;
+  result = __USAT(value, 31U);
+  ASSERT_TRUE(result == 0U);
+
+  value = INT32_MIN;
+  result = __USAT(value, 16U);
+  ASSERT_TRUE(result == 0U);
+
+  value = INT32_MIN;
+  result = __USAT(value, 8U);
+  ASSERT_TRUE(result == 0U);
+
+  value = INT32_MIN;
+  result = __USAT(value, 0U);
+  ASSERT_TRUE(result == 0U);
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/**
+\brief Test case: TC_CoreInstr_RRX
+\details
+- Check if __USAT instrinsic saturates unsigned integer values.
+*/
+void TC_CoreInstr_RRX (void) {
+#if ((defined (__ARM_ARCH_7M__        ) && (__ARM_ARCH_7M__        == 1)) || \
+     (defined (__ARM_ARCH_7EM__       ) && (__ARM_ARCH_7EM__       == 1)) || \
+     (defined (__ARM_ARCH_8M_MAIN__   ) && (__ARM_ARCH_8M_MAIN__   == 1)) || \
+     (defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1))    )
+
+  volatile uint32_t  value  = 0U;
+  volatile uint32_t  result = 0U;
+  volatile xPSR_Type xPSR;
+
+  value = 0x80000002;
+  xPSR.w = __get_xPSR();
+  result = __RRX(value);
+  ASSERT_TRUE(result == (0x40000001 | (uint32_t)(xPSR.b.C << 31)));
+#endif
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+#if ((defined (__ARM_ARCH_7M__        ) && (__ARM_ARCH_7M__        == 1)) || \
+     (defined (__ARM_ARCH_7EM__       ) && (__ARM_ARCH_7EM__       == 1)) || \
+     (defined (__ARM_ARCH_8M_MAIN__   ) && (__ARM_ARCH_8M_MAIN__   == 1)) || \
+     (defined (__ARM_ARCH_8M_BASE__   ) && (__ARM_ARCH_8M_BASE__   == 1)) || \
+     (defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) || \
+     (defined(__CORTEX_A)                                               )    )
+
+/// Exclusive byte value
+static volatile uint8_t TC_CoreInstr_LoadStoreExclusive_byte = 0x47U;
+
+/// Exclusive halfword value
+static volatile uint16_t TC_CoreInstr_LoadStoreExclusive_hword = 0x0815U;
+
+/// Exclusive word value
+static volatile uint32_t TC_CoreInstr_LoadStoreExclusive_word = 0x08154711U;
+
+/**
+\brief Interrupt function for TC_CoreInstr_LoadStoreExclusive
+\details
+The interrupt manipulates all the global data
+which disrupts the exclusive sequences in the test
+*/
+static void TC_CoreInstr_LoadStoreExclusive_IRQHandler(void) {
+
+  const uint8_t b = __LDREXB(&TC_CoreInstr_LoadStoreExclusive_byte);
+  __STREXB((uint8_t)~b, &TC_CoreInstr_LoadStoreExclusive_byte);
+
+  const uint16_t hw = __LDREXH(&TC_CoreInstr_LoadStoreExclusive_hword);
+  __STREXH((uint16_t)~hw, &TC_CoreInstr_LoadStoreExclusive_hword);
+
+  const uint32_t w = __LDREXW(&TC_CoreInstr_LoadStoreExclusive_word);
+  __STREXW((uint32_t)~w, &TC_CoreInstr_LoadStoreExclusive_word);
+}
+
+/**
+\brief Helper function for TC_CoreInstr_LoadStoreExclusive to enable test interrupt.
+\details
+This helper function implements interrupt enabling according to target
+architecture, i.e. Cortex-A or Cortex-M.
+*/
+static void TC_CoreInstr_LoadStoreExclusive_IRQEnable(void) {
+#if defined(__CORTEX_M)
+  TST_IRQHandler = TC_CoreInstr_LoadStoreExclusive_IRQHandler;
+  NVIC_EnableIRQ(Interrupt0_IRQn);
+#elif defined(__CORTEX_A)
+  IRQ_SetHandler(SGI0_IRQn, TC_CoreInstr_LoadStoreExclusive_IRQHandler);
+  IRQ_Enable(SGI0_IRQn);
+#else
+  #error __CORTEX_M or __CORTEX_A must be defined!
+#endif
+  __enable_irq();
+}
+
+/**
+\brief Helper function for TC_CoreInstr_LoadStoreExclusive to set test interrupt pending.
+\details
+This helper function implements set pending the test interrupt according to target
+architecture, i.e. Cortex-A or Cortex-M.
+*/
+static void TC_CoreInstr_LoadStoreExclusive_IRQPend(void) {
+#if defined(__CORTEX_M)
+  NVIC_SetPendingIRQ(Interrupt0_IRQn);
+#elif defined(__CORTEX_A)
+  IRQ_SetPending(SGI0_IRQn);
+#else
+  #error __CORTEX_M or __CORTEX_A must be defined!
+#endif
+  for(uint32_t i = 10U; i > 0U; --i) {}
+}
+
+/**
+\brief Helper function for TC_CoreInstr_LoadStoreExclusive to disable test interrupt.
+\details
+This helper function implements interrupt disabling according to target
+architecture, i.e. Cortex-A or Cortex-M.
+*/
+static void TC_CoreInstr_LoadStoreExclusive_IRQDisable(void) {
+  __disable_irq();
+#if defined(__CORTEX_M)
+  NVIC_DisableIRQ(Interrupt0_IRQn);
+  TST_IRQHandler = NULL;
+#elif defined(__CORTEX_A)
+  IRQ_Disable(SGI0_IRQn);
+  IRQ_SetHandler(SGI0_IRQn, NULL);
+#else
+  #error __CORTEX_M or __CORTEX_A must be defined!
+#endif
+}
+#endif
+
+/**
+\brief Test case: TC_CoreInstr_LoadStoreExclusive
+\details
+Checks exclusive load and store instructions:
+- LDREXB, LDREXH, LDREXW
+- STREXB, STREXH, STREXW
+- CLREX
+*/
+void TC_CoreInstr_LoadStoreExclusive (void) {
+#if ((defined (__ARM_ARCH_7M__        ) && (__ARM_ARCH_7M__        == 1)) || \
+     (defined (__ARM_ARCH_7EM__       ) && (__ARM_ARCH_7EM__       == 1)) || \
+     (defined (__ARM_ARCH_8M_MAIN__   ) && (__ARM_ARCH_8M_MAIN__   == 1)) || \
+     (defined (__ARM_ARCH_8M_BASE__   ) && (__ARM_ARCH_8M_BASE__   == 1)) || \
+     (defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) || \
+     (defined(__CORTEX_A)                                               )    )
+  uint8_t  u8,  u8Inv;
+  uint16_t u16, u16Inv;
+  uint32_t u32, u32Inv;
+  uint32_t result;
+
+  /* 1. Test exclusives without interruption */
+  u8 = __LDREXB(&TC_CoreInstr_LoadStoreExclusive_byte);
+  ASSERT_TRUE(u8 == TC_CoreInstr_LoadStoreExclusive_byte);
+
+  result = __STREXB(u8+1U, &TC_CoreInstr_LoadStoreExclusive_byte);
+  ASSERT_TRUE(result == 0U);
+  ASSERT_TRUE(TC_CoreInstr_LoadStoreExclusive_byte == u8+1U);
+
+  u16 = __LDREXH(&TC_CoreInstr_LoadStoreExclusive_hword);
+  ASSERT_TRUE(u16 == TC_CoreInstr_LoadStoreExclusive_hword);
+
+  result = __STREXH(u16+1U, &TC_CoreInstr_LoadStoreExclusive_hword);
+  ASSERT_TRUE(result == 0U);
+  ASSERT_TRUE(TC_CoreInstr_LoadStoreExclusive_hword == u16+1U);
+
+  u32 = __LDREXW(&TC_CoreInstr_LoadStoreExclusive_word);
+  ASSERT_TRUE(u32 == TC_CoreInstr_LoadStoreExclusive_word);
+
+  result = __STREXW(u32+1U, &TC_CoreInstr_LoadStoreExclusive_word);
+  ASSERT_TRUE(result == 0U);
+  ASSERT_TRUE(TC_CoreInstr_LoadStoreExclusive_word == u32+1U);
+
+  /* 2. Test exclusives with clear */
+  u8 = __LDREXB(&TC_CoreInstr_LoadStoreExclusive_byte);
+  ASSERT_TRUE(u8 == TC_CoreInstr_LoadStoreExclusive_byte);
+
+  __CLREX();
+
+  result = __STREXB(u8+1U, &TC_CoreInstr_LoadStoreExclusive_byte);
+  ASSERT_TRUE(result == 1U);
+  ASSERT_TRUE(TC_CoreInstr_LoadStoreExclusive_byte == u8);
+
+  u16 = __LDREXH(&TC_CoreInstr_LoadStoreExclusive_hword);
+  ASSERT_TRUE(u16 == TC_CoreInstr_LoadStoreExclusive_hword);
+
+  __CLREX();
+
+  result = __STREXH(u16+1U, &TC_CoreInstr_LoadStoreExclusive_hword);
+  ASSERT_TRUE(result == 1U);
+  ASSERT_TRUE(TC_CoreInstr_LoadStoreExclusive_hword == u16);
+
+  u32 = __LDREXW(&TC_CoreInstr_LoadStoreExclusive_word);
+  ASSERT_TRUE(u32 == TC_CoreInstr_LoadStoreExclusive_word);
+
+  __CLREX();
+
+  result = __STREXW(u32+1U, &TC_CoreInstr_LoadStoreExclusive_word);
+  ASSERT_TRUE(result == 1U);
+  ASSERT_TRUE(TC_CoreInstr_LoadStoreExclusive_word == u32);
+
+  /* 3. Test exclusives with interruption */
+  TC_CoreInstr_LoadStoreExclusive_IRQEnable();
+
+  u8 = __LDREXB(&TC_CoreInstr_LoadStoreExclusive_byte);
+  ASSERT_TRUE(u8 == TC_CoreInstr_LoadStoreExclusive_byte);
+
+  TC_CoreInstr_LoadStoreExclusive_IRQPend();
+
+  result = __STREXB(u8+1U, &TC_CoreInstr_LoadStoreExclusive_byte);
+  ASSERT_TRUE(result == 1U);
+  u8Inv = (uint8_t)~u8;
+  ASSERT_TRUE(u8Inv == TC_CoreInstr_LoadStoreExclusive_byte);
+
+  u16 = __LDREXH(&TC_CoreInstr_LoadStoreExclusive_hword);
+  ASSERT_TRUE(u16 == TC_CoreInstr_LoadStoreExclusive_hword);
+
+  TC_CoreInstr_LoadStoreExclusive_IRQPend();
+
+  result = __STREXH(u16+1U, &TC_CoreInstr_LoadStoreExclusive_hword);
+  ASSERT_TRUE(result == 1U);
+  u16Inv = (uint16_t)~u16;
+  ASSERT_TRUE(u16Inv == TC_CoreInstr_LoadStoreExclusive_hword);
+
+  u32 = __LDREXW(&TC_CoreInstr_LoadStoreExclusive_word);
+  ASSERT_TRUE(u32 == TC_CoreInstr_LoadStoreExclusive_word);
+
+  TC_CoreInstr_LoadStoreExclusive_IRQPend();
+
+  result = __STREXW(u32+1U, &TC_CoreInstr_LoadStoreExclusive_word);
+  ASSERT_TRUE(result == 1U);
+  u32Inv = (uint32_t)~u32;
+  ASSERT_TRUE(u32Inv == TC_CoreInstr_LoadStoreExclusive_word);
+
+  TC_CoreInstr_LoadStoreExclusive_IRQDisable();
+#endif
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+#if ((defined (__ARM_ARCH_7M__        ) && (__ARM_ARCH_7M__        == 1)) || \
+     (defined (__ARM_ARCH_7EM__       ) && (__ARM_ARCH_7EM__       == 1)) || \
+     (defined (__ARM_ARCH_8M_MAIN__   ) && (__ARM_ARCH_8M_MAIN__   == 1)) || \
+     (defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1))    )
+
+/// byte value unprivileged access
+static volatile uint8_t TC_CoreInstr_LoadStoreUnpriv_byte = 0x47U;
+
+/// halfword value unprivileged access
+static volatile uint16_t TC_CoreInstr_LoadStoreUnpriv_hword = 0x0815U;
+
+/// word value unprivileged access
+static volatile uint32_t TC_CoreInstr_LoadStoreUnpriv_word = 0x08154711U;
+#endif
+
+
+/**
+\brief Test case: TC_CoreInstr_LoadStoreUnpriv
+\details
+Checks load/store unprivileged instructions:
+- LDRBT, LDRHT, LDRT
+- STRBT, STRHT, STRT
+*/
+void TC_CoreInstr_LoadStoreUnpriv (void) {
+#if ((defined (__ARM_ARCH_7M__        ) && (__ARM_ARCH_7M__        == 1)) || \
+     (defined (__ARM_ARCH_7EM__       ) && (__ARM_ARCH_7EM__       == 1)) || \
+     (defined (__ARM_ARCH_8M_MAIN__   ) && (__ARM_ARCH_8M_MAIN__   == 1)) || \
+     (defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1))    )
+  uint8_t  u8     = 0U;
+  uint16_t u16    = 0U;
+  uint32_t u32    = 0U;
+
+  /* 1. Test without interruption */
+  u8 = __LDRBT(&TC_CoreInstr_LoadStoreUnpriv_byte);
+  ASSERT_TRUE(u8 == TC_CoreInstr_LoadStoreUnpriv_byte);
+
+  __STRBT(u8+1U, &TC_CoreInstr_LoadStoreUnpriv_byte);
+  ASSERT_TRUE(TC_CoreInstr_LoadStoreUnpriv_byte == u8+1U);
+
+  u16 = __LDRHT(&TC_CoreInstr_LoadStoreUnpriv_hword);
+  ASSERT_TRUE(u16 == TC_CoreInstr_LoadStoreUnpriv_hword);
+
+  __STRHT(u16+1U, &TC_CoreInstr_LoadStoreUnpriv_hword);
+  ASSERT_TRUE(TC_CoreInstr_LoadStoreUnpriv_hword == u16+1U);
+
+  u32 = __LDRT(&TC_CoreInstr_LoadStoreUnpriv_word);
+  ASSERT_TRUE(u32 == TC_CoreInstr_LoadStoreUnpriv_word);
+
+  __STRT(u32+1U, &TC_CoreInstr_LoadStoreUnpriv_word);
+  ASSERT_TRUE(TC_CoreInstr_LoadStoreUnpriv_word == u32+1U);
+#endif
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+#if ((defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) || \
+     (defined (__ARM_ARCH_8M_MAIN__   ) && (__ARM_ARCH_8M_MAIN__   == 1)) || \
+     (defined (__ARM_ARCH_8M_BASE__   ) && (__ARM_ARCH_8M_BASE__   == 1))    )
+
+/// byte value unprivileged access
+static volatile uint8_t TC_CoreInstr_LoadStoreAcquire_byte = 0x47U;
+
+/// halfword value unprivileged access
+static volatile uint16_t TC_CoreInstr_LoadStoreAcquire_hword = 0x0815U;
+
+/// word value unprivileged access
+static volatile uint32_t TC_CoreInstr_LoadStoreAcquire_word = 0x08154711U;
+#endif
+
+
+/**
+\brief Test case: TC_CoreInstr_LoadStoreAquire
+\details
+Checks Load-Acquire and Store-Release instructions:
+- LDAB, LDAH, LDA
+- STLB, STLH, STL
+*/
+void TC_CoreInstr_LoadStoreAcquire (void) {
+#if ((defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) || \
+     (defined (__ARM_ARCH_8M_MAIN__   ) && (__ARM_ARCH_8M_MAIN__   == 1)) || \
+     (defined (__ARM_ARCH_8M_BASE__   ) && (__ARM_ARCH_8M_BASE__   == 1))    )
+  uint8_t  u8     = 0U;
+  uint16_t u16    = 0U;
+  uint32_t u32    = 0U;
+
+  /* 1. Test without interruption */
+  u8 = __LDAB(&TC_CoreInstr_LoadStoreAcquire_byte);
+  ASSERT_TRUE(u8 == TC_CoreInstr_LoadStoreAcquire_byte);
+
+  __STLB(u8+1U, &TC_CoreInstr_LoadStoreAcquire_byte);
+  ASSERT_TRUE(TC_CoreInstr_LoadStoreAcquire_byte == u8+1U);
+
+  u16 = __LDAH(&TC_CoreInstr_LoadStoreAcquire_hword);
+  ASSERT_TRUE(u16 == TC_CoreInstr_LoadStoreAcquire_hword);
+
+  __STLH(u16+1U, &TC_CoreInstr_LoadStoreAcquire_hword);
+  ASSERT_TRUE(TC_CoreInstr_LoadStoreAcquire_hword == u16+1U);
+
+  u32 = __LDA(&TC_CoreInstr_LoadStoreAcquire_word);
+  ASSERT_TRUE(u32 == TC_CoreInstr_LoadStoreAcquire_word);
+
+  __STL(u32+1U, &TC_CoreInstr_LoadStoreAcquire_word);
+  ASSERT_TRUE(TC_CoreInstr_LoadStoreAcquire_word == u32+1U);
+#endif
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+#if ((defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) || \
+     (defined (__ARM_ARCH_8M_MAIN__   ) && (__ARM_ARCH_8M_MAIN__   == 1)) || \
+     (defined (__ARM_ARCH_8M_BASE__   ) && (__ARM_ARCH_8M_BASE__   == 1))    )
+
+/// byte value unprivileged access
+static volatile uint8_t TC_CoreInstr_LoadStoreAcquireExclusive_byte = 0x47U;
+
+/// halfword value unprivileged access
+static volatile uint16_t TC_CoreInstr_LoadStoreAcquireExclusive_hword = 0x0815U;
+
+/// word value unprivileged access
+static volatile uint32_t TC_CoreInstr_LoadStoreAcquireExclusive_word = 0x08154711U;
+#endif
+
+
+/**
+\brief Test case: TC_CoreInstr_LoadStoreAquire
+\details
+Checks Load-Acquire and Store-Release exclusive instructions:
+- LDAEXB, LDAEXH, LDAEX
+- STLEXB, STLEXH, STLEX
+*/
+void TC_CoreInstr_LoadStoreAcquireExclusive (void) {
+#if ((defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) || \
+     (defined (__ARM_ARCH_8M_MAIN__   ) && (__ARM_ARCH_8M_MAIN__   == 1)) || \
+     (defined (__ARM_ARCH_8M_BASE__   ) && (__ARM_ARCH_8M_BASE__   == 1))    )
+  uint8_t  u8     = 0U;
+  uint16_t u16    = 0U;
+  uint32_t u32    = 0U;
+  uint32_t result = 0U;
+
+  /* 1. Test without interruption */
+  u8 = __LDAEXB(&TC_CoreInstr_LoadStoreAcquireExclusive_byte);
+  ASSERT_TRUE(u8 == TC_CoreInstr_LoadStoreAcquireExclusive_byte);
+
+  result = __STLEXB(u8+1U, &TC_CoreInstr_LoadStoreAcquireExclusive_byte);
+  ASSERT_TRUE(result == 0U);
+  ASSERT_TRUE(TC_CoreInstr_LoadStoreAcquireExclusive_byte == u8+1U);
+
+  u16 = __LDAEXH(&TC_CoreInstr_LoadStoreAcquireExclusive_hword);
+  ASSERT_TRUE(u16 == TC_CoreInstr_LoadStoreAcquireExclusive_hword);
+
+  result = __STLEXH(u16+1U, &TC_CoreInstr_LoadStoreAcquireExclusive_hword);
+  ASSERT_TRUE(result == 0U);
+  ASSERT_TRUE(TC_CoreInstr_LoadStoreAcquireExclusive_hword == u16+1U);
+
+  u32 = __LDAEX(&TC_CoreInstr_LoadStoreAcquireExclusive_word);
+  ASSERT_TRUE(u32 == TC_CoreInstr_LoadStoreAcquireExclusive_word);
+
+  result = __STLEX(u32+1U, &TC_CoreInstr_LoadStoreAcquireExclusive_word);
+  ASSERT_TRUE(result == 0U);
+  ASSERT_TRUE(TC_CoreInstr_LoadStoreAcquireExclusive_word == u32+1U);
+#endif
+}
+
+
+/**
+\brief Test case: TC_CoreInstr_UnalignedUint16
+\details
+Checks macro functions to access unaligned uint16_t values:
+- __UNALIGNED_UINT16_READ
+- __UNALIGNED_UINT16_WRITE
+*/
+void TC_CoreInstr_UnalignedUint16(void) {
+  uint8_t buffer[3] = { 0U, 0U, 0U };
+  uint16_t val;
+  
+  for(int i=0; i<2; i++) {
+    __UNALIGNED_UINT16_WRITE(&(buffer[i]), 0x4711U);
+    ASSERT_TRUE(buffer[i]       == 0x11U);
+    ASSERT_TRUE(buffer[i+1]     == 0x47U);
+    ASSERT_TRUE(buffer[(i+2)%3] == 0x00U);
+  
+    buffer[i] = 0x12U;
+    buffer[i+1] = 0x46U;
+  
+    val = __UNALIGNED_UINT16_READ(&(buffer[i]));
+    ASSERT_TRUE(val == 0x4612U);
+  
+    buffer[i]   = 0x00U;
+    buffer[i+1] = 0x00U;
+  }
+}
+
+
+/**
+\brief Test case: TC_CoreInstr_UnalignedUint32
+\details
+Checks macro functions to access unaligned uint32_t values:
+- __UNALIGNED_UINT32_READ
+- __UNALIGNED_UINT32_WRITE
+*/
+void TC_CoreInstr_UnalignedUint32(void) {
+  uint8_t buffer[7] = { 0U, 0U, 0U, 0U, 0U, 0U, 0U };
+  uint32_t val;
+  
+  for(int i=0; i<4; i++) {
+    __UNALIGNED_UINT32_WRITE(&(buffer[i]), 0x08154711UL);
+    ASSERT_TRUE(buffer[i+0]     == 0x11U);
+    ASSERT_TRUE(buffer[i+1]     == 0x47U);
+    ASSERT_TRUE(buffer[i+2]     == 0x15U);
+    ASSERT_TRUE(buffer[i+3]     == 0x08U);
+    ASSERT_TRUE(buffer[(i+4)%7] == 0x00U);
+    ASSERT_TRUE(buffer[(i+5)%7] == 0x00U);
+    ASSERT_TRUE(buffer[(i+6)%7] == 0x00U);
+  
+    buffer[i+0] = 0x12U;
+    buffer[i+1] = 0x46U;
+    buffer[i+2] = 0x14U;
+    buffer[i+3] = 0x09U;
+  
+    val = __UNALIGNED_UINT32_READ(&(buffer[i]));
+    ASSERT_TRUE(val == 0x09144612UL);
+  
+    buffer[i+0] = 0x00U;
+    buffer[i+1] = 0x00U;
+    buffer[i+2] = 0x00U;
+    buffer[i+3] = 0x00U;
+  }
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Source/CV_CoreSimd.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Source/CV_CoreSimd.c
@@ -1,0 +1,715 @@
+/*-----------------------------------------------------------------------------
+ *      Name:         CV_CoreSimd.c
+ *      Purpose:      CMSIS CORE validation tests implementation
+ *-----------------------------------------------------------------------------
+ *      Copyright (c) 2018 Arm Limited. All rights reserved.
+ *----------------------------------------------------------------------------*/
+
+#include "cmsis_compiler.h"
+
+#include "CV_Framework.h"
+#include "cmsis_cv.h"
+
+/*-----------------------------------------------------------------------------
+ *      Test implementation
+ *----------------------------------------------------------------------------*/
+
+/*-----------------------------------------------------------------------------
+ *      Test cases
+ *----------------------------------------------------------------------------*/
+
+/**
+\brief Test case: TC_CoreSimd_SatAddSub
+\details
+- Check Saturating addition and subtraction:
+  __QADD
+  __QSUB
+*/
+void TC_CoreSimd_SatAddSub (void) {
+#if ((defined (__ARM_ARCH_7EM__ ) && (__ARM_ARCH_7EM__  == 1)) || \
+     (defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1))     )
+  volatile int32_t op1_s32, op2_s32;
+  volatile int32_t res_s32;
+
+  /* --- __QADD Test ---------------------------------------------- */
+  op1_s32 = (int32_t)0x80000003;
+  op2_s32 = (int32_t)0x00000004;
+  res_s32 = __QADD(op1_s32, op2_s32);
+  ASSERT_TRUE(res_s32 == (int32_t)0x80000007);
+
+  op1_s32 = (int32_t)0x80000000;
+  op2_s32 = (int32_t)0x80000002;
+  res_s32 = __QADD(op1_s32, op2_s32);
+  ASSERT_TRUE(res_s32 == (int32_t)0x80000000);
+
+  /* --- __QSUB Test ---------------------------------------------- */
+  op1_s32 = (int32_t)0x80000003;
+  op2_s32 = (int32_t)0x00000004;
+  res_s32 = __QSUB(op1_s32, op2_s32);
+  ASSERT_TRUE(res_s32 == (int32_t)0x80000000);
+
+  op1_s32 = (int32_t)0x80000003;
+  op2_s32 = (int32_t)0x00000002;
+  res_s32 = __QSUB(op1_s32, op2_s32);
+  ASSERT_TRUE(res_s32 == (int32_t)0x80000001);
+#endif
+}
+
+/**
+\brief Test case: TC_CoreSimd_ParSat16
+\details
+- Check Parallel 16-bit saturation:
+  __SSAT16
+  __USAT16
+*/
+void TC_CoreSimd_ParSat16 (void) {
+#if ((defined (__ARM_ARCH_7EM__ ) && (__ARM_ARCH_7EM__  == 1)) || \
+     (defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1))     )
+  volatile int32_t op1_s32;
+  volatile int32_t res_s32;
+
+  /* --- __SSAT16 Test ---------------------------------------------- */
+  op1_s32 = (int32_t)0x80030168;
+  res_s32 = __SSAT16(op1_s32, 8);
+  ASSERT_TRUE(res_s32 == (int32_t)0xFF80007F);
+
+  /* --- __USAT16 Test ---------------------------------------------- */
+  op1_s32 = 0x0030168;
+  res_s32 = __USAT16(op1_s32, 8);
+  ASSERT_TRUE(res_s32 == 0x000300FF);
+#endif
+}
+
+/**
+\brief Test case: TC_CoreSimd_PackUnpack
+\details
+- Check Packing and unpacking:
+  __SXTB16
+  __SXTB16_RORn
+  __SXTAB16
+  __SXTAB16__RORn
+  __UXTB16
+  __UXTAB16
+*/
+void TC_CoreSimd_PackUnpack (void) {
+#if ((defined (__ARM_ARCH_7EM__ ) && (__ARM_ARCH_7EM__  == 1)) || \
+     (defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1))     )
+  volatile int32_t op1_s32, op2_s32;
+  volatile int32_t res_s32;
+
+  /* --- __SXTB16 Test ---------------------------------------------- */
+  op1_s32 = (int32_t)0x80830168;
+  res_s32 = __SXTB16(op1_s32);
+  ASSERT_TRUE(res_s32 == (int32_t)0xFF830068);
+
+  /* --- __SXTB16_ROR8 Test ----------------------------------------- */
+  op1_s32 = (int32_t)0x80830168;
+  res_s32 = __SXTB16_RORn(op1_s32, 8);
+  ASSERT_TRUE(res_s32 == (int32_t)0xFF800001);
+
+  /* --- __SXTB16_ROR16 Test ---------------------------------------- */
+  op1_s32 = (int32_t)0x80830168;
+  res_s32 = __SXTB16_RORn(op1_s32, 16);
+  ASSERT_TRUE(res_s32 == (int32_t)0x68FF83);
+
+  /* --- __SXTB16_ROR24 Test ---------------------------------------- */
+  op1_s32 = (int32_t)0x80830168;
+  res_s32 = __SXTB16_RORn(op1_s32, 24);
+  ASSERT_TRUE(res_s32 == (int32_t)0x1FF80);
+
+  /* --- __SXTAB16 Test --------------------------------------------- */
+  op1_s32 = (int32_t)0x000D0008;
+  op2_s32 = (int32_t)0x80830168;
+  res_s32 = __SXTAB16(op1_s32, op2_s32);
+  ASSERT_TRUE(res_s32 == (int32_t)0xFF900070);
+
+  /* --- __SXTAB16__ROR8 Test --------------------------------------- */
+  op1_s32 = (int32_t)0x000A000A;
+  op2_s32 = (int32_t)0x80830168;
+  res_s32 = __SXTAB16_RORn(op1_s32, op2_s32, 8);
+  ASSERT_TRUE(res_s32 == (int32_t)0xFF8A000B);
+
+  /* --- __SXTAB16__ROR8 Test --------------------------------------- */
+  op1_s32 = (int32_t)0xFFF6FFF6;
+  op2_s32 = (int32_t)0x80830168;
+  res_s32 = __SXTAB16_RORn(op1_s32, op2_s32, 8);
+  ASSERT_TRUE(res_s32 == (int32_t)0xFF76FFF7);
+
+  /* --- __SXTAB16__ROR16 Test -------------------------------------- */
+  op1_s32 = (int32_t)0xFFF60015;
+  op2_s32 = (int32_t)0x70880168;
+  res_s32 = __SXTAB16_RORn(op1_s32, op2_s32, 16);
+  ASSERT_TRUE(res_s32 == (int32_t)0x5EFF9D);
+
+  /* --- __SXTAB16__ROR24 Test -------------------------------------- */
+  op1_s32 = (int32_t)0xFFF60015;
+  op2_s32 = (int32_t)0x70880168;
+  res_s32 = __SXTAB16_RORn(op1_s32, op2_s32, 24);
+  ASSERT_TRUE(res_s32 == (int32_t)0xFFF70085);
+
+  /* --- __UXTB16 Test ---------------------------------------------- */
+  op1_s32 = (int32_t)0x80830168;
+  res_s32 = __UXTB16(op1_s32);
+  ASSERT_TRUE(res_s32 == 0x00830068);
+
+  /* --- __UXTAB16 Test --------------------------------------------- */
+  op1_s32 =          0x000D0008;
+  op2_s32 = (int32_t)0x80830168;
+  res_s32 = __UXTAB16(op1_s32, op2_s32);
+  ASSERT_TRUE(res_s32 == 0x00900070);
+#endif
+}
+
+/**
+\brief Test case: TC_CoreSimd_ParSel
+\details
+- Check Parallel selection:
+  __SEL
+*/
+void TC_CoreSimd_ParSel (void) {
+#if ((defined (__ARM_ARCH_7EM__ ) && (__ARM_ARCH_7EM__  == 1)) || \
+     (defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1))     )
+  volatile uint32_t res_u32;
+
+  volatile int32_t op1_s32, op2_s32;
+  volatile int32_t res_s32;
+
+  APSR_Type  apsr;
+  xPSR_Type  xpsr;
+
+  /* --- __SEL Test ---------------------------------------------- */
+  op1_s32 = 0x33221100;
+  op2_s32 = 0x77665544;
+
+  res_s32 = __SADD8(0x80808080, 0x00000000);            /* __sadd8   sets APSR.GE = 0x00 */
+  res_u32 = __get_APSR();
+  apsr.w = __get_APSR();
+  ASSERT_TRUE( (res_u32 == apsr.w) );
+  xpsr.w = __get_xPSR();
+  ASSERT_TRUE( (((res_u32 >> 16) & 0x0F) == xpsr.b.GE)  );
+  res_s32 = __SEL(op1_s32, op2_s32);                      /* __sel          APSR.GE = 0x00 */
+  ASSERT_TRUE( res_s32 == 0x77665544);
+
+  res_s32 = __SADD8(0x80808000, 0x00000000);            /* __sadd8   sets APSR.GE = 0x01 */
+  res_u32 = __get_APSR();
+  apsr.w = __get_APSR();
+  ASSERT_TRUE( (res_u32 == apsr.w)  );
+  xpsr.w = __get_xPSR();
+  ASSERT_TRUE( (((res_u32 >> 16) & 0x0F) == xpsr.b.GE)  );
+  res_s32 = __SEL(op1_s32, op2_s32);                      /* __sel          APSR.GE = 0x01 */
+  ASSERT_TRUE(res_s32 == 0x77665500);
+
+  res_s32 = __SADD8(0x80800080, 0x00000000);            /* __sadd8   sets APSR.GE = 0x02 */
+  res_u32 = __get_APSR();
+  apsr.w = __get_APSR();
+  ASSERT_TRUE( (res_u32 == apsr.w) );
+  xpsr.w = __get_xPSR();
+  ASSERT_TRUE( (((res_u32 >> 16) & 0x0F) == xpsr.b.GE)  );
+  res_s32 = __SEL(op1_s32, op2_s32);                      /* __sel          APSR.GE = 0x02 */
+  ASSERT_TRUE(res_s32 == 0x77661144);
+#endif
+}
+
+/**
+\brief Test case: TC_CoreSimd_ParAddSub8
+\details
+- Check Parallel 8-bit addition and subtraction:
+  __SADD8                                   S  Signed
+  __SSUB8                                   Q  Signed Saturating
+  __SHADD8                                  SH Signed Halving
+  __SHSUB8                                  U  Unsigned
+  __QADD8                                   UQ Unsigned Saturating
+  __QSUB8                                   UH Unsigned Halving
+  __UADD8
+  __USUB8
+  __UHADD8
+  __UHSUB8
+  __UQADD8
+  __UQSUB8
+*/
+void TC_CoreSimd_ParAddSub8 (void) {
+#if ((defined (__ARM_ARCH_7EM__ ) && (__ARM_ARCH_7EM__  == 1)) || \
+     (defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1))     )
+  volatile uint32_t op1_u32, op2_u32;
+  volatile uint32_t res_u32;
+
+  volatile int32_t op1_s32, op2_s32;
+  volatile int32_t res_s32;
+
+  /* --- __SADD8 Test ---------------------------------------------- */
+  op1_s32 = (int32_t)0x87858381;
+  op2_s32 = (int32_t)0x08060402;
+  res_s32 = __SADD8(op1_s32, op2_s32);
+  ASSERT_TRUE(res_s32 == (int32_t)0x8F8B8783);
+
+  /* --- __SSUB8 Test ---------------------------------------------- */
+  op1_s32 = (int32_t)0x8F8B8783;
+  op2_s32 = (int32_t)0x08060402;
+  res_s32 = __SSUB8(op1_s32, op2_s32);
+  ASSERT_TRUE(res_s32 == (int32_t)0x87858381);
+
+  /* --- __SHADD8 Test ---------------------------------------------- */
+  op1_s32 = 0x07050302;
+  op2_s32 = 0x08060402;
+  res_s32 = __SHADD8(op1_s32, op2_s32);
+  ASSERT_TRUE(res_s32 == 0x07050302);
+
+  /* --- __SHSUB8 Test ---------------------------------------------- */
+  op1_s32 = (int32_t)0x8F8B8783;
+  op2_s32 = 0x08060402;
+  res_s32 = __SHSUB8(op1_s32, op2_s32);
+  ASSERT_TRUE(res_s32 == (int32_t)0xC3C2C1C0);
+
+  /* --- __QADD8 Test ---------------------------------------------- */
+  op1_s32 = (int32_t)0x8085837F;
+  op2_s32 = (int32_t)0xFF060402;
+  res_s32 = __QADD8(op1_s32, op2_s32);
+  ASSERT_TRUE(res_s32 == (int32_t)0x808B877F);
+
+  /* --- __QSUB8 Test ---------------------------------------------- */
+  op1_s32 = (int32_t)0x808B8783;
+  op2_s32 = (int32_t)0x08060402;
+  res_s32 = __QSUB8(op1_s32, op2_s32);
+  ASSERT_TRUE(res_s32 == (int32_t)0x80858381);
+
+  /* --- __UADD8 Test ---------------------------------------------- */
+  op1_u32 = 0x07050301;
+  op2_u32 = 0x08060402;
+  res_u32 = __UADD8(op1_u32, op2_u32);
+  ASSERT_TRUE(res_u32 == 0x0F0B0703);
+
+  /* --- __USUB8 Test ---------------------------------------------- */
+  op1_u32 = 0x0F0B0703;
+  op2_u32 = 0x08060402;
+  res_u32 = __USUB8(op1_u32, op2_u32);
+  ASSERT_TRUE(res_u32 == 0x07050301);
+
+  /* --- __UHADD8 Test ---------------------------------------------- */
+  op1_u32 = 0x07050302;
+  op2_u32 = 0x08060402;
+  res_u32 = __UHADD8(op1_u32, op2_u32);
+  ASSERT_TRUE(res_u32 == 0x07050302);
+
+  /* --- __UHSUB8 Test ---------------------------------------------- */
+  op1_u32 = 0x0F0B0703;
+  op2_u32 = 0x08060402;
+  res_u32 = __UHSUB8(op1_u32, op2_u32);
+  ASSERT_TRUE(res_u32 == 0x03020100);
+
+  /* --- __UQADD8 Test ---------------------------------------------- */
+  op1_u32 = 0xFF050301;
+  op2_u32 = 0x08060402;
+  res_u32 = __UQADD8(op1_u32, op2_u32);
+  ASSERT_TRUE(res_u32 == 0xFF0B0703);
+
+  /* --- __UQSUB8 Test ---------------------------------------------- */
+  op1_u32 = 0x080B0702;
+  op2_u32 = 0x0F060408;
+  res_u32 = __UQSUB8(op1_u32, op2_u32);
+  ASSERT_TRUE(res_u32 == 0x00050300);
+#endif
+}
+
+/**
+\brief Test case: TC_CoreSimd_AbsDif8
+\details
+- Check Sum of 8-bit absolute differences:
+  __USAD8
+  __USADA8
+*/
+void TC_CoreSimd_AbsDif8 (void) {
+#if ((defined (__ARM_ARCH_7EM__ ) && (__ARM_ARCH_7EM__  == 1)) || \
+     (defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1))     )
+  volatile uint32_t op1_u32, op2_u32, op3_u32;
+  volatile uint32_t res_u32;
+
+  /* --- __USAD8 Test ---------------------------------------------- */
+  op1_u32 = 0x87858381;
+  op2_u32 = 0x08060402;
+  res_u32 = __USAD8(op1_u32, op2_u32);
+  ASSERT_TRUE(res_u32 == 0x000001FC);
+
+  /* --- __USADA8 Test ---------------------------------------------- */
+  op1_u32 = 0x87858381;
+  op2_u32 = 0x08060402;
+  op3_u32 = 0x00008000;
+  res_u32 = __USADA8(op1_u32, op2_u32, op3_u32);
+  ASSERT_TRUE(res_u32 == 0x000081FC);
+#endif
+}
+
+/**
+\brief Test case: TC_CoreSimd_ParAddSub16
+\details
+- Check Parallel 16-bit addition and subtraction:
+  __SADD16
+  __SSUB16
+  __SASX
+  __SSAX
+  __SHADD16
+  __SHSUB16
+  __SHASX
+  __SHSAX
+  __QADD16
+  __QSUB16
+  __QASX
+  __QSAX
+  __UADD16
+  __USUB16
+  __UASX
+  __USAX
+  __UHADD16
+  __UHSUB16
+  __UHASX
+  __UHSAX
+  __UQSUB16
+  __UQADD16
+  __UQASX
+  __UQSAX
+*/
+void TC_CoreSimd_ParAddSub16 (void) {
+#if ((defined (__ARM_ARCH_7EM__ ) && (__ARM_ARCH_7EM__  == 1)) || \
+     (defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1))     )
+  volatile uint32_t op1_u32, op2_u32;
+  volatile uint32_t res_u32;
+
+  volatile int32_t op1_s32, op2_s32;
+  volatile int32_t res_s32;
+
+  /* --- __SADD16 Test ---------------------------------------------- */
+  op1_s32 = (int32_t)0x80038001;
+  op2_s32 = (int32_t)0x00040002;
+  res_s32 = __SADD16(op1_s32, op2_s32);
+  ASSERT_TRUE(res_s32 == (int32_t)0x80078003);
+
+  /* --- __SSUB16 Test ---------------------------------------------- */
+  op1_s32 = (int32_t)0x80078003;
+  op2_s32 = (int32_t)0x00040002;
+  res_s32 = __SSUB16(op1_s32, op2_s32);
+  ASSERT_TRUE(res_s32 == (int32_t)0x80038001);
+
+  /* --- __SASX Test ---------------------------------------------- */
+  op1_s32 = (int32_t)0x80078003;
+  op2_s32 = (int32_t)0x00040002;
+  res_s32 = __SASX(op1_s32, op2_s32);
+  ASSERT_TRUE(res_s32 == (int32_t)0x80097FFF);
+
+  /* --- __SSAX Test ---------------------------------------------- */
+  op1_s32 = (int32_t)0x80038007;
+  op2_s32 = (int32_t)0x00020004;
+  res_s32 = __SSAX(op1_s32, op2_s32);
+  ASSERT_TRUE(res_s32 == (int32_t)0x7FFF8009);
+
+  /* --- __SHADD16 Test ---------------------------------------------- */
+  op1_s32 = (int32_t)0x80038001;
+  op2_s32 = (int32_t)0x00040002;
+  res_s32 = __SHADD16(op1_s32, op2_s32);
+  ASSERT_TRUE(res_s32 == (int32_t)0xC003C001);
+
+  /* --- __SHSUB16 Test ---------------------------------------------- */
+  op1_s32 = (int32_t)0x80078003;
+  op2_s32 = (int32_t)0x00040002;
+  res_s32 = __SHSUB16(op1_s32, op2_s32);
+  ASSERT_TRUE(res_s32 == (int32_t)0xC001C000);
+
+  /* --- __SHASX Test ---------------------------------------------- */
+  op1_s32 = (int32_t)0x80078003;
+  op2_s32 = (int32_t)0x00040002;
+  res_s32 = __SHASX(op1_s32, op2_s32);
+  ASSERT_TRUE(res_s32 == (int32_t)0xC004BFFF);
+
+  /* --- __SHSAX Test ---------------------------------------------- */
+  op1_s32 = (int32_t)0x80038007;
+  op2_s32 = (int32_t)0x00020004;
+  res_s32 = __SHSAX(op1_s32, op2_s32);
+  ASSERT_TRUE(res_s32 == (int32_t)0xBFFFC004);
+
+  /* --- __QADD16 Test ---------------------------------------------- */
+  op1_s32 = (int32_t)0x80038000;
+  op2_s32 = (int32_t)0x00048002;
+  res_s32 = __QADD16(op1_s32, op2_s32);
+  ASSERT_TRUE(res_s32 == (int32_t)0x80078000);
+
+  /* --- __QSUB16 Test ---------------------------------------------- */
+  op1_s32 = (int32_t)0x80038003;
+  op2_s32 = (int32_t)0x00040002;
+  res_s32 = __QSUB16(op1_s32, op2_s32);
+  ASSERT_TRUE(res_s32 == (int32_t)0x80008001);
+
+  /* --- __QASX Test ---------------------------------------------- */
+  op1_s32 = (int32_t)0x80078003;
+  op2_s32 = (int32_t)0x00040002;
+  res_s32 = __QASX(op1_s32, op2_s32);
+  ASSERT_TRUE(res_s32 == (int32_t)0x80098000);
+
+  /* --- __QSAX Test ---------------------------------------------- */
+  op1_s32 = (int32_t)0x80038007;
+  op2_s32 = (int32_t)0x00020004;
+  res_s32 = __QSAX(op1_s32, op2_s32);
+  ASSERT_TRUE(res_s32 == (int32_t)0x80008009);
+
+  /* --- __UADD16 Test ---------------------------------------------- */
+  op1_u32 = 0x00010002;
+  op2_u32 = 0x00020004;
+  res_u32 = __UADD16(op1_u32, op2_u32);
+  ASSERT_TRUE(res_u32 == 0x00030006);
+
+  /* --- __USUB16 Test ---------------------------------------------- */
+  op1_u32 = 0x00030006;
+  op2_u32 = 0x00020004;
+  res_u32 = __USUB16(op1_u32, op2_u32);
+  ASSERT_TRUE(res_u32 == 0x00010002);
+
+  /* --- __UASX Test ---------------------------------------------- */
+  op1_u32 = 0x80078003;
+  op2_u32 = 0x00040002;
+  res_u32 = __UASX(op1_u32, op2_u32);
+  ASSERT_TRUE(res_u32 == 0x80097FFF);
+
+  /* --- __USAX Test ---------------------------------------------- */
+  op1_u32 = 0x80038007;
+  op2_u32 = 0x00020004;
+  res_u32 = __USAX(op1_u32, op2_u32);
+  ASSERT_TRUE(res_u32 == 0x7FFF8009);
+
+  /* --- __UHADD16 Test ---------------------------------------------- */
+  op1_u32 = 0x00010002;
+  op2_u32 = 0x00020004;
+  res_u32 = __UHADD16(op1_u32, op2_u32);
+  ASSERT_TRUE(res_u32 == 0x00010003);
+
+  /* --- __UHSUB16 Test ---------------------------------------------- */
+  op1_u32 = 0x00030006;
+  op2_u32 = 0x00020004;
+  res_u32 = __UHSUB16(op1_u32, op2_u32);
+  ASSERT_TRUE(res_u32 == 0x00000001);
+
+  /* --- __UHASX Test ---------------------------------------------- */
+  op1_u32 = 0x80078003;
+  op2_u32 = 0x00040002;
+  res_u32 = __UHASX(op1_u32, op2_u32);
+  ASSERT_TRUE(res_u32 == 0x40043FFF);
+
+  /* --- __UHSAX Test ---------------------------------------------- */
+  op1_u32 = 0x80038007;
+  op2_u32 = 0x00020004;
+  res_u32 = __UHSAX(op1_u32, op2_u32);
+  ASSERT_TRUE(res_u32 == 0x3FFF4004);
+
+  /* --- __UQADD16 Test ---------------------------------------------- */
+  op1_u32 = 0xFFFE0002;
+  op2_u32 = 0x00020004;
+  res_u32 = __UQADD16(op1_u32, op2_u32);
+  ASSERT_TRUE(res_u32 == 0xFFFF0006);
+
+  /* --- __UQSUB16 Test ---------------------------------------------- */
+  op1_u32 = 0x00020006;
+  op2_u32 = 0x00030004;
+  res_u32 = __UQSUB16(op1_u32, op2_u32);
+  ASSERT_TRUE(res_u32 == 0x00000002);
+
+  /* --- __UQASX Test ---------------------------------------------- */
+  op1_u32 = 0xFFF80003;
+  op2_u32 = 0x00040009;
+  res_u32 = __UQASX(op1_u32, op2_u32);
+  ASSERT_TRUE(res_u32 == 0xFFFF0000);
+
+  /* --- __UQSAX Test ---------------------------------------------- */
+  op1_u32 = 0x0003FFF8;
+  op2_u32 = 0x00090004;
+  res_u32 = __UQSAX(op1_u32, op2_u32);
+  ASSERT_TRUE(res_u32 == 0x0000FFFF);
+#endif
+}
+
+/**
+\brief Test case: TC_CoreSimd_ParMul16
+\details
+- Check Parallel 16-bit multiplication:
+  __SMLAD
+  __SMLADX
+  __SMLALD
+  __SMLALDX
+  __SMLSD
+  __SMLSDX
+  __SMLSLD
+  __SMLSLDX
+  __SMUAD
+  __SMUADX
+  __SMUSD
+  __SMUSDX
+*/
+void TC_CoreSimd_ParMul16 (void) {
+#if ((defined (__ARM_ARCH_7EM__ ) && (__ARM_ARCH_7EM__  == 1)) || \
+     (defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1))     )
+  volatile int32_t op1_s32, op2_s32, op3_s32;
+  volatile int32_t res_s32;
+
+  volatile int64_t op1_s64;
+  volatile int64_t res_s64;
+
+  /* --- __SMLAD Test ---------------------------------------------- */
+  op1_s32 = 0x00030002;
+  op2_s32 = 0x00050004;
+  op3_s32 = 0x20000000;
+  res_s32 = __SMLAD(op1_s32, op2_s32, op3_s32);
+  ASSERT_TRUE(res_s32 == 0x20000017);
+
+  /* --- __SMLADX Test ---------------------------------------------- */
+  op1_s32 = 0x00030002;
+  op2_s32 = 0x00050004;
+  op3_s32 = 0x00000800;
+  res_s32 = __SMLADX(op1_s32, op2_s32, op3_s32);
+  ASSERT_TRUE(res_s32 == 0x00000816);
+
+  /* --- __SMLALD Test ---------------------------------------------- */
+  op1_s32 = 0x00030002;
+  op2_s32 = 0x00050004;
+  op1_s64 = 0x00000000200000000LL;
+  res_s64 = __SMLALD(op1_s32, op2_s32, op1_s64);
+  ASSERT_TRUE(res_s64 == 0x0000000200000017LL);
+
+  /* --- __SMLALDX Test ---------------------------------------------- */
+  op1_s32 = 0x00030002;
+  op2_s32 = 0x00050004;
+  op1_s64 = 0x00000000200000000LL;
+  res_s64 = __SMLALDX(op1_s32, op2_s32, op1_s64);
+  ASSERT_TRUE(res_s64 == 0x0000000200000016LL);
+
+  /* --- __SMLSD Test ---------------------------------------------- */
+  op1_s32 = 0x00030006;
+  op2_s32 = 0x00050004;
+  op3_s32 = 0x00000800;
+  res_s32 = __SMLSD(op1_s32, op2_s32, op3_s32);
+  ASSERT_TRUE(res_s32 == 0x00000809);
+
+  /* --- __SMLSDX Test ---------------------------------------------- */
+  op1_s32 = 0x00030002;
+  op2_s32 = 0x00050004;
+  op3_s32 = 0x00000800;
+  res_s32 = __SMLSDX(op1_s32, op2_s32, op3_s32);
+  ASSERT_TRUE(res_s32 == 0x000007FE);
+
+  /* --- __SMLSLD Test ---------------------------------------------- */
+  op1_s32 = 0x00030006;
+  op2_s32 = 0x00050004;
+  op1_s64 = 0x00000000200000000LL;
+  res_s64 = __SMLSLD(op1_s32, op2_s32, op1_s64);
+  ASSERT_TRUE(res_s64 == 0x0000000200000009LL);
+
+  /* --- __SMLSLDX Test ---------------------------------------------- */
+  op1_s32 = 0x00030006;
+  op2_s32 = 0x00050004;
+  op1_s64 = 0x00000000200000000LL;
+  res_s64 = __SMLSLDX(op1_s32, op2_s32, op1_s64);
+  ASSERT_TRUE(res_s64 == 0x0000000200000012LL);
+
+  /* --- __SMUAD Test ---------------------------------------------- */
+  op1_s32 = 0x00030001;
+  op2_s32 = 0x00040002;
+  res_s32 = __SMUAD(op1_s32,op2_s32);
+  ASSERT_TRUE(res_s32 == 0x0000000E);
+
+  op1_s32 = (int32_t)0xFFFDFFFF;
+  op2_s32 = (int32_t)0x00040002;
+  res_s32 = __SMUAD(op1_s32,op2_s32);
+  ASSERT_TRUE(res_s32 == (int32_t)0xFFFFFFF2);
+
+  /* --- __SMUADX Test ---------------------------------------------- */
+  op1_s32 = 0x00030001;
+  op2_s32 = 0x00040002;
+  res_s32 = __SMUADX(op1_s32,op2_s32);
+  ASSERT_TRUE(res_s32 == 0x0000000A);
+
+  op1_s32 = (int32_t)0xFFFDFFFF;
+  op2_s32 = (int32_t)0x00040002;
+  res_s32 = __SMUADX(op1_s32,op2_s32);
+  ASSERT_TRUE(res_s32 == (int32_t)0xFFFFFFF6);
+
+  /* --- __SMUSD Test ---------------------------------------------- */
+  op1_s32 = (int32_t)0x00030001;
+  op2_s32 = (int32_t)0x00040002;
+  res_s32 = __SMUSD(op1_s32,op2_s32);
+  ASSERT_TRUE(res_s32 == (int32_t)0xFFFFFFF6);
+
+  op1_s32 = (int32_t)0xFFFDFFFF;
+  op2_s32 = (int32_t)0x00040002;
+  res_s32 = __SMUSD(op1_s32,op2_s32);
+  ASSERT_TRUE(res_s32 == 0x0000000A);
+
+  /* --- __SMUSDX Test ---------------------------------------------- */
+  op1_s32 = 0x00030001;
+  op2_s32 = 0x00040002;
+  res_s32 = __SMUSDX(op1_s32,op2_s32);
+  ASSERT_TRUE(res_s32 == (int32_t)0xFFFFFFFE);
+
+  op1_s32 = (int32_t)0xFFFDFFFF;
+  op2_s32 = (int32_t)0x00040002;
+  res_s32 = __SMUSDX(op1_s32,op2_s32);
+  ASSERT_TRUE(res_s32 == (int32_t)0x00000002);
+#endif
+}
+
+/**
+\brief Test case: TC_CoreSimd_Part9
+\details
+- Check Packing Halfword:
+  __PKHBT
+  __PKHTB
+*/
+void TC_CoreSimd_Pack16 (void) {
+#if ((defined (__ARM_ARCH_7EM__ ) && (__ARM_ARCH_7EM__  == 1)) || \
+     (defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1))     )
+  volatile uint32_t op1_u32, op2_u32;
+  volatile uint32_t res_u32;
+
+  /* --- __PKHBT Test ---------------------------------------------- */
+  op1_u32 = 0x00000111;
+  op2_u32 = 0x22200000;
+  res_u32 = __PKHBT(op1_u32, op2_u32, 0);
+  ASSERT_TRUE(res_u32 == 0x22200111);
+
+  op1_u32 = 0x00000111;
+  op2_u32 = 0x22200000;
+  res_u32 = __PKHBT(op1_u32, op2_u32, 4);
+  ASSERT_TRUE(res_u32 == 0x22000111);
+
+  /* --- __PKHTB Test ---------------------------------------------- */
+  op1_u32 = 0x11100000;
+  op2_u32 = 0x00000222;
+  res_u32 = __PKHTB(op1_u32, op2_u32, 0);
+  ASSERT_TRUE(res_u32 == 0x11100222);
+
+  op1_u32 = 0x11100000;
+  op2_u32 = 0x00000222;
+  res_u32 = __PKHTB(op1_u32, op2_u32, 4);
+  ASSERT_TRUE(res_u32 == 0x11100022);
+#endif
+}
+
+/**
+\brief Test case: TC_CoreSimd_MulAcc32
+\details
+- Check Signed Most Significant Word Multiply Accumulate:
+  __SMMLA
+*/
+void TC_CoreSimd_MulAcc32 (void) {
+#if ((defined (__ARM_ARCH_7EM__ ) && (__ARM_ARCH_7EM__  == 1)) || \
+     (defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1))     )
+  volatile int32_t op1_s32, op2_s32, op3_s32;
+  volatile int32_t res_s32;
+
+  /* --- __SMMLA Test ---------------------------------------------- */
+  op1_s32 = 0x00000200;
+  op2_s32 = 0x00000004;
+  op3_s32 = 0x00000100;
+  res_s32 = __SMMLA(op1_s32, op2_s32, op3_s32);
+  ASSERT_TRUE(res_s32 == 0x00000100);
+
+  op1_s32 = 0x40000000;
+  op2_s32 = 0x00000010;
+  op3_s32 = 0x00000300;
+  res_s32 = __SMMLA(op1_s32, op2_s32, op3_s32);
+  ASSERT_TRUE(res_s32 == 0x00000304);
+#endif
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Source/CV_Framework.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Source/CV_Framework.c
@@ -1,0 +1,104 @@
+/*-----------------------------------------------------------------------------
+ *      Name:         cv_framework.c
+ *      Purpose:      Test framework entry point
+ *----------------------------------------------------------------------------
+ *      Copyright (c) 2017 ARM Limited. All rights reserved.
+ *----------------------------------------------------------------------------*/
+#include "CV_Framework.h"
+#include "cmsis_cv.h" 
+  
+/* Prototypes */
+void ts_cmsis_cv(void);
+void closeDebug(void);
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/**
+\defgroup framework_funcs Framework Functions
+\brief Functions in the Framework software component
+\details
+
+@{
+*/
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/**
+\brief Close the debug session.
+\details
+Debug session dead end - debug script should close session here.
+*/
+void closeDebug(void) {
+  __NOP();
+  // Test completed
+}
+
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+
+/**
+\brief This is CORE Validation test suite.
+\details
+Program flow:
+  -# Test report statistics is initialized
+  -# Test report headers are written to the standard output
+  -# All defined test cases are executed:
+      - Test case statistics is initialized
+      - Test case report header is written to the standard output
+      - Test case is executed
+      - Test case results are written to the standard output
+      - Test case report footer is written to the standard output
+      - Test case is closed
+  -# Test report footer is written to the standard output
+  -# Debug session ends in dead loop
+*/
+void ts_cmsis_cv () {
+  const char *fn;
+  uint32_t tc, no;
+  (void)ritf.Init ();                           /* Init test report                 */
+  (void)ritf.Open (ts.ReportTitle,              /* Write test report title          */
+                   ts.Date,                     /* Write compilation date           */
+                   ts.Time,                     /* Write compilation time           */
+                   ts.FileName);                /* Write module file name           */
+
+  /* Execute all test cases */
+  for (tc = 0; tc < ts.NumOfTC; tc++) {
+    no = ts.TCBaseNum+tc;                 /* Test case number                 */
+    fn = ts.TC[tc].TFName;                /* Test function name string        */
+    (void)ritf.Open_TC (no, fn);          /* Open test case #(Base + TC)      */
+    if (ts.TC[tc].en != 0U)  {
+      ts.TC[tc].TestFunc();               /* Execute test case if enabled     */
+    }
+    (void)ritf.Close_TC ();               /* Close test case                  */
+  }
+  (void)ritf.Close ();                    /* Close test report                */
+
+  closeDebug();                           /* Close debug session              */
+}
+
+/**
+\brief This is the entry point of the test framework.
+\details
+Program flow:
+  -# Hardware is first initialized if Init callback function is provided
+  -# Main thread is initialized
+*/
+void cmsis_cv (void) {
+  
+  /* Init test suite */
+  if (ts.Init != NULL) {
+    ts.Init();                           /* Init hardware                    */
+  }
+
+  ts_cmsis_cv();
+}
+
+void cmsis_cv_abort (const char *fn, uint32_t ln, char *desc) {
+  (void)__set_result(fn, ln, FAILED, desc);
+  (void)ritf.Close_TC();
+  (void)ritf.Close();
+  closeDebug();
+}
+
+/**
+@}
+*/ 
+// end of group framework_funcs

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Source/CV_GenTimer.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Source/CV_GenTimer.c
@@ -1,0 +1,72 @@
+/*-----------------------------------------------------------------------------
+ *      Name:         CV_GenTimer.c 
+ *      Purpose:      CMSIS CORE validation tests implementation
+ *-----------------------------------------------------------------------------
+ *      Copyright (c) 2017 ARM Limited. All rights reserved.
+ *----------------------------------------------------------------------------*/
+
+#include "cmsis_compiler.h"
+
+#include "CV_Framework.h"
+#include "cmsis_cv.h"
+
+/*-----------------------------------------------------------------------------
+ *      Test implementation
+ *----------------------------------------------------------------------------*/
+
+/*-----------------------------------------------------------------------------
+ *      Test cases
+ *----------------------------------------------------------------------------*/
+
+ 
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+void TC_GenTimer_CNTFRQ(void) {
+  const uint32_t cntfrq1 = __get_CNTFRQ();
+  __set_CNTFRQ(cntfrq1 + 1U);
+  const uint32_t cntfrq2 = __get_CNTFRQ();
+
+  ASSERT_TRUE((cntfrq1 + 1U) == cntfrq2);
+  
+  __set_CNTFRQ(cntfrq1);
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+void TC_GenTimer_CNTP_TVAL(void) {
+  const uint32_t cntp_tval1 = __get_CNTP_TVAL();
+  __set_CNTP_TVAL(cntp_tval1 + 1U);
+  const uint32_t cntp_tval2 = __get_CNTP_TVAL();
+
+  ASSERT_TRUE((cntp_tval2 - cntp_tval1) >= 1ULL);
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+void TC_GenTimer_CNTP_CTL(void) {
+  static const uint32_t CNTP_CTL_ENABLE = 0x01U;
+  const uint32_t cntp_ctl = __get_CNTP_CTL();
+  const uint32_t cntp_ctl_toggled = (cntp_ctl & (~CNTP_CTL_ENABLE)) | ((~cntp_ctl) & CNTP_CTL_ENABLE);
+  __set_CNTP_CTL(cntp_ctl_toggled);
+
+  const uint32_t cntp_ctl_new = __get_CNTP_CTL();
+
+  ASSERT_TRUE((cntp_ctl_toggled & CNTP_CTL_ENABLE) == (cntp_ctl_new & CNTP_CTL_ENABLE));
+  
+  __set_CNTP_CTL(cntp_ctl);
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+void TC_GenTimer_CNTPCT(void) {
+  const uint64_t cntpct1 = __get_CNTPCT();
+  for(int i=0; i<10; i++);
+  const uint64_t cntpct2 = __get_CNTPCT();
+
+  ASSERT_TRUE((cntpct2 - cntpct1) <= 120ULL);
+}
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+void TC_GenTimer_CNTP_CVAL(void) {
+  const uint64_t cntp_cval1 = __get_CNTP_CVAL();
+  __set_CNTP_CVAL(cntp_cval1 + 1ULL);
+  const uint64_t cntp_cval2 = __get_CNTP_CVAL();
+
+  ASSERT_TRUE((cntp_cval2 - cntp_cval1) >= 1ULL);
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Source/CV_MPU_ARMv7.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Source/CV_MPU_ARMv7.c
@@ -1,0 +1,121 @@
+/*-----------------------------------------------------------------------------
+ *      Name:         CV_MPU_ARMv7.c 
+ *      Purpose:      CMSIS CORE validation tests implementation
+ *-----------------------------------------------------------------------------
+ *      Copyright (c) 2017 ARM Limited. All rights reserved.
+ *----------------------------------------------------------------------------*/
+
+#include "CV_Framework.h"
+#include "cmsis_cv.h"
+
+/*-----------------------------------------------------------------------------
+ *      Test implementation
+ *----------------------------------------------------------------------------*/
+
+#if defined(__MPU_PRESENT) && __MPU_PRESENT
+static void ClearMpu(void) {
+  for(uint32_t i = 0U; i < 8U; ++i) {
+    MPU->RNR = i;
+    MPU->RBAR = 0U;
+    MPU->RASR = 0U;
+  }
+}
+#endif
+
+/*-----------------------------------------------------------------------------
+ *      Test cases
+ *----------------------------------------------------------------------------*/
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/**
+\brief Test case: TC_MPU_SetClear
+\details
+- Check if ARM_MPU_Load correctly loads MPU table to registers.
+*/
+void TC_MPU_SetClear(void)
+{
+#if defined(__MPU_PRESENT) && __MPU_PRESENT
+  static const ARM_MPU_Region_t table[] = {
+    { .RBAR = 0U, .RASR = 0U },
+    { .RBAR = ARM_MPU_RBAR(2U, 0x30000000U), .RASR = ARM_MPU_RASR(1U, ARM_MPU_AP_FULL, 0U, 0U, 0U, 0U, 0U, ARM_MPU_REGION_SIZE_128MB) },
+    { .RBAR = 0x50000000U, .RASR = ARM_MPU_RASR(0U, ARM_MPU_AP_FULL, 0U, 0U, 0U, 0U, 0U, ARM_MPU_REGION_SIZE_64MB) }
+  };
+  
+  #define ASSERT_MPU_REGION(rnr, region) \
+    MPU->RNR = rnr; \
+    ASSERT_TRUE((MPU->RBAR & MPU_RBAR_ADDR_Msk) == (region.RBAR & MPU_RBAR_ADDR_Msk)); \
+    ASSERT_TRUE(MPU->RASR == region.RASR)
+  
+  ClearMpu();
+    
+  ARM_MPU_SetRegion(table[1].RBAR, table[1].RASR);
+  
+  ASSERT_MPU_REGION(1U, table[0]);
+  ASSERT_MPU_REGION(2U, table[1]);
+  ASSERT_MPU_REGION(3U, table[0]);
+  
+  ARM_MPU_SetRegionEx(5U, table[2].RBAR, table[2].RASR);
+  
+  ASSERT_MPU_REGION(4U, table[0]);
+  ASSERT_MPU_REGION(5U, table[2]);
+  ASSERT_MPU_REGION(6U, table[0]);
+  
+  ARM_MPU_ClrRegion(5U);
+  
+  MPU->RNR = 5U;
+  ASSERT_TRUE((MPU->RASR & MPU_RASR_ENABLE_Msk) == 0U);
+  
+  #undef ASSERT_MPU_REGION
+#endif
+}
+  
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/**
+\brief Test case: TC_MPU_Load
+\details
+- Check if ARM_MPU_Load correctly loads MPU table to registers.
+*/
+void TC_MPU_Load(void)
+{
+#if defined(__MPU_PRESENT) && __MPU_PRESENT
+  static const ARM_MPU_Region_t table[] = {
+    { .RBAR = ARM_MPU_RBAR(0U, 0x10000000U), .RASR = ARM_MPU_RASR(1U, ARM_MPU_AP_FULL, 0U, 0U, 0U, 0U, 0U, ARM_MPU_REGION_SIZE_32MB)  },
+    { .RBAR = ARM_MPU_RBAR(1U, 0x20000000U), .RASR = ARM_MPU_RASR(1U, ARM_MPU_AP_FULL, 0U, 0U, 0U, 0U, 0U, ARM_MPU_REGION_SIZE_64MB)  },
+    { .RBAR = ARM_MPU_RBAR(2U, 0x30000000U), .RASR = ARM_MPU_RASR(1U, ARM_MPU_AP_FULL, 0U, 0U, 0U, 0U, 0U, ARM_MPU_REGION_SIZE_128MB) },
+    { .RBAR = ARM_MPU_RBAR(3U, 0x40000000U), .RASR = ARM_MPU_RASR(1U, ARM_MPU_AP_FULL, 0U, 0U, 0U, 0U, 0U, ARM_MPU_REGION_SIZE_256MB) },
+    { .RBAR = ARM_MPU_RBAR(4U, 0x50000000U), .RASR = ARM_MPU_RASR(1U, ARM_MPU_AP_FULL, 0U, 0U, 0U, 0U, 0U, ARM_MPU_REGION_SIZE_512MB) },
+    { .RBAR = ARM_MPU_RBAR(5U, 0x60000000U), .RASR = ARM_MPU_RASR(1U, ARM_MPU_AP_FULL, 0U, 0U, 0U, 0U, 0U, ARM_MPU_REGION_SIZE_16MB)  },
+    { .RBAR = ARM_MPU_RBAR(6U, 0x70000000U), .RASR = ARM_MPU_RASR(1U, ARM_MPU_AP_FULL, 0U, 0U, 0U, 0U, 0U, ARM_MPU_REGION_SIZE_8MB)   },
+    { .RBAR = ARM_MPU_RBAR(7U, 0x80000000U), .RASR = ARM_MPU_RASR(1U, ARM_MPU_AP_FULL, 0U, 0U, 0U, 0U, 0U, ARM_MPU_REGION_SIZE_4MB)   }
+  };
+  
+  #define ASSERT_MPU_REGION(rnr, table) \
+    MPU->RNR = rnr; \
+    ASSERT_TRUE((MPU->RBAR & MPU_RBAR_ADDR_Msk) == (table[rnr].RBAR & MPU_RBAR_ADDR_Msk)); \
+    ASSERT_TRUE(MPU->RASR == table[rnr].RASR)
+
+  ClearMpu();
+  
+  ARM_MPU_Load(&(table[0]), 1U);
+  
+  ASSERT_MPU_REGION(0U, table);
+  
+  ARM_MPU_Load(&(table[1]), 5U);
+
+  ASSERT_MPU_REGION(0U, table);
+  ASSERT_MPU_REGION(1U, table);
+  ASSERT_MPU_REGION(2U, table);
+  ASSERT_MPU_REGION(3U, table);
+  ASSERT_MPU_REGION(4U, table);
+  ASSERT_MPU_REGION(5U, table);
+
+  ARM_MPU_Load(&(table[6]), 2U);
+
+  ASSERT_MPU_REGION(5U, table);
+  ASSERT_MPU_REGION(6U, table);
+  ASSERT_MPU_REGION(7U, table);
+
+  #undef ASSERT_MPU_REGION
+#endif
+}
+

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Source/CV_MPU_ARMv8.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Source/CV_MPU_ARMv8.c
@@ -1,0 +1,113 @@
+/*-----------------------------------------------------------------------------
+ *      Name:         CV_MPU_ARMv7.c 
+ *      Purpose:      CMSIS CORE validation tests implementation
+ *-----------------------------------------------------------------------------
+ *      Copyright (c) 2017 ARM Limited. All rights reserved.
+ *----------------------------------------------------------------------------*/
+
+#include "CV_Framework.h"
+#include "cmsis_cv.h"
+
+/*-----------------------------------------------------------------------------
+ *      Test implementation
+ *----------------------------------------------------------------------------*/
+
+#if defined(__MPU_PRESENT) && __MPU_PRESENT
+static void ClearMpu(void) {
+  for(uint32_t i = 0U; i < 8U; ++i) {
+    MPU->RNR = i;
+    MPU->RBAR = 0U;
+    MPU->RLAR = 0U;
+  }
+}
+#endif
+
+/*-----------------------------------------------------------------------------
+ *      Test cases
+ *----------------------------------------------------------------------------*/
+
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/**
+\brief Test case: TC_MPU_SetClear
+\details
+- Check if ARM_MPU_Load correctly loads MPU table to registers.
+*/
+void TC_MPU_SetClear(void)
+{
+#if defined(__MPU_PRESENT) && __MPU_PRESENT
+  static const ARM_MPU_Region_t table[] = {
+    { .RBAR = 0U, .RLAR = 0U },
+    { .RBAR = ARM_MPU_RBAR(0x30000000U, 0U, 1U, 1U, 1U), .RLAR = ARM_MPU_RLAR(0x38000000U, 0U) }
+  };
+  
+  #define ASSERT_MPU_REGION(rnr, region) \
+    MPU->RNR = rnr; \
+    ASSERT_TRUE(MPU->RBAR == region.RBAR); \
+    ASSERT_TRUE(MPU->RLAR == region.RLAR)
+  
+  ClearMpu();
+    
+  ARM_MPU_SetRegion(2U, table[1].RBAR, table[1].RLAR);
+  
+  ASSERT_MPU_REGION(1U, table[0]);
+  ASSERT_MPU_REGION(2U, table[1]);
+  ASSERT_MPU_REGION(3U, table[0]);
+  
+  ARM_MPU_ClrRegion(2U);
+  
+  MPU->RNR = 2U;
+  ASSERT_TRUE((MPU->RLAR & MPU_RLAR_EN_Msk) == 0U);
+  
+  #undef ASSERT_MPU_REGION
+#endif
+}
+  
+/*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
+/**
+\brief Test case: TC_MPU_Load
+\details
+- Check if ARM_MPU_Load correctly loads MPU table to registers.
+*/
+void TC_MPU_Load(void)
+{
+#if defined(__MPU_PRESENT) && __MPU_PRESENT
+  static const ARM_MPU_Region_t table[] = {
+    { .RBAR = ARM_MPU_RBAR(0x10000000U, 0U, 1U, 1U, 1U), .RLAR = ARM_MPU_RLAR(0x18000000U, 0U) },
+    { .RBAR = ARM_MPU_RBAR(0x20000000U, 0U, 1U, 1U, 1U), .RLAR = ARM_MPU_RLAR(0x27000000U, 0U) },
+    { .RBAR = ARM_MPU_RBAR(0x30000000U, 0U, 1U, 1U, 1U), .RLAR = ARM_MPU_RLAR(0x36000000U, 0U) },
+    { .RBAR = ARM_MPU_RBAR(0x40000000U, 0U, 1U, 1U, 1U), .RLAR = ARM_MPU_RLAR(0x45000000U, 0U) },
+    { .RBAR = ARM_MPU_RBAR(0x50000000U, 0U, 1U, 1U, 1U), .RLAR = ARM_MPU_RLAR(0x54000000U, 0U) },
+    { .RBAR = ARM_MPU_RBAR(0x60000000U, 0U, 1U, 1U, 1U), .RLAR = ARM_MPU_RLAR(0x63000000U, 0U) },
+    { .RBAR = ARM_MPU_RBAR(0x70000000U, 0U, 1U, 1U, 1U), .RLAR = ARM_MPU_RLAR(0x72000000U, 0U) },
+    { .RBAR = ARM_MPU_RBAR(0x80000000U, 0U, 1U, 1U, 1U), .RLAR = ARM_MPU_RLAR(0x31000000U, 0U) }
+  };
+  
+  #define ASSERT_MPU_REGION(rnr, table) \
+    MPU->RNR = rnr; \
+    ASSERT_TRUE(MPU->RBAR == table[rnr].RBAR); \
+    ASSERT_TRUE(MPU->RLAR == table[rnr].RLAR)
+
+  ClearMpu();
+  
+  ARM_MPU_Load(0U, &(table[0]), 1U);
+  
+  ASSERT_MPU_REGION(0U, table);
+  
+  ARM_MPU_Load(1U, &(table[1]), 5U);
+
+  ASSERT_MPU_REGION(0U, table);
+  ASSERT_MPU_REGION(1U, table);
+  ASSERT_MPU_REGION(2U, table);
+  ASSERT_MPU_REGION(3U, table);
+  ASSERT_MPU_REGION(4U, table);
+  ASSERT_MPU_REGION(5U, table);
+
+  ARM_MPU_Load(6U, &(table[6]), 2U);
+
+  ASSERT_MPU_REGION(5U, table);
+  ASSERT_MPU_REGION(6U, table);
+  ASSERT_MPU_REGION(7U, table);
+
+  #undef ASSERT_MPU_REGION
+#endif 
+}

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Source/CV_Report.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Source/CV_Report.c
@@ -1,0 +1,393 @@
+/*-----------------------------------------------------------------------------
+ *      Name:         cv_report.c
+ *      Purpose:      Report statistics and layout implementation
+ *-----------------------------------------------------------------------------
+ *      Copyright (c) 2017 - 2018 Arm Limited. All rights reserved.
+ *----------------------------------------------------------------------------*/
+#include "CV_Report.h"
+#include <stdio.h>
+#include <string.h>
+
+TEST_REPORT test_report;
+static AS_STAT     current_assertions;   /* Current test case assertions statistics  */
+#define TAS (&test_report.assertions)         /* Total assertions             */
+#define CAS (&current_assertions)             /* Current assertions           */
+
+#ifdef DISABLE_SEMIHOSTING
+#if defined (__CC_ARM)
+  #pragma import __use_no_semihosting
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  __ASM(".global __use_no_semihosting");
+#endif
+#define PRINT(x)
+#define FLUSH()
+void _sys_exit(int return_code) {}
+#else
+#define PRINT(x) MsgPrint x
+#define FLUSH()  MsgFlush()
+#endif // DISABLE_SEMIHOSTING
+
+static uint8_t Passed[] = "PASSED";
+static uint8_t Warning[] = "WARNING";
+static uint8_t Failed[] = "FAILED";
+static uint8_t NotExe[] = "NOT EXECUTED";
+
+
+/*-----------------------------------------------------------------------------
+ * Test report function prototypes
+ *----------------------------------------------------------------------------*/
+static BOOL     tr_Init   (void);
+static BOOL     tc_Init   (void);
+static uint8_t *tr_Eval   (void);
+static uint8_t *tc_Eval   (void);
+static BOOL     StatCount (TC_RES res);
+
+/*-----------------------------------------------------------------------------
+ * Printer function prototypes
+ *----------------------------------------------------------------------------*/
+static void MsgPrint (const char *msg, ...);
+static void MsgFlush (void);
+
+
+/*-----------------------------------------------------------------------------
+ * Assert interface function prototypes
+ *----------------------------------------------------------------------------*/
+static BOOL As_File_Result (TC_RES res);
+static BOOL As_File_Dbgi   (TC_RES res, const char *fn, uint32_t ln, char *desc);
+
+TC_ITF tcitf = {
+  As_File_Result,
+  As_File_Dbgi,
+};
+
+
+/*-----------------------------------------------------------------------------
+ * Test report interface function prototypes
+ *----------------------------------------------------------------------------*/
+BOOL tr_File_Init  (void);
+BOOL tr_File_Open  (const char *title, const char *date, const char *time, const char *fn);
+BOOL tr_File_Close (void);
+BOOL tc_File_Open  (uint32_t num, const char *fn);
+BOOL tc_File_Close (void);
+
+REPORT_ITF ritf = {
+  tr_File_Init,
+  tr_File_Open,
+  tr_File_Close,
+  tc_File_Open,
+  tc_File_Close
+};
+
+
+/*-----------------------------------------------------------------------------
+ * Init test report
+ *----------------------------------------------------------------------------*/
+BOOL tr_File_Init (void) {
+  return (tr_Init());
+}
+
+
+/*-----------------------------------------------------------------------------
+ * Open test report
+ *----------------------------------------------------------------------------*/
+#if (PRINT_XML_REPORT==1)
+BOOL tr_File_Open (const char *title, const char *date, const char *time, const char *fn) {
+  PRINT(("<?xml version=\"1.0\"?>\n"));
+  PRINT(("<?xml-stylesheet href=\"TR_Style.xsl\" type=\"text/xsl\" ?>\n"));
+  PRINT(("<report>\n"));
+  PRINT(("<test>\n"));
+  PRINT(("<title>%s</title>\n", title));
+  PRINT(("<date>%s</date>\n",   date));
+  PRINT(("<time>%s</time>\n",   time));
+  PRINT(("<file>%s</file>\n",   fn));
+  PRINT(("<test_cases>\n"));
+#else
+BOOL tr_File_Open (const char *title, const char *date, const char *time, const char __attribute__((unused)) *fn) {
+  PRINT(("%s   %s   %s \n\n", title, date, time));
+#endif
+  return (__TRUE);
+}
+
+
+/*-----------------------------------------------------------------------------
+ * Open test case
+ *----------------------------------------------------------------------------*/
+BOOL tc_File_Open (uint32_t num, const char *fn) {
+  (void)tc_Init ();
+#if (PRINT_XML_REPORT==1)
+  PRINT(("<tc>\n"));
+  PRINT(("<no>%d</no>\n",     num));
+  PRINT(("<func>%s</func>\n", fn));
+  PRINT(("<req></req>"));
+  PRINT(("<meth></meth>"));
+  PRINT(("<dbgi>\n"));
+#else
+  PRINT(("TEST %02d: %-42s ", num, fn));
+#endif
+  return (__TRUE);
+}
+
+
+/*-----------------------------------------------------------------------------
+ * Close test case
+ *----------------------------------------------------------------------------*/
+BOOL tc_File_Close (void) {
+  uint8_t *res = tc_Eval();
+#if (PRINT_XML_REPORT==1)
+  PRINT(("</dbgi>\n"));
+  PRINT(("<res>%s</res>\n", res));
+  PRINT(("</tc>\n"));
+#else
+  if ((res==Passed)||(res==NotExe)) {
+    PRINT(("%s\n", res));
+  } else {
+    PRINT(("\n"));
+  }
+#endif
+  FLUSH();
+  return (__TRUE);
+}
+
+
+/*-----------------------------------------------------------------------------
+ * Close test report
+ *----------------------------------------------------------------------------*/
+BOOL tr_File_Close (void) {
+#if (PRINT_XML_REPORT==1)
+  PRINT(("</test_cases>\n"));
+  PRINT(("<summary>\n"));
+  PRINT(("<tcnt>%d</tcnt>\n", test_report.tests));
+  PRINT(("<exec>%d</exec>\n", test_report.executed));
+  PRINT(("<pass>%d</pass>\n", test_report.passed));
+  PRINT(("<fail>%d</fail>\n", test_report.failed));
+  PRINT(("<warn>%d</warn>\n", test_report.warnings));
+  PRINT(("<tres>%s</tres>\n", tr_Eval()));
+  PRINT(("</summary>\n"));
+  PRINT(("</test>\n"));
+  PRINT(("</report>\n"));
+#else
+  PRINT(("\nTest Summary: %d Tests, %d Executed, %d Passed, %d Failed, %d Warnings.\n",
+         test_report.tests,
+         test_report.executed,
+         test_report.passed,
+         test_report.failed,
+         test_report.warnings));
+  PRINT(("Test Result: %s\n", tr_Eval()));
+#endif
+  FLUSH();
+  return (__TRUE);
+}
+
+
+/*-----------------------------------------------------------------------------
+ * Assertion result counter
+ *----------------------------------------------------------------------------*/
+static BOOL As_File_Result (TC_RES res) {
+  return (StatCount (res));
+}
+
+
+/*-----------------------------------------------------------------------------
+ * Set debug information state
+ *----------------------------------------------------------------------------*/
+#if (PRINT_XML_REPORT==1)
+static BOOL As_File_Dbgi (TC_RES __attribute__((unused)) res, const char *fn, uint32_t ln, char *desc) {
+  PRINT(("<detail>\n"));
+  if (desc!=NULL) PRINT(("<desc>%s</desc>\n", desc));
+  PRINT(("<module>%s</module>\n", fn));
+  PRINT(("<line>%d</line>\n", ln));
+  PRINT(("</detail>\n"));
+#else
+static BOOL As_File_Dbgi (TC_RES res, const char *fn, uint32_t ln, char *desc) {
+  PRINT(("\n  %s (%d)", fn, ln));
+  if (res==WARNING){ PRINT((" [WARNING]")); }
+  if (res==FAILED) { PRINT((" [FAILED]"));  }
+  if (desc!=NULL)  { PRINT((" %s", desc));  }
+#endif
+  return (__TRUE);
+}
+
+
+/*-----------------------------------------------------------------------------
+ * Init test report
+ *----------------------------------------------------------------------------*/
+static BOOL tr_Init (void) {
+  TAS->passed = 0;
+  TAS->failed = 0;
+  TAS->warnings = 0;
+  return (__TRUE);
+}
+
+
+/*-----------------------------------------------------------------------------
+ * Init test case
+ *----------------------------------------------------------------------------*/
+static BOOL tc_Init (void) {
+  CAS->passed = 0;
+  CAS->failed = 0;
+  CAS->warnings = 0;
+  return (__TRUE);
+}
+
+
+/*-----------------------------------------------------------------------------
+ * Evaluate test report results
+ *----------------------------------------------------------------------------*/
+static uint8_t *tr_Eval (void) {
+  if (test_report.failed > 0U) {
+    /* Test fails if any test case failed */
+    return (Failed);
+  }
+  else if (test_report.warnings > 0U) {
+    /* Test warns if any test case warnings */
+    return (Warning);
+  }
+  else if (test_report.passed > 0U) {
+    /* Test passes if at least one test case passed */
+    return (Passed);
+  }
+  else {
+    /* No test cases were executed */
+    return (NotExe);
+  }
+}
+
+
+/*-----------------------------------------------------------------------------
+ * Evaluate test case results
+ *----------------------------------------------------------------------------*/
+static uint8_t *tc_Eval (void) {
+  test_report.tests++;
+  test_report.executed++;
+
+  if (CAS->failed > 0U) {
+    /* Test case fails if any failed assertion recorded */
+    test_report.failed++;
+    return Failed;
+  }
+  else if (CAS->warnings > 0U) {
+    /* Test case warns if any warnings assertion recorded */
+    test_report.warnings++;
+    return Warning;
+  }
+  else if (CAS->passed > 0U) {
+    /* Test case passes if at least one assertion passed */
+    test_report.passed++;
+    return Passed;
+  }
+  else {
+    /* Assert was not invoked - nothing to evaluate */
+    test_report.executed--;
+    return NotExe;
+  }
+}
+
+
+/*-----------------------------------------------------------------------------
+ * Statistics result counter
+ *----------------------------------------------------------------------------*/
+static BOOL StatCount (TC_RES res) {
+  switch (res) {
+    case PASSED:
+      CAS->passed++;
+      TAS->passed++;
+      break;
+
+    case WARNING:
+      CAS->warnings++;
+      TAS->warnings++;
+      break;
+
+    case FAILED:
+      CAS->failed++;
+      TAS->failed++;
+      break;
+
+    case NOT_EXECUTED:
+      return (__FALSE);
+
+    default:
+      break;
+  }
+  return (__TRUE);
+}
+
+
+/*-----------------------------------------------------------------------------
+ * Set result
+ *----------------------------------------------------------------------------*/
+TC_RES __set_result (const char *fn, uint32_t ln, TC_RES res, char* desc) {
+
+  // save assertion result
+  switch (res) {
+    case PASSED:
+      if (TAS->passed < BUFFER_ASSERTIONS) {
+        test_report.assertions.info.passed[TAS->passed].module = fn;
+        test_report.assertions.info.passed[TAS->passed].line = ln;
+      }
+      break;
+    case FAILED:
+      if (TAS->failed < BUFFER_ASSERTIONS) {
+        test_report.assertions.info.failed[TAS->failed].module = fn;
+        test_report.assertions.info.failed[TAS->failed].line = ln;
+      }
+      break;
+    case WARNING:
+      if (TAS->warnings < BUFFER_ASSERTIONS) {
+        test_report.assertions.info.warnings[TAS->warnings].module = fn;
+        test_report.assertions.info.warnings[TAS->warnings].line = ln;
+      }
+      break;
+    case NOT_EXECUTED:
+      break;
+
+    default:
+      break;
+  }
+
+  // set debug info (if the test case didn't pass)
+  if (res != PASSED) { (void)tcitf.Dbgi (res, fn, ln, desc); }
+  // set result
+  (void)tcitf.Result (res);
+  return (res);
+}
+
+/*-----------------------------------------------------------------------------
+ * Assert true
+ *----------------------------------------------------------------------------*/
+TC_RES __assert_true (const char *fn, uint32_t ln, uint32_t cond) {
+  TC_RES res = FAILED;
+  if (cond != 0U) { res = PASSED; }
+  (void)__set_result(fn, ln, res, NULL);
+  return (res);
+}
+
+#ifndef DISABLE_SEMIHOSTING
+/*-----------------------------------------------------------------------------
+ *       MsgFlush:  Flush the standard output
+ *----------------------------------------------------------------------------*/
+static void MsgFlush(void) {
+  (void)fflush(stdout);
+}
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+#endif
+/*-----------------------------------------------------------------------------
+ *       MsgPrint:  Print a message to the standard output
+ *----------------------------------------------------------------------------*/
+static void MsgPrint (const char *msg, ...) {
+  va_list args;
+  va_start(args, msg);
+  vprintf(msg, args);
+  va_end(args);
+}
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang diagnostic pop
+#endif
+#endif // DISABLE_SEMIHOSTING
+
+/*-----------------------------------------------------------------------------
+ * End of file
+ *----------------------------------------------------------------------------*/

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Source/Config/CV_Config.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Source/Config/CV_Config.h
@@ -1,0 +1,158 @@
+/*-----------------------------------------------------------------------------
+ *      Name:         CV_Config.h
+ *      Purpose:      CV Config header
+ *----------------------------------------------------------------------------
+ *      Copyright (c) 2017 - 2018 Arm Limited. All rights reserved.
+ *----------------------------------------------------------------------------*/
+#ifndef __CV_CONFIG_H
+#define __CV_CONFIG_H
+
+#include "RTE_Components.h"
+#include CMSIS_device_header
+
+#define RTE_CV_COREINSTR 1
+#define RTE_CV_COREFUNC  1
+#define RTE_CV_CORESIMD  1
+#define RTE_CV_MPUFUNC   (__MPU_PRESENT)
+#if defined __ICACHE_PRESENT || defined __DCACHE_PRESENT
+#define RTE_CV_L1CACHE   (__ICACHE_PRESENT || __DCACHE_PRESENT)
+#endif
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+// <h> Common Test Settings
+// <o> Print Output Format <0=> Plain Text <1=> XML
+// <i> Set the test results output format to plain text or XML
+#ifndef PRINT_XML_REPORT
+#define PRINT_XML_REPORT            1
+#endif
+// <o> Buffer size for assertions results
+// <i> Set the buffer size for assertions results buffer
+#define BUFFER_ASSERTIONS           128U
+// </h>
+
+// <h> Disable Test Cases
+// <i> Uncheck to disable an individual test case
+// <q0> TC_CoreInstr_NOP
+#define TC_COREINSTR_NOP_EN                        1
+// <q0> TC_CoreInstr_SEV
+#define TC_COREINSTR_SEV_EN                        1
+// <q0> TC_CoreInstr_BKPT
+#define TC_COREINSTR_BKPT_EN                       1
+// <q0> TC_CoreInstr_ISB
+#define TC_COREINSTR_ISB_EN                        1
+// <q0> TC_CoreInstr_DSB
+#define TC_COREINSTR_DSB_EN                        1
+// <q0> TC_CoreInstr_DMB
+#define TC_COREINSTR_DMB_EN                        1
+// <q0> TC_CoreInstr_WFI
+#define TC_COREINSTR_WFI_EN                        0
+// <q0> TC_CoreInstr_WFE
+#define TC_COREINSTR_WFE_EN                        0
+
+// <q0> TC_CoreInstr_REV
+#define TC_COREINSTR_REV_EN                        1
+// <q0> TC_CoreInstr_REV16
+#define TC_COREINSTR_REV16_EN                      1
+// <q0> TC_CoreInstr_REVSH
+#define TC_COREINSTR_REVSH_EN                      1
+// <q0> TC_CoreInstr_ROR
+#define TC_COREINSTR_ROR_EN                        1
+// <q0> TC_CoreInstr_RBIT
+#define TC_COREINSTR_RBIT_EN                       1
+// <q0> TC_CoreInstr_CLZ
+#define TC_COREINSTR_CLZ_EN                        1
+// <q0> TC_CoreInstr_SSAT
+#define TC_COREINSTR_SSAT_EN                       1
+// <q0> TC_CoreInstr_USAT
+#define TC_COREINSTR_USAT_EN                       1
+// <q0> TC_CoreInstr_RRX
+#define TC_COREINSTR_RRX_EN                        1
+// <q0> TC_CoreInstr_LoadStoreExlusive
+#define TC_COREINSTR_LOADSTOREEXCLUSIVE_EN         1
+// <q0> TC_CoreInstr_LoadStoreUnpriv
+#define TC_COREINSTR_LOADSTOREUNPRIV_EN            1
+// <q0> TC_CoreInstr_LoadStoreAcquire
+#define TC_COREINSTR_LOADSTOREACQUIRE_EN           1
+// <q0> TC_CoreInstr_LoadStoreAcquireExclusive
+#define TC_COREINSTR_LOADSTOREACQUIREEXCLUSIVE_EN  1
+// <q0> TC_CoreInstr_UnalignedUint16
+#define TC_COREINSTR_UNALIGNEDUINT16_EN            1
+// <q0> TC_CoreInstr_UnalignedUint32
+#define TC_COREINSTR_UNALIGNEDUINT32_EN            1
+
+// <q0> TC_CoreSimd_SatAddSub
+#define TC_CORESIMD_SATADDSUB_EN                   1
+// <q0> TC_CoreSimd_ParSat16
+#define TC_CORESIMD_PARSAT16_EN                    1
+// <q0> TC_CoreSimd_PackUnpack
+#define TC_CORESIMD_PACKUNPACK_EN                  1
+// <q0> TC_CoreSimd_ParSel
+#define TC_CORESIMD_PARSEL_EN                      1
+// <q0> TC_CoreSimd_ParAddSub8
+#define TC_CORESIMD_PARADDSUB8_EN                  1
+// <q0> TC_CoreSimd_AbsDif8
+#define TC_CORESIMD_ABSDIF8_EN                     1
+// <q0> TC_CoreSimd_ParAddSub16
+#define TC_CORESIMD_PARADDSUB16_EN                 1
+// <q0> TC_CoreSimd_ParMul16
+#define TC_CORESIMD_PARMUL16_EN                    1
+// <q0> TC_CoreSimd_Pack16
+#define TC_CORESIMD_PACK16_EN                      1
+// <q0> TC_CoreSimd_MulAcc32
+#define TC_CORESIMD_MULACC32_EN                    1
+
+// <q0> TC_CoreFunc_EnDisIRQ
+#define TC_COREFUNC_ENDISIRQ_EN                    1
+// <q0> TC_CoreFunc_IRQPrio
+#define TC_COREFUNC_IRQPRIO_EN                     1
+// <q0> TC_CoreFunc_EncDecIRQPrio
+#define TC_COREFUNC_ENCDECIRQPRIO_EN               1
+// <q0> TC_CoreFunc_IRQVect
+#define TC_COREFUNC_IRQVECT_EN                     1
+// <q0> TC_CoreFunc_Control
+#define TC_COREFUNC_CONTROL_EN                     1
+// <q0> TC_CoreFunc_IPSR
+#define TC_COREFUNC_IPSR_EN                        1
+// <q0> TC_CoreFunc_APSR
+#define TC_COREFUNC_APSR_EN                        1
+// <q0> TC_CoreFunc_PSP
+#define TC_COREFUNC_PSP_EN                         1
+// <q0> TC_CoreFunc_MSP
+#define TC_COREFUNC_MSP_EN                         1
+
+// <q0> TC_CoreFunc_PSPLIM
+#define TC_COREFUNC_PSPLIM_EN                      1
+// <q0> TC_CoreFunc_PSPLIM_NS
+#define TC_COREFUNC_PSPLIM_NS_EN                   1
+// <q0> TC_CoreFunc_MSPLIM
+#define TC_COREFUNC_MSPLIM_EN                      1
+// <q0> TC_CoreFunc_MSPLIM_NS
+#define TC_COREFUNC_MSPLIM_NS_EN                   1
+// <q0> TC_CoreFunc_PRIMASK
+#define TC_COREFUNC_PRIMASK_EN                     1
+// <q0> TC_CoreFunc_FAULTMASK
+#define TC_COREFUNC_FAULTMASK_EN                   1
+// <q0> TC_CoreFunc_BASEPRI
+#define TC_COREFUNC_BASEPRI_EN                     1
+// <q0> TC_CoreFunc_FPUType
+#define TC_COREFUNC_FPUTYPE_EN                     1
+// <q0> TC_CoreFunc_FPSCR
+#define TC_COREFUNC_FPSCR_EN                       1
+
+// <q0> TC_MPU_SetClear
+#define TC_MPU_SETCLEAR_EN                         1
+// <q0> TC_MPU_Load
+#define TC_MPU_LOAD_EN                             1
+
+// <q0> TC_CML1Cache_EnDisableICache
+#define TC_CML1CACHE_ENDISABLE_ICACHE              1
+// <q0> TC_CML1Cache_EnDisableDCache
+#define TC_CML1CACHE_ENDISABLE_DCACHE              1
+// <q0> TC_CML1Cache_CleanDCacheByAddrWhileDisabled
+#define TC_CML1CACHE_CLEANDCACHEBYADDRWHILEDISABLED 1
+
+// </h>
+
+#endif /* __CV_CONFIG_H */
+

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Source/Config/CV_Config_template.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Source/Config/CV_Config_template.h
@@ -1,0 +1,146 @@
+/*-----------------------------------------------------------------------------
+ *      Name:         CV_Config.h
+ *      Purpose:      CV Config header
+ *----------------------------------------------------------------------------
+ *      Copyright (c) 2017 - 2018 Arm Limited. All rights reserved.
+ *----------------------------------------------------------------------------*/
+#ifndef __CV_CONFIG_H
+#define __CV_CONFIG_H
+
+#include "RTE_Components.h"
+#include CMSIS_device_header
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+// <h> Common Test Settings
+// <o> Print Output Format <0=> Plain Text <1=> XML
+// <i> Set the test results output format to plain text or XML
+#ifndef PRINT_XML_REPORT
+#define PRINT_XML_REPORT            1
+#endif
+// <o> Buffer size for assertions results
+// <i> Set the buffer size for assertions results buffer
+#define BUFFER_ASSERTIONS           128U
+// </h>
+
+// <h> Disable Test Cases
+// <i> Uncheck to disable an individual test case
+// <q0> TC_CoreInstr_NOP
+#define TC_COREINSTR_NOP_EN                        1
+// <q0> TC_CoreInstr_SEV
+#define TC_COREINSTR_SEV_EN                        1
+// <q0> TC_CoreInstr_BKPT
+#define TC_COREINSTR_BKPT_EN                       1
+// <q0> TC_CoreInstr_ISB
+#define TC_COREINSTR_ISB_EN                        1
+// <q0> TC_CoreInstr_DSB
+#define TC_COREINSTR_DSB_EN                        1
+// <q0> TC_CoreInstr_DMB
+#define TC_COREINSTR_DMB_EN                        1
+// <q0> TC_CoreInstr_WFI
+#define TC_COREINSTR_WFI_EN                        0
+// <q0> TC_CoreInstr_WFE
+#define TC_COREINSTR_WFE_EN                        0
+
+// <q0> TC_CoreInstr_REV
+#define TC_COREINSTR_REV_EN                        1
+// <q0> TC_CoreInstr_REV16
+#define TC_COREINSTR_REV16_EN                      1
+// <q0> TC_CoreInstr_REVSH
+#define TC_COREINSTR_REVSH_EN                      1
+// <q0> TC_CoreInstr_ROR
+#define TC_COREINSTR_ROR_EN                        1
+// <q0> TC_CoreInstr_RBIT
+#define TC_COREINSTR_RBIT_EN                       1
+// <q0> TC_CoreInstr_CLZ
+#define TC_COREINSTR_CLZ_EN                        1
+// <q0> TC_CoreInstr_SSAT
+#define TC_COREINSTR_SSAT_EN                       1
+// <q0> TC_CoreInstr_USAT
+#define TC_COREINSTR_USAT_EN                       1
+// <q0> TC_CoreInstr_RRX
+#define TC_COREINSTR_RRX_EN                        1
+// <q0> TC_CoreInstr_LoadStoreExlusive
+#define TC_COREINSTR_LOADSTOREEXCLUSIVE_EN         1
+// <q0> TC_CoreInstr_LoadStoreUnpriv
+#define TC_COREINSTR_LOADSTOREUNPRIV_EN            1
+// <q0> TC_CoreInstr_LoadStoreAcquire
+#define TC_COREINSTR_LOADSTOREACQUIRE_EN           1
+// <q0> TC_CoreInstr_LoadStoreAcquireExclusive
+#define TC_COREINSTR_LOADSTOREACQUIREEXCLUSIVE_EN  1
+
+// <q0> TC_CoreSimd_SatAddSub
+#define TC_CORESIMD_SATADDSUB_EN                   1
+// <q0> TC_CoreSimd_ParSat16
+#define TC_CORESIMD_PARSAT16_EN                    1
+// <q0> TC_CoreSimd_PackUnpack
+#define TC_CORESIMD_PACKUNPACK_EN                  1
+// <q0> TC_CoreSimd_ParSel
+#define TC_CORESIMD_PARSEL_EN                      1
+// <q0> TC_CoreSimd_ParAddSub8
+#define TC_CORESIMD_PARADDSUB8_EN                  1
+// <q0> TC_CoreSimd_AbsDif8
+#define TC_CORESIMD_ABSDIF8_EN                     1
+// <q0> TC_CoreSimd_ParAddSub16
+#define TC_CORESIMD_PARADDSUB16_EN                 1
+// <q0> TC_CoreSimd_ParMul16
+#define TC_CORESIMD_PARMUL16_EN                    1
+// <q0> TC_CoreSimd_Pack16
+#define TC_CORESIMD_PACK16_EN                      1
+// <q0> TC_CoreSimd_MulAcc32
+#define TC_CORESIMD_MULACC32_EN                    1
+
+// <q0> TC_CoreFunc_EnDisIRQ
+#define TC_COREFUNC_ENDISIRQ_EN                    1
+// <q0> TC_CoreFunc_IRQPrio
+#define TC_COREFUNC_IRQPRIO_EN                     1
+// <q0> TC_CoreFunc_EncDecIRQPrio
+#define TC_COREFUNC_ENCDECIRQPRIO_EN               1
+// <q0> TC_CoreFunc_IRQVect
+#define TC_COREFUNC_IRQVECT_EN                     1
+// <q0> TC_CoreFunc_Control
+#define TC_COREFUNC_CONTROL_EN                     1
+// <q0> TC_CoreFunc_IPSR
+#define TC_COREFUNC_IPSR_EN                        1
+// <q0> TC_CoreFunc_APSR
+#define TC_COREFUNC_APSR_EN                        1
+// <q0> TC_CoreFunc_PSP
+#define TC_COREFUNC_PSP_EN                         1
+// <q0> TC_CoreFunc_MSP
+#define TC_COREFUNC_MSP_EN                         1
+
+// <q0> TC_CoreFunc_PSPLIM
+#define TC_COREFUNC_PSPLIM_EN                      1
+// <q0> TC_CoreFunc_PSPLIM_NS
+#define TC_COREFUNC_PSPLIM_NS_EN                   1
+// <q0> TC_CoreFunc_MSPLIM
+#define TC_COREFUNC_MSPLIM_EN                      1
+// <q0> TC_CoreFunc_MSPLIM_NS
+#define TC_COREFUNC_MSPLIM_NS_EN                   1
+// <q0> TC_CoreFunc_PRIMASK
+#define TC_COREFUNC_PRIMASK_EN                     1
+// <q0> TC_CoreFunc_FAULTMASK
+#define TC_COREFUNC_FAULTMASK_EN                   1
+// <q0> TC_CoreFunc_BASEPRI
+#define TC_COREFUNC_BASEPRI_EN                     1
+// <q0> TC_CoreFunc_FPUType
+#define TC_COREFUNC_FPUTYPE_EN                     1
+// <q0> TC_CoreFunc_FPSCR
+#define TC_COREFUNC_FPSCR_EN                       1
+
+// <q0> TC_MPU_SetClear
+#define TC_MPU_SETCLEAR_EN                         1
+// <q0> TC_MPU_Load
+#define TC_MPU_LOAD_EN                             1
+
+// <q0> TC_CML1Cache_EnDisableICache
+#define TC_CML1CACHE_ENDISABLE_ICACHE              1
+// <q0> TC_CML1Cache_EnDisableDCache
+#define TC_CML1CACHE_ENDISABLE_DCACHE              1
+// <q0> TC_CML1Cache_CleanDCacheByAddrWhileDisabled
+#define TC_CML1CACHE_CLEANDCACHEBYADDRWHILEDISABLED 1
+
+// </h>
+
+#endif /* __CV_CONFIG_H */
+

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Source/Config/partition_ARMCM23.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Source/Config/partition_ARMCM23.h
@@ -1,0 +1,832 @@
+/**************************************************************************//**
+ * @file     partition_ARMCM23.h
+ * @brief    CMSIS-CORE Initial Setup for Secure / Non-Secure Zones for ARMCM23
+ * @version  V5.3.1
+ * @date     09. July 2018
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2018 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PARTITION_ARMCM23_H
+#define PARTITION_ARMCM23_H
+
+/*
+//-------- <<< Use Configuration Wizard in Context Menu >>> -----------------
+*/
+
+/*
+// <e>Initialize Security Attribution Unit (SAU) CTRL register
+*/
+#define SAU_INIT_CTRL          1
+
+/*
+//   <q> Enable SAU
+//   <i> Value for SAU->CTRL register bit ENABLE
+*/
+#define SAU_INIT_CTRL_ENABLE   1
+
+/*
+//   <o> When SAU is disabled
+//     <0=> All Memory is Secure
+//     <1=> All Memory is Non-Secure
+//   <i> Value for SAU->CTRL register bit ALLNS
+//   <i> When all Memory is Non-Secure (ALLNS is 1), IDAU can override memory map configuration.
+*/
+#define SAU_INIT_CTRL_ALLNS  0
+
+/*
+// </e>
+*/
+
+/*
+// <h>Initialize Security Attribution Unit (SAU) Address Regions
+// <i>SAU configuration specifies regions to be one of:
+// <i> - Secure and Non-Secure Callable
+// <i> - Non-Secure
+// <i>Note: All memory regions not configured by SAU are Secure
+*/
+#define SAU_REGIONS_MAX   8                 /* Max. number of SAU regions */
+
+/*
+//   <e>Initialize SAU Region 0
+//   <i> Setup SAU Region 0 memory attributes
+*/
+#define SAU_INIT_REGION0    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START0     0x00000000      /* start address of SAU region 0 */
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END0       0x001FFFFF      /* end address of SAU region 0 */
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC0       1
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 1
+//   <i> Setup SAU Region 1 memory attributes
+*/
+#define SAU_INIT_REGION1    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START1     0x00200000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END1       0x003FFFFF
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC1       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 2
+//   <i> Setup SAU Region 2 memory attributes
+*/
+#define SAU_INIT_REGION2    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START2     0x20200000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END2       0x203FFFFF
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC2       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 3
+//   <i> Setup SAU Region 3 memory attributes
+*/
+#define SAU_INIT_REGION3    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START3     0x40000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END3       0x40040000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC3       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 4
+//   <i> Setup SAU Region 4 memory attributes
+*/
+#define SAU_INIT_REGION4    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START4     0x00000000      /* start address of SAU region 4 */
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END4       0x00000000      /* end address of SAU region 4 */
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC4       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 5
+//   <i> Setup SAU Region 5 memory attributes
+*/
+#define SAU_INIT_REGION5    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START5     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END5       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC5       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 6
+//   <i> Setup SAU Region 6 memory attributes
+*/
+#define SAU_INIT_REGION6    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START6     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END6       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC6       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 7
+//   <i> Setup SAU Region 7 memory attributes
+*/
+#define SAU_INIT_REGION7    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START7     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END7       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC7       0
+/*
+//   </e>
+*/
+
+/*
+// </h>
+*/
+
+/*
+// <e>Setup behaviour of Sleep and Exception Handling
+*/
+#define SCB_CSR_AIRCR_INIT  1
+
+/*
+//   <o> Deep Sleep can be enabled by
+//     <0=>Secure and Non-Secure state
+//     <1=>Secure state only
+//   <i> Value for SCB->CSR register bit DEEPSLEEPS
+*/
+#define SCB_CSR_DEEPSLEEPS_VAL  1
+
+/*
+//   <o>System reset request accessible from
+//     <0=> Secure and Non-Secure state
+//     <1=> Secure state only
+//   <i> Value for SCB->AIRCR register bit SYSRESETREQS
+*/
+#define SCB_AIRCR_SYSRESETREQS_VAL  1
+
+/*
+//   <o>Priority of Non-Secure exceptions is
+//     <0=> Not altered
+//     <1=> Lowered to 0x80-0xFF
+//   <i> Value for SCB->AIRCR register bit PRIS
+*/
+#define SCB_AIRCR_PRIS_VAL      1
+
+/*
+//   <o>BusFault, HardFault, and NMI target
+//     <0=> Secure state
+//     <1=> Non-Secure state
+//   <i> Value for SCB->AIRCR register bit BFHFNMINS
+*/
+#define SCB_AIRCR_BFHFNMINS_VAL 0
+
+/*
+// </e>
+*/
+
+
+/*
+// <e>Setup behaviour of single SysTick
+*/
+#define SCB_ICSR_INIT 0
+
+/*
+//   <o> in a single SysTick implementation, SysTick is
+//     <0=>Secure
+//     <1=>Non-Secure
+//   <i> Value for SCB->ICSR register bit STTNS
+//   <i> only for single SysTick implementation 
+*/
+#define SCB_ICSR_STTNS_VAL  0
+
+/*
+// </e>
+*/
+
+
+/*
+// <h>Setup Interrupt Target
+*/
+
+/*
+//   <e>Initialize ITNS 0 (Interrupts 0..31)
+*/
+#define NVIC_INIT_ITNS0    1
+
+/*
+// Interrupts 0..31
+//   <o.0>  Interrupt 0   <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 1   <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 2   <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 3   <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 4   <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 5   <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 6   <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 7   <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 8   <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 9   <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 10  <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 11  <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 12  <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 13  <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 14  <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 15  <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 16  <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 17  <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 18  <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 19  <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 20  <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 21  <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 22  <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 23  <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 24  <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 25  <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 26  <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 27  <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 28  <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 29  <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 30  <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 31  <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS0_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 1 (Interrupts 32..63)
+*/
+#define NVIC_INIT_ITNS1    1
+
+/*
+// Interrupts 32..63
+//   <o.0>  Interrupt 32  <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 33  <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 34  <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 35  <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 36  <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 37  <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 38  <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 39  <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 40  <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 41  <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 42  <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 43  <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 44  <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 45  <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 46  <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 47  <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 48  <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 49  <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 50  <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 51  <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 52  <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 53  <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 54  <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 55  <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 56  <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 57  <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 58  <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 59  <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 60  <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 61  <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 62  <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 63  <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS1_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 2 (Interrupts 64..95)
+*/
+#define NVIC_INIT_ITNS2    0
+
+/*
+// Interrupts 64..95
+//   <o.0>  Interrupt 64  <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 65  <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 66  <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 67  <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 68  <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 69  <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 70  <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 71  <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 72  <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 73  <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 74  <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 75  <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 76  <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 77  <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 78  <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 79  <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 80  <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 81  <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 82  <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 83  <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 84  <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 85  <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 86  <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 87  <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 88  <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 89  <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 90  <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 91  <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 92  <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 93  <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 94  <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 95  <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS2_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 3 (Interrupts 96..127)
+*/
+#define NVIC_INIT_ITNS3    0
+
+/*
+// Interrupts 96..127
+//   <o.0>  Interrupt 96  <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 97  <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 98  <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 99  <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 100 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 101 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 102 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 103 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 104 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 105 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 106 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 107 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 108 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 109 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 110 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 111 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 112 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 113 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 114 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 115 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 116 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 117 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 118 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 119 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 120 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 121 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 122 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 123 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 124 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 125 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 126 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 127 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS3_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 4 (Interrupts 128..159)
+*/
+#define NVIC_INIT_ITNS4    0
+
+/*
+// Interrupts 128..159
+//   <o.0>  Interrupt 128 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 129 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 130 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 131 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 132 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 133 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 134 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 135 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 136 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 137 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 138 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 139 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 140 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 141 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 142 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 143 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 144 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 145 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 146 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 147 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 148 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 149 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 150 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 151 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 152 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 153 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 154 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 155 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 156 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 157 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 158 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 159 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS4_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 5 (Interrupts 160..191)
+*/
+#define NVIC_INIT_ITNS5    0
+
+/*
+// Interrupts 160..191
+//   <o.0>  Interrupt 160 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 161 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 162 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 163 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 164 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 165 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 166 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 167 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 168 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 169 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 170 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 171 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 172 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 173 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 174 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 175 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 176 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 177 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 178 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 179 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 180 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 181 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 182 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 183 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 184 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 185 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 186 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 187 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 188 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 189 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 190 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 191 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS5_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 6 (Interrupts 192..223)
+*/
+#define NVIC_INIT_ITNS6    0
+
+/*
+// Interrupts 192..223
+//   <o.0>  Interrupt 192 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 193 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 194 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 195 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 196 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 197 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 198 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 199 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 200 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 201 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 202 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 203 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 204 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 205 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 206 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 207 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 208 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 209 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 210 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 211 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 212 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 213 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 214 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 215 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 216 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 217 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 218 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 219 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 220 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 221 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 222 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 223 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS6_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 7 (Interrupts 224..255)
+*/
+#define NVIC_INIT_ITNS7    0
+
+/*
+// Interrupts 224..255
+//   <o.0>  Interrupt 224 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 225 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 226 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 227 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 228 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 229 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 230 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 231 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 232 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 233 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 234 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 235 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 236 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 237 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 238 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 239 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 240 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 241 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 242 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 243 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 244 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 245 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 246 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 247 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 248 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 249 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 250 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 251 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 252 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 253 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 254 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 255 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS7_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+// </h>
+*/
+
+
+
+/*
+    max 128 SAU regions.
+    SAU regions are defined in partition.h
+ */
+
+#define SAU_INIT_REGION(n) \
+    SAU->RNR  =  (n                                     & SAU_RNR_REGION_Msk); \
+    SAU->RBAR =  (SAU_INIT_START##n                     & SAU_RBAR_BADDR_Msk); \
+    SAU->RLAR =  (SAU_INIT_END##n                       & SAU_RLAR_LADDR_Msk) | \
+                ((SAU_INIT_NSC##n << SAU_RLAR_NSC_Pos)  & SAU_RLAR_NSC_Msk)   | 1U
+
+/**
+  \brief   Setup a SAU Region
+  \details Writes the region information contained in SAU_Region to the
+           registers SAU_RNR, SAU_RBAR, and SAU_RLAR
+ */
+__STATIC_INLINE void TZ_SAU_Setup (void)
+{
+
+#if defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U)
+
+  #if defined (SAU_INIT_REGION0) && (SAU_INIT_REGION0 == 1U)
+    SAU_INIT_REGION(0);
+  #endif
+
+  #if defined (SAU_INIT_REGION1) && (SAU_INIT_REGION1 == 1U)
+    SAU_INIT_REGION(1);
+  #endif
+
+  #if defined (SAU_INIT_REGION2) && (SAU_INIT_REGION2 == 1U)
+    SAU_INIT_REGION(2);
+  #endif
+
+  #if defined (SAU_INIT_REGION3) && (SAU_INIT_REGION3 == 1U)
+    SAU_INIT_REGION(3);
+  #endif
+
+  #if defined (SAU_INIT_REGION4) && (SAU_INIT_REGION4 == 1U)
+    SAU_INIT_REGION(4);
+  #endif
+
+  #if defined (SAU_INIT_REGION5) && (SAU_INIT_REGION5 == 1U)
+    SAU_INIT_REGION(5);
+  #endif
+
+  #if defined (SAU_INIT_REGION6) && (SAU_INIT_REGION6 == 1U)
+    SAU_INIT_REGION(6);
+  #endif
+
+  #if defined (SAU_INIT_REGION7) && (SAU_INIT_REGION7 == 1U)
+    SAU_INIT_REGION(7);
+  #endif
+
+  /* repeat this for all possible SAU regions */
+
+#endif /* defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U) */
+
+
+  #if defined (SAU_INIT_CTRL) && (SAU_INIT_CTRL == 1U)
+    SAU->CTRL = ((SAU_INIT_CTRL_ENABLE << SAU_CTRL_ENABLE_Pos) & SAU_CTRL_ENABLE_Msk) |
+                ((SAU_INIT_CTRL_ALLNS  << SAU_CTRL_ALLNS_Pos)  & SAU_CTRL_ALLNS_Msk)   ;
+  #endif
+
+  #if defined (SCB_CSR_AIRCR_INIT) && (SCB_CSR_AIRCR_INIT == 1U)
+    SCB->SCR   = (SCB->SCR   & ~(SCB_SCR_SLEEPDEEPS_Msk    )) |
+                   ((SCB_CSR_DEEPSLEEPS_VAL     << SCB_SCR_SLEEPDEEPS_Pos)     & SCB_SCR_SLEEPDEEPS_Msk);
+
+    SCB->AIRCR = (SCB->AIRCR & ~(SCB_AIRCR_VECTKEY_Msk   | SCB_AIRCR_SYSRESETREQS_Msk |
+                                 SCB_AIRCR_BFHFNMINS_Msk |  SCB_AIRCR_PRIS_Msk)        )                     |
+                   ((0x05FAU                    << SCB_AIRCR_VECTKEY_Pos)      & SCB_AIRCR_VECTKEY_Msk)      |
+                   ((SCB_AIRCR_SYSRESETREQS_VAL << SCB_AIRCR_SYSRESETREQS_Pos) & SCB_AIRCR_SYSRESETREQS_Msk) |
+                   ((SCB_AIRCR_PRIS_VAL         << SCB_AIRCR_PRIS_Pos)         & SCB_AIRCR_PRIS_Msk)         |
+                   ((SCB_AIRCR_BFHFNMINS_VAL    << SCB_AIRCR_BFHFNMINS_Pos)    & SCB_AIRCR_BFHFNMINS_Msk);
+  #endif /* defined (SCB_CSR_AIRCR_INIT) && (SCB_CSR_AIRCR_INIT == 1U) */
+
+  #if defined (SCB_ICSR_INIT) && (SCB_ICSR_INIT == 1U)
+    SCB->ICSR  = (SCB->ICSR  & ~(SCB_ICSR_STTNS_Msk        )) |
+                   ((SCB_ICSR_STTNS_VAL         << SCB_ICSR_STTNS_Pos)         & SCB_ICSR_STTNS_Msk);
+  #endif /* defined (SCB_ICSR_INIT) && (SCB_ICSR_INIT == 1U) */
+
+  #if defined (NVIC_INIT_ITNS0) && (NVIC_INIT_ITNS0 == 1U)
+    NVIC->ITNS[0] = NVIC_INIT_ITNS0_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS1) && (NVIC_INIT_ITNS1 == 1U)
+    NVIC->ITNS[1] = NVIC_INIT_ITNS1_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS2) && (NVIC_INIT_ITNS2 == 1U)
+    NVIC->ITNS[2] = NVIC_INIT_ITNS2_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS3) && (NVIC_INIT_ITNS3 == 1U)
+    NVIC->ITNS[3] = NVIC_INIT_ITNS3_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS4) && (NVIC_INIT_ITNS4 == 1U)
+    NVIC->ITNS[4] = NVIC_INIT_ITNS4_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS5) && (NVIC_INIT_ITNS5 == 1U)
+    NVIC->ITNS[5] = NVIC_INIT_ITNS5_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS6) && (NVIC_INIT_ITNS6 == 1U)
+    NVIC->ITNS[6] = NVIC_INIT_ITNS6_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS7) && (NVIC_INIT_ITNS7 == 1U)
+    NVIC->ITNS[7] = NVIC_INIT_ITNS7_VAL;
+  #endif
+
+  /* repeat this for all possible ITNS elements */
+
+}
+
+#endif  /* PARTITION_ARMCM23_H */

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Source/Config/partition_ARMCM33.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Source/Config/partition_ARMCM33.h
@@ -1,0 +1,1260 @@
+/**************************************************************************//**
+ * @file     partition_ARMCM33.h
+ * @brief    CMSIS-CORE Initial Setup for Secure / Non-Secure Zones for ARMCM33
+ * @version  V5.3.1
+ * @date     09. July 2018
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2018 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PARTITION_ARMCM33_H
+#define PARTITION_ARMCM33_H
+
+/*
+//-------- <<< Use Configuration Wizard in Context Menu >>> -----------------
+*/
+
+/*
+// <e>Initialize Security Attribution Unit (SAU) CTRL register
+*/
+#define SAU_INIT_CTRL          1
+
+/*
+//   <q> Enable SAU
+//   <i> Value for SAU->CTRL register bit ENABLE
+*/
+#define SAU_INIT_CTRL_ENABLE   1
+
+/*
+//   <o> When SAU is disabled
+//     <0=> All Memory is Secure
+//     <1=> All Memory is Non-Secure
+//   <i> Value for SAU->CTRL register bit ALLNS
+//   <i> When all Memory is Non-Secure (ALLNS is 1), IDAU can override memory map configuration.
+*/
+#define SAU_INIT_CTRL_ALLNS  0
+
+/*
+// </e>
+*/
+
+/*
+// <h>Initialize Security Attribution Unit (SAU) Address Regions
+// <i>SAU configuration specifies regions to be one of:
+// <i> - Secure and Non-Secure Callable
+// <i> - Non-Secure
+// <i>Note: All memory regions not configured by SAU are Secure
+*/
+#define SAU_REGIONS_MAX   8                 /* Max. number of SAU regions */
+
+/*
+//   <e>Initialize SAU Region 0
+//   <i> Setup SAU Region 0 memory attributes
+*/
+#define SAU_INIT_REGION0    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START0     0x00000000      /* start address of SAU region 0 */
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END0       0x001FFFFF      /* end address of SAU region 0 */
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC0       1
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 1
+//   <i> Setup SAU Region 1 memory attributes
+*/
+#define SAU_INIT_REGION1    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START1     0x00200000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END1       0x003FFFFF
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC1       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 2
+//   <i> Setup SAU Region 2 memory attributes
+*/
+#define SAU_INIT_REGION2    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START2     0x20200000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END2       0x203FFFFF
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC2       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 3
+//   <i> Setup SAU Region 3 memory attributes
+*/
+#define SAU_INIT_REGION3    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START3     0x40000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END3       0x40040000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC3       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 4
+//   <i> Setup SAU Region 4 memory attributes
+*/
+#define SAU_INIT_REGION4    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START4     0x00000000      /* start address of SAU region 4 */
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END4       0x00000000      /* end address of SAU region 4 */
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC4       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 5
+//   <i> Setup SAU Region 5 memory attributes
+*/
+#define SAU_INIT_REGION5    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START5     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END5       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC5       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 6
+//   <i> Setup SAU Region 6 memory attributes
+*/
+#define SAU_INIT_REGION6    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START6     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END6       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC6       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 7
+//   <i> Setup SAU Region 7 memory attributes
+*/
+#define SAU_INIT_REGION7    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START7     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END7       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC7       0
+/*
+//   </e>
+*/
+
+/*
+// </h>
+*/
+
+/*
+// <e>Setup behaviour of Sleep and Exception Handling
+*/
+#define SCB_CSR_AIRCR_INIT  1
+
+/*
+//   <o> Deep Sleep can be enabled by
+//     <0=>Secure and Non-Secure state
+//     <1=>Secure state only
+//   <i> Value for SCB->CSR register bit DEEPSLEEPS
+*/
+#define SCB_CSR_DEEPSLEEPS_VAL  1
+
+/*
+//   <o>System reset request accessible from
+//     <0=> Secure and Non-Secure state
+//     <1=> Secure state only
+//   <i> Value for SCB->AIRCR register bit SYSRESETREQS
+*/
+#define SCB_AIRCR_SYSRESETREQS_VAL  1
+
+/*
+//   <o>Priority of Non-Secure exceptions is
+//     <0=> Not altered
+//     <1=> Lowered to 0x80-0xFF
+//   <i> Value for SCB->AIRCR register bit PRIS
+*/
+#define SCB_AIRCR_PRIS_VAL      1
+
+/*
+//   <o>BusFault, HardFault, and NMI target
+//     <0=> Secure state
+//     <1=> Non-Secure state
+//   <i> Value for SCB->AIRCR register bit BFHFNMINS
+*/
+#define SCB_AIRCR_BFHFNMINS_VAL 0
+
+/*
+// </e>
+*/
+
+/*
+// <e>Setup behaviour of Floating Point Unit
+*/
+#define TZ_FPU_NS_USAGE 1
+
+/*
+// <o>Floating Point Unit usage
+//     <0=> Secure state only
+//     <3=> Secure and Non-Secure state
+//   <i> Value for SCB->NSACR register bits CP10, CP11
+*/
+#define SCB_NSACR_CP10_11_VAL       3
+
+/*
+// <o>Treat floating-point registers as Secure
+//     <0=> Disabled
+//     <1=> Enabled
+//   <i> Value for FPU->FPCCR register bit TS
+*/
+#define FPU_FPCCR_TS_VAL            0
+
+/*
+// <o>Clear on return (CLRONRET) accessibility
+//     <0=> Secure and Non-Secure state
+//     <1=> Secure state only
+//   <i> Value for FPU->FPCCR register bit CLRONRETS
+*/
+#define FPU_FPCCR_CLRONRETS_VAL     0
+
+/*
+// <o>Clear floating-point caller saved registers on exception return
+//     <0=> Disabled
+//     <1=> Enabled
+//   <i> Value for FPU->FPCCR register bit CLRONRET
+*/
+#define FPU_FPCCR_CLRONRET_VAL      1
+
+/*
+// </e>
+*/
+
+/*
+// <h>Setup Interrupt Target
+*/
+
+/*
+//   <e>Initialize ITNS 0 (Interrupts 0..31)
+*/
+#define NVIC_INIT_ITNS0    1
+
+/*
+// Interrupts 0..31
+//   <o.0>  Interrupt 0   <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 1   <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 2   <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 3   <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 4   <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 5   <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 6   <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 7   <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 8   <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 9   <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 10  <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 11  <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 12  <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 13  <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 14  <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 15  <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 16  <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 17  <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 18  <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 19  <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 20  <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 21  <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 22  <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 23  <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 24  <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 25  <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 26  <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 27  <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 28  <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 29  <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 30  <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 31  <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS0_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 1 (Interrupts 32..63)
+*/
+#define NVIC_INIT_ITNS1    1
+
+/*
+// Interrupts 32..63
+//   <o.0>  Interrupt 32  <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 33  <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 34  <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 35  <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 36  <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 37  <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 38  <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 39  <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 40  <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 41  <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 42  <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 43  <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 44  <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 45  <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 46  <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 47  <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 48  <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 49  <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 50  <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 51  <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 52  <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 53  <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 54  <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 55  <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 56  <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 57  <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 58  <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 59  <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 60  <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 61  <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 62  <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 63  <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS1_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 2 (Interrupts 64..95)
+*/
+#define NVIC_INIT_ITNS2    0
+
+/*
+// Interrupts 64..95
+//   <o.0>  Interrupt 64  <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 65  <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 66  <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 67  <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 68  <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 69  <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 70  <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 71  <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 72  <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 73  <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 74  <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 75  <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 76  <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 77  <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 78  <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 79  <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 80  <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 81  <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 82  <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 83  <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 84  <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 85  <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 86  <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 87  <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 88  <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 89  <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 90  <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 91  <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 92  <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 93  <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 94  <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 95  <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS2_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 3 (Interrupts 96..127)
+*/
+#define NVIC_INIT_ITNS3    0
+
+/*
+// Interrupts 96..127
+//   <o.0>  Interrupt 96  <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 97  <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 98  <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 99  <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 100 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 101 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 102 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 103 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 104 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 105 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 106 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 107 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 108 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 109 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 110 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 111 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 112 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 113 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 114 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 115 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 116 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 117 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 118 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 119 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 120 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 121 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 122 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 123 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 124 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 125 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 126 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 127 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS3_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 4 (Interrupts 128..159)
+*/
+#define NVIC_INIT_ITNS4    0
+
+/*
+// Interrupts 128..159
+//   <o.0>  Interrupt 128 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 129 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 130 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 131 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 132 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 133 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 134 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 135 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 136 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 137 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 138 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 139 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 140 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 141 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 142 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 143 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 144 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 145 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 146 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 147 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 148 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 149 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 150 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 151 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 152 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 153 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 154 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 155 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 156 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 157 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 158 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 159 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS4_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 5 (Interrupts 160..191)
+*/
+#define NVIC_INIT_ITNS5    0
+
+/*
+// Interrupts 160..191
+//   <o.0>  Interrupt 160 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 161 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 162 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 163 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 164 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 165 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 166 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 167 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 168 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 169 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 170 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 171 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 172 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 173 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 174 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 175 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 176 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 177 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 178 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 179 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 180 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 181 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 182 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 183 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 184 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 185 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 186 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 187 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 188 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 189 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 190 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 191 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS5_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 6 (Interrupts 192..223)
+*/
+#define NVIC_INIT_ITNS6    0
+
+/*
+// Interrupts 192..223
+//   <o.0>  Interrupt 192 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 193 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 194 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 195 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 196 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 197 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 198 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 199 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 200 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 201 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 202 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 203 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 204 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 205 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 206 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 207 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 208 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 209 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 210 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 211 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 212 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 213 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 214 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 215 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 216 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 217 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 218 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 219 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 220 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 221 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 222 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 223 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS6_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 7 (Interrupts 224..255)
+*/
+#define NVIC_INIT_ITNS7    0
+
+/*
+// Interrupts 224..255
+//   <o.0>  Interrupt 224 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 225 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 226 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 227 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 228 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 229 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 230 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 231 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 232 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 233 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 234 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 235 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 236 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 237 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 238 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 239 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 240 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 241 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 242 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 243 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 244 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 245 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 246 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 247 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 248 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 249 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 250 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 251 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 252 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 253 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 254 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 255 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS7_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 8 (Interrupts 256..287)
+*/
+#define NVIC_INIT_ITNS8    0
+
+/*
+// Interrupts 256..287
+//   <o.0>  Interrupt 256 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 257 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 258 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 259 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 260 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 261 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 262 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 263 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 264 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 265 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 266 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 267 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 268 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 269 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 270 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 271 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 272 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 273 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 274 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 275 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 276 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 277 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 278 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 279 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 280 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 281 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 282 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 283 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 284 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 285 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 286 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 287 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS8_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 9 (Interrupts 288..319)
+*/
+#define NVIC_INIT_ITNS9    0
+
+/*
+// Interrupts 288..319
+//   <o.0>  Interrupt 288 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 289 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 290 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 291 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 292 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 293 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 294 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 295 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 296 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 297 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 298 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 299 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 300 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 301 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 302 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 303 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 304 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 305 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 306 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 307 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 308 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 309 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 310 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 311 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 312 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 313 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 314 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 315 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 316 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 317 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 318 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 319 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS9_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 10 (Interrupts 320..351)
+*/
+#define NVIC_INIT_ITNS10   0
+
+/*
+// Interrupts 320..351
+//   <o.0>  Interrupt 320 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 321 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 322 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 323 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 324 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 325 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 326 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 327 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 328 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 329 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 330 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 331 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 332 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 333 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 334 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 335 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 336 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 337 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 338 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 339 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 340 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 341 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 342 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 343 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 344 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 345 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 346 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 347 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 348 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 349 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 350 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 351 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS10_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 11 (Interrupts 352..383)
+*/
+#define NVIC_INIT_ITNS11   0
+
+/*
+// Interrupts 352..383
+//   <o.0>  Interrupt 352 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 353 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 354 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 355 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 356 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 357 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 358 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 359 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 360 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 361 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 362 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 363 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 364 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 365 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 366 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 367 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 368 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 369 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 370 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 371 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 372 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 373 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 374 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 375 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 376 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 377 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 378 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 379 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 380 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 381 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 382 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 383 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS11_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 12 (Interrupts 384..415)
+*/
+#define NVIC_INIT_ITNS12   0
+
+/*
+// Interrupts 384..415
+//   <o.0>  Interrupt 384 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 385 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 386 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 387 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 388 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 389 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 390 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 391 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 392 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 393 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 394 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 395 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 396 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 397 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 398 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 399 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 400 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 401 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 402 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 403 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 404 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 405 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 406 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 407 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 408 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 409 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 410 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 411 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 412 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 413 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 414 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 415 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS12_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 13 (Interrupts 416..447)
+*/
+#define NVIC_INIT_ITNS13   0
+
+/*
+// Interrupts 416..447
+//   <o.0>  Interrupt 416 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 417 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 418 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 419 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 420 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 421 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 422 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 423 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 424 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 425 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 426 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 427 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 428 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 429 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 430 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 431 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 432 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 433 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 434 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 435 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 436 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 437 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 438 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 439 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 440 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 441 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 442 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 443 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 444 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 445 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 446 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 447 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS13_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 14 (Interrupts 448..479)
+*/
+#define NVIC_INIT_ITNS14   0
+
+/*
+// Interrupts 448..479
+//   <o.0>  Interrupt 448 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 449 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 450 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 451 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 452 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 453 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 454 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 455 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 456 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 457 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 458 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 459 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 460 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 461 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 462 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 463 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 464 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 465 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 466 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 467 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 468 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 469 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 470 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 471 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 472 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 473 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 474 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 475 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 476 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 477 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 478 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 479 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS14_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 15 (Interrupts 480..511)
+*/
+#define NVIC_INIT_ITNS15   0
+
+/*
+// Interrupts 480..511
+//   <o.0>  Interrupt 480 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 481 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 482 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 483 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 484 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 485 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 486 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 487 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 488 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 489 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 490 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 491 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 492 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 493 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 494 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 495 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 496 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 497 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 498 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 499 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 500 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 501 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 502 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 503 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 504 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 505 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 506 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 507 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 508 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 509 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 510 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 511 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS15_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+// </h>
+*/
+
+
+
+/*
+    max 128 SAU regions.
+    SAU regions are defined in partition.h
+ */
+
+#define SAU_INIT_REGION(n) \
+    SAU->RNR  =  (n                                     & SAU_RNR_REGION_Msk); \
+    SAU->RBAR =  (SAU_INIT_START##n                     & SAU_RBAR_BADDR_Msk); \
+    SAU->RLAR =  (SAU_INIT_END##n                       & SAU_RLAR_LADDR_Msk) | \
+                ((SAU_INIT_NSC##n << SAU_RLAR_NSC_Pos)  & SAU_RLAR_NSC_Msk)   | 1U
+
+/**
+  \brief   Setup a SAU Region
+  \details Writes the region information contained in SAU_Region to the
+           registers SAU_RNR, SAU_RBAR, and SAU_RLAR
+ */
+__STATIC_INLINE void TZ_SAU_Setup (void)
+{
+
+#if defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U)
+
+  #if defined (SAU_INIT_REGION0) && (SAU_INIT_REGION0 == 1U)
+    SAU_INIT_REGION(0);
+  #endif
+
+  #if defined (SAU_INIT_REGION1) && (SAU_INIT_REGION1 == 1U)
+    SAU_INIT_REGION(1);
+  #endif
+
+  #if defined (SAU_INIT_REGION2) && (SAU_INIT_REGION2 == 1U)
+    SAU_INIT_REGION(2);
+  #endif
+
+  #if defined (SAU_INIT_REGION3) && (SAU_INIT_REGION3 == 1U)
+    SAU_INIT_REGION(3);
+  #endif
+
+  #if defined (SAU_INIT_REGION4) && (SAU_INIT_REGION4 == 1U)
+    SAU_INIT_REGION(4);
+  #endif
+
+  #if defined (SAU_INIT_REGION5) && (SAU_INIT_REGION5 == 1U)
+    SAU_INIT_REGION(5);
+  #endif
+
+  #if defined (SAU_INIT_REGION6) && (SAU_INIT_REGION6 == 1U)
+    SAU_INIT_REGION(6);
+  #endif
+
+  #if defined (SAU_INIT_REGION7) && (SAU_INIT_REGION7 == 1U)
+    SAU_INIT_REGION(7);
+  #endif
+
+  /* repeat this for all possible SAU regions */
+
+#endif /* defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U) */
+
+
+  #if defined (SAU_INIT_CTRL) && (SAU_INIT_CTRL == 1U)
+    SAU->CTRL = ((SAU_INIT_CTRL_ENABLE << SAU_CTRL_ENABLE_Pos) & SAU_CTRL_ENABLE_Msk) |
+                ((SAU_INIT_CTRL_ALLNS  << SAU_CTRL_ALLNS_Pos)  & SAU_CTRL_ALLNS_Msk)   ;
+  #endif
+
+  #if defined (SCB_CSR_AIRCR_INIT) && (SCB_CSR_AIRCR_INIT == 1U)
+    SCB->SCR   = (SCB->SCR   & ~(SCB_SCR_SLEEPDEEPS_Msk    )) |
+                   ((SCB_CSR_DEEPSLEEPS_VAL     << SCB_SCR_SLEEPDEEPS_Pos)     & SCB_SCR_SLEEPDEEPS_Msk);
+
+    SCB->AIRCR = (SCB->AIRCR & ~(SCB_AIRCR_VECTKEY_Msk   | SCB_AIRCR_SYSRESETREQS_Msk |
+                                 SCB_AIRCR_BFHFNMINS_Msk | SCB_AIRCR_PRIS_Msk          ))                    |
+                   ((0x05FAU                    << SCB_AIRCR_VECTKEY_Pos)      & SCB_AIRCR_VECTKEY_Msk)      |
+                   ((SCB_AIRCR_SYSRESETREQS_VAL << SCB_AIRCR_SYSRESETREQS_Pos) & SCB_AIRCR_SYSRESETREQS_Msk) |
+                   ((SCB_AIRCR_PRIS_VAL         << SCB_AIRCR_PRIS_Pos)         & SCB_AIRCR_PRIS_Msk)         |
+                   ((SCB_AIRCR_BFHFNMINS_VAL    << SCB_AIRCR_BFHFNMINS_Pos)    & SCB_AIRCR_BFHFNMINS_Msk);
+  #endif /* defined (SCB_CSR_AIRCR_INIT) && (SCB_CSR_AIRCR_INIT == 1U) */
+
+  #if defined (__FPU_USED) && (__FPU_USED == 1U) && \
+      defined (TZ_FPU_NS_USAGE) && (TZ_FPU_NS_USAGE == 1U)
+
+    SCB->NSACR = (SCB->NSACR & ~(SCB_NSACR_CP10_Msk | SCB_NSACR_CP10_Msk)) |
+                   ((SCB_NSACR_CP10_11_VAL << SCB_NSACR_CP10_Pos) & (SCB_NSACR_CP10_Msk | SCB_NSACR_CP11_Msk));
+
+    FPU->FPCCR = (FPU->FPCCR & ~(FPU_FPCCR_TS_Msk | FPU_FPCCR_CLRONRETS_Msk | FPU_FPCCR_CLRONRET_Msk)) |
+                   ((FPU_FPCCR_TS_VAL        << FPU_FPCCR_TS_Pos       ) & FPU_FPCCR_TS_Msk       ) |
+                   ((FPU_FPCCR_CLRONRETS_VAL << FPU_FPCCR_CLRONRETS_Pos) & FPU_FPCCR_CLRONRETS_Msk) |
+                   ((FPU_FPCCR_CLRONRET_VAL  << FPU_FPCCR_CLRONRET_Pos ) & FPU_FPCCR_CLRONRET_Msk );
+  #endif
+
+  #if defined (NVIC_INIT_ITNS0) && (NVIC_INIT_ITNS0 == 1U)
+    NVIC->ITNS[0] = NVIC_INIT_ITNS0_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS1) && (NVIC_INIT_ITNS1 == 1U)
+    NVIC->ITNS[1] = NVIC_INIT_ITNS1_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS2) && (NVIC_INIT_ITNS2 == 1U)
+    NVIC->ITNS[2] = NVIC_INIT_ITNS2_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS3) && (NVIC_INIT_ITNS3 == 1U)
+    NVIC->ITNS[3] = NVIC_INIT_ITNS3_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS4) && (NVIC_INIT_ITNS4 == 1U)
+    NVIC->ITNS[4] = NVIC_INIT_ITNS4_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS5) && (NVIC_INIT_ITNS5 == 1U)
+    NVIC->ITNS[5] = NVIC_INIT_ITNS5_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS6) && (NVIC_INIT_ITNS6 == 1U)
+    NVIC->ITNS[6] = NVIC_INIT_ITNS6_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS7) && (NVIC_INIT_ITNS7 == 1U)
+    NVIC->ITNS[7] = NVIC_INIT_ITNS7_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS8) && (NVIC_INIT_ITNS8 == 1U)
+    NVIC->ITNS[8] = NVIC_INIT_ITNS8_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS9) && (NVIC_INIT_ITNS9 == 1U)
+    NVIC->ITNS[9] = NVIC_INIT_ITNS9_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS10) && (NVIC_INIT_ITNS10 == 1U)
+    NVIC->ITNS[10] = NVIC_INIT_ITNS10_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS11) && (NVIC_INIT_ITNS11 == 1U)
+    NVIC->ITNS[11] = NVIC_INIT_ITNS11_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS12) && (NVIC_INIT_ITNS12 == 1U)
+    NVIC->ITNS[12] = NVIC_INIT_ITNS12_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS13) && (NVIC_INIT_ITNS13 == 1U)
+    NVIC->ITNS[13] = NVIC_INIT_ITNS13_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS14) && (NVIC_INIT_ITNS14 == 1U)
+    NVIC->ITNS[14] = NVIC_INIT_ITNS14_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS15) && (NVIC_INIT_ITNS15 == 1U)
+    NVIC->ITNS[15] = NVIC_INIT_ITNS15_VAL;
+  #endif
+
+  /* repeat this for all possible ITNS elements */
+
+}
+
+#endif  /* PARTITION_ARMCM33_H */

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Source/Config/partition_ARMCM35P.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Source/Config/partition_ARMCM35P.h
@@ -1,0 +1,1260 @@
+/**************************************************************************//**
+ * @file     partition_ARMCM35P.h
+ * @brief    CMSIS-CORE Initial Setup for Secure / Non-Secure Zones for ARMCM35P
+ * @version  V5.4.1
+ * @date     03. September 2018
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2018 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PARTITION_ARMCM35P_H
+#define PARTITION_ARMCM35P_H
+
+/*
+//-------- <<< Use Configuration Wizard in Context Menu >>> -----------------
+*/
+
+/*
+// <e>Initialize Security Attribution Unit (SAU) CTRL register
+*/
+#define SAU_INIT_CTRL          1
+
+/*
+//   <q> Enable SAU
+//   <i> Value for SAU->CTRL register bit ENABLE
+*/
+#define SAU_INIT_CTRL_ENABLE   1
+
+/*
+//   <o> When SAU is disabled
+//     <0=> All Memory is Secure
+//     <1=> All Memory is Non-Secure
+//   <i> Value for SAU->CTRL register bit ALLNS
+//   <i> When all Memory is Non-Secure (ALLNS is 1), IDAU can override memory map configuration.
+*/
+#define SAU_INIT_CTRL_ALLNS  0
+
+/*
+// </e>
+*/
+
+/*
+// <h>Initialize Security Attribution Unit (SAU) Address Regions
+// <i>SAU configuration specifies regions to be one of:
+// <i> - Secure and Non-Secure Callable
+// <i> - Non-Secure
+// <i>Note: All memory regions not configured by SAU are Secure
+*/
+#define SAU_REGIONS_MAX   8                 /* Max. number of SAU regions */
+
+/*
+//   <e>Initialize SAU Region 0
+//   <i> Setup SAU Region 0 memory attributes
+*/
+#define SAU_INIT_REGION0    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START0     0x00000000      /* start address of SAU region 0 */
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END0       0x001FFFFF      /* end address of SAU region 0 */
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC0       1
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 1
+//   <i> Setup SAU Region 1 memory attributes
+*/
+#define SAU_INIT_REGION1    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START1     0x00200000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END1       0x003FFFFF
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC1       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 2
+//   <i> Setup SAU Region 2 memory attributes
+*/
+#define SAU_INIT_REGION2    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START2     0x20200000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END2       0x203FFFFF
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC2       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 3
+//   <i> Setup SAU Region 3 memory attributes
+*/
+#define SAU_INIT_REGION3    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START3     0x40000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END3       0x40040000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC3       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 4
+//   <i> Setup SAU Region 4 memory attributes
+*/
+#define SAU_INIT_REGION4    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START4     0x00000000      /* start address of SAU region 4 */
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END4       0x00000000      /* end address of SAU region 4 */
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC4       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 5
+//   <i> Setup SAU Region 5 memory attributes
+*/
+#define SAU_INIT_REGION5    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START5     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END5       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC5       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 6
+//   <i> Setup SAU Region 6 memory attributes
+*/
+#define SAU_INIT_REGION6    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START6     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END6       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC6       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 7
+//   <i> Setup SAU Region 7 memory attributes
+*/
+#define SAU_INIT_REGION7    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START7     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END7       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC7       0
+/*
+//   </e>
+*/
+
+/*
+// </h>
+*/
+
+/*
+// <e>Setup behaviour of Sleep and Exception Handling
+*/
+#define SCB_CSR_AIRCR_INIT  1
+
+/*
+//   <o> Deep Sleep can be enabled by
+//     <0=>Secure and Non-Secure state
+//     <1=>Secure state only
+//   <i> Value for SCB->CSR register bit DEEPSLEEPS
+*/
+#define SCB_CSR_DEEPSLEEPS_VAL  1
+
+/*
+//   <o>System reset request accessible from
+//     <0=> Secure and Non-Secure state
+//     <1=> Secure state only
+//   <i> Value for SCB->AIRCR register bit SYSRESETREQS
+*/
+#define SCB_AIRCR_SYSRESETREQS_VAL  1
+
+/*
+//   <o>Priority of Non-Secure exceptions is
+//     <0=> Not altered
+//     <1=> Lowered to 0x80-0xFF
+//   <i> Value for SCB->AIRCR register bit PRIS
+*/
+#define SCB_AIRCR_PRIS_VAL      1
+
+/*
+//   <o>BusFault, HardFault, and NMI target
+//     <0=> Secure state
+//     <1=> Non-Secure state
+//   <i> Value for SCB->AIRCR register bit BFHFNMINS
+*/
+#define SCB_AIRCR_BFHFNMINS_VAL 0
+
+/*
+// </e>
+*/
+
+/*
+// <e>Setup behaviour of Floating Point Unit
+*/
+#define TZ_FPU_NS_USAGE 1
+
+/*
+// <o>Floating Point Unit usage
+//     <0=> Secure state only
+//     <3=> Secure and Non-Secure state
+//   <i> Value for SCB->NSACR register bits CP10, CP11
+*/
+#define SCB_NSACR_CP10_11_VAL       3
+
+/*
+// <o>Treat floating-point registers as Secure
+//     <0=> Disabled
+//     <1=> Enabled
+//   <i> Value for FPU->FPCCR register bit TS
+*/
+#define FPU_FPCCR_TS_VAL            0
+
+/*
+// <o>Clear on return (CLRONRET) accessibility
+//     <0=> Secure and Non-Secure state
+//     <1=> Secure state only
+//   <i> Value for FPU->FPCCR register bit CLRONRETS
+*/
+#define FPU_FPCCR_CLRONRETS_VAL     0
+
+/*
+// <o>Clear floating-point caller saved registers on exception return
+//     <0=> Disabled
+//     <1=> Enabled
+//   <i> Value for FPU->FPCCR register bit CLRONRET
+*/
+#define FPU_FPCCR_CLRONRET_VAL      1
+
+/*
+// </e>
+*/
+
+/*
+// <h>Setup Interrupt Target
+*/
+
+/*
+//   <e>Initialize ITNS 0 (Interrupts 0..31)
+*/
+#define NVIC_INIT_ITNS0    1
+
+/*
+// Interrupts 0..31
+//   <o.0>  Interrupt 0   <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 1   <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 2   <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 3   <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 4   <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 5   <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 6   <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 7   <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 8   <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 9   <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 10  <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 11  <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 12  <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 13  <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 14  <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 15  <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 16  <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 17  <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 18  <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 19  <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 20  <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 21  <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 22  <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 23  <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 24  <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 25  <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 26  <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 27  <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 28  <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 29  <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 30  <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 31  <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS0_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 1 (Interrupts 32..63)
+*/
+#define NVIC_INIT_ITNS1    1
+
+/*
+// Interrupts 32..63
+//   <o.0>  Interrupt 32  <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 33  <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 34  <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 35  <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 36  <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 37  <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 38  <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 39  <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 40  <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 41  <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 42  <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 43  <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 44  <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 45  <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 46  <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 47  <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 48  <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 49  <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 50  <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 51  <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 52  <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 53  <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 54  <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 55  <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 56  <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 57  <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 58  <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 59  <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 60  <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 61  <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 62  <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 63  <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS1_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 2 (Interrupts 64..95)
+*/
+#define NVIC_INIT_ITNS2    0
+
+/*
+// Interrupts 64..95
+//   <o.0>  Interrupt 64  <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 65  <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 66  <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 67  <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 68  <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 69  <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 70  <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 71  <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 72  <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 73  <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 74  <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 75  <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 76  <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 77  <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 78  <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 79  <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 80  <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 81  <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 82  <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 83  <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 84  <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 85  <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 86  <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 87  <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 88  <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 89  <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 90  <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 91  <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 92  <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 93  <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 94  <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 95  <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS2_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 3 (Interrupts 96..127)
+*/
+#define NVIC_INIT_ITNS3    0
+
+/*
+// Interrupts 96..127
+//   <o.0>  Interrupt 96  <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 97  <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 98  <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 99  <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 100 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 101 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 102 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 103 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 104 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 105 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 106 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 107 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 108 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 109 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 110 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 111 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 112 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 113 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 114 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 115 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 116 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 117 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 118 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 119 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 120 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 121 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 122 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 123 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 124 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 125 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 126 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 127 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS3_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 4 (Interrupts 128..159)
+*/
+#define NVIC_INIT_ITNS4    0
+
+/*
+// Interrupts 128..159
+//   <o.0>  Interrupt 128 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 129 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 130 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 131 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 132 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 133 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 134 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 135 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 136 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 137 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 138 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 139 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 140 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 141 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 142 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 143 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 144 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 145 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 146 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 147 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 148 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 149 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 150 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 151 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 152 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 153 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 154 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 155 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 156 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 157 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 158 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 159 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS4_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 5 (Interrupts 160..191)
+*/
+#define NVIC_INIT_ITNS5    0
+
+/*
+// Interrupts 160..191
+//   <o.0>  Interrupt 160 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 161 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 162 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 163 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 164 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 165 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 166 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 167 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 168 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 169 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 170 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 171 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 172 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 173 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 174 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 175 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 176 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 177 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 178 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 179 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 180 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 181 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 182 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 183 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 184 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 185 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 186 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 187 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 188 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 189 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 190 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 191 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS5_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 6 (Interrupts 192..223)
+*/
+#define NVIC_INIT_ITNS6    0
+
+/*
+// Interrupts 192..223
+//   <o.0>  Interrupt 192 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 193 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 194 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 195 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 196 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 197 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 198 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 199 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 200 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 201 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 202 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 203 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 204 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 205 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 206 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 207 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 208 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 209 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 210 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 211 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 212 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 213 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 214 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 215 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 216 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 217 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 218 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 219 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 220 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 221 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 222 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 223 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS6_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 7 (Interrupts 224..255)
+*/
+#define NVIC_INIT_ITNS7    0
+
+/*
+// Interrupts 224..255
+//   <o.0>  Interrupt 224 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 225 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 226 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 227 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 228 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 229 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 230 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 231 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 232 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 233 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 234 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 235 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 236 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 237 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 238 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 239 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 240 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 241 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 242 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 243 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 244 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 245 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 246 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 247 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 248 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 249 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 250 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 251 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 252 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 253 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 254 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 255 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS7_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 8 (Interrupts 256..287)
+*/
+#define NVIC_INIT_ITNS8    0
+
+/*
+// Interrupts 256..287
+//   <o.0>  Interrupt 256 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 257 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 258 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 259 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 260 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 261 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 262 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 263 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 264 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 265 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 266 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 267 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 268 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 269 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 270 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 271 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 272 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 273 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 274 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 275 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 276 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 277 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 278 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 279 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 280 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 281 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 282 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 283 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 284 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 285 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 286 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 287 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS8_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 9 (Interrupts 288..319)
+*/
+#define NVIC_INIT_ITNS9    0
+
+/*
+// Interrupts 288..319
+//   <o.0>  Interrupt 288 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 289 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 290 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 291 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 292 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 293 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 294 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 295 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 296 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 297 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 298 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 299 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 300 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 301 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 302 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 303 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 304 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 305 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 306 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 307 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 308 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 309 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 310 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 311 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 312 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 313 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 314 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 315 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 316 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 317 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 318 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 319 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS9_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 10 (Interrupts 320..351)
+*/
+#define NVIC_INIT_ITNS10   0
+
+/*
+// Interrupts 320..351
+//   <o.0>  Interrupt 320 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 321 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 322 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 323 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 324 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 325 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 326 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 327 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 328 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 329 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 330 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 331 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 332 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 333 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 334 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 335 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 336 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 337 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 338 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 339 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 340 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 341 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 342 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 343 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 344 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 345 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 346 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 347 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 348 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 349 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 350 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 351 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS10_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 11 (Interrupts 352..383)
+*/
+#define NVIC_INIT_ITNS11   0
+
+/*
+// Interrupts 352..383
+//   <o.0>  Interrupt 352 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 353 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 354 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 355 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 356 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 357 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 358 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 359 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 360 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 361 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 362 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 363 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 364 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 365 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 366 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 367 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 368 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 369 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 370 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 371 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 372 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 373 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 374 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 375 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 376 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 377 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 378 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 379 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 380 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 381 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 382 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 383 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS11_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 12 (Interrupts 384..415)
+*/
+#define NVIC_INIT_ITNS12   0
+
+/*
+// Interrupts 384..415
+//   <o.0>  Interrupt 384 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 385 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 386 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 387 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 388 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 389 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 390 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 391 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 392 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 393 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 394 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 395 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 396 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 397 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 398 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 399 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 400 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 401 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 402 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 403 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 404 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 405 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 406 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 407 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 408 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 409 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 410 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 411 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 412 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 413 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 414 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 415 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS12_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 13 (Interrupts 416..447)
+*/
+#define NVIC_INIT_ITNS13   0
+
+/*
+// Interrupts 416..447
+//   <o.0>  Interrupt 416 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 417 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 418 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 419 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 420 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 421 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 422 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 423 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 424 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 425 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 426 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 427 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 428 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 429 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 430 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 431 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 432 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 433 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 434 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 435 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 436 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 437 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 438 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 439 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 440 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 441 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 442 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 443 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 444 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 445 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 446 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 447 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS13_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 14 (Interrupts 448..479)
+*/
+#define NVIC_INIT_ITNS14   0
+
+/*
+// Interrupts 448..479
+//   <o.0>  Interrupt 448 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 449 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 450 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 451 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 452 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 453 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 454 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 455 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 456 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 457 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 458 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 459 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 460 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 461 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 462 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 463 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 464 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 465 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 466 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 467 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 468 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 469 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 470 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 471 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 472 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 473 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 474 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 475 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 476 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 477 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 478 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 479 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS14_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 15 (Interrupts 480..511)
+*/
+#define NVIC_INIT_ITNS15   0
+
+/*
+// Interrupts 480..511
+//   <o.0>  Interrupt 480 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 481 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 482 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 483 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 484 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 485 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 486 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 487 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 488 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 489 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 490 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 491 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 492 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 493 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 494 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 495 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 496 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 497 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 498 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 499 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 500 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 501 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 502 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 503 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 504 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 505 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 506 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 507 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 508 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 509 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 510 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 511 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS15_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+// </h>
+*/
+
+
+
+/*
+    max 128 SAU regions.
+    SAU regions are defined in partition.h
+ */
+
+#define SAU_INIT_REGION(n) \
+    SAU->RNR  =  (n                                     & SAU_RNR_REGION_Msk); \
+    SAU->RBAR =  (SAU_INIT_START##n                     & SAU_RBAR_BADDR_Msk); \
+    SAU->RLAR =  (SAU_INIT_END##n                       & SAU_RLAR_LADDR_Msk) | \
+                ((SAU_INIT_NSC##n << SAU_RLAR_NSC_Pos)  & SAU_RLAR_NSC_Msk)   | 1U
+
+/**
+  \brief   Setup a SAU Region
+  \details Writes the region information contained in SAU_Region to the
+           registers SAU_RNR, SAU_RBAR, and SAU_RLAR
+ */
+__STATIC_INLINE void TZ_SAU_Setup (void)
+{
+
+#if defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U)
+
+  #if defined (SAU_INIT_REGION0) && (SAU_INIT_REGION0 == 1U)
+    SAU_INIT_REGION(0);
+  #endif
+
+  #if defined (SAU_INIT_REGION1) && (SAU_INIT_REGION1 == 1U)
+    SAU_INIT_REGION(1);
+  #endif
+
+  #if defined (SAU_INIT_REGION2) && (SAU_INIT_REGION2 == 1U)
+    SAU_INIT_REGION(2);
+  #endif
+
+  #if defined (SAU_INIT_REGION3) && (SAU_INIT_REGION3 == 1U)
+    SAU_INIT_REGION(3);
+  #endif
+
+  #if defined (SAU_INIT_REGION4) && (SAU_INIT_REGION4 == 1U)
+    SAU_INIT_REGION(4);
+  #endif
+
+  #if defined (SAU_INIT_REGION5) && (SAU_INIT_REGION5 == 1U)
+    SAU_INIT_REGION(5);
+  #endif
+
+  #if defined (SAU_INIT_REGION6) && (SAU_INIT_REGION6 == 1U)
+    SAU_INIT_REGION(6);
+  #endif
+
+  #if defined (SAU_INIT_REGION7) && (SAU_INIT_REGION7 == 1U)
+    SAU_INIT_REGION(7);
+  #endif
+
+  /* repeat this for all possible SAU regions */
+
+#endif /* defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U) */
+
+
+  #if defined (SAU_INIT_CTRL) && (SAU_INIT_CTRL == 1U)
+    SAU->CTRL = ((SAU_INIT_CTRL_ENABLE << SAU_CTRL_ENABLE_Pos) & SAU_CTRL_ENABLE_Msk) |
+                ((SAU_INIT_CTRL_ALLNS  << SAU_CTRL_ALLNS_Pos)  & SAU_CTRL_ALLNS_Msk)   ;
+  #endif
+
+  #if defined (SCB_CSR_AIRCR_INIT) && (SCB_CSR_AIRCR_INIT == 1U)
+    SCB->SCR   = (SCB->SCR   & ~(SCB_SCR_SLEEPDEEPS_Msk    )) |
+                   ((SCB_CSR_DEEPSLEEPS_VAL     << SCB_SCR_SLEEPDEEPS_Pos)     & SCB_SCR_SLEEPDEEPS_Msk);
+
+    SCB->AIRCR = (SCB->AIRCR & ~(SCB_AIRCR_VECTKEY_Msk   | SCB_AIRCR_SYSRESETREQS_Msk |
+                                 SCB_AIRCR_BFHFNMINS_Msk | SCB_AIRCR_PRIS_Msk          ))                    |
+                   ((0x05FAU                    << SCB_AIRCR_VECTKEY_Pos)      & SCB_AIRCR_VECTKEY_Msk)      |
+                   ((SCB_AIRCR_SYSRESETREQS_VAL << SCB_AIRCR_SYSRESETREQS_Pos) & SCB_AIRCR_SYSRESETREQS_Msk) |
+                   ((SCB_AIRCR_PRIS_VAL         << SCB_AIRCR_PRIS_Pos)         & SCB_AIRCR_PRIS_Msk)         |
+                   ((SCB_AIRCR_BFHFNMINS_VAL    << SCB_AIRCR_BFHFNMINS_Pos)    & SCB_AIRCR_BFHFNMINS_Msk);
+  #endif /* defined (SCB_CSR_AIRCR_INIT) && (SCB_CSR_AIRCR_INIT == 1U) */
+
+  #if defined (__FPU_USED) && (__FPU_USED == 1U) && \
+      defined (TZ_FPU_NS_USAGE) && (TZ_FPU_NS_USAGE == 1U)
+
+    SCB->NSACR = (SCB->NSACR & ~(SCB_NSACR_CP10_Msk | SCB_NSACR_CP10_Msk)) |
+                   ((SCB_NSACR_CP10_11_VAL << SCB_NSACR_CP10_Pos) & (SCB_NSACR_CP10_Msk | SCB_NSACR_CP11_Msk));
+
+    FPU->FPCCR = (FPU->FPCCR & ~(FPU_FPCCR_TS_Msk | FPU_FPCCR_CLRONRETS_Msk | FPU_FPCCR_CLRONRET_Msk)) |
+                   ((FPU_FPCCR_TS_VAL        << FPU_FPCCR_TS_Pos       ) & FPU_FPCCR_TS_Msk       ) |
+                   ((FPU_FPCCR_CLRONRETS_VAL << FPU_FPCCR_CLRONRETS_Pos) & FPU_FPCCR_CLRONRETS_Msk) |
+                   ((FPU_FPCCR_CLRONRET_VAL  << FPU_FPCCR_CLRONRET_Pos ) & FPU_FPCCR_CLRONRET_Msk );
+  #endif
+
+  #if defined (NVIC_INIT_ITNS0) && (NVIC_INIT_ITNS0 == 1U)
+    NVIC->ITNS[0] = NVIC_INIT_ITNS0_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS1) && (NVIC_INIT_ITNS1 == 1U)
+    NVIC->ITNS[1] = NVIC_INIT_ITNS1_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS2) && (NVIC_INIT_ITNS2 == 1U)
+    NVIC->ITNS[2] = NVIC_INIT_ITNS2_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS3) && (NVIC_INIT_ITNS3 == 1U)
+    NVIC->ITNS[3] = NVIC_INIT_ITNS3_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS4) && (NVIC_INIT_ITNS4 == 1U)
+    NVIC->ITNS[4] = NVIC_INIT_ITNS4_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS5) && (NVIC_INIT_ITNS5 == 1U)
+    NVIC->ITNS[5] = NVIC_INIT_ITNS5_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS6) && (NVIC_INIT_ITNS6 == 1U)
+    NVIC->ITNS[6] = NVIC_INIT_ITNS6_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS7) && (NVIC_INIT_ITNS7 == 1U)
+    NVIC->ITNS[7] = NVIC_INIT_ITNS7_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS8) && (NVIC_INIT_ITNS8 == 1U)
+    NVIC->ITNS[8] = NVIC_INIT_ITNS8_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS9) && (NVIC_INIT_ITNS9 == 1U)
+    NVIC->ITNS[9] = NVIC_INIT_ITNS9_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS10) && (NVIC_INIT_ITNS10 == 1U)
+    NVIC->ITNS[10] = NVIC_INIT_ITNS10_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS11) && (NVIC_INIT_ITNS11 == 1U)
+    NVIC->ITNS[11] = NVIC_INIT_ITNS11_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS12) && (NVIC_INIT_ITNS12 == 1U)
+    NVIC->ITNS[12] = NVIC_INIT_ITNS12_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS13) && (NVIC_INIT_ITNS13 == 1U)
+    NVIC->ITNS[13] = NVIC_INIT_ITNS13_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS14) && (NVIC_INIT_ITNS14 == 1U)
+    NVIC->ITNS[14] = NVIC_INIT_ITNS14_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS15) && (NVIC_INIT_ITNS15 == 1U)
+    NVIC->ITNS[15] = NVIC_INIT_ITNS15_VAL;
+  #endif
+
+  /* repeat this for all possible ITNS elements */
+
+}
+
+#endif  /* PARTITION_ARMCM35P_H */

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Source/Config/partition_ARMCM55.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Source/Config/partition_ARMCM55.h
@@ -1,0 +1,1261 @@
+/**************************************************************************//**
+ * @file     partition_ARMCM55.h
+ * @brief    CMSIS-CORE Initial Setup for Secure / Non-Secure Zones for Armv8.1-M Mainline
+ * @version  V1.0.0
+ * @date     20. March 2020
+ ******************************************************************************/
+/*
+ * Copyright (c) 2020 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PARTITION_ARMCM55_H
+#define PARTITION_ARMCM55_H
+
+/*
+//-------- <<< Use Configuration Wizard in Context Menu >>> -----------------
+*/
+
+/*
+// <e>Initialize Security Attribution Unit (SAU) CTRL register
+*/
+#define SAU_INIT_CTRL          1
+
+/*
+//   <q> Enable SAU
+//   <i> Value for SAU->CTRL register bit ENABLE
+*/
+#define SAU_INIT_CTRL_ENABLE   1
+
+/*
+//   <o> When SAU is disabled
+//     <0=> All Memory is Secure
+//     <1=> All Memory is Non-Secure
+//   <i> Value for SAU->CTRL register bit ALLNS
+//   <i> When all Memory is Non-Secure (ALLNS is 1), IDAU can override memory map configuration.
+*/
+#define SAU_INIT_CTRL_ALLNS  0
+
+/*
+// </e>
+*/
+
+/*
+// <h>Initialize Security Attribution Unit (SAU) Address Regions
+// <i>SAU configuration specifies regions to be one of:
+// <i> - Secure and Non-Secure Callable
+// <i> - Non-Secure
+// <i>Note: All memory regions not configured by SAU are Secure
+*/
+#define SAU_REGIONS_MAX   8                 /* Max. number of SAU regions */
+
+/*
+//   <e>Initialize SAU Region 0
+//   <i> Setup SAU Region 0 memory attributes
+*/
+#define SAU_INIT_REGION0    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START0     0x00000000      /* start address of SAU region 0 */
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END0       0x001FFFFF      /* end address of SAU region 0 */
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC0       1
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 1
+//   <i> Setup SAU Region 1 memory attributes
+*/
+#define SAU_INIT_REGION1    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START1     0x00200000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END1       0x003FFFFF
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC1       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 2
+//   <i> Setup SAU Region 2 memory attributes
+*/
+#define SAU_INIT_REGION2    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START2     0x20200000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END2       0x203FFFFF
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC2       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 3
+//   <i> Setup SAU Region 3 memory attributes
+*/
+#define SAU_INIT_REGION3    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START3     0x40000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END3       0x40040000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC3       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 4
+//   <i> Setup SAU Region 4 memory attributes
+*/
+#define SAU_INIT_REGION4    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START4     0x00000000      /* start address of SAU region 4 */
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END4       0x00000000      /* end address of SAU region 4 */
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC4       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 5
+//   <i> Setup SAU Region 5 memory attributes
+*/
+#define SAU_INIT_REGION5    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START5     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END5       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC5       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 6
+//   <i> Setup SAU Region 6 memory attributes
+*/
+#define SAU_INIT_REGION6    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START6     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END6       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC6       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 7
+//   <i> Setup SAU Region 7 memory attributes
+*/
+#define SAU_INIT_REGION7    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START7     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END7       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC7       0
+/*
+//   </e>
+*/
+
+/*
+// </h>
+*/
+
+/*
+// <e>Setup behaviour of Sleep and Exception Handling
+*/
+#define SCB_CSR_AIRCR_INIT  1
+
+/*
+//   <o> Deep Sleep can be enabled by
+//     <0=>Secure and Non-Secure state
+//     <1=>Secure state only
+//   <i> Value for SCB->CSR register bit DEEPSLEEPS
+*/
+#define SCB_CSR_DEEPSLEEPS_VAL  1
+
+/*
+//   <o>System reset request accessible from
+//     <0=> Secure and Non-Secure state
+//     <1=> Secure state only
+//   <i> Value for SCB->AIRCR register bit SYSRESETREQS
+*/
+#define SCB_AIRCR_SYSRESETREQS_VAL  1
+
+/*
+//   <o>Priority of Non-Secure exceptions is
+//     <0=> Not altered
+//     <1=> Lowered to 0x80-0xFF
+//   <i> Value for SCB->AIRCR register bit PRIS
+*/
+#define SCB_AIRCR_PRIS_VAL      1
+
+/*
+//   <o>BusFault, HardFault, and NMI target
+//     <0=> Secure state
+//     <1=> Non-Secure state
+//   <i> Value for SCB->AIRCR register bit BFHFNMINS
+*/
+#define SCB_AIRCR_BFHFNMINS_VAL 0
+
+/*
+// </e>
+*/
+
+/*
+// <e>Setup behaviour of Floating Point and Vector Unit (FPU/MVE)
+*/
+#define TZ_FPU_NS_USAGE 1
+
+/*
+// <o>Floating Point and Vector Unit usage
+//     <0=> Secure state only
+//     <3=> Secure and Non-Secure state
+//   <i> Value for SCB->NSACR register bits CP10, CP11
+*/
+#define SCB_NSACR_CP10_11_VAL       3
+
+/*
+// <o>Treat floating-point registers as Secure
+//     <0=> Disabled
+//     <1=> Enabled
+//   <i> Value for FPU->FPCCR register bit TS
+*/
+#define FPU_FPCCR_TS_VAL            0
+
+/*
+// <o>Clear on return (CLRONRET) accessibility
+//     <0=> Secure and Non-Secure state
+//     <1=> Secure state only
+//   <i> Value for FPU->FPCCR register bit CLRONRETS
+*/
+#define FPU_FPCCR_CLRONRETS_VAL     0
+
+/*
+// <o>Clear floating-point caller saved registers on exception return
+//     <0=> Disabled
+//     <1=> Enabled
+//   <i> Value for FPU->FPCCR register bit CLRONRET
+*/
+#define FPU_FPCCR_CLRONRET_VAL      1
+
+/*
+// </e>
+*/
+
+/*
+// <h>Setup Interrupt Target
+*/
+
+/*
+//   <e>Initialize ITNS 0 (Interrupts 0..31)
+*/
+#define NVIC_INIT_ITNS0    1
+
+/*
+// Interrupts 0..31
+//   <o.0>  Interrupt 0   <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 1   <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 2   <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 3   <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 4   <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 5   <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 6   <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 7   <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 8   <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 9   <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 10  <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 11  <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 12  <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 13  <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 14  <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 15  <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 16  <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 17  <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 18  <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 19  <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 20  <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 21  <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 22  <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 23  <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 24  <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 25  <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 26  <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 27  <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 28  <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 29  <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 30  <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 31  <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS0_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 1 (Interrupts 32..63)
+*/
+#define NVIC_INIT_ITNS1    1
+
+/*
+// Interrupts 32..63
+//   <o.0>  Interrupt 32  <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 33  <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 34  <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 35  <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 36  <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 37  <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 38  <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 39  <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 40  <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 41  <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 42  <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 43  <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 44  <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 45  <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 46  <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 47  <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 48  <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 49  <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 50  <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 51  <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 52  <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 53  <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 54  <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 55  <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 56  <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 57  <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 58  <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 59  <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 60  <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 61  <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 62  <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 63  <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS1_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 2 (Interrupts 64..95)
+*/
+#define NVIC_INIT_ITNS2    0
+
+/*
+// Interrupts 64..95
+//   <o.0>  Interrupt 64  <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 65  <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 66  <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 67  <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 68  <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 69  <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 70  <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 71  <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 72  <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 73  <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 74  <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 75  <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 76  <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 77  <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 78  <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 79  <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 80  <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 81  <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 82  <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 83  <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 84  <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 85  <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 86  <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 87  <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 88  <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 89  <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 90  <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 91  <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 92  <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 93  <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 94  <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 95  <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS2_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 3 (Interrupts 96..127)
+*/
+#define NVIC_INIT_ITNS3    0
+
+/*
+// Interrupts 96..127
+//   <o.0>  Interrupt 96  <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 97  <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 98  <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 99  <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 100 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 101 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 102 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 103 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 104 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 105 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 106 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 107 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 108 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 109 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 110 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 111 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 112 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 113 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 114 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 115 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 116 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 117 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 118 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 119 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 120 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 121 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 122 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 123 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 124 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 125 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 126 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 127 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS3_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 4 (Interrupts 128..159)
+*/
+#define NVIC_INIT_ITNS4    0
+
+/*
+// Interrupts 128..159
+//   <o.0>  Interrupt 128 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 129 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 130 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 131 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 132 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 133 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 134 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 135 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 136 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 137 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 138 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 139 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 140 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 141 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 142 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 143 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 144 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 145 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 146 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 147 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 148 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 149 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 150 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 151 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 152 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 153 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 154 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 155 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 156 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 157 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 158 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 159 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS4_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 5 (Interrupts 160..191)
+*/
+#define NVIC_INIT_ITNS5    0
+
+/*
+// Interrupts 160..191
+//   <o.0>  Interrupt 160 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 161 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 162 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 163 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 164 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 165 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 166 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 167 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 168 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 169 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 170 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 171 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 172 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 173 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 174 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 175 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 176 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 177 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 178 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 179 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 180 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 181 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 182 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 183 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 184 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 185 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 186 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 187 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 188 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 189 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 190 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 191 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS5_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 6 (Interrupts 192..223)
+*/
+#define NVIC_INIT_ITNS6    0
+
+/*
+// Interrupts 192..223
+//   <o.0>  Interrupt 192 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 193 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 194 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 195 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 196 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 197 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 198 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 199 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 200 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 201 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 202 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 203 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 204 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 205 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 206 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 207 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 208 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 209 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 210 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 211 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 212 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 213 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 214 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 215 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 216 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 217 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 218 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 219 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 220 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 221 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 222 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 223 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS6_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 7 (Interrupts 224..255)
+*/
+#define NVIC_INIT_ITNS7    0
+
+/*
+// Interrupts 224..255
+//   <o.0>  Interrupt 224 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 225 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 226 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 227 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 228 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 229 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 230 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 231 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 232 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 233 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 234 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 235 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 236 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 237 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 238 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 239 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 240 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 241 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 242 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 243 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 244 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 245 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 246 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 247 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 248 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 249 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 250 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 251 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 252 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 253 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 254 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 255 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS7_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 8 (Interrupts 256..287)
+*/
+#define NVIC_INIT_ITNS8    0
+
+/*
+// Interrupts 256..287
+//   <o.0>  Interrupt 256 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 257 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 258 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 259 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 260 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 261 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 262 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 263 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 264 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 265 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 266 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 267 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 268 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 269 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 270 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 271 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 272 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 273 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 274 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 275 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 276 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 277 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 278 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 279 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 280 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 281 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 282 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 283 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 284 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 285 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 286 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 287 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS8_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 9 (Interrupts 288..319)
+*/
+#define NVIC_INIT_ITNS9    0
+
+/*
+// Interrupts 288..319
+//   <o.0>  Interrupt 288 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 289 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 290 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 291 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 292 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 293 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 294 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 295 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 296 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 297 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 298 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 299 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 300 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 301 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 302 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 303 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 304 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 305 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 306 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 307 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 308 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 309 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 310 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 311 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 312 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 313 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 314 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 315 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 316 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 317 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 318 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 319 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS9_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 10 (Interrupts 320..351)
+*/
+#define NVIC_INIT_ITNS10   0
+
+/*
+// Interrupts 320..351
+//   <o.0>  Interrupt 320 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 321 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 322 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 323 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 324 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 325 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 326 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 327 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 328 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 329 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 330 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 331 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 332 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 333 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 334 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 335 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 336 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 337 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 338 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 339 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 340 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 341 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 342 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 343 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 344 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 345 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 346 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 347 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 348 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 349 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 350 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 351 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS10_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 11 (Interrupts 352..383)
+*/
+#define NVIC_INIT_ITNS11   0
+
+/*
+// Interrupts 352..383
+//   <o.0>  Interrupt 352 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 353 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 354 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 355 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 356 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 357 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 358 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 359 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 360 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 361 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 362 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 363 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 364 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 365 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 366 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 367 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 368 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 369 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 370 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 371 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 372 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 373 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 374 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 375 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 376 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 377 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 378 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 379 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 380 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 381 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 382 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 383 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS11_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 12 (Interrupts 384..415)
+*/
+#define NVIC_INIT_ITNS12   0
+
+/*
+// Interrupts 384..415
+//   <o.0>  Interrupt 384 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 385 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 386 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 387 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 388 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 389 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 390 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 391 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 392 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 393 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 394 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 395 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 396 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 397 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 398 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 399 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 400 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 401 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 402 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 403 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 404 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 405 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 406 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 407 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 408 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 409 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 410 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 411 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 412 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 413 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 414 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 415 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS12_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 13 (Interrupts 416..447)
+*/
+#define NVIC_INIT_ITNS13   0
+
+/*
+// Interrupts 416..447
+//   <o.0>  Interrupt 416 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 417 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 418 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 419 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 420 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 421 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 422 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 423 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 424 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 425 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 426 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 427 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 428 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 429 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 430 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 431 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 432 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 433 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 434 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 435 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 436 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 437 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 438 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 439 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 440 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 441 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 442 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 443 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 444 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 445 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 446 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 447 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS13_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 14 (Interrupts 448..479)
+*/
+#define NVIC_INIT_ITNS14   0
+
+/*
+// Interrupts 448..479
+//   <o.0>  Interrupt 448 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 449 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 450 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 451 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 452 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 453 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 454 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 455 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 456 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 457 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 458 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 459 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 460 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 461 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 462 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 463 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 464 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 465 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 466 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 467 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 468 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 469 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 470 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 471 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 472 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 473 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 474 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 475 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 476 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 477 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 478 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 479 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS14_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 15 (Interrupts 480..511)
+*/
+#define NVIC_INIT_ITNS15   0
+
+/*
+// Interrupts 480..511
+//   <o.0>  Interrupt 480 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 481 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 482 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 483 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 484 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 485 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 486 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 487 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 488 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 489 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 490 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 491 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 492 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 493 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 494 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 495 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 496 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 497 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 498 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 499 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 500 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 501 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 502 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 503 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 504 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 505 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 506 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 507 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 508 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 509 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 510 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 511 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS15_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+// </h>
+*/
+
+
+
+/*
+    max 128 SAU regions.
+    SAU regions are defined in partition.h
+ */
+
+#define SAU_INIT_REGION(n) \
+    SAU->RNR  =  (n                                     & SAU_RNR_REGION_Msk); \
+    SAU->RBAR =  (SAU_INIT_START##n                     & SAU_RBAR_BADDR_Msk); \
+    SAU->RLAR =  (SAU_INIT_END##n                       & SAU_RLAR_LADDR_Msk) | \
+                ((SAU_INIT_NSC##n << SAU_RLAR_NSC_Pos)  & SAU_RLAR_NSC_Msk)   | 1U
+
+/**
+  \brief   Setup a SAU Region
+  \details Writes the region information contained in SAU_Region to the
+           registers SAU_RNR, SAU_RBAR, and SAU_RLAR
+ */
+__STATIC_INLINE void TZ_SAU_Setup (void)
+{
+
+#if defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U)
+
+  #if defined (SAU_INIT_REGION0) && (SAU_INIT_REGION0 == 1U)
+    SAU_INIT_REGION(0);
+  #endif
+
+  #if defined (SAU_INIT_REGION1) && (SAU_INIT_REGION1 == 1U)
+    SAU_INIT_REGION(1);
+  #endif
+
+  #if defined (SAU_INIT_REGION2) && (SAU_INIT_REGION2 == 1U)
+    SAU_INIT_REGION(2);
+  #endif
+
+  #if defined (SAU_INIT_REGION3) && (SAU_INIT_REGION3 == 1U)
+    SAU_INIT_REGION(3);
+  #endif
+
+  #if defined (SAU_INIT_REGION4) && (SAU_INIT_REGION4 == 1U)
+    SAU_INIT_REGION(4);
+  #endif
+
+  #if defined (SAU_INIT_REGION5) && (SAU_INIT_REGION5 == 1U)
+    SAU_INIT_REGION(5);
+  #endif
+
+  #if defined (SAU_INIT_REGION6) && (SAU_INIT_REGION6 == 1U)
+    SAU_INIT_REGION(6);
+  #endif
+
+  #if defined (SAU_INIT_REGION7) && (SAU_INIT_REGION7 == 1U)
+    SAU_INIT_REGION(7);
+  #endif
+
+  /* repeat this for all possible SAU regions */
+
+#endif /* defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U) */
+
+
+  #if defined (SAU_INIT_CTRL) && (SAU_INIT_CTRL == 1U)
+    SAU->CTRL = ((SAU_INIT_CTRL_ENABLE << SAU_CTRL_ENABLE_Pos) & SAU_CTRL_ENABLE_Msk) |
+                ((SAU_INIT_CTRL_ALLNS  << SAU_CTRL_ALLNS_Pos)  & SAU_CTRL_ALLNS_Msk)   ;
+  #endif
+
+  #if defined (SCB_CSR_AIRCR_INIT) && (SCB_CSR_AIRCR_INIT == 1U)
+    SCB->SCR   = (SCB->SCR   & ~(SCB_SCR_SLEEPDEEPS_Msk    )) |
+                   ((SCB_CSR_DEEPSLEEPS_VAL     << SCB_SCR_SLEEPDEEPS_Pos)     & SCB_SCR_SLEEPDEEPS_Msk);
+
+    SCB->AIRCR = (SCB->AIRCR & ~(SCB_AIRCR_VECTKEY_Msk   | SCB_AIRCR_SYSRESETREQS_Msk |
+                                 SCB_AIRCR_BFHFNMINS_Msk | SCB_AIRCR_PRIS_Msk          ))                    |
+                   ((0x05FAU                    << SCB_AIRCR_VECTKEY_Pos)      & SCB_AIRCR_VECTKEY_Msk)      |
+                   ((SCB_AIRCR_SYSRESETREQS_VAL << SCB_AIRCR_SYSRESETREQS_Pos) & SCB_AIRCR_SYSRESETREQS_Msk) |
+                   ((SCB_AIRCR_PRIS_VAL         << SCB_AIRCR_PRIS_Pos)         & SCB_AIRCR_PRIS_Msk)         |
+                   ((SCB_AIRCR_BFHFNMINS_VAL    << SCB_AIRCR_BFHFNMINS_Pos)    & SCB_AIRCR_BFHFNMINS_Msk);
+  #endif /* defined (SCB_CSR_AIRCR_INIT) && (SCB_CSR_AIRCR_INIT == 1U) */
+
+  #if (((defined (__FPU_USED) && (__FPU_USED == 1U))              || \
+        (defined (__ARM_FEATURE_MVE) && (__ARM_FEATURE_MVE > 0))) && \
+       (defined (TZ_FPU_NS_USAGE) && (TZ_FPU_NS_USAGE == 1U)))
+
+    SCB->NSACR = (SCB->NSACR & ~(SCB_NSACR_CP10_Msk | SCB_NSACR_CP11_Msk)) |
+                   ((SCB_NSACR_CP10_11_VAL << SCB_NSACR_CP10_Pos) & (SCB_NSACR_CP10_Msk | SCB_NSACR_CP11_Msk));
+
+    FPU->FPCCR = (FPU->FPCCR & ~(FPU_FPCCR_TS_Msk | FPU_FPCCR_CLRONRETS_Msk | FPU_FPCCR_CLRONRET_Msk)) |
+                   ((FPU_FPCCR_TS_VAL        << FPU_FPCCR_TS_Pos       ) & FPU_FPCCR_TS_Msk       ) |
+                   ((FPU_FPCCR_CLRONRETS_VAL << FPU_FPCCR_CLRONRETS_Pos) & FPU_FPCCR_CLRONRETS_Msk) |
+                   ((FPU_FPCCR_CLRONRET_VAL  << FPU_FPCCR_CLRONRET_Pos ) & FPU_FPCCR_CLRONRET_Msk );
+  #endif
+
+  #if defined (NVIC_INIT_ITNS0) && (NVIC_INIT_ITNS0 == 1U)
+    NVIC->ITNS[0] = NVIC_INIT_ITNS0_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS1) && (NVIC_INIT_ITNS1 == 1U)
+    NVIC->ITNS[1] = NVIC_INIT_ITNS1_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS2) && (NVIC_INIT_ITNS2 == 1U)
+    NVIC->ITNS[2] = NVIC_INIT_ITNS2_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS3) && (NVIC_INIT_ITNS3 == 1U)
+    NVIC->ITNS[3] = NVIC_INIT_ITNS3_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS4) && (NVIC_INIT_ITNS4 == 1U)
+    NVIC->ITNS[4] = NVIC_INIT_ITNS4_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS5) && (NVIC_INIT_ITNS5 == 1U)
+    NVIC->ITNS[5] = NVIC_INIT_ITNS5_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS6) && (NVIC_INIT_ITNS6 == 1U)
+    NVIC->ITNS[6] = NVIC_INIT_ITNS6_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS7) && (NVIC_INIT_ITNS7 == 1U)
+    NVIC->ITNS[7] = NVIC_INIT_ITNS7_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS8) && (NVIC_INIT_ITNS8 == 1U)
+    NVIC->ITNS[8] = NVIC_INIT_ITNS8_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS9) && (NVIC_INIT_ITNS9 == 1U)
+    NVIC->ITNS[9] = NVIC_INIT_ITNS9_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS10) && (NVIC_INIT_ITNS10 == 1U)
+    NVIC->ITNS[10] = NVIC_INIT_ITNS10_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS11) && (NVIC_INIT_ITNS11 == 1U)
+    NVIC->ITNS[11] = NVIC_INIT_ITNS11_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS12) && (NVIC_INIT_ITNS12 == 1U)
+    NVIC->ITNS[12] = NVIC_INIT_ITNS12_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS13) && (NVIC_INIT_ITNS13 == 1U)
+    NVIC->ITNS[13] = NVIC_INIT_ITNS13_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS14) && (NVIC_INIT_ITNS14 == 1U)
+    NVIC->ITNS[14] = NVIC_INIT_ITNS14_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS15) && (NVIC_INIT_ITNS15 == 1U)
+    NVIC->ITNS[15] = NVIC_INIT_ITNS15_VAL;
+  #endif
+
+  /* repeat this for all possible ITNS elements */
+
+}
+
+#endif  /* PARTITION_ARMCM55_H */

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Source/ConfigA/CV_Config.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Source/ConfigA/CV_Config.h
@@ -1,0 +1,118 @@
+/*-----------------------------------------------------------------------------
+ *      Name:         CV_Config.h
+ *      Purpose:      CV Config header
+ *----------------------------------------------------------------------------
+ *      Copyright (c) 2017 - 2021 ARM Limited. All rights reserved.
+ *----------------------------------------------------------------------------*/
+#ifndef __CV_CONFIG_H
+#define __CV_CONFIG_H
+
+#include "RTE_Components.h"
+#include CMSIS_device_header
+
+#define RTE_CV_COREINSTR  1
+#define RTE_CV_COREFUNC   1
+#define RTE_CV_L1CACHE    1
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+// <h> Common Test Settings
+// <o> Print Output Format <0=> Plain Text <1=> XML
+// <i> Set the test results output format to plain text or XML
+#ifndef PRINT_XML_REPORT
+#define PRINT_XML_REPORT            1
+#endif
+// <o> Buffer size for assertions results
+// <i> Set the buffer size for assertions results buffer
+#define BUFFER_ASSERTIONS           128U
+// </h>
+
+// <h> Disable Test Cases
+// <i> Uncheck to disable an individual test case
+// <q0> TC_CoreInstr_NOP
+#define TC_COREINSTR_NOP_EN                   1
+// <q0> TC_CoreInstr_REV
+#define TC_COREINSTR_REV_EN                   1
+// <q0> TC_CoreInstr_REV16
+#define TC_COREINSTR_REV16_EN                 1
+// <q0> TC_CoreInstr_REVSH
+#define TC_COREINSTR_REVSH_EN                 1
+// <q0> TC_CoreInstr_ROR
+#define TC_COREINSTR_ROR_EN                   1
+// <q0> TC_CoreInstr_RBIT
+#define TC_COREINSTR_RBIT_EN                  1
+// <q0> TC_CoreInstr_CLZ
+#define TC_COREINSTR_CLZ_EN                   1
+// <q0> TC_CoreInstr_Exclusives
+#define TC_COREINSTR_EXCLUSIVES_EN            1
+// <q0> TC_CoreInstr_SSAT
+#define TC_COREINSTR_SSAT_EN                  1
+// <q0> TC_CoreInstr_USAT
+#define TC_COREINSTR_USAT_EN                  1
+
+// <q0> TC_CoreAFunc_IRQ
+#define TC_COREAFUNC_IRQ                      1
+// <q0> TC_CoreAFunc_FaultIRQ
+#define TC_COREAFUNC_FAULTIRQ                 1
+// <q0> TC_CoreAFunc_FPSCR
+#define TC_COREAFUNC_FPSCR                    1
+// <q0> TC_CoreAFunc_CPSR
+#define TC_COREAFUNC_CPSR                     1
+// <q0> TC_CoreAFunc_Mode
+#define TC_COREAFUNC_MODE                     1
+// <q0> TC_CoreAFunc_FPEXC
+#define TC_COREAFUNC_FPEXC                    1
+// <q0> TC_CoreAFunc_ACTLR
+#define TC_COREAFUNC_ACTLR                    1
+// <q0> TC_CoreAFunc_CPACR
+#define TC_COREAFUNC_CPACR                    1
+// <q0> TC_CoreAFunc_DFSR
+#define TC_COREAFUNC_DFSR                     1
+// <q0> TC_CoreAFunc_IFSR
+#define TC_COREAFUNC_IFSR                     1
+// <q0> TC_CoreAFunc_ISR
+#define TC_COREAFUNC_ISR                      1
+// <q0> TC_CoreAFunc_CBAR
+#define TC_COREAFUNC_CBAR                     1
+// <q0> TC_CoreAFunc_TTBR0
+#define TC_COREAFUNC_TTBR0                    1
+// <q0> TC_CoreAFunc_DACR
+#define TC_COREAFUNC_DACR                     1
+// <q0> TC_CoreAFunc_SCTLR
+#define TC_COREAFUNC_SCTLR                    1
+// <q0> TC_CoreAFunc_MPIDR
+#define TC_COREAFUNC_MPIDR                    1
+// <q0> TC_CoreAFunc_VBAR
+#define TC_COREAFUNC_VBAR                     1
+// <q0> TC_CoreAFunc_MVBAR
+#define TC_COREAFUNC_MVBAR                    1
+// <q0> TC_CoreAFunc_FPU_Enable
+#define TC_COREAFUNC_FPU_ENABLE               1
+
+// <q0> TC_GenTimer_CNTFRQ
+#define TC_GENTIMER_CNTFRQ                    1
+// <q0> TC_GenTimer_CNTP_TVAL
+#define TC_GENTIMER_CNTP_TVAL                 1
+// <q0> TC_GenTimer_CNTP_CTL
+#define TC_GENTIMER_CNTP_CTL                  1
+// <q0> TC_GenTimer_CNTPCT
+#define TC_GENTIMER_CNTPCT                    1
+// <q0> TC_GenTimer_CNTP_CVAL
+#define TC_GENTIMER_CNTP_CVAL                 1
+
+// <q0> TC_CAL1Cache_EnDisable
+#define TC_CAL1CACHE_ENDISABLE                1
+// <q0> TC_CAL1Cache_EnDisableBTAC
+#define TC_CAL1CACHE_ENDISABLEBTAC            1
+// <q0> TC_CAL1Cache_log2_up
+#define TC_CAL1CACHE_LOG2_UP                  1
+// <q0> TC_CAL1Cache_InvalidateDCacheAll
+#define TC_CAL1CACHE_INVALIDATEDCACHEALL      1
+// <q0> TC_CAL1Cache_CleanDCacheAll
+#define TC_CAL1CACHE_CLEANDCACHEALL           1
+// <q0> TC_CAL1Cache_CleanInvalidateDCacheAll
+#define TC_CAL1CACHE_CLEANINVALIDATEDCACHEALL 1
+// </h>
+
+#endif /* __CV_CONFIG_H */
+

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Source/ConfigA/CV_Config_template.h
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Source/ConfigA/CV_Config_template.h
@@ -1,0 +1,114 @@
+/*-----------------------------------------------------------------------------
+ *      Name:         CV_Config.h
+ *      Purpose:      CV Config header
+ *----------------------------------------------------------------------------
+ *      Copyright (c) 2017 - 2021 ARM Limited. All rights reserved.
+ *----------------------------------------------------------------------------*/
+#ifndef __CV_CONFIG_H
+#define __CV_CONFIG_H
+
+#include "RTE_Components.h"
+#include CMSIS_device_header
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+// <h> Common Test Settings
+// <o> Print Output Format <0=> Plain Text <1=> XML
+// <i> Set the test results output format to plain text or XML
+#ifndef PRINT_XML_REPORT
+#define PRINT_XML_REPORT            0
+#endif
+// <o> Buffer size for assertions results
+// <i> Set the buffer size for assertions results buffer
+#define BUFFER_ASSERTIONS           128U
+// </h>
+
+// <h> Disable Test Cases
+// <i> Uncheck to disable an individual test case
+// <q0> TC_CoreInstr_NOP
+#define TC_COREINSTR_NOP_EN                   1
+// <q0> TC_CoreInstr_REV
+#define TC_COREINSTR_REV_EN                   1
+// <q0> TC_CoreInstr_REV16
+#define TC_COREINSTR_REV16_EN                 1
+// <q0> TC_CoreInstr_REVSH
+#define TC_COREINSTR_REVSH_EN                 1
+// <q0> TC_CoreInstr_ROR
+#define TC_COREINSTR_ROR_EN                   1
+// <q0> TC_CoreInstr_RBIT
+#define TC_COREINSTR_RBIT_EN                  1
+// <q0> TC_CoreInstr_CLZ
+#define TC_COREINSTR_CLZ_EN                   1
+// <q0> TC_CoreInstr_Exclusives
+#define TC_COREINSTR_EXCLUSIVES_EN            1
+// <q0> TC_CoreInstr_SSAT
+#define TC_COREINSTR_SSAT_EN                  1
+// <q0> TC_CoreInstr_USAT
+#define TC_COREINSTR_USAT_EN                  1
+
+// <q0> TC_CoreAFunc_IRQ
+#define TC_COREAFUNC_IRQ                      1
+// <q0> TC_CoreAFunc_FaultIRQ
+#define TC_COREAFUNC_FAULTIRQ                 1
+// <q0> TC_CoreAFunc_FPSCR
+#define TC_COREAFUNC_FPSCR                    1
+// <q0> TC_CoreAFunc_CPSR
+#define TC_COREAFUNC_CPSR                     1
+// <q0> TC_CoreAFunc_Mode
+#define TC_COREAFUNC_MODE                     1
+// <q0> TC_CoreAFunc_FPEXC
+#define TC_COREAFUNC_FPEXC                    1
+// <q0> TC_CoreAFunc_ACTLR
+#define TC_COREAFUNC_ACTLR                    1
+// <q0> TC_CoreAFunc_CPACR
+#define TC_COREAFUNC_CPACR                    1
+// <q0> TC_CoreAFunc_DFSR
+#define TC_COREAFUNC_DFSR                     1
+// <q0> TC_CoreAFunc_IFSR
+#define TC_COREAFUNC_IFSR                     1
+// <q0> TC_CoreAFunc_ISR
+#define TC_COREAFUNC_ISR                      1
+// <q0> TC_CoreAFunc_CBAR
+#define TC_COREAFUNC_CBAR                     1
+// <q0> TC_CoreAFunc_TTBR0
+#define TC_COREAFUNC_TTBR0                    1
+// <q0> TC_CoreAFunc_DACR
+#define TC_COREAFUNC_DACR                     1
+// <q0> TC_CoreAFunc_SCTLR
+#define TC_COREAFUNC_SCTLR                    1
+// <q0> TC_CoreAFunc_MPIDR
+#define TC_COREAFUNC_MPIDR                    1
+// <q0> TC_CoreAFunc_VBAR
+#define TC_COREAFUNC_VBAR                     1
+// <q0> TC_CoreAFunc_MVBAR
+#define TC_COREAFUNC_MVBAR                    1
+// <q0> TC_CoreAFunc_FPU_Enable
+#define TC_COREAFUNC_FPU_ENABLE               1
+
+// <q0> TC_GenTimer_CNTFRQ
+#define TC_GENTIMER_CNTFRQ                    1
+// <q0> TC_GenTimer_CNTP_TVAL
+#define TC_GENTIMER_CNTP_TVAL                 1
+// <q0> TC_GenTimer_CNTP_CTL
+#define TC_GENTIMER_CNTP_CTL                  1
+// <q0> TC_GenTimer_CNTPCT
+#define TC_GENTIMER_CNTPCT                    1
+// <q0> TC_GenTimer_CNTP_CVAL
+#define TC_GENTIMER_CNTP_CVAL                 1
+
+// <q0> TC_CAL1Cache_EnDisable
+#define TC_CAL1CACHE_ENDISABLE                1
+// <q0> TC_CAL1Cache_EnDisableBTAC
+#define TC_CAL1CACHE_ENDISABLEBTAC            1
+// <q0> TC_CAL1Cache_log2_up
+#define TC_CAL1CACHE_LOG2_UP                  1
+// <q0> TC_CAL1Cache_InvalidateDCacheAll
+#define TC_CAL1CACHE_INVALIDATEDCACHEALL      1
+// <q0> TC_CAL1Cache_CleanDCacheAll
+#define TC_CAL1CACHE_CLEANDCACHEALL           1
+// <q0> TC_CAL1Cache_CleanInvalidateDCacheAll
+#define TC_CAL1CACHE_CLEANINVALIDATEDCACHEALL 1
+// </h>
+
+#endif /* __CV_CONFIG_H */
+

--- a/platform/ext/cmsis/CMSIS/CoreValidation/Source/cmsis_cv.c
+++ b/platform/ext/cmsis/CMSIS/CoreValidation/Source/cmsis_cv.c
@@ -1,0 +1,186 @@
+/*-----------------------------------------------------------------------------
+ *      Name:         cmsis_cv.c
+ *      Purpose:      Driver validation test cases entry point
+ *----------------------------------------------------------------------------
+ *      Copyright (c) 2017 - 2021 Arm Limited. All rights reserved.
+ *----------------------------------------------------------------------------*/
+#include "cmsis_cv.h"
+#include "RTE_Components.h"
+#include "CV_Framework.h"
+#include "CV_Config.h"
+
+/*-----------------------------------------------------------------------------
+ *      Prototypes
+ *----------------------------------------------------------------------------*/
+
+void Interrupt0_Handler(void);
+
+/*-----------------------------------------------------------------------------
+ *      Variables declarations
+ *----------------------------------------------------------------------------*/
+
+void (*TST_IRQHandler)(void);
+
+void Interrupt0_Handler(void) {
+  if (TST_IRQHandler != NULL) TST_IRQHandler();
+}
+
+/*-----------------------------------------------------------------------------
+ *      Init test suite
+ *----------------------------------------------------------------------------*/
+static void TS_Init (void) {
+  TST_IRQHandler = NULL;
+
+#ifdef RTE_CV_MEASURETICKS
+  StartCortexCycleCounter();
+#endif
+}
+
+/*-----------------------------------------------------------------------------
+ *      Test cases list
+ *----------------------------------------------------------------------------*/
+static TEST_CASE TC_LIST[] = {
+#if defined(RTE_CV_COREINSTR) && RTE_CV_COREINSTR
+  #if defined(__CORTEX_M)
+    TCD ( TC_CoreInstr_NOP,                        TC_COREINSTR_NOP_EN                       ),
+    TCD ( TC_CoreInstr_WFI,                        TC_COREINSTR_WFI_EN                       ),
+    TCD ( TC_CoreInstr_WFE,                        TC_COREINSTR_WFE_EN                       ),
+    TCD ( TC_CoreInstr_SEV,                        TC_COREINSTR_SEV_EN                       ),
+    TCD ( TC_CoreInstr_BKPT,                       TC_COREINSTR_BKPT_EN                      ),
+    TCD ( TC_CoreInstr_ISB,                        TC_COREINSTR_ISB_EN                       ),
+    TCD ( TC_CoreInstr_DSB,                        TC_COREINSTR_DSB_EN                       ),
+    TCD ( TC_CoreInstr_DMB,                        TC_COREINSTR_DMB_EN                       ),
+    TCD ( TC_CoreInstr_REV,                        TC_COREINSTR_REV_EN                       ),
+    TCD ( TC_CoreInstr_REV16,                      TC_COREINSTR_REV16_EN                     ),
+    TCD ( TC_CoreInstr_REVSH,                      TC_COREINSTR_REVSH_EN                     ),
+    TCD ( TC_CoreInstr_ROR,                        TC_COREINSTR_ROR_EN                       ),
+    TCD ( TC_CoreInstr_RBIT,                       TC_COREINSTR_RBIT_EN                      ),
+    TCD ( TC_CoreInstr_CLZ,                        TC_COREINSTR_CLZ_EN                       ),
+    TCD ( TC_CoreInstr_SSAT,                       TC_COREINSTR_SSAT_EN                      ),
+    TCD ( TC_CoreInstr_USAT,                       TC_COREINSTR_USAT_EN                      ),
+    TCD ( TC_CoreInstr_RRX,                        TC_COREINSTR_RRX_EN                       ),
+    TCD ( TC_CoreInstr_LoadStoreExclusive,         TC_COREINSTR_LOADSTOREEXCLUSIVE_EN        ),
+    TCD ( TC_CoreInstr_LoadStoreUnpriv,            TC_COREINSTR_LOADSTOREUNPRIV_EN           ),
+    TCD ( TC_CoreInstr_LoadStoreAcquire,           TC_COREINSTR_LOADSTOREACQUIRE_EN          ),
+    TCD ( TC_CoreInstr_LoadStoreAcquireExclusive,  TC_COREINSTR_LOADSTOREACQUIREEXCLUSIVE_EN ),
+    TCD ( TC_CoreInstr_UnalignedUint16,            TC_COREINSTR_UNALIGNEDUINT16_EN           ),
+    TCD ( TC_CoreInstr_UnalignedUint32,            TC_COREINSTR_UNALIGNEDUINT32_EN           ),
+
+  #elif defined(__CORTEX_A)
+    TCD (TC_CoreInstr_NOP,                         TC_COREINSTR_NOP_EN                 ),
+    TCD (TC_CoreInstr_REV,                         TC_COREINSTR_REV_EN                 ),
+    TCD (TC_CoreInstr_REV16,                       TC_COREINSTR_REV16_EN               ),
+    TCD (TC_CoreInstr_REVSH,                       TC_COREINSTR_REVSH_EN               ),
+    TCD (TC_CoreInstr_ROR,                         TC_COREINSTR_ROR_EN                 ),
+    TCD (TC_CoreInstr_RBIT,                        TC_COREINSTR_RBIT_EN                ),
+    TCD (TC_CoreInstr_CLZ,                         TC_COREINSTR_CLZ_EN                 ),
+    TCD (TC_CoreInstr_SSAT,                        TC_COREINSTR_SSAT_EN                ),
+    TCD (TC_CoreInstr_USAT,                        TC_COREINSTR_USAT_EN                ),
+    TCD (TC_CoreInstr_LoadStoreExclusive,          TC_COREINSTR_EXCLUSIVES_EN          ),
+  #endif
+#endif /* RTE_CV_COREINSTR */
+
+#if defined (RTE_CV_CORESIMD) && RTE_CV_CORESIMD
+    TCD ( TC_CoreSimd_SatAddSub,                   TC_CORESIMD_SATADDSUB_EN                  ),
+    TCD ( TC_CoreSimd_ParSat16,                    TC_CORESIMD_PARSAT16_EN                   ),
+    TCD ( TC_CoreSimd_PackUnpack,                  TC_CORESIMD_PACKUNPACK_EN                 ),
+    TCD ( TC_CoreSimd_ParSel,                      TC_CORESIMD_PARSEL_EN                     ),
+    TCD ( TC_CoreSimd_ParAddSub8,                  TC_CORESIMD_PARADDSUB8_EN                 ),
+    TCD ( TC_CoreSimd_AbsDif8,                     TC_CORESIMD_ABSDIF8_EN                    ),
+    TCD ( TC_CoreSimd_ParAddSub16,                 TC_CORESIMD_PARADDSUB16_EN                ),
+    TCD ( TC_CoreSimd_ParMul16,                    TC_CORESIMD_PARMUL16_EN                   ),
+    TCD ( TC_CoreSimd_Pack16,                      TC_CORESIMD_PACK16_EN                     ),
+    TCD ( TC_CoreSimd_MulAcc32,                    TC_CORESIMD_MULACC32_EN                   ),
+#endif /* RTE_CV_CORESIMD */
+
+#if defined(RTE_CV_COREFUNC) && RTE_CV_COREFUNC
+  #if defined(__CORTEX_M)
+    TCD ( TC_CoreFunc_EnDisIRQ,                    TC_COREFUNC_ENDISIRQ_EN                   ),
+    TCD ( TC_CoreFunc_IRQPrio,                     TC_COREFUNC_IRQPRIO_EN                    ),
+    TCD ( TC_CoreFunc_EncDecIRQPrio,               TC_COREFUNC_ENCDECIRQPRIO_EN              ),
+    TCD ( TC_CoreFunc_IRQVect,                     TC_COREFUNC_IRQVECT_EN                    ),
+    TCD ( TC_CoreFunc_Control,                     TC_COREFUNC_CONTROL_EN                    ),
+    TCD ( TC_CoreFunc_IPSR,                        TC_COREFUNC_IPSR_EN                       ),
+    TCD ( TC_CoreFunc_APSR,                        TC_COREFUNC_APSR_EN                       ),
+    TCD ( TC_CoreFunc_PSP,                         TC_COREFUNC_PSP_EN                        ),
+    TCD ( TC_CoreFunc_MSP,                         TC_COREFUNC_MSP_EN                        ),
+    TCD ( TC_CoreFunc_PSPLIM,                      TC_COREFUNC_PSPLIM_EN                     ),
+    TCD ( TC_CoreFunc_PSPLIM_NS,                   TC_COREFUNC_PSPLIM_NS_EN                  ),
+    TCD ( TC_CoreFunc_MSPLIM,                      TC_COREFUNC_MSPLIM_EN                     ),
+    TCD ( TC_CoreFunc_MSPLIM_NS,                   TC_COREFUNC_MSPLIM_NS_EN                  ),
+    TCD ( TC_CoreFunc_PRIMASK,                     TC_COREFUNC_PRIMASK_EN                    ),
+    TCD ( TC_CoreFunc_FAULTMASK,                   TC_COREFUNC_FAULTMASK_EN                  ),
+    TCD ( TC_CoreFunc_BASEPRI,                     TC_COREFUNC_BASEPRI_EN                    ),
+    TCD ( TC_CoreFunc_FPUType,                     TC_COREFUNC_FPUTYPE_EN                    ),
+    TCD ( TC_CoreFunc_FPSCR,                       TC_COREFUNC_FPSCR_EN                      ),
+
+  #elif defined(__CORTEX_A)
+    TCD ( TC_CoreAFunc_IRQ,                        TC_COREAFUNC_IRQ                          ),
+    TCD ( TC_CoreAFunc_FaultIRQ,                   TC_COREAFUNC_FAULTIRQ                     ),
+    TCD ( TC_CoreAFunc_FPSCR,                      TC_COREAFUNC_FPSCR                        ),
+    TCD ( TC_CoreAFunc_CPSR,                       TC_COREAFUNC_CPSR                         ),
+    TCD ( TC_CoreAFunc_Mode,                       TC_COREAFUNC_MODE                         ),
+    TCD ( TC_CoreAFunc_FPEXC,                      TC_COREAFUNC_FPEXC                        ),
+    TCD ( TC_CoreAFunc_ACTLR,                      TC_COREAFUNC_ACTLR                        ),
+    TCD ( TC_CoreAFunc_CPACR,                      TC_COREAFUNC_CPACR                        ),
+    TCD ( TC_CoreAFunc_DFSR,                       TC_COREAFUNC_DFSR                         ),
+    TCD ( TC_CoreAFunc_IFSR,                       TC_COREAFUNC_IFSR                         ),
+    TCD ( TC_CoreAFunc_ISR,                        TC_COREAFUNC_ISR                          ),
+    TCD ( TC_CoreAFunc_CBAR,                       TC_COREAFUNC_CBAR                         ),
+    TCD ( TC_CoreAFunc_TTBR0,                      TC_COREAFUNC_TTBR0                        ),
+    TCD ( TC_CoreAFunc_DACR,                       TC_COREAFUNC_DACR                         ),
+    TCD ( TC_CoreAFunc_SCTLR,                      TC_COREAFUNC_SCTLR                        ),
+    TCD ( TC_CoreAFunc_MPIDR,                      TC_COREAFUNC_MPIDR                        ),
+    TCD ( TC_CoreAFunc_VBAR,                       TC_COREAFUNC_VBAR                         ),
+    TCD ( TC_CoreAFunc_MVBAR,                      TC_COREAFUNC_MVBAR                        ),
+    TCD ( TC_CoreAFunc_FPU_Enable,                 TC_COREAFUNC_FPU_ENABLE                   ),
+  #endif
+#endif /* RTE_CV_COREFUNC */
+
+#if defined(RTE_CV_MPUFUNC) && RTE_CV_MPUFUNC
+    TCD ( TC_MPU_SetClear,                         TC_MPU_SETCLEAR_EN                        ),
+    TCD ( TC_MPU_Load,                             TC_MPU_LOAD_EN                            ),
+#endif /* RTE_CV_MPUFUNC */
+
+#if defined(RTE_CV_GENTIMER) && RTE_CV_GENTIMER
+    TCD ( TC_GenTimer_CNTFRQ,                      TC_GENTIMER_CNTFRQ                        ),
+    TCD ( TC_GenTimer_CNTP_TVAL,                   TC_GENTIMER_CNTP_TVAL                     ),
+    TCD ( TC_GenTimer_CNTP_CTL,                    TC_GENTIMER_CNTP_CTL                      ),
+    TCD ( TC_GenTimer_CNTPCT,                      TC_GENTIMER_CNTPCT                        ),
+    TCD ( TC_GenTimer_CNTP_CVAL,                   TC_GENTIMER_CNTP_CVAL                     ),
+#endif /* RTE_CV_GENTIMER */
+
+#if defined(RTE_CV_L1CACHE) && RTE_CV_L1CACHE
+  #if defined(__CORTEX_M)
+    TCD ( TC_CML1Cache_EnDisableICache,              TC_CML1CACHE_ENDISABLE_ICACHE          ),
+    TCD ( TC_CML1Cache_EnDisableDCache,              TC_CML1CACHE_ENDISABLE_DCACHE          ),
+    TCD ( TC_CML1Cache_CleanDCacheByAddrWhileDisabled, TC_CML1CACHE_CLEANDCACHEBYADDRWHILEDISABLED),
+  #elif defined(__CORTEX_A)
+    TCD ( TC_CAL1Cache_EnDisable,                    TC_CAL1CACHE_ENDISABLE                 ),
+    TCD ( TC_CAL1Cache_EnDisableBTAC,                TC_CAL1CACHE_ENDISABLEBTAC             ),
+    TCD ( TC_CAL1Cache_log2_up,                      TC_CAL1CACHE_LOG2_UP                   ),
+    TCD ( TC_CAL1Cache_InvalidateDCacheAll,          TC_CAL1CACHE_INVALIDATEDCACHEALL       ),
+    TCD ( TC_CAL1Cache_CleanDCacheAll,               TC_CAL1CACHE_CLEANDCACHEALL            ),
+    TCD ( TC_CAL1Cache_CleanInvalidateDCacheAll,     TC_CAL1CACHE_CLEANINVALIDATEDCACHEALL  ),
+  #endif 
+#endif /* RTE_CV_L1CACHE */
+};
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdate-time"
+#endif
+/*-----------------------------------------------------------------------------
+ *      Test suite description
+ *----------------------------------------------------------------------------*/
+TEST_SUITE ts = {
+  __FILE__, __DATE__, __TIME__,
+  "CMSIS-CORE Test Suite",
+  TS_Init,
+  1,
+  TC_LIST,
+  ARRAY_SIZE (TC_LIST),
+};
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang diagnostic pop
+#endif

--- a/platform/ext/cmsis/CMSIS/Driver/DriverTemplates/Driver_CAN.c
+++ b/platform/ext/cmsis/CMSIS/Driver/DriverTemplates/Driver_CAN.c
@@ -1,0 +1,317 @@
+/*
+ * Copyright (c) 2015-2020 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+#include "Driver_CAN.h"
+
+#define ARM_CAN_DRV_VERSION ARM_DRIVER_VERSION_MAJOR_MINOR(1,0) // CAN driver version
+
+// Driver Version
+static const ARM_DRIVER_VERSION can_driver_version = { ARM_CAN_API_VERSION, ARM_CAN_DRV_VERSION };
+
+// Driver Capabilities
+static const ARM_CAN_CAPABILITIES can_driver_capabilities = {
+  32U,  // Number of CAN Objects available
+  0U,   // Does not support reentrant calls to ARM_CAN_MessageSend, ARM_CAN_MessageRead, ARM_CAN_ObjectConfigure and abort message sending used by ARM_CAN_Control.
+  0U,   // Does not support CAN with Flexible Data-rate mode (CAN_FD)
+  0U,   // Does not support restricted operation mode
+  0U,   // Does not support bus monitoring mode
+  0U,   // Does not support internal loopback mode
+  0U,   // Does not support external loopback mode
+  0U    // Reserved (must be zero)
+};
+
+// Object Capabilities
+static const ARM_CAN_OBJ_CAPABILITIES can_object_capabilities = {
+  1U,   // Object supports transmission
+  1U,   // Object supports reception
+  0U,   // Object does not support RTR reception and automatic Data transmission
+  0U,   // Object does not support RTR transmission and automatic Data reception
+  0U,   // Object does not allow assignment of multiple filters to it
+  0U,   // Object does not support exact identifier filtering
+  0U,   // Object does not support range identifier filtering
+  0U,   // Object does not support mask identifier filtering
+  0U,   // Object can not buffer messages
+  0U    // Reserved (must be zero)
+};
+
+static uint8_t                     can_driver_powered     = 0U;
+static uint8_t                     can_driver_initialized = 0U;
+static ARM_CAN_SignalUnitEvent_t   CAN_SignalUnitEvent    = NULL;
+static ARM_CAN_SignalObjectEvent_t CAN_SignalObjectEvent  = NULL;
+
+//
+//   Functions
+//
+
+static ARM_DRIVER_VERSION ARM_CAN_GetVersion (void) {
+  // Return driver version
+  return can_driver_version;
+}
+
+static ARM_CAN_CAPABILITIES ARM_CAN_GetCapabilities (void) {
+  // Return driver capabilities
+  return can_driver_capabilities;
+}
+
+static int32_t ARM_CAN_Initialize (ARM_CAN_SignalUnitEvent_t   cb_unit_event,
+                                   ARM_CAN_SignalObjectEvent_t cb_object_event) {
+
+  if (can_driver_initialized != 0U) { return ARM_DRIVER_OK; }
+
+  CAN_SignalUnitEvent   = cb_unit_event;
+  CAN_SignalObjectEvent = cb_object_event;
+
+  // Add code for pin, memory, RTX objects initialization
+  // ..
+
+  can_driver_initialized = 1U;
+
+  return ARM_DRIVER_OK;
+}
+
+static int32_t ARM_CAN_Uninitialize (void) {
+
+  // Add code for pin, memory, RTX objects de-initialization
+  // ..
+
+  can_driver_initialized = 0U;
+
+  return ARM_DRIVER_OK;
+}
+
+static int32_t ARM_CAN_PowerControl (ARM_POWER_STATE state) {
+  switch (state) {
+    case ARM_POWER_OFF:
+      can_driver_powered = 0U;
+      // Add code to disable interrupts and put peripheral into reset mode,
+      // and if possible disable clock
+      // ..
+
+      break;
+
+    case ARM_POWER_FULL:
+      if (can_driver_initialized == 0U) { return ARM_DRIVER_ERROR; }
+      if (can_driver_powered     != 0U) { return ARM_DRIVER_OK;    }
+
+      // Add code to enable clocks, reset variables enable interrupts
+      // and put peripheral into operational
+      // ..
+
+      can_driver_powered = 1U;
+      break;
+
+    case ARM_POWER_LOW:
+      return ARM_DRIVER_ERROR_UNSUPPORTED;
+  }
+
+  return ARM_DRIVER_OK;
+}
+
+static uint32_t ARM_CAN_GetClock (void) {
+
+  // Add code to return peripheral clock frequency
+  // ..
+}
+
+static int32_t ARM_CAN_SetBitrate (ARM_CAN_BITRATE_SELECT select, uint32_t bitrate, uint32_t bit_segments) {
+
+  if (can_driver_powered == 0U) { return ARM_DRIVER_ERROR; }
+
+  // Add code to setup peripheral parameters to generate specified bitrate
+  // with specified bit segments
+  // ..
+
+  return ARM_DRIVER_OK;
+}
+
+static int32_t ARM_CAN_SetMode (ARM_CAN_MODE mode) {
+
+  if (can_driver_powered == 0U) { return ARM_DRIVER_ERROR; }
+
+  switch (mode) {
+    case ARM_CAN_MODE_INITIALIZATION:
+      // Add code to put peripheral into initialization mode
+      // ..
+      break;
+    case ARM_CAN_MODE_NORMAL:
+      // Add code to put peripheral into normal operation mode
+      // ..
+      break;
+    case ARM_CAN_MODE_RESTRICTED:
+      // Add code to put peripheral into restricted operation mode
+      // ..
+      break;
+    case ARM_CAN_MODE_MONITOR:
+      // Add code to put peripheral into bus monitoring mode
+      // ..
+      break;
+    case ARM_CAN_MODE_LOOPBACK_INTERNAL:
+      // Add code to put peripheral into internal loopback mode
+      // ..
+      break;
+    case ARM_CAN_MODE_LOOPBACK_EXTERNAL:
+      // Add code to put peripheral into external loopback mode
+      // ..
+      break;
+  }
+
+  return ARM_DRIVER_OK;
+}
+
+static ARM_CAN_OBJ_CAPABILITIES ARM_CAN_ObjectGetCapabilities (uint32_t obj_idx) {
+  // Return object capabilities
+  return can_object_capabilities;
+}
+
+static int32_t ARM_CAN_ObjectSetFilter (uint32_t obj_idx, ARM_CAN_FILTER_OPERATION operation, uint32_t id, uint32_t arg) {
+
+  if (can_driver_powered == 0U) { return ARM_DRIVER_ERROR; }
+
+  switch (operation) {
+    case ARM_CAN_FILTER_ID_EXACT_ADD:
+      // Add code to setup peripheral to receive messages with specified exact ID
+      break;
+    case ARM_CAN_FILTER_ID_MASKABLE_ADD:
+      // Add code to setup peripheral to receive messages with specified maskable ID
+      break;
+    case ARM_CAN_FILTER_ID_RANGE_ADD:
+      // Add code to setup peripheral to receive messages within specified range of IDs
+      break;
+    case ARM_CAN_FILTER_ID_EXACT_REMOVE:
+      // Add code to remove specified exact ID from being received by peripheral
+      break;
+    case ARM_CAN_FILTER_ID_MASKABLE_REMOVE:
+      // Add code to remove specified maskable ID from being received by peripheral
+      break;
+    case ARM_CAN_FILTER_ID_RANGE_REMOVE:
+      // Add code to remove specified range of IDs from being received by peripheral
+      break;
+  }
+
+  return ARM_DRIVER_OK;
+}
+
+static int32_t ARM_CAN_ObjectConfigure (uint32_t obj_idx, ARM_CAN_OBJ_CONFIG obj_cfg) {
+
+  if (can_driver_powered == 0U) { return ARM_DRIVER_ERROR; }
+
+  switch (obj_cfg) {
+    case ARM_CAN_OBJ_INACTIVE:
+      // Deactivate object
+      // ..
+      break;
+    case ARM_CAN_OBJ_RX_RTR_TX_DATA:
+      // Setup object to automatically return data when RTR with it's ID is received
+      // ..
+      break;
+    case ARM_CAN_OBJ_TX_RTR_RX_DATA:
+      // Setup object to send RTR and receive data response
+      // ..
+      break;
+    case ARM_CAN_OBJ_TX:
+      // Setup object to be used for sending messages
+      // ..
+      break;
+    case ARM_CAN_OBJ_RX:
+      // Setup object to be used for receiving messages
+      // ..
+      break;
+  }
+
+  return ARM_DRIVER_OK;
+}
+
+static int32_t ARM_CAN_MessageSend (uint32_t obj_idx, ARM_CAN_MSG_INFO *msg_info, const uint8_t *data, uint8_t size) {
+
+  if (can_driver_powered == 0U) { return ARM_DRIVER_ERROR; }
+
+  // Add code to send requested message
+  // ..
+
+  return ((int32_t)size);
+}
+
+static int32_t ARM_CAN_MessageRead (uint32_t obj_idx, ARM_CAN_MSG_INFO *msg_info, uint8_t *data, uint8_t size) {
+
+  if (can_driver_powered == 0U) { return ARM_DRIVER_ERROR;  }
+
+  // Add code to read previously received message
+  // (reception was started when object was configured for reception)
+  // ..
+
+  return ((int32_t)size);
+}
+
+static int32_t ARM_CAN_Control (uint32_t control, uint32_t arg) {
+
+  if (can_driver_powered == 0U) { return ARM_DRIVER_ERROR; }
+
+  switch (control & ARM_CAN_CONTROL_Msk) {
+    case ARM_CAN_ABORT_MESSAGE_SEND:
+      // Add code to abort message pending to be sent
+      // ..
+      break;
+    case ARM_CAN_SET_FD_MODE:
+      // Add code to enable Flexible Data-rate mode
+      // ..
+      break;
+    case ARM_CAN_SET_TRANSCEIVER_DELAY:
+      // Add code to set transceiver delay
+      // ..
+      break;
+    default:
+      // Handle unknown control code
+      return ARM_DRIVER_ERROR_UNSUPPORTED;
+  }
+
+  return ARM_DRIVER_OK;
+}
+
+static ARM_CAN_STATUS ARM_CAN_GetStatus (void) {
+
+  // Add code to return device bus and error status
+  // ..
+}
+
+
+// IRQ handlers
+// Add interrupt routines to handle transmission, reception, error and status interrupts
+// ..
+
+// CAN driver functions structure
+
+extern \
+ARM_DRIVER_CAN Driver_CAN0;
+ARM_DRIVER_CAN Driver_CAN0 = {
+  ARM_CAN_GetVersion,
+  ARM_CAN_GetCapabilities,
+  ARM_CAN_Initialize,
+  ARM_CAN_Uninitialize,
+  ARM_CAN_PowerControl,
+  ARM_CAN_GetClock,
+  ARM_CAN_SetBitrate,
+  ARM_CAN_SetMode,
+  ARM_CAN_ObjectGetCapabilities,
+  ARM_CAN_ObjectSetFilter,
+  ARM_CAN_ObjectConfigure,
+  ARM_CAN_MessageSend,
+  ARM_CAN_MessageRead,
+  ARM_CAN_Control,
+  ARM_CAN_GetStatus
+};
+

--- a/platform/ext/cmsis/CMSIS/Driver/DriverTemplates/Driver_ETH_MAC.c
+++ b/platform/ext/cmsis/CMSIS/Driver/DriverTemplates/Driver_ETH_MAC.c
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2013-2020 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Driver_ETH_MAC.h"
+
+#define ARM_ETH_MAC_DRV_VERSION    ARM_DRIVER_VERSION_MAJOR_MINOR(1, 0) /* driver version */
+
+/* Driver Version */
+static const ARM_DRIVER_VERSION DriverVersion = {
+    ARM_ETH_MAC_API_VERSION,
+    ARM_ETH_MAC_DRV_VERSION
+};
+
+/* Driver Capabilities */
+static const ARM_ETH_MAC_CAPABILITIES DriverCapabilities = {
+    0, /* 1 = IPv4 header checksum verified on receive */
+    0, /* 1 = IPv6 checksum verification supported on receive */
+    0, /* 1 = UDP payload checksum verified on receive */
+    0, /* 1 = TCP payload checksum verified on receive */
+    0, /* 1 = ICMP payload checksum verified on receive */
+    0, /* 1 = IPv4 header checksum generated on transmit */
+    0, /* 1 = IPv6 checksum generation supported on transmit */
+    0, /* 1 = UDP payload checksum generated on transmit */
+    0, /* 1 = TCP payload checksum generated on transmit */
+    0, /* 1 = ICMP payload checksum generated on transmit */
+    0, /* Ethernet Media Interface type */
+    0, /* 1 = driver provides initial valid MAC address */
+    0, /* 1 = callback event \ref ARM_ETH_MAC_EVENT_RX_FRAME generated */
+    0, /* 1 = callback event \ref ARM_ETH_MAC_EVENT_TX_FRAME generated */
+    0, /* 1 = wakeup event \ref ARM_ETH_MAC_EVENT_WAKEUP generated */
+    0, /* 1 = Precision Timer supported */
+    0  /* Reserved (must be zero) */
+};
+
+//
+//  Functions
+//
+
+static ARM_DRIVER_VERSION ARM_ETH_MAC_GetVersion(void)
+{
+  return DriverVersion;
+}
+
+static ARM_ETH_MAC_CAPABILITIES ARM_ETH_MAC_GetCapabilities(void)
+{
+  return DriverCapabilities;
+}
+
+static int32_t ARM_ETH_MAC_Initialize(ARM_ETH_MAC_SignalEvent_t cb_event)
+{
+}
+
+static int32_t ARM_ETH_MAC_Uninitialize(void)
+{
+}
+
+static int32_t ARM_ETH_MAC_PowerControl(ARM_POWER_STATE state)
+{
+    switch (state)
+    {
+    case ARM_POWER_OFF:
+        break;
+
+    case ARM_POWER_LOW:
+        break;
+
+    case ARM_POWER_FULL:
+        break;
+    }
+    return ARM_DRIVER_OK;
+}
+
+static int32_t ARM_ETH_MAC_GetMacAddress(ARM_ETH_MAC_ADDR *ptr_addr)
+{
+}
+
+static int32_t ARM_ETH_MAC_SetMacAddress(const ARM_ETH_MAC_ADDR *ptr_addr)
+{
+}
+
+static int32_t ARM_ETH_MAC_SetAddressFilter(const ARM_ETH_MAC_ADDR *ptr_addr, uint32_t num_addr)
+{
+}
+
+static int32_t ARM_ETH_MAC_SendFrame(const uint8_t *frame, uint32_t len, uint32_t flags)
+{
+}
+
+static int32_t ARM_ETH_MAC_ReadFrame(uint8_t *frame, uint32_t len)
+{
+}
+
+static uint32_t ARM_ETH_MAC_GetRxFrameSize(void)
+{
+}
+
+static int32_t ARM_ETH_MAC_GetRxFrameTime(ARM_ETH_MAC_TIME *time)
+{
+}
+
+static int32_t ARM_ETH_MAC_GetTxFrameTime(ARM_ETH_MAC_TIME *time)
+{
+}
+
+static int32_t ARM_ETH_MAC_Control(uint32_t control, uint32_t arg)
+{
+    switch (control)
+    {
+    case ARM_ETH_MAC_CONFIGURE:
+
+        switch (arg & ARM_ETH_MAC_SPEED_Msk)
+        {
+        case ARM_ETH_MAC_SPEED_10M:
+            break;
+        case ARM_ETH_SPEED_100M:
+            break;
+        default:
+            return ARM_DRIVER_ERROR_UNSUPPORTED;
+        }
+
+        switch (arg & ARM_ETH_MAC_DUPLEX_Msk)
+        {
+        case ARM_ETH_MAC_DUPLEX_FULL:
+            break;
+        }
+
+        if (arg & ARM_ETH_MAC_LOOPBACK)
+        {
+        }
+
+        if ((arg & ARM_ETH_MAC_CHECKSUM_OFFLOAD_RX) ||
+            (arg & ARM_ETH_MAC_CHECKSUM_OFFLOAD_TX))
+        {
+            return ARM_DRIVER_ERROR_UNSUPPORTED;
+        }
+
+        if (!(arg & ARM_ETH_MAC_ADDRESS_BROADCAST))
+        {
+        }
+
+        if (arg & ARM_ETH_MAC_ADDRESS_MULTICAST)
+        {
+        }
+
+        if (arg & ARM_ETH_MAC_ADDRESS_ALL)
+        {
+        }
+
+        break;
+
+    case ARM_ETH_MAC_CONTROL_TX:
+        break;
+
+    case ARM_ETH_MAC_CONTROL_RX:
+        break;
+
+    case ARM_ETH_MAC_FLUSH:
+        if (arg & ARM_ETH_MAC_FLUSH_RX)
+        {
+        }
+        if (arg & ARM_ETH_MAC_FLUSH_TX)
+        {
+        }
+        break;
+
+    case ARM_ETH_MAC_SLEEP:
+        break;
+
+    case ARM_ETH_MAC_VLAN_FILTER:
+        break;
+
+    default:
+        return ARM_DRIVER_ERROR_UNSUPPORTED;
+    }
+}
+
+static int32_t ARM_ETH_MAC_ControlTimer(uint32_t control, ARM_ETH_MAC_TIME *time)
+{
+}
+
+static int32_t ARM_ETH_MAC_PHY_Read(uint8_t phy_addr, uint8_t reg_addr, uint16_t *data)
+{
+}
+
+static int32_t ARM_ETH_MAC_PHY_Write(uint8_t phy_addr, uint8_t reg_addr, uint16_t data)
+{
+}
+
+static void ARM_ETH_MAC_SignalEvent(uint32_t event)
+{
+}
+
+// End ETH MAC Interface
+
+extern \
+ARM_DRIVER_ETH_MAC Driver_ETH_MAC0;
+ARM_DRIVER_ETH_MAC Driver_ETH_MAC0 =
+{
+    ARM_ETH_MAC_GetVersion,
+    ARM_ETH_MAC_GetCapabilities,
+    ARM_ETH_MAC_Initialize,
+    ARM_ETH_MAC_Uninitialize,
+    ARM_ETH_MAC_PowerControl,
+    ARM_ETH_MAC_GetMacAddress,
+    ARM_ETH_MAC_SetMacAddress,
+    ARM_ETH_MAC_SetAddressFilter,
+    ARM_ETH_MAC_SendFrame,
+    ARM_ETH_MAC_ReadFrame,
+    ARM_ETH_MAC_GetRxFrameSize,
+    ARM_ETH_MAC_GetRxFrameTime,
+    ARM_ETH_MAC_GetTxFrameTime,
+    ARM_ETH_MAC_ControlTimer,
+    ARM_ETH_MAC_Control,
+    ARM_ETH_MAC_PHY_Read,
+    ARM_ETH_MAC_PHY_Write
+};

--- a/platform/ext/cmsis/CMSIS/Driver/DriverTemplates/Driver_ETH_PHY.c
+++ b/platform/ext/cmsis/CMSIS/Driver/DriverTemplates/Driver_ETH_PHY.c
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2013-2020 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+#include "Driver_ETH_PHY.h"
+
+#define ARM_ETH_PHY_DRV_VERSION    ARM_DRIVER_VERSION_MAJOR_MINOR(1, 0) /* driver version */
+
+/* Driver Version */
+static const ARM_DRIVER_VERSION DriverVersion = {
+    ARM_ETH_PHY_API_VERSION,
+    ARM_ETH_PHY_DRV_VERSION
+};
+
+//
+// Functions
+//
+
+static ARM_DRIVER_VERSION ARM_ETH_PHY_GetVersion(void)
+{
+  return DriverVersion;
+}
+
+static int32_t ARM_ETH_PHY_Initialize(ARM_ETH_PHY_Read_t fn_read, ARM_ETH_PHY_Write_t fn_write)
+{
+}
+
+static int32_t ARM_ETH_PHY_Uninitialize(void)
+{
+}
+
+static int32_t ARM_ETH_PHY_PowerControl(ARM_POWER_STATE state)
+{
+    switch (state)
+    {
+    case ARM_POWER_OFF:
+        break;
+
+    case ARM_POWER_LOW:
+        break;
+
+    case ARM_POWER_FULL:
+        break;
+    }
+    return ARM_DRIVER_OK;
+}
+
+static int32_t ARM_ETH_PHY_SetInterface(uint32_t interface)
+{
+    switch (interface)
+    {
+    case ARM_ETH_INTERFACE_MII:
+        break;
+    case ARM_ETH_INTERFACE_RMII:
+        break;
+    default:
+        return ARM_DRIVER_ERROR_UNSUPPORTED;
+    }
+}
+
+static int32_t ARM_ETH_PHY_SetMode(uint32_t mode)
+{
+    switch (mode & ARM_ETH_PHY_SPEED_Msk)
+    {
+    case ARM_ETH_PHY_SPEED_10M:
+        break;
+    case ARM_ETH_PHY_SPEED_100M:
+        break;
+    default:
+        return ARM_DRIVER_ERROR_UNSUPPORTED;
+    }
+
+    switch (mode & ARM_ETH_PHY_DUPLEX_Msk)
+    {
+    case ARM_ETH_PHY_DUPLEX_HALF:
+        break;
+    case ARM_ETH_PHY_DUPLEX_FULL:
+        break;
+    }
+
+    if (mode & ARM_ETH_PHY_AUTO_NEGOTIATE)
+    {
+    }
+
+    if (mode & ARM_ETH_PHY_LOOPBACK)
+    {
+    }
+
+    if (mode & ARM_ETH_PHY_ISOLATE)
+    {
+    }
+}
+
+static ARM_ETH_LINK_STATE ARM_ETH_PHY_GetLinkState(void)
+{
+}
+
+static ARM_ETH_LINK_INFO ARM_ETH_PHY_GetLinkInfo(void)
+{
+}
+
+extern \
+ARM_DRIVER_ETH_PHY Driver_ETH_PHY0;
+ARM_DRIVER_ETH_PHY Driver_ETH_PHY0 =
+{
+    ARM_ETH_PHY_GetVersion,
+    ARM_ETH_PHY_Initialize,
+    ARM_ETH_PHY_Uninitialize,
+    ARM_ETH_PHY_PowerControl,
+    ARM_ETH_PHY_SetInterface,
+    ARM_ETH_PHY_SetMode,
+    ARM_ETH_PHY_GetLinkState,
+    ARM_ETH_PHY_GetLinkInfo,
+};

--- a/platform/ext/cmsis/CMSIS/Driver/DriverTemplates/Driver_Flash.c
+++ b/platform/ext/cmsis/CMSIS/Driver/DriverTemplates/Driver_Flash.c
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2013-2020 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+#include "Driver_Flash.h"
+
+#define ARM_FLASH_DRV_VERSION    ARM_DRIVER_VERSION_MAJOR_MINOR(1, 0) /* driver version */
+
+/* Sector Information */
+#ifdef FLASH_SECTORS
+static ARM_FLASH_SECTOR FLASH_SECTOR_INFO[FLASH_SECTOR_COUNT] = {
+    FLASH_SECTORS
+};
+#else
+#define FLASH_SECTOR_INFO    NULL
+#endif
+
+/* Flash Information */
+static ARM_FLASH_INFO FlashInfo = {
+    0, /* FLASH_SECTOR_INFO  */
+    0, /* FLASH_SECTOR_COUNT */
+    0, /* FLASH_SECTOR_SIZE  */
+    0, /* FLASH_PAGE_SIZE    */
+    0, /* FLASH_PROGRAM_UNIT */
+    0, /* FLASH_ERASED_VALUE */
+  { 0, 0, 0 }  /* Reserved (must be zero) */
+};
+
+/* Flash Status */
+static ARM_FLASH_STATUS FlashStatus;
+
+/* Driver Version */
+static const ARM_DRIVER_VERSION DriverVersion = {
+    ARM_FLASH_API_VERSION,
+    ARM_FLASH_DRV_VERSION
+};
+
+/* Driver Capabilities */
+static const ARM_FLASH_CAPABILITIES DriverCapabilities = {
+    0, /* event_ready */
+    0, /* data_width = 0:8-bit, 1:16-bit, 2:32-bit */
+    0, /* erase_chip */
+    0  /* reserved (must be zero) */
+};
+
+//
+// Functions
+//
+
+static ARM_DRIVER_VERSION ARM_Flash_GetVersion(void)
+{
+  return DriverVersion;
+}
+
+static ARM_FLASH_CAPABILITIES ARM_Flash_GetCapabilities(void)
+{
+  return DriverCapabilities;
+}
+
+static int32_t ARM_Flash_Initialize(ARM_Flash_SignalEvent_t cb_event)
+{
+}
+
+static int32_t ARM_Flash_Uninitialize(void)
+{
+}
+
+static int32_t ARM_Flash_PowerControl(ARM_POWER_STATE state)
+{
+    switch (state)
+    {
+    case ARM_POWER_OFF:
+        break;
+
+    case ARM_POWER_LOW:
+        break;
+
+    case ARM_POWER_FULL:
+        break;
+    }
+    return ARM_DRIVER_OK;
+}
+
+static int32_t ARM_Flash_ReadData(uint32_t addr, void *data, uint32_t cnt)
+{
+}
+
+static int32_t ARM_Flash_ProgramData(uint32_t addr, const void *data, uint32_t cnt)
+{
+}
+
+static int32_t ARM_Flash_EraseSector(uint32_t addr)
+{
+}
+
+static int32_t ARM_Flash_EraseChip(void)
+{
+}
+
+static ARM_FLASH_STATUS ARM_Flash_GetStatus(void)
+{
+  return FlashStatus;
+}
+
+static ARM_FLASH_INFO * ARM_Flash_GetInfo(void)
+{
+  return &FlashInfo;
+}
+
+static void ARM_Flash_SignalEvent(uint32_t event)
+{
+}
+
+// End Flash Interface
+
+extern \
+ARM_DRIVER_FLASH Driver_Flash0;
+ARM_DRIVER_FLASH Driver_Flash0 = {
+    ARM_Flash_GetVersion,
+    ARM_Flash_GetCapabilities,
+    ARM_Flash_Initialize,
+    ARM_Flash_Uninitialize,
+    ARM_Flash_PowerControl,
+    ARM_Flash_ReadData,
+    ARM_Flash_ProgramData,
+    ARM_Flash_EraseSector,
+    ARM_Flash_EraseChip,
+    ARM_Flash_GetStatus,
+    ARM_Flash_GetInfo
+};

--- a/platform/ext/cmsis/CMSIS/Driver/DriverTemplates/Driver_GPIO.c
+++ b/platform/ext/cmsis/CMSIS/Driver/DriverTemplates/Driver_GPIO.c
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2023 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Driver_GPIO.h"
+
+// Pin mapping
+#define GPIO_MAX_PINS           64U
+#define PIN_IS_AVAILABLE(n)     ((n) < GPIO_MAX_PINS)
+
+
+// Setup GPIO Interface
+static int32_t GPIO_Setup (ARM_GPIO_Pin_t pin, ARM_GPIO_SignalEvent_t cb_event) {
+  int32_t result = ARM_DRIVER_OK;
+
+  if (PIN_IS_AVAILABLE(pin)) {
+  } else {
+    result = ARM_GPIO_ERROR_PIN;
+  }
+
+  return result;
+}
+
+// Set GPIO Direction
+static int32_t GPIO_SetDirection (ARM_GPIO_Pin_t pin, ARM_GPIO_DIRECTION direction) {
+  int32_t result = ARM_DRIVER_OK;
+
+  if (PIN_IS_AVAILABLE(pin)) {
+    switch (direction) {
+      case ARM_GPIO_INPUT:
+        break;
+      case ARM_GPIO_OUTPUT:
+        break;
+      default:
+        result = ARM_DRIVER_ERROR_PARAMETER;
+        break;
+    }
+  } else {
+    result = ARM_GPIO_ERROR_PIN;
+  }
+
+  return result;
+}
+
+// Set GPIO Output Mode
+static int32_t GPIO_SetOutputMode (ARM_GPIO_Pin_t pin, ARM_GPIO_OUTPUT_MODE mode) {
+  int32_t result = ARM_DRIVER_OK;
+
+  if (PIN_IS_AVAILABLE(pin)) {
+    switch (mode) {
+      case ARM_GPIO_PUSH_PULL:
+        break;
+      case ARM_GPIO_OPEN_DRAIN:
+        break;
+      default:
+        result = ARM_DRIVER_ERROR_PARAMETER;
+        break;
+    }
+  } else {
+    result = ARM_GPIO_ERROR_PIN;
+  }
+
+  return result;
+}
+
+// Set GPIO Pull Resistor
+static int32_t GPIO_SetPullResistor (ARM_GPIO_Pin_t pin, ARM_GPIO_PULL_RESISTOR resistor) {
+  int32_t result = ARM_DRIVER_OK;
+
+  if (PIN_IS_AVAILABLE(pin)) {
+    switch (resistor) {
+      case ARM_GPIO_PULL_NONE:
+        break;
+      case ARM_GPIO_PULL_UP:
+        break;
+      case ARM_GPIO_PULL_DOWN:
+        break;
+      default:
+        result = ARM_DRIVER_ERROR_PARAMETER;
+        break;
+    }
+  } else {
+    result = ARM_GPIO_ERROR_PIN;
+  }
+
+  return result;
+}
+
+// Set GPIO Event Trigger
+static int32_t GPIO_SetEventTrigger (ARM_GPIO_Pin_t pin, ARM_GPIO_EVENT_TRIGGER trigger) {
+  int32_t result = ARM_DRIVER_OK;
+
+  if (PIN_IS_AVAILABLE(pin)) {
+    switch (trigger) {
+      case ARM_GPIO_TRIGGER_NONE:
+        break;
+      case ARM_GPIO_TRIGGER_RISING_EDGE:
+        break;
+      case ARM_GPIO_TRIGGER_FALLING_EDGE:
+        break;
+      case ARM_GPIO_TRIGGER_EITHER_EDGE:
+        break;
+      default:
+        result = ARM_DRIVER_ERROR_PARAMETER;
+        break;
+    }
+  } else {
+    result = ARM_GPIO_ERROR_PIN;
+  }
+
+  return result;
+}
+
+// Set GPIO Output Level
+static void GPIO_SetOutput (ARM_GPIO_Pin_t pin, uint32_t val) {
+
+  if (PIN_IS_AVAILABLE(pin)) {
+  }
+}
+
+// Get GPIO Input Level
+static uint32_t GPIO_GetInput (ARM_GPIO_Pin_t pin) {
+  uint32_t val = 0U;
+
+  if (PIN_IS_AVAILABLE(pin)) {
+  }
+  return val;
+}
+
+
+// GPIO Driver access structure
+ARM_DRIVER_GPIO Driver_GPIO0 = {
+  GPIO_Setup,
+  GPIO_SetDirection,
+  GPIO_SetOutputMode,
+  GPIO_SetPullResistor,
+  GPIO_SetEventTrigger,
+  GPIO_SetOutput,
+  GPIO_GetInput
+};

--- a/platform/ext/cmsis/CMSIS/Driver/DriverTemplates/Driver_I2C.c
+++ b/platform/ext/cmsis/CMSIS/Driver/DriverTemplates/Driver_I2C.c
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2013-2020 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+#include "Driver_I2C.h"
+
+#define ARM_I2C_DRV_VERSION    ARM_DRIVER_VERSION_MAJOR_MINOR(1, 0) /* driver version */
+
+/* Driver Version */
+static const ARM_DRIVER_VERSION DriverVersion = {
+    ARM_I2C_API_VERSION,
+    ARM_I2C_DRV_VERSION
+};
+
+/* Driver Capabilities */
+static const ARM_I2C_CAPABILITIES DriverCapabilities = {
+    0  /* supports 10-bit addressing */
+};
+
+//
+//  Functions
+//
+
+static ARM_DRIVER_VERSION ARM_I2C_GetVersion(void)
+{
+  return DriverVersion;
+}
+
+static ARM_I2C_CAPABILITIES ARM_I2C_GetCapabilities(void)
+{
+  return DriverCapabilities;
+}
+
+static int32_t ARM_I2C_Initialize(ARM_I2C_SignalEvent_t cb_event)
+{
+}
+
+static int32_t ARM_I2C_Uninitialize(void)
+{
+}
+
+static int32_t ARM_I2C_PowerControl(ARM_POWER_STATE state)
+{
+    switch (state)
+    {
+    case ARM_POWER_OFF:
+        break;
+
+    case ARM_POWER_LOW:
+        break;
+
+    case ARM_POWER_FULL:
+        break;
+    }
+    return ARM_DRIVER_OK;
+}
+
+static int32_t ARM_I2C_MasterTransmit(uint32_t addr, const uint8_t *data, uint32_t num, bool xfer_pending)
+{
+}
+
+static int32_t ARM_I2C_MasterReceive(uint32_t addr, uint8_t *data, uint32_t num, bool xfer_pending)
+{
+}
+
+static int32_t ARM_I2C_SlaveTransmit(const uint8_t *data, uint32_t num)
+{
+}
+
+static int32_t ARM_I2C_SlaveReceive(uint8_t *data, uint32_t num)
+{
+}
+
+static int32_t ARM_I2C_GetDataCount(void)
+{
+}
+
+static int32_t ARM_I2C_Control(uint32_t control, uint32_t arg)
+{
+    switch (control)
+    {
+    case ARM_I2C_OWN_ADDRESS:
+        break;
+
+    case ARM_I2C_BUS_SPEED:
+        switch (arg)
+        {
+        case ARM_I2C_BUS_SPEED_STANDARD:
+            break;
+        case ARM_I2C_BUS_SPEED_FAST:
+            break;
+        case ARM_I2C_BUS_SPEED_FAST_PLUS:
+            break;
+        default:
+            return ARM_DRIVER_ERROR_UNSUPPORTED;
+        }
+        break;
+
+    case ARM_I2C_BUS_CLEAR:
+        break;
+
+    case ARM_I2C_ABORT_TRANSFER:
+        break;
+
+    default:
+        return ARM_DRIVER_ERROR_UNSUPPORTED;
+    }
+}
+
+static ARM_I2C_STATUS ARM_I2C_GetStatus(void)
+{
+}
+
+static void ARM_I2C_SignalEvent(uint32_t event)
+{
+    // function body
+}
+
+// End I2C Interface
+
+extern \
+ARM_DRIVER_I2C Driver_I2C0;
+ARM_DRIVER_I2C Driver_I2C0 = {
+    ARM_I2C_GetVersion,
+    ARM_I2C_GetCapabilities,
+    ARM_I2C_Initialize,
+    ARM_I2C_Uninitialize,
+    ARM_I2C_PowerControl,
+    ARM_I2C_MasterTransmit,
+    ARM_I2C_MasterReceive,
+    ARM_I2C_SlaveTransmit,
+    ARM_I2C_SlaveReceive,
+    ARM_I2C_GetDataCount,
+    ARM_I2C_Control,
+    ARM_I2C_GetStatus
+};

--- a/platform/ext/cmsis/CMSIS/Driver/DriverTemplates/Driver_MCI.c
+++ b/platform/ext/cmsis/CMSIS/Driver/DriverTemplates/Driver_MCI.c
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2013-2020 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+#include "Driver_MCI.h"
+
+#define ARM_MCI_DRV_VERSION    ARM_DRIVER_VERSION_MAJOR_MINOR(1, 0) /* driver version */
+
+/* Driver Version */
+static const ARM_DRIVER_VERSION DriverVersion = {
+    ARM_MCI_API_VERSION,
+    ARM_MCI_DRV_VERSION
+};
+
+/* Driver Capabilities */
+static const ARM_MCI_CAPABILITIES DriverCapabilities = {
+    0, /* cd_state          */
+    0, /* cd_event          */
+    0, /* wp_state          */
+    0, /* vdd               */
+    0, /* vdd_1v8           */
+    0, /* vccq              */
+    0, /* vccq_1v8          */
+    0, /* vccq_1v2          */
+    0, /* data_width_4      */
+    0, /* data_width_8      */
+    0, /* data_width_4_ddr  */
+    0, /* data_width_8_ddr  */
+    0, /* high_speed        */
+    0, /* uhs_signaling     */
+    0, /* uhs_tuning        */
+    0, /* uhs_sdr50         */
+    0, /* uhs_sdr104        */
+    0, /* uhs_ddr50         */
+    0, /* uhs_driver_type_a */
+    0, /* uhs_driver_type_c */
+    0, /* uhs_driver_type_d */
+    0, /* sdio_interrupt    */
+    0, /* read_wait         */
+    0, /* suspend_resume    */
+    0, /* mmc_interrupt     */
+    0, /* mmc_boot          */
+    0, /* rst_n             */
+    0, /* ccs               */
+    0, /* ccs_timeout       */
+    0  /* Reserved          */
+};
+
+//
+//   Functions
+//
+
+static ARM_DRIVER_VERSION ARM_MCI_GetVersion(void)
+{
+  return DriverVersion;
+}
+
+static ARM_MCI_CAPABILITIES ARM_MCI_GetCapabilities(void)
+{
+  return DriverCapabilities;
+}
+
+static int32_t ARM_MCI_Initialize(ARM_MCI_SignalEvent_t cb_event)
+{
+}
+
+static int32_t ARM_MCI_Uninitialize(void)
+{
+}
+
+static int32_t ARM_MCI_PowerControl(ARM_POWER_STATE state)
+{
+    switch (state)
+    {
+    case ARM_POWER_OFF:
+        break;
+
+    case ARM_POWER_LOW:
+        break;
+
+    case ARM_POWER_FULL:
+        break;
+    }
+    return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static int32_t ARM_MCI_CardPower(uint32_t voltage)
+{
+    switch (voltage & ARM_MCI_POWER_VDD_Msk)
+    {
+    case ARM_MCI_POWER_VDD_OFF:
+        return ARM_DRIVER_OK;
+
+    case ARM_MCI_POWER_VDD_3V3:
+        return ARM_DRIVER_OK;
+
+    default:
+        break;
+    }
+    return ARM_DRIVER_ERROR;
+}
+
+static int32_t ARM_MCI_ReadCD(void)
+{
+}
+
+static int32_t ARM_MCI_ReadWP(void)
+{
+}
+
+static int32_t ARM_MCI_SendCommand(uint32_t cmd, uint32_t arg, uint32_t flags, uint32_t *response)
+{
+}
+
+static int32_t ARM_MCI_SetupTransfer(uint8_t  *data, uint32_t block_count, uint32_t block_size, uint32_t mode)
+{
+}
+
+static int32_t ARM_MCI_AbortTransfer(void)
+{
+}
+
+static int32_t ARM_MCI_Control(uint32_t control, uint32_t arg)
+{
+    switch (control)
+    {
+    case ARM_MCI_BUS_SPEED:
+        break;
+
+    case ARM_MCI_BUS_SPEED_MODE:
+        break;
+
+    case ARM_MCI_BUS_CMD_MODE:
+        /* Implement external pull-up control to support MMC cards in open-drain mode */
+        /* Default mode is push-pull and is configured in Driver_MCI0.Initialize()    */
+        if (arg == ARM_MCI_BUS_CMD_PUSH_PULL)
+        {
+            /* Configure external circuit to work in push-pull mode */
+        }
+        else if (arg == ARM_MCI_BUS_CMD_OPEN_DRAIN)
+        {
+            /* Configure external circuit to work in open-drain mode */
+        }
+        else
+        {
+            return ARM_DRIVER_ERROR_UNSUPPORTED;
+        }
+        break;
+
+    case ARM_MCI_BUS_DATA_WIDTH:
+        switch (arg)
+        {
+        case ARM_MCI_BUS_DATA_WIDTH_1:
+            break;
+        case ARM_MCI_BUS_DATA_WIDTH_4:
+            break;
+        case ARM_MCI_BUS_DATA_WIDTH_8:
+            break;
+        default:
+            return ARM_DRIVER_ERROR_UNSUPPORTED;
+        }
+        break;
+
+    case ARM_MCI_CONTROL_RESET:
+        break;
+
+    case ARM_MCI_CONTROL_CLOCK_IDLE:
+        break;
+
+    case ARM_MCI_DATA_TIMEOUT:
+        break;
+
+    case ARM_MCI_MONITOR_SDIO_INTERRUPT:
+        break;
+
+    case ARM_MCI_CONTROL_READ_WAIT:
+        break;
+
+    case ARM_MCI_DRIVER_STRENGTH:
+    default: return ARM_DRIVER_ERROR_UNSUPPORTED;
+    }
+}
+
+static ARM_MCI_STATUS ARM_MCI_GetStatus(void)
+{
+}
+
+static void ARM_MCI_SignalEvent(uint32_t event)
+{
+    // function body
+}
+
+// End MCI Interface
+
+extern \
+ARM_DRIVER_MCI Driver_MCI0;
+ARM_DRIVER_MCI Driver_MCI0 = {
+    ARM_MCI_GetVersion,
+    ARM_MCI_GetCapabilities,
+    ARM_MCI_Initialize,
+    ARM_MCI_Uninitialize,
+    ARM_MCI_PowerControl,
+    ARM_MCI_CardPower,
+    ARM_MCI_ReadCD,
+    ARM_MCI_ReadWP,
+    ARM_MCI_SendCommand,
+    ARM_MCI_SetupTransfer,
+    ARM_MCI_AbortTransfer,
+    ARM_MCI_Control,
+    ARM_MCI_GetStatus
+};

--- a/platform/ext/cmsis/CMSIS/Driver/DriverTemplates/Driver_NAND.c
+++ b/platform/ext/cmsis/CMSIS/Driver/DriverTemplates/Driver_NAND.c
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2013-2020 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+#include "Driver_NAND.h"
+
+#define ARM_NAND_DRV_VERSION ARM_DRIVER_VERSION_MAJOR_MINOR(1, 0)   /* driver version */
+
+/* Driver Version */
+static const ARM_DRIVER_VERSION DriverVersion = {
+  ARM_NAND_API_VERSION,
+  ARM_NAND_DRV_VERSION
+};
+
+/* Driver Capabilities */
+static const ARM_NAND_CAPABILITIES DriverCapabilities = {
+  0,                 /* Signal Device Ready event (R/Bn rising edge)                        */
+  0,                 /* Supports re-entrant operation (SendCommand/Address, Read/WriteData) */
+  0,                 /* Supports Sequence operation (ExecuteSequence, AbortSequence)        */
+  0,                 /* Supports VCC Power Supply Control                                   */
+  0,                 /* Supports 1.8 VCC Power Supply                                       */
+  0,                 /* Supports VCCQ I/O Power Supply Control                              */
+  0,                 /* Supports 1.8 VCCQ I/O Power Supply                                  */
+  0,                 /* Supports VPP High Voltage Power Supply Control                      */
+  0,                 /* Supports WPn (Write Protect) Control                                */
+  0,                 /* Number of CEn (Chip Enable) lines: ce_lines + 1                     */
+  0,                 /* Supports manual CEn (Chip Enable) Control                           */
+  0,                 /* Supports R/Bn (Ready/Busy) Monitoring                               */
+  0,                 /* Supports 16-bit data                                                */
+  0,                 /* Supports NV-DDR  Data Interface (ONFI)                              */
+  0,                 /* Supports NV-DDR2 Data Interface (ONFI)                              */
+  0,                 /* Fastest (highest) SDR     Timing Mode supported (ONFI)              */
+  0,                 /* Fastest (highest) NV_DDR  Timing Mode supported (ONFI)              */
+  0,                 /* Fastest (highest) NV_DDR2 Timing Mode supported (ONFI)              */
+  0,                 /* Supports Driver Strength 2.0x = 18 Ohms                             */
+  0,                 /* Supports Driver Strength 1.4x = 25 Ohms                             */
+  0,                 /* Supports Driver Strength 0.7x = 50 Ohms                             */
+#if (ARM_NAND_API_VERSION > 0x201U)
+  0                  /* Reserved (must be zero)                                             */
+#endif
+};
+
+/* Exported functions */
+
+static ARM_DRIVER_VERSION ARM_NAND_GetVersion (void) {
+  return DriverVersion;
+}
+
+static ARM_NAND_CAPABILITIES ARM_NAND_GetCapabilities (void) {
+  return DriverCapabilities;
+}
+
+static int32_t ARM_NAND_Initialize (ARM_NAND_SignalEvent_t cb_event) {
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static int32_t ARM_NAND_Uninitialize (void) {
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static int32_t ARM_NAND_PowerControl (ARM_POWER_STATE state) {
+
+  switch ((int32_t)state) {
+    case ARM_POWER_OFF:
+      return ARM_DRIVER_ERROR_UNSUPPORTED;
+
+    case ARM_POWER_LOW:
+      return ARM_DRIVER_ERROR_UNSUPPORTED;
+
+    case ARM_POWER_FULL:
+      return ARM_DRIVER_ERROR_UNSUPPORTED;
+
+    default:
+      return ARM_DRIVER_ERROR_UNSUPPORTED;
+  }
+  return ARM_DRIVER_OK;
+}
+
+static int32_t ARM_NAND_DevicePower (uint32_t voltage) {
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static int32_t ARM_NAND_WriteProtect (uint32_t dev_num, bool enable) {
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static int32_t ARM_NAND_ChipEnable (uint32_t dev_num, bool enable) {
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static int32_t ARM_NAND_GetDeviceBusy (uint32_t dev_num) {
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static int32_t ARM_NAND_SendCommand (uint32_t dev_num, uint8_t cmd) {
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static int32_t ARM_NAND_SendAddress (uint32_t dev_num, uint8_t addr) {
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static int32_t ARM_NAND_ReadData (uint32_t dev_num, void *data, uint32_t cnt, uint32_t mode) {
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static int32_t ARM_NAND_WriteData (uint32_t dev_num, const void *data, uint32_t cnt, uint32_t mode) {
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static int32_t ARM_NAND_ExecuteSequence (uint32_t dev_num, uint32_t code, uint32_t cmd,
+                                         uint32_t addr_col, uint32_t addr_row,
+                                         void *data, uint32_t data_cnt,
+                                         uint8_t *status, uint32_t *count) {
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static int32_t ARM_NAND_AbortSequence (uint32_t dev_num) {
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static int32_t ARM_NAND_Control (uint32_t dev_num, uint32_t control, uint32_t arg) {
+
+  switch (control) {
+    case ARM_NAND_BUS_MODE:
+      return ARM_DRIVER_ERROR_UNSUPPORTED;
+
+    case ARM_NAND_BUS_DATA_WIDTH:
+      return ARM_DRIVER_ERROR_UNSUPPORTED; 
+
+    case ARM_NAND_DEVICE_READY_EVENT:
+      return ARM_DRIVER_ERROR_UNSUPPORTED;
+
+    default:
+      return ARM_DRIVER_ERROR_UNSUPPORTED;
+  }
+
+  return ARM_DRIVER_ERROR;
+}
+
+static ARM_NAND_STATUS ARM_NAND_GetStatus (uint32_t dev_num) {
+  ARM_NAND_STATUS stat;
+
+  stat.busy      = 0U;
+  stat.ecc_error = 0U;
+
+  return stat;
+}
+
+static int32_t ARM_NAND_InquireECC (int32_t index, ARM_NAND_ECC_INFO *info) {
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+/* NAND Driver Control Block */
+extern \
+ARM_DRIVER_NAND Driver_NAND0;
+ARM_DRIVER_NAND Driver_NAND0 = {
+  ARM_NAND_GetVersion,
+  ARM_NAND_GetCapabilities,
+  ARM_NAND_Initialize,
+  ARM_NAND_Uninitialize,
+  ARM_NAND_PowerControl,
+  ARM_NAND_DevicePower,
+  ARM_NAND_WriteProtect,
+  ARM_NAND_ChipEnable,
+  ARM_NAND_GetDeviceBusy,
+  ARM_NAND_SendCommand,
+  ARM_NAND_SendAddress,
+  ARM_NAND_ReadData,
+  ARM_NAND_WriteData,
+  ARM_NAND_ExecuteSequence,
+  ARM_NAND_AbortSequence,
+  ARM_NAND_Control,
+  ARM_NAND_GetStatus,
+  ARM_NAND_InquireECC
+};

--- a/platform/ext/cmsis/CMSIS/Driver/DriverTemplates/Driver_SAI.c
+++ b/platform/ext/cmsis/CMSIS/Driver/DriverTemplates/Driver_SAI.c
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2013-2020 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+#include "Driver_SAI.h"
+
+#define ARM_SAI_DRV_VERSION    ARM_DRIVER_VERSION_MAJOR_MINOR(1, 0) /* driver version */
+
+/* Driver Version */
+static const ARM_DRIVER_VERSION DriverVersion = {
+    ARM_SAI_API_VERSION,
+    ARM_SAI_DRV_VERSION
+};
+
+/* Driver Capabilities */
+static const ARM_SAI_CAPABILITIES DriverCapabilities = {
+    1, /* supports asynchronous Transmit/Receive */
+    0, /* supports synchronous Transmit/Receive */
+    0, /* supports user defined Protocol */
+    1, /* supports I2S Protocol */
+    0, /* supports MSB/LSB justified Protocol */
+    0, /* supports PCM short/long frame Protocol */
+    0, /* supports AC'97 Protocol */
+    0, /* supports Mono mode */
+    0, /* supports Companding */
+    0, /* supports MCLK (Master Clock) pin */
+    0, /* supports Frame error event: \ref ARM_SAI_EVENT_FRAME_ERROR */
+    0  /* reserved (must be zero) */
+};
+
+//
+//  Functions
+//
+
+static ARM_DRIVER_VERSION ARM_SAI_GetVersion (void)
+{
+  return DriverVersion;
+}
+
+static ARM_SAI_CAPABILITIES ARM_SAI_GetCapabilities (void)
+{
+  return DriverCapabilities;
+}
+
+static int32_t ARM_SAI_Initialize (ARM_SAI_SignalEvent_t cb_event)
+{
+}
+
+static int32_t ARM_SAI_Uninitialize (void)
+{
+}
+
+static int32_t ARM_SAI_PowerControl (ARM_POWER_STATE state)
+{
+    switch (state)
+    {
+    case ARM_POWER_OFF:
+        break;
+
+    case ARM_POWER_LOW:
+        break;
+
+    case ARM_POWER_FULL:
+        break;
+    }
+    return ARM_DRIVER_OK;
+}
+
+static int32_t ARM_SAI_Send (const void *data, uint32_t num)
+{
+}
+
+static int32_t ARM_SAI_Receive (void *data, uint32_t num)
+{
+}
+
+static uint32_t ARM_SAI_GetTxCount (void)
+{
+}
+
+static uint32_t ARM_SAI_GetRxCount (void)
+{
+}
+
+static int32_t ARM_SAI_Control (uint32_t control, uint32_t arg1, uint32_t arg2)
+{
+}
+
+static ARM_SAI_STATUS ARM_SAI_GetStatus (void)
+{
+}
+
+static void ARM_SAI_SignalEvent(uint32_t event)
+{
+    // function body
+}
+
+// End SAI Interface
+
+extern \
+ARM_DRIVER_SAI Driver_SAI0;
+ARM_DRIVER_SAI Driver_SAI0 = {
+    ARM_SAI_GetVersion,
+    ARM_SAI_GetCapabilities,
+    ARM_SAI_Initialize,
+    ARM_SAI_Uninitialize,
+    ARM_SAI_PowerControl,
+    ARM_SAI_Send,
+    ARM_SAI_Receive,
+    ARM_SAI_GetTxCount,
+    ARM_SAI_GetRxCount,
+    ARM_SAI_Control,
+    ARM_SAI_GetStatus
+};

--- a/platform/ext/cmsis/CMSIS/Driver/DriverTemplates/Driver_SPI.c
+++ b/platform/ext/cmsis/CMSIS/Driver/DriverTemplates/Driver_SPI.c
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2013-2020 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+#include "Driver_SPI.h"
+
+#define ARM_SPI_DRV_VERSION    ARM_DRIVER_VERSION_MAJOR_MINOR(1, 0) /* driver version */
+
+/* Driver Version */
+static const ARM_DRIVER_VERSION DriverVersion = {
+    ARM_SPI_API_VERSION,
+    ARM_SPI_DRV_VERSION
+};
+
+/* Driver Capabilities */
+static const ARM_SPI_CAPABILITIES DriverCapabilities = {
+    0, /* Reserved (must be zero) */
+    0, /* TI Synchronous Serial Interface */
+    0, /* Microwire Interface */
+    0, /* Signal Mode Fault event: \ref ARM_SPI_EVENT_MODE_FAULT */
+    0  /* Reserved (must be zero) */
+};
+
+//
+//  Functions
+//
+
+static ARM_DRIVER_VERSION ARM_SPI_GetVersion(void)
+{
+  return DriverVersion;
+}
+
+static ARM_SPI_CAPABILITIES ARM_SPI_GetCapabilities(void)
+{
+  return DriverCapabilities;
+}
+
+static int32_t ARM_SPI_Initialize(ARM_SPI_SignalEvent_t cb_event)
+{
+}
+
+static int32_t ARM_SPI_Uninitialize(void)
+{
+}
+
+static int32_t ARM_SPI_PowerControl(ARM_POWER_STATE state)
+{
+    switch (state)
+    {
+    case ARM_POWER_OFF:
+        break;
+
+    case ARM_POWER_LOW:
+        break;
+
+    case ARM_POWER_FULL:
+        break;
+    }
+    return ARM_DRIVER_OK;
+}
+
+static int32_t ARM_SPI_Send(const void *data, uint32_t num)
+{
+}
+
+static int32_t ARM_SPI_Receive(void *data, uint32_t num)
+{
+}
+
+static int32_t ARM_SPI_Transfer(const void *data_out, void *data_in, uint32_t num)
+{
+}
+
+static uint32_t ARM_SPI_GetDataCount(void)
+{
+}
+
+static int32_t ARM_SPI_Control(uint32_t control, uint32_t arg)
+{
+    switch (control & ARM_SPI_CONTROL_Msk)
+    {
+    default:
+        return ARM_DRIVER_ERROR_UNSUPPORTED;
+
+    case ARM_SPI_MODE_INACTIVE:             // SPI Inactive
+        return ARM_DRIVER_OK;
+
+    case ARM_SPI_MODE_MASTER:               // SPI Master (Output on MOSI, Input on MISO); arg = Bus Speed in bps
+        break;
+
+    case ARM_SPI_MODE_SLAVE:                // SPI Slave  (Output on MISO, Input on MOSI)
+        break;
+
+    case ARM_SPI_SET_BUS_SPEED:             // Set Bus Speed in bps; arg = value
+        break;
+
+    case ARM_SPI_GET_BUS_SPEED:             // Get Bus Speed in bps
+        break;
+
+    case ARM_SPI_SET_DEFAULT_TX_VALUE:      // Set default Transmit value; arg = value
+        break;
+
+    case ARM_SPI_CONTROL_SS:                // Control Slave Select; arg = 0:inactive, 1:active
+        break;
+
+    case ARM_SPI_ABORT_TRANSFER:            // Abort current data transfer
+        break;
+    }
+}
+
+static ARM_SPI_STATUS ARM_SPI_GetStatus(void)
+{
+}
+
+static void ARM_SPI_SignalEvent(uint32_t event)
+{
+    // function body
+}
+
+// End SPI Interface
+
+extern \
+ARM_DRIVER_SPI Driver_SPI0;
+ARM_DRIVER_SPI Driver_SPI0 = {
+    ARM_SPI_GetVersion,
+    ARM_SPI_GetCapabilities,
+    ARM_SPI_Initialize,
+    ARM_SPI_Uninitialize,
+    ARM_SPI_PowerControl,
+    ARM_SPI_Send,
+    ARM_SPI_Receive,
+    ARM_SPI_Transfer,
+    ARM_SPI_GetDataCount,
+    ARM_SPI_Control,
+    ARM_SPI_GetStatus
+};

--- a/platform/ext/cmsis/CMSIS/Driver/DriverTemplates/Driver_Storage.c
+++ b/platform/ext/cmsis/CMSIS/Driver/DriverTemplates/Driver_Storage.c
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2013-2020 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#include "Driver_Storage.h"
+
+#define ARM_STORAGE_DRV_VERSION    ARM_DRIVER_VERSION_MAJOR_MINOR(1, 0) /* driver version */
+
+/* Driver Version */
+static const ARM_DRIVER_VERSION DriverVersion = {
+    ARM_STORAGE_API_VERSION,
+    ARM_STORAGE_DRV_VERSION
+};
+
+/* Driver Capabilities */
+static const ARM_STORAGE_CAPABILITIES DriverCapabilities = {
+    0,  /* Asynchronous Mode */
+    0,  /* Supports EraseAll operation */
+    0   /* Reserved */
+};
+
+
+//
+// Functions
+//
+
+static ARM_DRIVER_VERSION ARM_Storage_GetVersion (void)  {
+  return DriverVersion;
+}
+
+static ARM_STORAGE_CAPABILITIES ARM_Storage_GetCapabilities (void)  {
+  return DriverCapabilities;
+}
+
+static int32_t ARM_Storage_Initialize (ARM_Storage_Callback_t callback)  {
+}
+
+static int32_t ARM_Storage_Uninitialize (void)  {
+}
+
+static int32_t ARM_Storage_PowerControl (ARM_POWER_STATE state)
+{
+    switch (state)
+    {
+    case ARM_POWER_OFF:
+        break;
+
+    case ARM_POWER_LOW:
+        break;
+
+    case ARM_POWER_FULL:
+        break;
+    }
+    return ARM_DRIVER_OK;
+}
+
+static int32_t ARM_Storage_ReadData (uint64_t addr, void *data, uint32_t size)  {
+}
+
+static int32_t ARM_Storage_ProgramData (uint64_t addr, const void *data, uint32_t size)  {
+}
+
+static int32_t ARM_Storage_Erase (uint64_t addr, uint32_t size)  {
+}
+
+static int32_t ARM_Storage_EraseAll (void)  {
+}
+
+static ARM_STORAGE_STATUS ARM_Storage_GetStatus (void)  {
+}
+
+static int32_t ARM_Storage_GetInfo (ARM_STORAGE_INFO *info)  {
+}
+
+static uint32_t ARM_Storage_ResolveAddress(uint64_t addr) {
+}
+
+static int32_t ARM_Storage_GetNextBlock(const ARM_STORAGE_BLOCK* prev_block, ARM_STORAGE_BLOCK *next_block) {
+}
+
+static int32_t ARM_Storage_GetBlock(uint64_t addr, ARM_STORAGE_BLOCK *block) {
+}
+
+// End Storage Interface
+
+extern \
+ARM_DRIVER_STORAGE Driver_Storage0;
+ARM_DRIVER_STORAGE Driver_Storage0 = {
+    ARM_Storage_GetVersion,
+    ARM_Storage_GetCapabilities,
+    ARM_Storage_Initialize,
+    ARM_Storage_Uninitialize,
+    ARM_Storage_PowerControl,
+    ARM_Storage_ReadData,
+    ARM_Storage_ProgramData,
+    ARM_Storage_Erase,
+    ARM_Storage_EraseAll,
+    ARM_Storage_GetStatus,
+    ARM_Storage_GetInfo,
+    ARM_Storage_ResolveAddress,
+    ARM_Storage_GetNextBlock,
+    ARM_Storage_GetBlock
+};

--- a/platform/ext/cmsis/CMSIS/Driver/DriverTemplates/Driver_USART.c
+++ b/platform/ext/cmsis/CMSIS/Driver/DriverTemplates/Driver_USART.c
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2013-2020 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Driver_USART.h"
+
+#define ARM_USART_DRV_VERSION    ARM_DRIVER_VERSION_MAJOR_MINOR(1, 0)  /* driver version */
+
+/* Driver Version */
+static const ARM_DRIVER_VERSION DriverVersion = { 
+    ARM_USART_API_VERSION,
+    ARM_USART_DRV_VERSION
+};
+
+/* Driver Capabilities */
+static const ARM_USART_CAPABILITIES DriverCapabilities = {
+    1, /* supports UART (Asynchronous) mode */
+    0, /* supports Synchronous Master mode */
+    0, /* supports Synchronous Slave mode */
+    0, /* supports UART Single-wire mode */
+    0, /* supports UART IrDA mode */
+    0, /* supports UART Smart Card mode */
+    0, /* Smart Card Clock generator available */
+    0, /* RTS Flow Control available */
+    0, /* CTS Flow Control available */
+    0, /* Transmit completed event: \ref ARM_USART_EVENT_TX_COMPLETE */
+    0, /* Signal receive character timeout event: \ref ARM_USART_EVENT_RX_TIMEOUT */
+    0, /* RTS Line: 0=not available, 1=available */
+    0, /* CTS Line: 0=not available, 1=available */
+    0, /* DTR Line: 0=not available, 1=available */
+    0, /* DSR Line: 0=not available, 1=available */
+    0, /* DCD Line: 0=not available, 1=available */
+    0, /* RI Line: 0=not available, 1=available */
+    0, /* Signal CTS change event: \ref ARM_USART_EVENT_CTS */
+    0, /* Signal DSR change event: \ref ARM_USART_EVENT_DSR */
+    0, /* Signal DCD change event: \ref ARM_USART_EVENT_DCD */
+    0, /* Signal RI change event: \ref ARM_USART_EVENT_RI */
+    0  /* Reserved (must be zero) */
+};
+
+//
+//   Functions
+//
+
+static ARM_DRIVER_VERSION ARM_USART_GetVersion(void)
+{
+  return DriverVersion;
+}
+
+static ARM_USART_CAPABILITIES ARM_USART_GetCapabilities(void)
+{
+  return DriverCapabilities;
+}
+
+static int32_t ARM_USART_Initialize(ARM_USART_SignalEvent_t cb_event)
+{
+}
+
+static int32_t ARM_USART_Uninitialize(void)
+{
+}
+
+static int32_t ARM_USART_PowerControl(ARM_POWER_STATE state)
+{
+    switch (state)
+    {
+    case ARM_POWER_OFF:
+        break;
+
+    case ARM_POWER_LOW:
+        break;
+
+    case ARM_POWER_FULL:
+        break;
+    }
+    return ARM_DRIVER_OK;
+}
+
+static int32_t ARM_USART_Send(const void *data, uint32_t num)
+{
+}
+
+static int32_t ARM_USART_Receive(void *data, uint32_t num)
+{
+}
+
+static int32_t ARM_USART_Transfer(const void *data_out, void *data_in, uint32_t num)
+{
+}
+
+static uint32_t ARM_USART_GetTxCount(void)
+{
+}
+
+static uint32_t ARM_USART_GetRxCount(void)
+{
+}
+
+static int32_t ARM_USART_Control(uint32_t control, uint32_t arg)
+{
+}
+
+static ARM_USART_STATUS ARM_USART_GetStatus(void)
+{
+}
+
+static int32_t ARM_USART_SetModemControl(ARM_USART_MODEM_CONTROL control)
+{
+}
+
+static ARM_USART_MODEM_STATUS ARM_USART_GetModemStatus(void)
+{
+}
+
+static void ARM_USART_SignalEvent(uint32_t event)
+{
+    // function body
+}
+
+// End USART Interface
+
+extern \
+ARM_DRIVER_USART Driver_USART0;
+ARM_DRIVER_USART Driver_USART0 = {
+    ARM_USART_GetVersion,
+    ARM_USART_GetCapabilities,
+    ARM_USART_Initialize,
+    ARM_USART_Uninitialize,
+    ARM_USART_PowerControl,
+    ARM_USART_Send,
+    ARM_USART_Receive,
+    ARM_USART_Transfer,
+    ARM_USART_GetTxCount,
+    ARM_USART_GetRxCount,
+    ARM_USART_Control,
+    ARM_USART_GetStatus,
+    ARM_USART_SetModemControl,
+    ARM_USART_GetModemStatus
+};

--- a/platform/ext/cmsis/CMSIS/Driver/DriverTemplates/Driver_USBD.c
+++ b/platform/ext/cmsis/CMSIS/Driver/DriverTemplates/Driver_USBD.c
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2013-2020 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+#include "Driver_USBD.h"
+
+#define ARM_USBD_DRV_VERSION    ARM_DRIVER_VERSION_MAJOR_MINOR(1, 0) /* driver version */
+
+/* Driver Version */
+static const ARM_DRIVER_VERSION usbd_driver_version = { 
+    ARM_USBD_API_VERSION,
+    ARM_USBD_DRV_VERSION
+};
+
+/* Driver Capabilities */
+static const ARM_USBD_CAPABILITIES usbd_driver_capabilities = {
+    0, /* vbus_detection */
+    0, /* event_vbus_on */
+    0, /* event_vbus_off */
+    0  /* reserved */
+};
+
+//
+// Functions
+//
+
+static ARM_DRIVER_VERSION ARM_USBD_GetVersion(void)
+{
+  return usbd_driver_version;
+}
+
+static ARM_USBD_CAPABILITIES ARM_USBD_GetCapabilities(void)
+{
+  return usbd_driver_capabilities;
+}
+
+static int32_t ARM_USBD_Initialize(ARM_USBD_SignalDeviceEvent_t cb_device_event,
+                                   ARM_USBD_SignalEndpointEvent_t cb_endpoint_event)
+{
+}
+
+static int32_t ARM_USBD_Uninitialize(void)
+{
+}
+
+static int32_t ARM_USBD_PowerControl(ARM_POWER_STATE state)
+{
+    switch (state)
+    {
+    case ARM_POWER_OFF:
+        break;
+
+    case ARM_POWER_LOW:
+        break;
+
+    case ARM_POWER_FULL:
+        break;
+    }
+    return ARM_DRIVER_OK;
+}
+
+static int32_t ARM_USBD_DeviceConnect(void)
+{
+}
+
+static int32_t ARM_USBD_DeviceDisconnect(void)
+{
+}
+
+static ARM_USBD_STATE ARM_USBD_DeviceGetState(void)
+{
+}
+
+static int32_t ARM_USBD_DeviceRemoteWakeup(void)
+{
+}
+
+static int32_t ARM_USBD_DeviceSetAddress(uint8_t dev_addr)
+{
+}
+
+static int32_t ARM_USBD_ReadSetupPacket(uint8_t *setup)
+{
+}
+
+static int32_t ARM_USBD_EndpointConfigure(uint8_t  ep_addr,
+                                          uint8_t  ep_type,
+                                          uint16_t ep_max_packet_size)
+{
+}
+
+static int32_t ARM_USBD_EndpointUnconfigure(uint8_t ep_addr)
+{
+}
+
+static int32_t ARM_USBD_EndpointStall(uint8_t ep_addr, bool stall)
+{
+}
+
+static int32_t ARM_USBD_EndpointTransfer(uint8_t ep_addr, uint8_t *data, uint32_t num)
+{
+}
+
+static uint32_t ARM_USBD_EndpointTransferGetResult(uint8_t ep_addr)
+{
+}
+
+static int32_t ARM_USBD_EndpointTransferAbort(uint8_t ep_addr)
+{
+}
+
+static uint16_t ARM_USBD_GetFrameNumber(void)
+{
+}
+
+static void ARM_USBD_SignalDeviceEvent(uint32_t event)
+{
+    // function body
+}
+
+static void ARM_USBD_SignalEndpointEvent(uint8_t ep_addr, uint32_t ep_event)
+{
+    // function body
+}
+
+// End USBD Interface
+
+extern \
+ARM_DRIVER_USBD Driver_USBD0;
+ARM_DRIVER_USBD Driver_USBD0 =
+{
+    ARM_USBD_GetVersion,
+    ARM_USBD_GetCapabilities,
+    ARM_USBD_Initialize,
+    ARM_USBD_Uninitialize,
+    ARM_USBD_PowerControl,
+    ARM_USBD_DeviceConnect,
+    ARM_USBD_DeviceDisconnect,
+    ARM_USBD_DeviceGetState,
+    ARM_USBD_DeviceRemoteWakeup,
+    ARM_USBD_DeviceSetAddress,
+    ARM_USBD_ReadSetupPacket,
+    ARM_USBD_EndpointConfigure,
+    ARM_USBD_EndpointUnconfigure,
+    ARM_USBD_EndpointStall,
+    ARM_USBD_EndpointTransfer,
+    ARM_USBD_EndpointTransferGetResult,
+    ARM_USBD_EndpointTransferAbort,
+    ARM_USBD_GetFrameNumber
+};

--- a/platform/ext/cmsis/CMSIS/Driver/DriverTemplates/Driver_USBH.c
+++ b/platform/ext/cmsis/CMSIS/Driver/DriverTemplates/Driver_USBH.c
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2013-2020 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+#include "Driver_USBH.h"
+
+/* USB Host Driver */
+
+#define ARM_USBH_DRV_VERSION    ARM_DRIVER_VERSION_MAJOR_MINOR(1, 0) /* driver version */
+
+/* Driver Version */
+static const ARM_DRIVER_VERSION usbh_driver_version = { 
+    ARM_USBH_API_VERSION,
+    ARM_USBH_DRV_VERSION
+};
+
+/* Driver Capabilities */
+static const ARM_USBH_CAPABILITIES usbd_driver_capabilities = {
+    0x0001, /* Root HUB available Ports Mask   */
+    0,      /* Automatic SPLIT packet handling */
+    0,      /* Signal Connect event */
+    0,      /* Signal Disconnect event */
+    0,      /* Signal Overcurrent event */
+    0       /* Reserved (must be zero) */
+};
+
+//
+// Functions
+//
+
+static ARM_DRIVER_VERSION ARM_USBH_GetVersion(void)
+{
+  return usbh_driver_version;
+}
+
+static ARM_USBH_CAPABILITIES ARM_USBH_GetCapabilities(void)
+{
+  return usbd_driver_capabilities;
+}
+
+static int32_t ARM_USBH_Initialize(ARM_USBH_SignalPortEvent_t cb_port_event,
+                                   ARM_USBH_SignalPipeEvent_t cb_pipe_event)
+{
+}
+
+static int32_t ARM_USBH_Uninitialize(void)
+{
+}
+
+static int32_t ARM_USBH_PowerControl(ARM_POWER_STATE state)
+{
+    switch (state)
+    {
+    case ARM_POWER_OFF:
+        break;
+
+    case ARM_POWER_LOW:
+        break;
+
+    case ARM_POWER_FULL:
+        break;
+    }
+    return ARM_DRIVER_OK;
+}
+
+static int32_t ARM_USBH_PortVbusOnOff(uint8_t port, bool vbus)
+{
+}
+
+static int32_t ARM_USBH_PortReset(uint8_t port)
+{
+}
+
+static int32_t ARM_USBH_PortSuspend(uint8_t port)
+{
+}
+
+static int32_t ARM_USBH_PortResume(uint8_t port)
+{
+}
+
+static ARM_USBH_PORT_STATE ARM_USBH_PortGetState(uint8_t port)
+{
+}
+
+static ARM_USBH_PIPE_HANDLE ARM_USBH_PipeCreate(uint8_t  dev_addr,
+                                                uint8_t  dev_speed,
+                                                uint8_t  hub_addr,
+                                                uint8_t  hub_port,
+                                                uint8_t  ep_addr,
+                                                uint8_t  ep_type,
+                                                uint16_t ep_max_packet_size,
+                                                uint8_t  ep_interval)
+{
+}
+
+static int32_t ARM_USBH_PipeModify(ARM_USBH_PIPE_HANDLE pipe_hndl,
+                            uint8_t  dev_addr,
+                            uint8_t  dev_speed,
+                            uint8_t  hub_addr,
+                            uint8_t  hub_port,
+                            uint16_t ep_max_packet_size)
+{
+}
+
+static int32_t ARM_USBH_PipeDelete(ARM_USBH_PIPE_HANDLE pipe_hndl)
+{
+}
+
+static int32_t ARM_USBH_PipeReset(ARM_USBH_PIPE_HANDLE pipe_hndl)
+{
+}
+
+static int32_t ARM_USBH_PipeTransfer(ARM_USBH_PIPE_HANDLE pipe_hndl,
+                              uint32_t packet,
+                              uint8_t *data,
+                              uint32_t num)
+{
+}
+
+static uint32_t ARM_USBH_PipeTransferGetResult(ARM_USBH_PIPE_HANDLE pipe_hndl)
+{
+}
+
+static int32_t ARM_USBH_PipeTransferAbort(ARM_USBH_PIPE_HANDLE pipe_hndl)
+{
+}
+
+static uint16_t ARM_USBH_GetFrameNumber(void)
+{
+}
+
+static void ARM_USBH_SignalPortEvent(uint8_t port, uint32_t event)
+{
+    // function body
+}
+
+static void ARM_USBH_SignalPipeEvent(ARM_USBH_PIPE_HANDLE pipe_hndl, uint32_t event)
+{
+    // function body
+}
+
+// End USBH Interface
+
+extern \
+ARM_DRIVER_USBH Driver_USBH0;
+ARM_DRIVER_USBH Driver_USBH0 = {
+  ARM_USBH_GetVersion,
+  ARM_USBH_GetCapabilities,
+  ARM_USBH_Initialize,
+  ARM_USBH_Uninitialize,
+  ARM_USBH_PowerControl,
+  ARM_USBH_PortVbusOnOff,
+  ARM_USBH_PortReset,
+  ARM_USBH_PortSuspend,
+  ARM_USBH_PortResume,
+  ARM_USBH_PortGetState,
+  ARM_USBH_PipeCreate,
+  ARM_USBH_PipeModify,
+  ARM_USBH_PipeDelete,
+  ARM_USBH_PipeReset,
+  ARM_USBH_PipeTransfer,
+  ARM_USBH_PipeTransferGetResult,
+  ARM_USBH_PipeTransferAbort,
+  ARM_USBH_GetFrameNumber
+};
+

--- a/platform/ext/cmsis/CMSIS/Driver/DriverTemplates/Driver_WiFi.c
+++ b/platform/ext/cmsis/CMSIS/Driver/DriverTemplates/Driver_WiFi.c
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2013-2020 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Driver_WiFi.h"
+
+#define ARM_WIFI_DRV_VERSION ARM_DRIVER_VERSION_MAJOR_MINOR(1, 0)        // Driver version
+
+// Driver Version
+static const ARM_DRIVER_VERSION driver_version = {
+  ARM_WIFI_API_VERSION,
+  ARM_WIFI_DRV_VERSION 
+};
+
+// Driver Capabilities
+static const ARM_WIFI_CAPABILITIES driver_capabilities = { 
+  0U,                                   // Station supported
+  0U,                                   // Access Point supported
+  0U,                                   // Concurrent Station and Access Point not supported
+  0U,                                   // WiFi Protected Setup (WPS) for Station supported
+  0U,                                   // WiFi Protected Setup (WPS) for Access Point not supported
+  0U,                                   // Access Point: event generated on Station connect
+  0U,                                   // Access Point: event not generated on Station disconnect
+  0U,                                   // Event not generated on Ethernet frame reception in bypass mode
+  0U,                                   // Bypass or pass-through mode (Ethernet interface) not supported
+  0U,                                   // IP (UDP/TCP) (Socket interface) supported
+  0U,                                   // IPv6 (Socket interface) not supported
+  0U,                                   // Ping (ICMP) supported
+  0U                                    // Reserved (must be zero)
+};
+static ARM_DRIVER_VERSION ARM_WiFi_GetVersion (void) {
+  return driver_version;
+}
+
+static ARM_WIFI_CAPABILITIES ARM_WiFi_GetCapabilities (void) { 
+  return driver_capabilities;
+}
+
+static int32_t ARM_WiFi_Initialize (ARM_WIFI_SignalEvent_t cb_event) {
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static int32_t ARM_WiFi_Uninitialize (void) {
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static int32_t ARM_WiFi_PowerControl (ARM_POWER_STATE state) {
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static int32_t ARM_WiFi_GetModuleInfo (char *module_info, uint32_t max_len) {
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static int32_t ARM_WiFi_SetOption (uint32_t interface, uint32_t option, const void *data, uint32_t len) {
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static int32_t ARM_WiFi_GetOption (uint32_t interface, uint32_t option, void *data, uint32_t *len) {
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+static int32_t ARM_WiFi_Scan (ARM_WIFI_SCAN_INFO_t scan_info[], uint32_t max_num) {
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static int32_t ARM_WiFi_Activate (uint32_t interface, const ARM_WIFI_CONFIG_t *config) {
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static int32_t ARM_WiFi_Deactivate (uint32_t interface) {
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static uint32_t ARM_WiFi_IsConnected (void) {
+  return 0U;
+}
+
+static int32_t ARM_WiFi_GetNetInfo (ARM_WIFI_NET_INFO_t *net_info) {
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static int32_t ARM_WiFi_BypassControl (uint32_t interface, uint32_t mode) {
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static int32_t ARM_WiFi_EthSendFrame (uint32_t interface, const uint8_t *frame, uint32_t len){
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static int32_t ARM_WiFi_EthReadFrame (uint32_t interface, uint8_t *frame, uint32_t len){
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static uint32_t ARM_WiFi_EthGetRxFrameSize (uint32_t interface){
+  return 0U;
+}
+
+static int32_t ARM_WiFi_SocketCreate (int32_t af, int32_t type, int32_t protocol) {
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static int32_t ARM_WiFi_SocketBind (int32_t socket, const uint8_t *ip, uint32_t ip_len, uint16_t port) {
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static int32_t ARM_WiFi_SocketListen (int32_t socket, int32_t backlog) {
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static int32_t ARM_WiFi_SocketAccept (int32_t socket, uint8_t *ip, uint32_t *ip_len, uint16_t *port) {
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static int32_t ARM_WiFi_SocketConnect (int32_t socket, const uint8_t *ip, uint32_t ip_len, uint16_t port) {
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static int32_t ARM_WiFi_SocketRecv (int32_t socket, void *buf, uint32_t len) {
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static int32_t ARM_WiFi_SocketRecvFrom (int32_t socket, void *buf, uint32_t len, uint8_t *ip, uint32_t *ip_len, uint16_t *port) {
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static int32_t ARM_WiFi_SocketSend (int32_t socket, const void *buf, uint32_t len) {
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static int32_t ARM_WiFi_SocketSendTo (int32_t socket, const void *buf, uint32_t len, const uint8_t *ip, uint32_t ip_len, uint16_t port) {
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static int32_t ARM_WiFi_SocketGetSockName (int32_t socket, uint8_t *ip, uint32_t *ip_len, uint16_t *port) {
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static int32_t ARM_WiFi_SocketGetPeerName (int32_t socket, uint8_t *ip, uint32_t *ip_len, uint16_t *port) {
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static int32_t ARM_WiFi_SocketGetOpt (int32_t socket, int32_t opt_id, void *opt_val, uint32_t *opt_len) {
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static int32_t ARM_WiFi_SocketSetOpt (int32_t socket, int32_t opt_id, const void *opt_val, uint32_t opt_len) {
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static int32_t ARM_WiFi_SocketClose (int32_t socket) {
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static int32_t ARM_WiFi_SocketGetHostByName (const char *name, int32_t af, uint8_t *ip, uint32_t *ip_len) {
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static int32_t ARM_WiFi_Ping (const uint8_t *ip, uint32_t ip_len) {
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+/* WiFi Driver Control Block */
+extern \
+ARM_DRIVER_WIFI Driver_WiFi0;
+ARM_DRIVER_WIFI Driver_WiFi0 = { 
+  ARM_WiFi_GetVersion,
+  ARM_WiFi_GetCapabilities,
+  ARM_WiFi_Initialize,
+  ARM_WiFi_Uninitialize,
+  ARM_WiFi_PowerControl,
+  ARM_WiFi_GetModuleInfo,
+  ARM_WiFi_SetOption,
+  ARM_WiFi_GetOption,
+  ARM_WiFi_Scan,
+  ARM_WiFi_Activate,
+  ARM_WiFi_Deactivate,
+  ARM_WiFi_IsConnected,
+  ARM_WiFi_GetNetInfo,
+  ARM_WiFi_BypassControl,
+  ARM_WiFi_EthSendFrame,
+  ARM_WiFi_EthReadFrame,
+  ARM_WiFi_EthGetRxFrameSize,
+  ARM_WiFi_SocketCreate,
+  ARM_WiFi_SocketBind,
+  ARM_WiFi_SocketListen,
+  ARM_WiFi_SocketAccept,
+  ARM_WiFi_SocketConnect,
+  ARM_WiFi_SocketRecv,
+  ARM_WiFi_SocketRecvFrom,
+  ARM_WiFi_SocketSend,
+  ARM_WiFi_SocketSendTo,
+  ARM_WiFi_SocketGetSockName,
+  ARM_WiFi_SocketGetPeerName,
+  ARM_WiFi_SocketGetOpt,
+  ARM_WiFi_SocketSetOpt,
+  ARM_WiFi_SocketClose,
+  ARM_WiFi_SocketGetHostByName,
+  ARM_WiFi_Ping
+};

--- a/platform/ext/cmsis/CMSIS/Driver/Include/Driver_CAN.h
+++ b/platform/ext/cmsis/CMSIS/Driver/Include/Driver_CAN.h
@@ -1,0 +1,386 @@
+/*
+ * Copyright (c) 2015-2020 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * $Date:        31. March 2020
+ * $Revision:    V1.3
+ *
+ * Project:      CAN (Controller Area Network) Driver definitions
+ */
+
+/* History:
+ *  Version 1.3
+ *    Removed volatile from ARM_CAN_STATUS
+ *  Version 1.2
+ *    Added ARM_CAN_UNIT_STATE_BUS_OFF unit state and
+ *    ARM_CAN_EVENT_UNIT_INACTIVE unit event
+ *  Version 1.1
+ *    ARM_CAN_STATUS made volatile
+ *  Version 1.0
+ *    Initial release
+ */
+
+#ifndef DRIVER_CAN_H_
+#define DRIVER_CAN_H_
+
+#ifdef  __cplusplus
+extern "C"
+{
+#endif
+
+#include "Driver_Common.h"
+
+#define ARM_CAN_API_VERSION ARM_DRIVER_VERSION_MAJOR_MINOR(1,3)  /* API version */
+
+
+#define _ARM_Driver_CAN_(n)      Driver_CAN##n
+#define  ARM_Driver_CAN_(n) _ARM_Driver_CAN_(n)
+
+
+/****** CAN Bitrate selection codes *****/
+typedef enum _ARM_CAN_BITRATE_SELECT {
+  ARM_CAN_BITRATE_NOMINAL,              ///< Select nominal (flexible data-rate arbitration) bitrate
+  ARM_CAN_BITRATE_FD_DATA               ///< Select flexible data-rate data bitrate
+} ARM_CAN_BITRATE_SELECT;
+
+/****** CAN Bit Propagation Segment codes (PROP_SEG) *****/
+#define ARM_CAN_BIT_PROP_SEG_Pos        0UL       ///< bits 7..0
+#define ARM_CAN_BIT_PROP_SEG_Msk       (0xFFUL << ARM_CAN_BIT_PROP_SEG_Pos)
+#define ARM_CAN_BIT_PROP_SEG(x)      (((x)     << ARM_CAN_BIT_PROP_SEG_Pos) & ARM_CAN_BIT_PROP_SEG_Msk)
+
+/****** CAN Bit Phase Buffer Segment 1 (PHASE_SEG1) codes *****/
+#define ARM_CAN_BIT_PHASE_SEG1_Pos      8UL       ///< bits 15..8
+#define ARM_CAN_BIT_PHASE_SEG1_Msk     (0xFFUL << ARM_CAN_BIT_PHASE_SEG1_Pos)
+#define ARM_CAN_BIT_PHASE_SEG1(x)    (((x)     << ARM_CAN_BIT_PHASE_SEG1_Pos) & ARM_CAN_BIT_PHASE_SEG1_Msk)
+
+/****** CAN Bit Phase Buffer Segment 2 (PHASE_SEG2) codes *****/
+#define ARM_CAN_BIT_PHASE_SEG2_Pos      16UL      ///< bits 23..16
+#define ARM_CAN_BIT_PHASE_SEG2_Msk     (0xFFUL << ARM_CAN_BIT_PHASE_SEG2_Pos)
+#define ARM_CAN_BIT_PHASE_SEG2(x)    (((x)     << ARM_CAN_BIT_PHASE_SEG2_Pos) & ARM_CAN_BIT_PHASE_SEG2_Msk)
+
+/****** CAN Bit (Re)Synchronization Jump Width Segment (SJW) *****/
+#define ARM_CAN_BIT_SJW_Pos             24UL      ///< bits 28..24
+#define ARM_CAN_BIT_SJW_Msk            (0x1FUL << ARM_CAN_BIT_SJW_Pos)
+#define ARM_CAN_BIT_SJW(x)           (((x)     << ARM_CAN_BIT_SJW_Pos) & ARM_CAN_BIT_SJW_Msk)
+
+/****** CAN Mode codes *****/
+typedef enum _ARM_CAN_MODE {
+  ARM_CAN_MODE_INITIALIZATION,          ///< Initialization mode
+  ARM_CAN_MODE_NORMAL,                  ///< Normal operation mode
+  ARM_CAN_MODE_RESTRICTED,              ///< Restricted operation mode
+  ARM_CAN_MODE_MONITOR,                 ///< Bus monitoring mode
+  ARM_CAN_MODE_LOOPBACK_INTERNAL,       ///< Loopback internal mode
+  ARM_CAN_MODE_LOOPBACK_EXTERNAL        ///< Loopback external mode
+} ARM_CAN_MODE;
+
+/****** CAN Filter Operation codes *****/
+typedef enum _ARM_CAN_FILTER_OPERATION {
+  ARM_CAN_FILTER_ID_EXACT_ADD,          ///< Add    exact id filter
+  ARM_CAN_FILTER_ID_EXACT_REMOVE,       ///< Remove exact id filter
+  ARM_CAN_FILTER_ID_RANGE_ADD,          ///< Add    range id filter
+  ARM_CAN_FILTER_ID_RANGE_REMOVE,       ///< Remove range id filter
+  ARM_CAN_FILTER_ID_MASKABLE_ADD,       ///< Add    maskable id filter
+  ARM_CAN_FILTER_ID_MASKABLE_REMOVE     ///< Remove maskable id filter
+} ARM_CAN_FILTER_OPERATION;
+
+/****** CAN Object Configuration codes *****/
+typedef enum _ARM_CAN_OBJ_CONFIG {
+  ARM_CAN_OBJ_INACTIVE,                 ///< CAN object inactive
+  ARM_CAN_OBJ_TX,                       ///< CAN transmit object
+  ARM_CAN_OBJ_RX,                       ///< CAN receive object
+  ARM_CAN_OBJ_RX_RTR_TX_DATA,           ///< CAN object that on RTR reception automatically transmits Data Frame
+  ARM_CAN_OBJ_TX_RTR_RX_DATA            ///< CAN object that transmits RTR and automatically receives Data Frame
+} ARM_CAN_OBJ_CONFIG;
+
+/**
+\brief CAN Object Capabilities
+*/
+typedef struct _ARM_CAN_OBJ_CAPABILITIES {
+  uint32_t tx               : 1;        ///< Object supports transmission
+  uint32_t rx               : 1;        ///< Object supports reception
+  uint32_t rx_rtr_tx_data   : 1;        ///< Object supports RTR reception and automatic Data Frame transmission
+  uint32_t tx_rtr_rx_data   : 1;        ///< Object supports RTR transmission and automatic Data Frame reception
+  uint32_t multiple_filters : 1;        ///< Object allows assignment of multiple filters to it
+  uint32_t exact_filtering  : 1;        ///< Object supports exact identifier filtering
+  uint32_t range_filtering  : 1;        ///< Object supports range identifier filtering
+  uint32_t mask_filtering   : 1;        ///< Object supports mask identifier filtering
+  uint32_t message_depth    : 8;        ///< Number of messages buffers (FIFO) for that object
+  uint32_t reserved         : 16;       ///< Reserved (must be zero)
+} ARM_CAN_OBJ_CAPABILITIES;
+
+/****** CAN Control Function Operation codes *****/
+#define ARM_CAN_CONTROL_Pos             0UL
+#define ARM_CAN_CONTROL_Msk            (0xFFUL << ARM_CAN_CONTROL_Pos)
+#define ARM_CAN_SET_FD_MODE            (1UL    << ARM_CAN_CONTROL_Pos)          ///< Set FD operation mode;                   arg: 0 = disable, 1 = enable
+#define ARM_CAN_ABORT_MESSAGE_SEND     (2UL    << ARM_CAN_CONTROL_Pos)          ///< Abort sending of CAN message;            arg = object
+#define ARM_CAN_CONTROL_RETRANSMISSION (3UL    << ARM_CAN_CONTROL_Pos)          ///< Enable/disable automatic retransmission; arg: 0 = disable, 1 = enable (default state)
+#define ARM_CAN_SET_TRANSCEIVER_DELAY  (4UL    << ARM_CAN_CONTROL_Pos)          ///< Set transceiver delay;                   arg = delay in time quanta
+
+/****** CAN ID Frame Format codes *****/
+#define ARM_CAN_ID_IDE_Pos              31UL
+#define ARM_CAN_ID_IDE_Msk             (1UL    << ARM_CAN_ID_IDE_Pos)
+
+/****** CAN Identifier encoding *****/
+#define ARM_CAN_STANDARD_ID(id)        (id & 0x000007FFUL)                      ///< CAN identifier in standard format (11-bits)
+#define ARM_CAN_EXTENDED_ID(id)       ((id & 0x1FFFFFFFUL) | ARM_CAN_ID_IDE_Msk)///< CAN identifier in extended format (29-bits)
+
+/**
+\brief CAN Message Information
+*/
+typedef struct _ARM_CAN_MSG_INFO {
+  uint32_t id;                          ///< CAN identifier with frame format specifier (bit 31)
+  uint32_t rtr              : 1;        ///< Remote transmission request frame
+  uint32_t edl              : 1;        ///< Flexible data-rate format extended data length
+  uint32_t brs              : 1;        ///< Flexible data-rate format with bitrate switch 
+  uint32_t esi              : 1;        ///< Flexible data-rate format error state indicator
+  uint32_t dlc              : 4;        ///< Data length code
+  uint32_t reserved         : 24;
+} ARM_CAN_MSG_INFO;
+
+/****** CAN specific error code *****/
+#define ARM_CAN_INVALID_BITRATE_SELECT (ARM_DRIVER_ERROR_SPECIFIC - 1)          ///< Bitrate selection not supported
+#define ARM_CAN_INVALID_BITRATE        (ARM_DRIVER_ERROR_SPECIFIC - 2)          ///< Requested bitrate not supported
+#define ARM_CAN_INVALID_BIT_PROP_SEG   (ARM_DRIVER_ERROR_SPECIFIC - 3)          ///< Propagation segment value not supported
+#define ARM_CAN_INVALID_BIT_PHASE_SEG1 (ARM_DRIVER_ERROR_SPECIFIC - 4)          ///< Phase segment 1 value not supported
+#define ARM_CAN_INVALID_BIT_PHASE_SEG2 (ARM_DRIVER_ERROR_SPECIFIC - 5)          ///< Phase segment 2 value not supported
+#define ARM_CAN_INVALID_BIT_SJW        (ARM_DRIVER_ERROR_SPECIFIC - 6)          ///< SJW value not supported
+#define ARM_CAN_NO_MESSAGE_AVAILABLE   (ARM_DRIVER_ERROR_SPECIFIC - 7)          ///< Message is not available
+
+/****** CAN Status codes *****/
+#define ARM_CAN_UNIT_STATE_INACTIVE    (0U)             ///< Unit state: Not active on bus (initialization)
+#define ARM_CAN_UNIT_STATE_ACTIVE      (1U)             ///< Unit state: Active on bus (can generate active error frame)
+#define ARM_CAN_UNIT_STATE_PASSIVE     (2U)             ///< Unit state: Error passive (can not generate active error frame)
+#define ARM_CAN_UNIT_STATE_BUS_OFF     (3U)             ///< Unit state: Bus-off (can recover to active state)
+#define ARM_CAN_LEC_NO_ERROR           (0U)             ///< Last error code: No error
+#define ARM_CAN_LEC_BIT_ERROR          (1U)             ///< Last error code: Bit error
+#define ARM_CAN_LEC_STUFF_ERROR        (2U)             ///< Last error code: Bit stuffing error
+#define ARM_CAN_LEC_CRC_ERROR          (3U)             ///< Last error code: CRC error
+#define ARM_CAN_LEC_FORM_ERROR         (4U)             ///< Last error code: Illegal fixed-form bit
+#define ARM_CAN_LEC_ACK_ERROR          (5U)             ///< Last error code: Acknowledgment error
+
+/**
+\brief CAN Status
+*/
+typedef struct _ARM_CAN_STATUS {
+  uint32_t unit_state       : 4;        ///< Unit bus state
+  uint32_t last_error_code  : 4;        ///< Last error code
+  uint32_t tx_error_count   : 8;        ///< Transmitter error count
+  uint32_t rx_error_count   : 8;        ///< Receiver error count
+  uint32_t reserved         : 8;
+} ARM_CAN_STATUS;
+
+
+/****** CAN Unit Event *****/
+#define ARM_CAN_EVENT_UNIT_INACTIVE    (0U)             ///< Unit entered Inactive state
+#define ARM_CAN_EVENT_UNIT_ACTIVE      (1U)             ///< Unit entered Error Active state
+#define ARM_CAN_EVENT_UNIT_WARNING     (2U)             ///< Unit entered Error Warning state (one or both error counters >= 96)
+#define ARM_CAN_EVENT_UNIT_PASSIVE     (3U)             ///< Unit entered Error Passive state
+#define ARM_CAN_EVENT_UNIT_BUS_OFF     (4U)             ///< Unit entered Bus-off state
+
+/****** CAN Send/Receive Event *****/
+#define ARM_CAN_EVENT_SEND_COMPLETE    (1UL << 0)       ///< Send complete
+#define ARM_CAN_EVENT_RECEIVE          (1UL << 1)       ///< Message received
+#define ARM_CAN_EVENT_RECEIVE_OVERRUN  (1UL << 2)       ///< Received message overrun
+
+
+// Function documentation
+/**
+  \fn          ARM_DRIVER_VERSION ARM_CAN_GetVersion (void)
+  \brief       Get driver version.
+  \return      \ref ARM_DRIVER_VERSION
+
+  \fn          ARM_CAN_CAPABILITIES ARM_CAN_GetCapabilities (void)
+  \brief       Get driver capabilities.
+  \return      \ref ARM_CAN_CAPABILITIES
+
+  \fn          int32_t ARM_CAN_Initialize (ARM_CAN_SignalUnitEvent_t   cb_unit_event,
+                                           ARM_CAN_SignalObjectEvent_t cb_object_event)
+  \brief       Initialize CAN interface and register signal (callback) functions.
+  \param[in]   cb_unit_event   Pointer to \ref ARM_CAN_SignalUnitEvent callback function
+  \param[in]   cb_object_event Pointer to \ref ARM_CAN_SignalObjectEvent callback function
+  \return      \ref execution_status
+
+  \fn          int32_t ARM_CAN_Uninitialize (void)
+  \brief       De-initialize CAN interface.
+  \return      \ref execution_status
+
+  \fn          int32_t ARM_CAN_PowerControl (ARM_POWER_STATE state)
+  \brief       Control CAN interface power.
+  \param[in]   state  Power state
+                 - \ref ARM_POWER_OFF :  power off: no operation possible
+                 - \ref ARM_POWER_LOW :  low power mode: retain state, detect and signal wake-up events
+                 - \ref ARM_POWER_FULL : power on: full operation at maximum performance
+  \return      \ref execution_status
+
+  \fn          uint32_t ARM_CAN_GetClock (void)
+  \brief       Retrieve CAN base clock frequency.
+  \return      base clock frequency
+
+  \fn          int32_t ARM_CAN_SetBitrate (ARM_CAN_BITRATE_SELECT select, uint32_t bitrate, uint32_t bit_segments)
+  \brief       Set bitrate for CAN interface.
+  \param[in]   select       Bitrate selection
+                 - \ref ARM_CAN_BITRATE_NOMINAL : nominal (flexible data-rate arbitration) bitrate
+                 - \ref ARM_CAN_BITRATE_FD_DATA : flexible data-rate data bitrate
+  \param[in]   bitrate      Bitrate
+  \param[in]   bit_segments Bit segments settings
+                 - \ref ARM_CAN_BIT_PROP_SEG(x) :   number of time quanta for propagation time segment
+                 - \ref ARM_CAN_BIT_PHASE_SEG1(x) : number of time quanta for phase buffer segment 1
+                 - \ref ARM_CAN_BIT_PHASE_SEG2(x) : number of time quanta for phase buffer Segment 2
+                 - \ref ARM_CAN_BIT_SJW(x) :        number of time quanta for (re-)synchronization jump width
+  \return      \ref execution_status
+
+  \fn          int32_t ARM_CAN_SetMode (ARM_CAN_MODE mode)
+  \brief       Set operating mode for CAN interface.
+  \param[in]   mode   Operating mode
+                 - \ref ARM_CAN_MODE_INITIALIZATION :    initialization mode
+                 - \ref ARM_CAN_MODE_NORMAL :            normal operation mode
+                 - \ref ARM_CAN_MODE_RESTRICTED :        restricted operation mode
+                 - \ref ARM_CAN_MODE_MONITOR :           bus monitoring mode
+                 - \ref ARM_CAN_MODE_LOOPBACK_INTERNAL : loopback internal mode
+                 - \ref ARM_CAN_MODE_LOOPBACK_EXTERNAL : loopback external mode
+  \return      \ref execution_status
+
+  \fn          ARM_CAN_OBJ_CAPABILITIES ARM_CAN_ObjectGetCapabilities (uint32_t obj_idx)
+  \brief       Retrieve capabilities of an object.
+  \param[in]   obj_idx  Object index
+  \return      \ref ARM_CAN_OBJ_CAPABILITIES
+
+  \fn          int32_t ARM_CAN_ObjectSetFilter (uint32_t obj_idx, ARM_CAN_FILTER_OPERATION operation, uint32_t id, uint32_t arg)
+  \brief       Add or remove filter for message reception.
+  \param[in]   obj_idx      Object index of object that filter should be or is assigned to
+  \param[in]   operation    Operation on filter
+                 - \ref ARM_CAN_FILTER_ID_EXACT_ADD :       add    exact id filter
+                 - \ref ARM_CAN_FILTER_ID_EXACT_REMOVE :    remove exact id filter
+                 - \ref ARM_CAN_FILTER_ID_RANGE_ADD :       add    range id filter
+                 - \ref ARM_CAN_FILTER_ID_RANGE_REMOVE :    remove range id filter
+                 - \ref ARM_CAN_FILTER_ID_MASKABLE_ADD :    add    maskable id filter
+                 - \ref ARM_CAN_FILTER_ID_MASKABLE_REMOVE : remove maskable id filter
+  \param[in]   id           ID or start of ID range (depending on filter type)
+  \param[in]   arg          Mask or end of ID range (depending on filter type)
+  \return      \ref execution_status
+
+  \fn          int32_t ARM_CAN_ObjectConfigure (uint32_t obj_idx, ARM_CAN_OBJ_CONFIG obj_cfg)
+  \brief       Configure object.
+  \param[in]   obj_idx  Object index
+  \param[in]   obj_cfg  Object configuration state
+                 - \ref ARM_CAN_OBJ_INACTIVE :       deactivate object
+                 - \ref ARM_CAN_OBJ_RX :             configure object for reception
+                 - \ref ARM_CAN_OBJ_TX :             configure object for transmission
+                 - \ref ARM_CAN_OBJ_RX_RTR_TX_DATA : configure object that on RTR reception automatically transmits Data Frame
+                 - \ref ARM_CAN_OBJ_TX_RTR_RX_DATA : configure object that transmits RTR and automatically receives Data Frame
+  \return      \ref execution_status
+
+  \fn          int32_t ARM_CAN_MessageSend (uint32_t obj_idx, ARM_CAN_MSG_INFO *msg_info, const uint8_t *data, uint8_t size)
+  \brief       Send message on CAN bus.
+  \param[in]   obj_idx  Object index
+  \param[in]   msg_info Pointer to CAN message information
+  \param[in]   data     Pointer to data buffer
+  \param[in]   size     Number of data bytes to send
+  \return      value >= 0  number of data bytes accepted to send
+  \return      value < 0   \ref execution_status
+
+  \fn          int32_t ARM_CAN_MessageRead (uint32_t obj_idx, ARM_CAN_MSG_INFO *msg_info, uint8_t *data, uint8_t size)
+  \brief       Read message received on CAN bus.
+  \param[in]   obj_idx  Object index
+  \param[out]  msg_info Pointer to read CAN message information
+  \param[out]  data     Pointer to data buffer for read data
+  \param[in]   size     Maximum number of data bytes to read
+  \return      value >= 0  number of data bytes read
+  \return      value < 0   \ref execution_status
+
+  \fn          int32_t ARM_CAN_Control (uint32_t control, uint32_t arg)
+  \brief       Control CAN interface.
+  \param[in]   control  Operation
+                 - \ref ARM_CAN_SET_FD_MODE :            set FD operation mode
+                 - \ref ARM_CAN_ABORT_MESSAGE_SEND :     abort sending of CAN message
+                 - \ref ARM_CAN_CONTROL_RETRANSMISSION : enable/disable automatic retransmission
+                 - \ref ARM_CAN_SET_TRANSCEIVER_DELAY :  set transceiver delay
+  \param[in]   arg      Argument of operation
+  \return      \ref execution_status
+
+  \fn          ARM_CAN_STATUS ARM_CAN_GetStatus (void)
+  \brief       Get CAN status.
+  \return      CAN status \ref ARM_CAN_STATUS
+
+  \fn          void ARM_CAN_SignalUnitEvent (uint32_t event)
+  \brief       Signal CAN unit event.
+  \param[in]   event \ref CAN_unit_events
+
+  \fn          void ARM_CAN_SignalObjectEvent (uint32_t obj_idx, uint32_t event)
+  \brief       Signal CAN object event.
+  \param[in]   obj_idx  Object index
+  \param[in]   event \ref CAN_events
+*/
+
+typedef void (*ARM_CAN_SignalUnitEvent_t)   (uint32_t event);                   ///< Pointer to \ref ARM_CAN_SignalUnitEvent   : Signal CAN Unit Event.
+typedef void (*ARM_CAN_SignalObjectEvent_t) (uint32_t obj_idx, uint32_t event); ///< Pointer to \ref ARM_CAN_SignalObjectEvent : Signal CAN Object Event.
+
+
+/**
+\brief CAN Device Driver Capabilities.
+*/
+typedef struct _ARM_CAN_CAPABILITIES {
+  uint32_t num_objects            : 8;  ///< Number of \ref can_objects available
+  uint32_t reentrant_operation    : 1;  ///< Support for reentrant calls to \ref ARM_CAN_MessageSend, \ref ARM_CAN_MessageRead, \ref ARM_CAN_ObjectConfigure and abort message sending used by \ref ARM_CAN_Control
+  uint32_t fd_mode                : 1;  ///< Support for CAN with flexible data-rate mode (CAN_FD) (set by \ref ARM_CAN_Control)
+  uint32_t restricted_mode        : 1;  ///< Support for restricted operation mode (set by \ref ARM_CAN_SetMode)
+  uint32_t monitor_mode           : 1;  ///< Support for bus monitoring mode (set by \ref ARM_CAN_SetMode)
+  uint32_t internal_loopback      : 1;  ///< Support for internal loopback mode (set by \ref ARM_CAN_SetMode)
+  uint32_t external_loopback      : 1;  ///< Support for external loopback mode (set by \ref ARM_CAN_SetMode)
+  uint32_t reserved               : 18; ///< Reserved (must be zero)
+} ARM_CAN_CAPABILITIES;
+
+
+/**
+\brief Access structure of the CAN Driver.
+*/
+typedef struct _ARM_DRIVER_CAN {
+  ARM_DRIVER_VERSION       (*GetVersion)            (void);                             ///< Pointer to \ref ARM_CAN_GetVersion            : Get driver version.
+  ARM_CAN_CAPABILITIES     (*GetCapabilities)       (void);                             ///< Pointer to \ref ARM_CAN_GetCapabilities       : Get driver capabilities.
+  int32_t                  (*Initialize)            (ARM_CAN_SignalUnitEvent_t   cb_unit_event,                     
+                                                     ARM_CAN_SignalObjectEvent_t cb_object_event); ///< Pointer to \ref ARM_CAN_Initialize : Initialize CAN interface.
+  int32_t                  (*Uninitialize)          (void);                             ///< Pointer to \ref ARM_CAN_Uninitialize          : De-initialize CAN interface.
+  int32_t                  (*PowerControl)          (ARM_POWER_STATE          state);   ///< Pointer to \ref ARM_CAN_PowerControl          : Control CAN interface power.
+  uint32_t                 (*GetClock)              (void);                             ///< Pointer to \ref ARM_CAN_GetClock              : Retrieve CAN base clock frequency.
+  int32_t                  (*SetBitrate)            (ARM_CAN_BITRATE_SELECT   select,
+                                                     uint32_t                 bitrate,
+                                                     uint32_t                 bit_segments);       ///< Pointer to \ref ARM_CAN_SetBitrate : Set bitrate for CAN interface.
+  int32_t                  (*SetMode)               (ARM_CAN_MODE             mode);    ///< Pointer to \ref ARM_CAN_SetMode               : Set operating mode for CAN interface.
+  ARM_CAN_OBJ_CAPABILITIES (*ObjectGetCapabilities) (uint32_t                 obj_idx); ///< Pointer to \ref ARM_CAN_ObjectGetCapabilities : Retrieve capabilities of an object.
+  int32_t                  (*ObjectSetFilter)       (uint32_t                 obj_idx,
+                                                     ARM_CAN_FILTER_OPERATION operation,
+                                                     uint32_t                 id,
+                                                     uint32_t                 arg);     ///< Pointer to \ref ARM_CAN_ObjectSetFilter       : Add or remove filter for message reception.
+  int32_t                  (*ObjectConfigure)       (uint32_t                 obj_idx,
+                                                     ARM_CAN_OBJ_CONFIG       obj_cfg); ///< Pointer to \ref ARM_CAN_ObjectConfigure       : Configure object.
+  int32_t                  (*MessageSend)           (uint32_t                 obj_idx,
+                                                     ARM_CAN_MSG_INFO        *msg_info,
+                                                     const uint8_t           *data,
+                                                     uint8_t                  size);    ///< Pointer to \ref ARM_CAN_MessageSend           : Send message on CAN bus.
+  int32_t                  (*MessageRead)           (uint32_t                 obj_idx,
+                                                     ARM_CAN_MSG_INFO        *msg_info,
+                                                     uint8_t                 *data,
+                                                     uint8_t                  size);    ///< Pointer to \ref ARM_CAN_MessageRead           : Read message received on CAN bus.
+  int32_t                  (*Control)               (uint32_t                 control,
+                                                     uint32_t                 arg);     ///< Pointer to \ref ARM_CAN_Control               : Control CAN interface.
+  ARM_CAN_STATUS           (*GetStatus)             (void);                             ///< Pointer to \ref ARM_CAN_GetStatus             : Get CAN status.
+} const ARM_DRIVER_CAN;
+
+#ifdef  __cplusplus
+}
+#endif
+
+#endif /* DRIVER_CAN_H_ */

--- a/platform/ext/cmsis/CMSIS/Driver/Include/Driver_Common.h
+++ b/platform/ext/cmsis/CMSIS/Driver/Include/Driver_Common.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2013-2017 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * $Date:        2. Feb 2017
+ * $Revision:    V2.0
+ *
+ * Project:      Common Driver definitions
+ */
+
+/* History:
+ *  Version 2.0
+ *    Changed prefix ARM_DRV -> ARM_DRIVER
+ *    Added General return codes definitions
+ *  Version 1.10
+ *    Namespace prefix ARM_ added
+ *  Version 1.00
+ *    Initial release
+ */
+
+#ifndef DRIVER_COMMON_H_
+#define DRIVER_COMMON_H_
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#define ARM_DRIVER_VERSION_MAJOR_MINOR(major,minor) (((major) << 8) | (minor))
+
+/**
+\brief Driver Version
+*/
+typedef struct _ARM_DRIVER_VERSION {
+  uint16_t api;                         ///< API version
+  uint16_t drv;                         ///< Driver version
+} ARM_DRIVER_VERSION;
+
+/* General return codes */
+#define ARM_DRIVER_OK                 0 ///< Operation succeeded 
+#define ARM_DRIVER_ERROR             -1 ///< Unspecified error
+#define ARM_DRIVER_ERROR_BUSY        -2 ///< Driver is busy
+#define ARM_DRIVER_ERROR_TIMEOUT     -3 ///< Timeout occurred
+#define ARM_DRIVER_ERROR_UNSUPPORTED -4 ///< Operation not supported
+#define ARM_DRIVER_ERROR_PARAMETER   -5 ///< Parameter error
+#define ARM_DRIVER_ERROR_SPECIFIC    -6 ///< Start of driver specific errors 
+
+/**
+\brief General power states
+*/ 
+typedef enum _ARM_POWER_STATE {
+  ARM_POWER_OFF,                        ///< Power off: no operation possible
+  ARM_POWER_LOW,                        ///< Low Power mode: retain state, detect and signal wake-up events
+  ARM_POWER_FULL                        ///< Power on: full operation at maximum performance
+} ARM_POWER_STATE;
+
+#endif /* DRIVER_COMMON_H_ */

--- a/platform/ext/cmsis/CMSIS/Driver/Include/Driver_ETH.h
+++ b/platform/ext/cmsis/CMSIS/Driver/Include/Driver_ETH.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2013-2020 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * $Date:        24. January 2020
+ * $Revision:    V2.2
+ *
+ * Project:      Ethernet PHY and MAC Driver common definitions
+ */
+
+/* History:
+ *  Version 2.2
+ *    Removed volatile from ARM_ETH_LINK_INFO
+ *  Version 2.1
+ *    ARM_ETH_LINK_INFO made volatile
+ *  Version 2.0
+ *    Removed ARM_ETH_STATUS enumerator
+ *    Removed ARM_ETH_MODE enumerator
+ *  Version 1.10
+ *    Namespace prefix ARM_ added
+ *  Version 1.00
+ *    Initial release
+ */
+
+#ifndef DRIVER_ETH_H_
+#define DRIVER_ETH_H_
+
+#include "Driver_Common.h"
+
+/**
+\brief Ethernet Media Interface type
+*/
+#define ARM_ETH_INTERFACE_MII           (0U)    ///< Media Independent Interface (MII)
+#define ARM_ETH_INTERFACE_RMII          (1U)    ///< Reduced Media Independent Interface (RMII)
+#define ARM_ETH_INTERFACE_SMII          (2U)    ///< Serial Media Independent Interface (SMII)
+
+/**
+\brief Ethernet link speed
+*/
+#define ARM_ETH_SPEED_10M               (0U)    ///< 10 Mbps link speed
+#define ARM_ETH_SPEED_100M              (1U)    ///< 100 Mbps link speed
+#define ARM_ETH_SPEED_1G                (2U)    ///< 1 Gpbs link speed
+
+/**
+\brief Ethernet duplex mode
+*/
+#define ARM_ETH_DUPLEX_HALF             (0U)    ///< Half duplex link
+#define ARM_ETH_DUPLEX_FULL             (1U)    ///< Full duplex link
+
+/**
+\brief Ethernet link state
+*/
+typedef enum _ARM_ETH_LINK_STATE {
+  ARM_ETH_LINK_DOWN,                    ///< Link is down
+  ARM_ETH_LINK_UP                       ///< Link is up
+} ARM_ETH_LINK_STATE;
+
+/**
+\brief Ethernet link information
+*/
+typedef struct _ARM_ETH_LINK_INFO {
+  uint32_t speed    : 2;                ///< Link speed: 0= 10 MBit, 1= 100 MBit, 2= 1 GBit
+  uint32_t duplex   : 1;                ///< Duplex mode: 0= Half, 1= Full
+  uint32_t reserved : 29;
+} ARM_ETH_LINK_INFO;
+
+/**
+\brief Ethernet MAC Address
+*/
+typedef struct _ARM_ETH_MAC_ADDR {
+  uint8_t b[6];                         ///< MAC Address (6 bytes), MSB first
+} ARM_ETH_MAC_ADDR;
+
+#endif /* DRIVER_ETH_H_ */

--- a/platform/ext/cmsis/CMSIS/Driver/Include/Driver_ETH_MAC.h
+++ b/platform/ext/cmsis/CMSIS/Driver/Include/Driver_ETH_MAC.h
@@ -1,0 +1,309 @@
+/*
+ * Copyright (c) 2013-2020 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * $Date:        24. January 2020
+ * $Revision:    V2.2
+ *
+ * Project:      Ethernet MAC (Media Access Control) Driver definitions
+ */
+
+/* History:
+ *  Version 2.2
+ *    Removed volatile from ARM_ETH_LINK_INFO
+ *  Version 2.1
+ *    Added ARM_ETH_MAC_SLEEP Control
+ *  Version 2.0
+ *    Changed MAC Address handling:
+ *      moved from ARM_ETH_MAC_Initialize
+ *      to new functions ARM_ETH_MAC_GetMacAddress and ARM_ETH_MAC_SetMacAddress
+ *    Replaced ARM_ETH_MAC_SetMulticastAddr function with ARM_ETH_MAC_SetAddressFilter
+ *    Extended ARM_ETH_MAC_SendFrame function with flags
+ *    Added ARM_ETH_MAC_Control function:
+ *      more control options (Broadcast, Multicast, Checksum offload, VLAN, ...)
+ *      replaces ARM_ETH_MAC_SetMode
+ *      replaces ARM_ETH_MAC_EnableTx, ARM_ETH_MAC_EnableRx
+ *    Added optional event on transmitted frame
+ *    Added support for PTP (Precision Time Protocol) through new functions:
+ *       ARM_ETH_MAC_ControlTimer
+ *       ARM_ETH_MAC_GetRxFrameTime
+ *       ARM_ETH_MAC_GetTxFrameTime
+ *    Changed prefix ARM_DRV -> ARM_DRIVER
+ *    Changed return values of some functions to int32_t
+ *  Version 1.10
+ *    Name space prefix ARM_ added
+ *  Version 1.01
+ *    Renamed capabilities items for checksum offload
+ *  Version 1.00
+ *    Initial release
+ */
+
+#ifndef DRIVER_ETH_MAC_H_
+#define DRIVER_ETH_MAC_H_
+
+#ifdef  __cplusplus
+extern "C"
+{
+#endif
+
+#include "Driver_ETH.h"
+
+#define ARM_ETH_MAC_API_VERSION ARM_DRIVER_VERSION_MAJOR_MINOR(2,2)  /* API version */
+
+
+#define _ARM_Driver_ETH_MAC_(n)      Driver_ETH_MAC##n
+#define  ARM_Driver_ETH_MAC_(n) _ARM_Driver_ETH_MAC_(n)
+
+
+/****** Ethernet MAC Control Codes *****/
+
+#define ARM_ETH_MAC_CONFIGURE           (0x01UL)    ///< Configure MAC; arg = configuration
+#define ARM_ETH_MAC_CONTROL_TX          (0x02UL)    ///< Transmitter; arg: 0=disabled (default), 1=enabled
+#define ARM_ETH_MAC_CONTROL_RX          (0x03UL)    ///< Receiver; arg: 0=disabled (default), 1=enabled
+#define ARM_ETH_MAC_FLUSH               (0x04UL)    ///< Flush buffer; arg = ARM_ETH_MAC_FLUSH_...
+#define ARM_ETH_MAC_SLEEP               (0x05UL)    ///< Sleep mode; arg: 1=enter and wait for Magic packet, 0=exit
+#define ARM_ETH_MAC_VLAN_FILTER         (0x06UL)    ///< VLAN Filter for received frames; arg15..0: VLAN Tag; arg16: optional ARM_ETH_MAC_VLAN_FILTER_ID_ONLY; 0=disabled (default)
+
+/*----- Ethernet MAC Configuration -----*/
+#define ARM_ETH_MAC_SPEED_Pos            0
+#define ARM_ETH_MAC_SPEED_Msk           (3UL                 << ARM_ETH_MAC_SPEED_Pos)
+#define ARM_ETH_MAC_SPEED_10M           (ARM_ETH_SPEED_10M   << ARM_ETH_MAC_SPEED_Pos)  ///< 10 Mbps link speed
+#define ARM_ETH_MAC_SPEED_100M          (ARM_ETH_SPEED_100M  << ARM_ETH_MAC_SPEED_Pos)  ///< 100 Mbps link speed
+#define ARM_ETH_MAC_SPEED_1G            (ARM_ETH_SPEED_1G    << ARM_ETH_MAC_SPEED_Pos)  ///< 1 Gpbs link speed
+#define ARM_ETH_MAC_DUPLEX_Pos           2
+#define ARM_ETH_MAC_DUPLEX_Msk          (1UL                 << ARM_ETH_MAC_DUPLEX_Pos)
+#define ARM_ETH_MAC_DUPLEX_HALF         (ARM_ETH_DUPLEX_HALF << ARM_ETH_MAC_DUPLEX_Pos) ///< Half duplex link
+#define ARM_ETH_MAC_DUPLEX_FULL         (ARM_ETH_DUPLEX_FULL << ARM_ETH_MAC_DUPLEX_Pos) ///< Full duplex link
+#define ARM_ETH_MAC_LOOPBACK            (1UL << 4)  ///< Loop-back test mode
+#define ARM_ETH_MAC_CHECKSUM_OFFLOAD_RX (1UL << 5)  ///< Receiver Checksum offload
+#define ARM_ETH_MAC_CHECKSUM_OFFLOAD_TX (1UL << 6)  ///< Transmitter Checksum offload
+#define ARM_ETH_MAC_ADDRESS_BROADCAST   (1UL << 7)  ///< Accept frames with Broadcast address
+#define ARM_ETH_MAC_ADDRESS_MULTICAST   (1UL << 8)  ///< Accept frames with any Multicast address
+#define ARM_ETH_MAC_ADDRESS_ALL         (1UL << 9)  ///< Accept frames with any address (Promiscuous Mode)
+
+/*----- Ethernet MAC Flush Flags -----*/
+#define ARM_ETH_MAC_FLUSH_RX            (1UL << 0)  ///< Flush Receive buffer
+#define ARM_ETH_MAC_FLUSH_TX            (1UL << 1)  ///< Flush Transmit buffer
+
+/*----- Ethernet MAC VLAN Filter Flag -----*/
+#define ARM_ETH_MAC_VLAN_FILTER_ID_ONLY (1UL << 16) ///< Compare only the VLAN Identifier (12-bit)
+
+
+/****** Ethernet MAC Frame Transmit Flags *****/
+#define ARM_ETH_MAC_TX_FRAME_FRAGMENT   (1UL << 0)  ///< Indicate frame fragment
+#define ARM_ETH_MAC_TX_FRAME_EVENT      (1UL << 1)  ///< Generate event when frame is transmitted
+#define ARM_ETH_MAC_TX_FRAME_TIMESTAMP  (1UL << 2)  ///< Capture frame time stamp
+
+
+/****** Ethernet MAC Timer Control Codes *****/
+#define ARM_ETH_MAC_TIMER_GET_TIME      (0x01UL)    ///< Get current time
+#define ARM_ETH_MAC_TIMER_SET_TIME      (0x02UL)    ///< Set new time
+#define ARM_ETH_MAC_TIMER_INC_TIME      (0x03UL)    ///< Increment current time
+#define ARM_ETH_MAC_TIMER_DEC_TIME      (0x04UL)    ///< Decrement current time
+#define ARM_ETH_MAC_TIMER_SET_ALARM     (0x05UL)    ///< Set alarm time
+#define ARM_ETH_MAC_TIMER_ADJUST_CLOCK  (0x06UL)    ///< Adjust clock frequency; time->ns: correction factor * 2^31
+
+
+/**
+\brief Ethernet MAC Time
+*/
+typedef struct _ARM_ETH_MAC_TIME {
+  uint32_t ns;                          ///< Nano seconds
+  uint32_t sec;                         ///< Seconds
+} ARM_ETH_MAC_TIME;
+
+
+/****** Ethernet MAC Event *****/
+#define ARM_ETH_MAC_EVENT_RX_FRAME      (1UL << 0)  ///< Frame Received
+#define ARM_ETH_MAC_EVENT_TX_FRAME      (1UL << 1)  ///< Frame Transmitted
+#define ARM_ETH_MAC_EVENT_WAKEUP        (1UL << 2)  ///< Wake-up (on Magic Packet)
+#define ARM_ETH_MAC_EVENT_TIMER_ALARM   (1UL << 3)  ///< Timer Alarm
+
+
+// Function documentation
+/**
+  \fn          ARM_DRIVER_VERSION ARM_ETH_MAC_GetVersion (void)
+  \brief       Get driver version.
+  \return      \ref ARM_DRIVER_VERSION
+*/
+/**
+  \fn          ARM_ETH_MAC_CAPABILITIES ARM_ETH_MAC_GetCapabilities (void)
+  \brief       Get driver capabilities.
+  \return      \ref ARM_ETH_MAC_CAPABILITIES
+*/
+/**
+  \fn          int32_t ARM_ETH_MAC_Initialize (ARM_ETH_MAC_SignalEvent_t cb_event)
+  \brief       Initialize Ethernet MAC Device.
+  \param[in]   cb_event  Pointer to \ref ARM_ETH_MAC_SignalEvent
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_ETH_MAC_Uninitialize (void)
+  \brief       De-initialize Ethernet MAC Device.
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_ETH_MAC_PowerControl (ARM_POWER_STATE state)
+  \brief       Control Ethernet MAC Device Power.
+  \param[in]   state  Power state
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_ETH_MAC_GetMacAddress (ARM_ETH_MAC_ADDR *ptr_addr)
+  \brief       Get Ethernet MAC Address.
+  \param[in]   ptr_addr  Pointer to address
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_ETH_MAC_SetMacAddress (const ARM_ETH_MAC_ADDR *ptr_addr)
+  \brief       Set Ethernet MAC Address.
+  \param[in]   ptr_addr  Pointer to address
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_ETH_MAC_SetAddressFilter (const ARM_ETH_MAC_ADDR *ptr_addr,
+                                                           uint32_t          num_addr)
+  \brief       Configure Address Filter.
+  \param[in]   ptr_addr  Pointer to addresses
+  \param[in]   num_addr  Number of addresses to configure
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_ETH_MAC_SendFrame (const uint8_t *frame, uint32_t len, uint32_t flags)
+  \brief       Send Ethernet frame.
+  \param[in]   frame  Pointer to frame buffer with data to send
+  \param[in]   len    Frame buffer length in bytes
+  \param[in]   flags  Frame transmit flags (see ARM_ETH_MAC_TX_FRAME_...)
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_ETH_MAC_ReadFrame (uint8_t *frame, uint32_t len)
+  \brief       Read data of received Ethernet frame.
+  \param[in]   frame  Pointer to frame buffer for data to read into
+  \param[in]   len    Frame buffer length in bytes
+  \return      number of data bytes read or execution status
+                 - value >= 0: number of data bytes read
+                 - value < 0: error occurred, value is execution status as defined with \ref execution_status 
+*/
+/**
+  \fn          uint32_t ARM_ETH_MAC_GetRxFrameSize (void)
+  \brief       Get size of received Ethernet frame.
+  \return      number of bytes in received frame
+*/
+/**
+  \fn          int32_t ARM_ETH_MAC_GetRxFrameTime (ARM_ETH_MAC_TIME *time)
+  \brief       Get time of received Ethernet frame.
+  \param[in]   time  Pointer to time structure for data to read into
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_ETH_MAC_GetTxFrameTime (ARM_ETH_MAC_TIME *time)
+  \brief       Get time of transmitted Ethernet frame.
+  \param[in]   time  Pointer to time structure for data to read into
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_ETH_MAC_Control (uint32_t control, uint32_t arg)
+  \brief       Control Ethernet Interface.
+  \param[in]   control  Operation
+  \param[in]   arg      Argument of operation (optional)
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_ETH_MAC_ControlTimer (uint32_t control, ARM_ETH_MAC_TIME *time)
+  \brief       Control Precision Timer.
+  \param[in]   control  Operation
+  \param[in]   time     Pointer to time structure
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_ETH_MAC_PHY_Read (uint8_t phy_addr, uint8_t reg_addr, uint16_t *data)
+  \brief       Read Ethernet PHY Register through Management Interface.
+  \param[in]   phy_addr  5-bit device address
+  \param[in]   reg_addr  5-bit register address
+  \param[out]  data      Pointer where the result is written to
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_ETH_MAC_PHY_Write (uint8_t phy_addr, uint8_t reg_addr, uint16_t data)
+  \brief       Write Ethernet PHY Register through Management Interface.
+  \param[in]   phy_addr  5-bit device address
+  \param[in]   reg_addr  5-bit register address
+  \param[in]   data      16-bit data to write
+  \return      \ref execution_status
+*/
+
+/**
+  \fn          void ARM_ETH_MAC_SignalEvent (uint32_t event)
+  \brief       Callback function that signals a Ethernet Event.
+  \param[in]   event  event notification mask
+*/
+
+typedef void (*ARM_ETH_MAC_SignalEvent_t) (uint32_t event);  ///< Pointer to \ref ARM_ETH_MAC_SignalEvent : Signal Ethernet Event.
+
+
+/**
+\brief Ethernet MAC Capabilities
+*/
+typedef struct _ARM_ETH_MAC_CAPABILITIES {
+  uint32_t checksum_offload_rx_ip4  : 1;        ///< 1 = IPv4 header checksum verified on receive
+  uint32_t checksum_offload_rx_ip6  : 1;        ///< 1 = IPv6 checksum verification supported on receive
+  uint32_t checksum_offload_rx_udp  : 1;        ///< 1 = UDP payload checksum verified on receive
+  uint32_t checksum_offload_rx_tcp  : 1;        ///< 1 = TCP payload checksum verified on receive
+  uint32_t checksum_offload_rx_icmp : 1;        ///< 1 = ICMP payload checksum verified on receive
+  uint32_t checksum_offload_tx_ip4  : 1;        ///< 1 = IPv4 header checksum generated on transmit
+  uint32_t checksum_offload_tx_ip6  : 1;        ///< 1 = IPv6 checksum generation supported on transmit
+  uint32_t checksum_offload_tx_udp  : 1;        ///< 1 = UDP payload checksum generated on transmit
+  uint32_t checksum_offload_tx_tcp  : 1;        ///< 1 = TCP payload checksum generated on transmit
+  uint32_t checksum_offload_tx_icmp : 1;        ///< 1 = ICMP payload checksum generated on transmit
+  uint32_t media_interface          : 2;        ///< Ethernet Media Interface type
+  uint32_t mac_address              : 1;        ///< 1 = driver provides initial valid MAC address
+  uint32_t event_rx_frame           : 1;        ///< 1 = callback event \ref ARM_ETH_MAC_EVENT_RX_FRAME generated
+  uint32_t event_tx_frame           : 1;        ///< 1 = callback event \ref ARM_ETH_MAC_EVENT_TX_FRAME generated
+  uint32_t event_wakeup             : 1;        ///< 1 = wakeup event \ref ARM_ETH_MAC_EVENT_WAKEUP generated
+  uint32_t precision_timer          : 1;        ///< 1 = Precision Timer supported
+  uint32_t reserved                 : 15;       ///< Reserved (must be zero)
+} ARM_ETH_MAC_CAPABILITIES;
+
+
+/**
+\brief Access structure of the Ethernet MAC Driver
+*/
+typedef struct _ARM_DRIVER_ETH_MAC {
+  ARM_DRIVER_VERSION       (*GetVersion)      (void);                                                ///< Pointer to \ref ARM_ETH_MAC_GetVersion : Get driver version.
+  ARM_ETH_MAC_CAPABILITIES (*GetCapabilities) (void);                                                ///< Pointer to \ref ARM_ETH_MAC_GetCapabilities : Get driver capabilities.
+  int32_t                  (*Initialize)      (ARM_ETH_MAC_SignalEvent_t cb_event);                  ///< Pointer to \ref ARM_ETH_MAC_Initialize : Initialize Ethernet MAC Device.
+  int32_t                  (*Uninitialize)    (void);                                                ///< Pointer to \ref ARM_ETH_MAC_Uninitialize : De-initialize Ethernet MAC Device.
+  int32_t                  (*PowerControl)    (ARM_POWER_STATE state);                               ///< Pointer to \ref ARM_ETH_MAC_PowerControl : Control Ethernet MAC Device Power.
+  int32_t                  (*GetMacAddress)   (      ARM_ETH_MAC_ADDR *ptr_addr);                    ///< Pointer to \ref ARM_ETH_MAC_GetMacAddress : Get Ethernet MAC Address.
+  int32_t                  (*SetMacAddress)   (const ARM_ETH_MAC_ADDR *ptr_addr);                    ///< Pointer to \ref ARM_ETH_MAC_SetMacAddress : Set Ethernet MAC Address.
+  int32_t                  (*SetAddressFilter)(const ARM_ETH_MAC_ADDR *ptr_addr, uint32_t num_addr); ///< Pointer to \ref ARM_ETH_MAC_SetAddressFilter : Configure Address Filter.
+  int32_t                  (*SendFrame)       (const uint8_t *frame, uint32_t len, uint32_t flags);  ///< Pointer to \ref ARM_ETH_MAC_SendFrame : Send Ethernet frame.
+  int32_t                  (*ReadFrame)       (      uint8_t *frame, uint32_t len);                  ///< Pointer to \ref ARM_ETH_MAC_ReadFrame : Read data of received Ethernet frame.
+  uint32_t                 (*GetRxFrameSize)  (void);                                                ///< Pointer to \ref ARM_ETH_MAC_GetRxFrameSize : Get size of received Ethernet frame.
+  int32_t                  (*GetRxFrameTime)  (ARM_ETH_MAC_TIME *time);                              ///< Pointer to \ref ARM_ETH_MAC_GetRxFrameTime : Get time of received Ethernet frame.
+  int32_t                  (*GetTxFrameTime)  (ARM_ETH_MAC_TIME *time);                              ///< Pointer to \ref ARM_ETH_MAC_GetTxFrameTime : Get time of transmitted Ethernet frame.
+  int32_t                  (*ControlTimer)    (uint32_t control, ARM_ETH_MAC_TIME *time);            ///< Pointer to \ref ARM_ETH_MAC_ControlTimer : Control Precision Timer.
+  int32_t                  (*Control)         (uint32_t control, uint32_t arg);                      ///< Pointer to \ref ARM_ETH_MAC_Control : Control Ethernet Interface.
+  int32_t                  (*PHY_Read)        (uint8_t phy_addr, uint8_t reg_addr, uint16_t *data);  ///< Pointer to \ref ARM_ETH_MAC_PHY_Read : Read Ethernet PHY Register through Management Interface.
+  int32_t                  (*PHY_Write)       (uint8_t phy_addr, uint8_t reg_addr, uint16_t  data);  ///< Pointer to \ref ARM_ETH_MAC_PHY_Write : Write Ethernet PHY Register through Management Interface.
+} const ARM_DRIVER_ETH_MAC;
+
+#ifdef  __cplusplus
+}
+#endif
+
+#endif /* DRIVER_ETH_MAC_H_ */

--- a/platform/ext/cmsis/CMSIS/Driver/Include/Driver_ETH_PHY.h
+++ b/platform/ext/cmsis/CMSIS/Driver/Include/Driver_ETH_PHY.h
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2013-2020 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * $Date:        24. January 2020
+ * $Revision:    V2.2
+ *
+ * Project:      Ethernet PHY (Physical Transceiver) Driver definitions
+ */
+
+/* History:
+ *  Version 2.2
+ *    Removed volatile from ARM_ETH_LINK_INFO
+ *  Version 2.1
+ *    ARM_ETH_LINK_INFO made volatile
+ *  Version 2.0
+ *    changed parameter "mode" in function ARM_ETH_PHY_SetMode
+ *    Changed prefix ARM_DRV -> ARM_DRIVER
+ *    Changed return values of some functions to int32_t
+ *  Version 1.10
+ *    Namespace prefix ARM_ added
+ *  Version 1.00
+ *    Initial release
+ */
+
+#ifndef DRIVER_ETH_PHY_H_
+#define DRIVER_ETH_PHY_H_
+
+#ifdef  __cplusplus
+extern "C"
+{
+#endif
+
+#include "Driver_ETH.h"
+
+#define ARM_ETH_PHY_API_VERSION ARM_DRIVER_VERSION_MAJOR_MINOR(2,2)  /* API version */
+
+
+#define _ARM_Driver_ETH_PHY_(n)      Driver_ETH_PHY##n
+#define  ARM_Driver_ETH_PHY_(n) _ARM_Driver_ETH_PHY_(n)
+
+
+/****** Ethernet PHY Mode *****/
+#define ARM_ETH_PHY_SPEED_Pos            0
+#define ARM_ETH_PHY_SPEED_Msk           (3UL                 << ARM_ETH_PHY_SPEED_Pos)
+#define ARM_ETH_PHY_SPEED_10M           (ARM_ETH_SPEED_10M   << ARM_ETH_PHY_SPEED_Pos)  ///< 10 Mbps link speed
+#define ARM_ETH_PHY_SPEED_100M          (ARM_ETH_SPEED_100M  << ARM_ETH_PHY_SPEED_Pos)  ///< 100 Mbps link speed
+#define ARM_ETH_PHY_SPEED_1G            (ARM_ETH_SPEED_1G    << ARM_ETH_PHY_SPEED_Pos)  ///< 1 Gpbs link speed
+#define ARM_ETH_PHY_DUPLEX_Pos           2
+#define ARM_ETH_PHY_DUPLEX_Msk          (1UL                 << ARM_ETH_PHY_DUPLEX_Pos)
+#define ARM_ETH_PHY_DUPLEX_HALF         (ARM_ETH_DUPLEX_HALF << ARM_ETH_PHY_DUPLEX_Pos) ///< Half duplex link
+#define ARM_ETH_PHY_DUPLEX_FULL         (ARM_ETH_DUPLEX_FULL << ARM_ETH_PHY_DUPLEX_Pos) ///< Full duplex link
+#define ARM_ETH_PHY_AUTO_NEGOTIATE      (1UL << 3)                                      ///< Auto Negotiation mode
+#define ARM_ETH_PHY_LOOPBACK            (1UL << 4)                                      ///< Loop-back test mode
+#define ARM_ETH_PHY_ISOLATE             (1UL << 5)                                      ///< Isolate PHY from MII/RMII interface
+
+
+// Function documentation
+/**
+  \fn          ARM_DRIVER_VERSION ARM_ETH_PHY_GetVersion (void)
+  \brief       Get driver version.
+  \return      \ref ARM_DRIVER_VERSION
+*/
+/**
+  \fn          int32_t ARM_ETH_PHY_Initialize (ARM_ETH_PHY_Read_t  fn_read,
+                                               ARM_ETH_PHY_Write_t fn_write)
+  \brief       Initialize Ethernet PHY Device.
+  \param[in]   fn_read   Pointer to \ref ARM_ETH_MAC_PHY_Read
+  \param[in]   fn_write  Pointer to \ref ARM_ETH_MAC_PHY_Write
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_ETH_PHY_Uninitialize (void)
+  \brief       De-initialize Ethernet PHY Device.
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_ETH_PHY_PowerControl (ARM_POWER_STATE state)
+  \brief       Control Ethernet PHY Device Power.
+  \param[in]   state  Power state
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_ETH_PHY_SetInterface (uint32_t interface)
+  \brief       Set Ethernet Media Interface.
+  \param[in]   interface  Media Interface type
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_ETH_PHY_SetMode (uint32_t mode)
+  \brief       Set Ethernet PHY Device Operation mode.
+  \param[in]   mode  Operation Mode
+  \return      \ref execution_status
+*/
+/**
+  \fn          ARM_ETH_LINK_STATE ARM_ETH_PHY_GetLinkState (void)
+  \brief       Get Ethernet PHY Device Link state.
+  \return      current link status \ref ARM_ETH_LINK_STATE
+*/
+/**
+  \fn          ARM_ETH_LINK_INFO ARM_ETH_PHY_GetLinkInfo (void)
+  \brief       Get Ethernet PHY Device Link information.
+  \return      current link parameters \ref ARM_ETH_LINK_INFO
+*/
+
+
+typedef int32_t (*ARM_ETH_PHY_Read_t)  (uint8_t phy_addr, uint8_t reg_addr, uint16_t *data); ///< Pointer to \ref ARM_ETH_MAC_PHY_Read : Read Ethernet PHY Register.
+typedef int32_t (*ARM_ETH_PHY_Write_t) (uint8_t phy_addr, uint8_t reg_addr, uint16_t  data); ///< Pointer to \ref ARM_ETH_MAC_PHY_Write : Write Ethernet PHY Register.
+
+
+/**
+\brief Access structure of the Ethernet PHY Driver
+*/
+typedef struct _ARM_DRIVER_ETH_PHY {
+  ARM_DRIVER_VERSION (*GetVersion)   (void);                          ///< Pointer to \ref ARM_ETH_PHY_GetVersion : Get driver version.
+  int32_t            (*Initialize)   (ARM_ETH_PHY_Read_t  fn_read,
+                                      ARM_ETH_PHY_Write_t fn_write);  ///< Pointer to \ref ARM_ETH_PHY_Initialize : Initialize PHY Device.
+  int32_t            (*Uninitialize) (void);                          ///< Pointer to \ref ARM_ETH_PHY_Uninitialize : De-initialize PHY Device.
+  int32_t            (*PowerControl) (ARM_POWER_STATE state);         ///< Pointer to \ref ARM_ETH_PHY_PowerControl : Control PHY Device Power.
+  int32_t            (*SetInterface) (uint32_t interface);            ///< Pointer to \ref ARM_ETH_PHY_SetInterface : Set Ethernet Media Interface.
+  int32_t            (*SetMode)      (uint32_t mode);                 ///< Pointer to \ref ARM_ETH_PHY_SetMode : Set Ethernet PHY Device Operation mode.
+  ARM_ETH_LINK_STATE (*GetLinkState) (void);                          ///< Pointer to \ref ARM_ETH_PHY_GetLinkState : Get Ethernet PHY Device Link state.
+  ARM_ETH_LINK_INFO  (*GetLinkInfo)  (void);                          ///< Pointer to \ref ARM_ETH_PHY_GetLinkInfo : Get Ethernet PHY Device Link information.
+} const ARM_DRIVER_ETH_PHY;
+
+#ifdef  __cplusplus
+}
+#endif
+
+#endif /* DRIVER_ETH_PHY_H_ */

--- a/platform/ext/cmsis/CMSIS/Driver/Include/Driver_Flash.h
+++ b/platform/ext/cmsis/CMSIS/Driver/Include/Driver_Flash.h
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2013-2020 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * $Date:        24. January 2020
+ * $Revision:    V2.3
+ *
+ * Project:      Flash Driver definitions
+ */
+
+/* History:
+ *  Version 2.3
+ *    Removed volatile from ARM_FLASH_STATUS
+ *  Version 2.2
+ *    Padding bytes added to ARM_FLASH_INFO
+ *  Version 2.1
+ *    ARM_FLASH_STATUS made volatile
+ *  Version 2.0
+ *    Renamed driver NOR -> Flash (more generic)
+ *    Non-blocking operation
+ *    Added Events, Status and Capabilities
+ *    Linked Flash information (GetInfo)
+ *  Version 1.11
+ *    Changed prefix ARM_DRV -> ARM_DRIVER
+ *  Version 1.10
+ *    Namespace prefix ARM_ added
+ *  Version 1.00
+ *    Initial release
+ */
+
+#ifndef DRIVER_FLASH_H_
+#define DRIVER_FLASH_H_
+
+#ifdef  __cplusplus
+extern "C"
+{
+#endif
+
+#include "Driver_Common.h"
+
+#define ARM_FLASH_API_VERSION ARM_DRIVER_VERSION_MAJOR_MINOR(2,3)  /* API version */
+
+
+#define _ARM_Driver_Flash_(n)      Driver_Flash##n
+#define  ARM_Driver_Flash_(n) _ARM_Driver_Flash_(n)
+
+
+#define ARM_FLASH_SECTOR_INFO(addr,size) { (addr), (addr)+(size)-1 }
+
+/**
+\brief Flash Sector information
+*/
+typedef struct _ARM_FLASH_SECTOR {
+  uint32_t start;                       ///< Sector Start address
+  uint32_t end;                         ///< Sector End address (start+size-1)
+} const ARM_FLASH_SECTOR;
+
+/**
+\brief Flash information
+*/
+typedef struct _ARM_FLASH_INFO {
+  ARM_FLASH_SECTOR *sector_info;        ///< Sector layout information (NULL=Uniform sectors)
+  uint32_t          sector_count;       ///< Number of sectors
+  uint32_t          sector_size;        ///< Uniform sector size in bytes (0=sector_info used) 
+  uint32_t          page_size;          ///< Optimal programming page size in bytes
+  uint32_t          program_unit;       ///< Smallest programmable unit in bytes
+  uint8_t           erased_value;       ///< Contents of erased memory (usually 0xFF)
+  uint8_t           reserved[3];        ///< Reserved (must be zero)
+} const ARM_FLASH_INFO;
+
+
+/**
+\brief Flash Status
+*/
+typedef struct _ARM_FLASH_STATUS {
+  uint32_t busy     : 1;                ///< Flash busy flag
+  uint32_t error    : 1;                ///< Read/Program/Erase error flag (cleared on start of next operation)
+  uint32_t reserved : 30;
+} ARM_FLASH_STATUS;
+
+
+/****** Flash Event *****/
+#define ARM_FLASH_EVENT_READY           (1UL << 0)  ///< Flash Ready
+#define ARM_FLASH_EVENT_ERROR           (1UL << 1)  ///< Read/Program/Erase Error
+
+
+// Function documentation
+/**
+  \fn          ARM_DRIVER_VERSION ARM_Flash_GetVersion (void)
+  \brief       Get driver version.
+  \return      \ref ARM_DRIVER_VERSION
+*/
+/**
+  \fn          ARM_FLASH_CAPABILITIES ARM_Flash_GetCapabilities (void)
+  \brief       Get driver capabilities.
+  \return      \ref ARM_FLASH_CAPABILITIES
+*/
+/**
+  \fn          int32_t ARM_Flash_Initialize (ARM_Flash_SignalEvent_t cb_event)
+  \brief       Initialize the Flash Interface.
+  \param[in]   cb_event  Pointer to \ref ARM_Flash_SignalEvent
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_Flash_Uninitialize (void)
+  \brief       De-initialize the Flash Interface.
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_Flash_PowerControl (ARM_POWER_STATE state)
+  \brief       Control the Flash interface power.
+  \param[in]   state  Power state
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_Flash_ReadData (uint32_t addr, void *data, uint32_t cnt)
+  \brief       Read data from Flash.
+  \param[in]   addr  Data address.
+  \param[out]  data  Pointer to a buffer storing the data read from Flash.
+  \param[in]   cnt   Number of data items to read.
+  \return      number of data items read or \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_Flash_ProgramData (uint32_t addr, const void *data, uint32_t cnt)
+  \brief       Program data to Flash.
+  \param[in]   addr  Data address.
+  \param[in]   data  Pointer to a buffer containing the data to be programmed to Flash.
+  \param[in]   cnt   Number of data items to program.
+  \return      number of data items programmed or \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_Flash_EraseSector (uint32_t addr)
+  \brief       Erase Flash Sector.
+  \param[in]   addr  Sector address
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_Flash_EraseChip (void)
+  \brief       Erase complete Flash.
+               Optional function for faster full chip erase.
+  \return      \ref execution_status
+*/
+/**
+  \fn          ARM_FLASH_STATUS ARM_Flash_GetStatus (void)
+  \brief       Get Flash status.
+  \return      Flash status \ref ARM_FLASH_STATUS
+*/
+/**
+  \fn          ARM_FLASH_INFO * ARM_Flash_GetInfo (void)
+  \brief       Get Flash information.
+  \return      Pointer to Flash information \ref ARM_FLASH_INFO
+*/
+
+/**
+  \fn          void ARM_Flash_SignalEvent (uint32_t event)
+  \brief       Signal Flash event.
+  \param[in]   event  Event notification mask
+*/
+
+typedef void (*ARM_Flash_SignalEvent_t) (uint32_t event);    ///< Pointer to \ref ARM_Flash_SignalEvent : Signal Flash Event.
+
+
+/**
+\brief Flash Driver Capabilities.
+*/
+typedef struct _ARM_FLASH_CAPABILITIES {
+  uint32_t event_ready  : 1;            ///< Signal Flash Ready event
+  uint32_t data_width   : 2;            ///< Data width: 0=8-bit, 1=16-bit, 2=32-bit
+  uint32_t erase_chip   : 1;            ///< Supports EraseChip operation
+  uint32_t reserved     : 28;           ///< Reserved (must be zero)
+} ARM_FLASH_CAPABILITIES;
+
+
+/**
+\brief Access structure of the Flash Driver
+*/
+typedef struct _ARM_DRIVER_FLASH {
+  ARM_DRIVER_VERSION     (*GetVersion)     (void);                                          ///< Pointer to \ref ARM_Flash_GetVersion : Get driver version.
+  ARM_FLASH_CAPABILITIES (*GetCapabilities)(void);                                          ///< Pointer to \ref ARM_Flash_GetCapabilities : Get driver capabilities.
+  int32_t                (*Initialize)     (ARM_Flash_SignalEvent_t cb_event);              ///< Pointer to \ref ARM_Flash_Initialize : Initialize Flash Interface.
+  int32_t                (*Uninitialize)   (void);                                          ///< Pointer to \ref ARM_Flash_Uninitialize : De-initialize Flash Interface.
+  int32_t                (*PowerControl)   (ARM_POWER_STATE state);                         ///< Pointer to \ref ARM_Flash_PowerControl : Control Flash Interface Power.
+  int32_t                (*ReadData)       (uint32_t addr,       void *data, uint32_t cnt); ///< Pointer to \ref ARM_Flash_ReadData : Read data from Flash.
+  int32_t                (*ProgramData)    (uint32_t addr, const void *data, uint32_t cnt); ///< Pointer to \ref ARM_Flash_ProgramData : Program data to Flash.
+  int32_t                (*EraseSector)    (uint32_t addr);                                 ///< Pointer to \ref ARM_Flash_EraseSector : Erase Flash Sector.
+  int32_t                (*EraseChip)      (void);                                          ///< Pointer to \ref ARM_Flash_EraseChip : Erase complete Flash.
+  ARM_FLASH_STATUS       (*GetStatus)      (void);                                          ///< Pointer to \ref ARM_Flash_GetStatus : Get Flash status.
+  ARM_FLASH_INFO *       (*GetInfo)        (void);                                          ///< Pointer to \ref ARM_Flash_GetInfo : Get Flash information.
+} const ARM_DRIVER_FLASH;
+
+#ifdef  __cplusplus
+}
+#endif
+
+#endif /* DRIVER_FLASH_H_ */

--- a/platform/ext/cmsis/CMSIS/Driver/Include/Driver_GPIO.h
+++ b/platform/ext/cmsis/CMSIS/Driver/Include/Driver_GPIO.h
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2023 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * $Date:        2. March 2023
+ * $Revision:    V1.0
+ *
+ * Project:      GPIO (General-purpose Input/Output) Driver definitions
+ */
+
+#ifndef DRIVER_GPIO_H_
+#define DRIVER_GPIO_H_
+
+#ifdef  __cplusplus
+extern "C"
+{
+#endif
+
+#include "Driver_Common.h"
+
+
+/**
+\brief GPIO Pin
+*/
+typedef uint32_t ARM_GPIO_Pin_t;
+
+/**
+\brief GPIO Direction
+*/
+typedef enum {
+  ARM_GPIO_INPUT,                       ///< Input (default)
+  ARM_GPIO_OUTPUT                       ///< Output
+} ARM_GPIO_DIRECTION;
+
+/**
+\brief GPIO Output Mode
+*/
+typedef enum {
+  ARM_GPIO_PUSH_PULL,                   ///< Push-pull (default)
+  ARM_GPIO_OPEN_DRAIN                   ///< Open-drain
+} ARM_GPIO_OUTPUT_MODE;
+
+/**
+\brief GPIO Pull Resistor
+*/
+typedef enum {
+  ARM_GPIO_PULL_NONE,                   ///< None (default)
+  ARM_GPIO_PULL_UP,                     ///< Pull-up
+  ARM_GPIO_PULL_DOWN                    ///< Pull-down
+} ARM_GPIO_PULL_RESISTOR;
+
+/**
+\brief GPIO Event Trigger
+*/
+typedef enum {
+  ARM_GPIO_TRIGGER_NONE,                ///< None (default)
+  ARM_GPIO_TRIGGER_RISING_EDGE,         ///< Rising-edge
+  ARM_GPIO_TRIGGER_FALLING_EDGE,        ///< Falling-edge
+  ARM_GPIO_TRIGGER_EITHER_EDGE          ///< Either edge (rising and falling)
+} ARM_GPIO_EVENT_TRIGGER;
+
+
+/****** GPIO Event *****/
+#define ARM_GPIO_EVENT_RISING_EDGE      (1UL << 0)  ///< Rising-edge detected
+#define ARM_GPIO_EVENT_FALLING_EDGE     (1UL << 1)  ///< Falling-edge detected
+#define ARM_GPIO_EVENT_EITHER_EDGE      (1UL << 2)  ///< Either edge detected (only when hardware cannot distinguish between rising and falling edge)
+
+
+/****** GPIO specific error codes *****/
+#define ARM_GPIO_ERROR_PIN              (ARM_DRIVER_ERROR_SPECIFIC - 1) ///< Specified Pin not available
+
+
+// Function documentation
+/**
+  \fn          int32_t ARM_GPIO_Setup (ARM_GPIO_Pin_t pin, ARM_GPIO_SignalEvent_t cb_event)
+  \brief       Setup GPIO Interface.
+  \param[in]   pin  GPIO Pin
+  \param[in]   cb_event  Pointer to \ref ARM_GPIO_SignalEvent
+  \return      \ref execution_status
+
+  \fn          int32_t ARM_GPIO_SetDirection (ARM_GPIO_Pin_t pin, ARM_GPIO_DIRECTION direction)
+  \brief       Set GPIO Direction.
+  \param[in]   pin  GPIO Pin
+  \param[in]   direction  \ref ARM_GPIO_DIRECTION
+  \return      \ref execution_status
+
+  \fn          int32_t ARM_GPIO_SetOutputMode (ARM_GPIO_Pin_t pin, ARM_GPIO_OUTPUT_MODE mode)
+  \brief       Set GPIO Output Mode.
+  \param[in]   pin  GPIO Pin
+  \param[in]   mode  \ref ARM_GPIO_OUTPUT_MODE
+  \return      \ref execution_status
+
+  \fn          int32_t ARM_GPIO_SetPullResistor (ARM_GPIO_Pin_t pin, ARM_GPIO_PULL_RESISTOR resistor)
+  \brief       Set GPIO Pull Resistor.
+  \param[in]   pin  GPIO Pin
+  \param[in]   resistor  \ref ARM_GPIO_PULL_RESISTOR
+  \return      \ref execution_status
+
+  \fn          int32_t ARM_GPIO_SetEventTrigger (ARM_GPIO_Pin_t pin, ARM_GPIO_EVENT_TRIGGER trigger)
+  \brief       Set GPIO Event Trigger.
+  \param[in]   pin  GPIO Pin
+  \param[in]   trigger  \ref ARM_GPIO_EVENT_TRIGGER
+  \return      \ref execution_status
+
+  \fn          void ARM_GPIO_SetOutput (ARM_GPIO_Pin_t pin, uint32_t val)
+  \brief       Set GPIO Output Level.
+  \param[in]   pin  GPIO Pin
+  \param[in]   val  GPIO Pin Level (0 or 1)
+
+  \fn          uint32_t ARM_GPIO_GetInput (ARM_GPIO_Pin_t pin)
+  \brief       Get GPIO Input Level.
+  \param[in]   pin  GPIO Pin
+  \return      GPIO Pin Level (0 or 1)
+
+  \fn          void ARM_GPIO_SignalEvent (ARM_GPIO_Pin_t pin, uint32_t event)
+  \brief       Signal GPIO Events.
+  \param[in]   pin    GPIO Pin on which event occurred
+  \param[in]   event  \ref GPIO_events notification mask
+*/
+
+typedef void (*ARM_GPIO_SignalEvent_t) (ARM_GPIO_Pin_t pin, uint32_t event);  /* Pointer to \ref ARM_GPIO_SignalEvent : Signal GPIO Event */
+
+
+/**
+\brief Access structure of the GPIO Driver.
+*/
+typedef struct {
+  int32_t  (*Setup)           (ARM_GPIO_Pin_t pin, ARM_GPIO_SignalEvent_t cb_event); ///< Pointer to \ref ARM_GPIO_Setup : Setup GPIO Interface.
+  int32_t  (*SetDirection)    (ARM_GPIO_Pin_t pin, ARM_GPIO_DIRECTION direction);    ///< Pointer to \ref ARM_GPIO_SetDirection : Set GPIO Direction.
+  int32_t  (*SetOutputMode)   (ARM_GPIO_Pin_t pin, ARM_GPIO_OUTPUT_MODE mode);       ///< Pointer to \ref ARM_GPIO_SetOutputMode : Set GPIO Output Mode.
+  int32_t  (*SetPullResistor) (ARM_GPIO_Pin_t pin, ARM_GPIO_PULL_RESISTOR resistor); ///< Pointer to \ref ARM_GPIO_SetPullResistor : Set GPIO Pull Resistor.
+  int32_t  (*SetEventTrigger) (ARM_GPIO_Pin_t pin, ARM_GPIO_EVENT_TRIGGER trigger);  ///< Pointer to \ref ARM_GPIO_SetEventTrigger : Set GPIO Event Trigger.
+  void     (*SetOutput)       (ARM_GPIO_Pin_t pin, uint32_t val);                    ///< Pointer to \ref ARM_GPIO_SetOutput : Set GPIO Output Level.
+  uint32_t (*GetInput)        (ARM_GPIO_Pin_t pin);                                  ///< Pointer to \ref ARM_GPIO_GetInput : Get GPIO Input Level.
+} const ARM_DRIVER_GPIO;
+
+#ifdef  __cplusplus
+}
+#endif
+
+#endif /* DRIVER_GPIO_H_ */

--- a/platform/ext/cmsis/CMSIS/Driver/Include/Driver_I2C.h
+++ b/platform/ext/cmsis/CMSIS/Driver/Include/Driver_I2C.h
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2013-2020 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * $Date:        31. March 2020
+ * $Revision:    V2.4
+ *
+ * Project:      I2C (Inter-Integrated Circuit) Driver definitions
+ */
+
+/* History:
+ *  Version 2.4
+ *    Removed volatile from ARM_I2C_STATUS
+ *  Version 2.3
+ *    ARM_I2C_STATUS made volatile
+ *  Version 2.2
+ *    Removed function ARM_I2C_MasterTransfer in order to simplify drivers
+ *      and added back parameter "xfer_pending" to functions
+ *      ARM_I2C_MasterTransmit and ARM_I2C_MasterReceive
+ *  Version 2.1
+ *    Added function ARM_I2C_MasterTransfer and removed parameter "xfer_pending"
+ *      from functions ARM_I2C_MasterTransmit and ARM_I2C_MasterReceive
+ *    Added function ARM_I2C_GetDataCount
+ *    Removed flag "address_nack" from ARM_I2C_STATUS
+ *    Replaced events ARM_I2C_EVENT_MASTER_DONE and ARM_I2C_EVENT_SLAVE_DONE
+ *      with event ARM_I2C_EVENT_TRANSFER_DONE
+ *    Added event ARM_I2C_EVENT_TRANSFER_INCOMPLETE
+ *    Removed parameter "arg" from function ARM_I2C_SignalEvent
+ *  Version 2.0
+ *    New simplified driver:
+ *      complexity moved to upper layer (especially data handling)
+ *      more unified API for different communication interfaces
+ *    Added:
+ *      Slave Mode
+ *    Changed prefix ARM_DRV -> ARM_DRIVER
+ *  Version 1.10
+ *    Namespace prefix ARM_ added
+ *  Version 1.00
+ *    Initial release
+ */
+
+#ifndef DRIVER_I2C_H_
+#define DRIVER_I2C_H_
+
+#ifdef  __cplusplus
+extern "C"
+{
+#endif
+
+#include "Driver_Common.h"
+
+#define ARM_I2C_API_VERSION ARM_DRIVER_VERSION_MAJOR_MINOR(2,4)  /* API version */
+
+
+#define _ARM_Driver_I2C_(n)      Driver_I2C##n
+#define  ARM_Driver_I2C_(n) _ARM_Driver_I2C_(n)
+
+
+/****** I2C Control Codes *****/
+
+#define ARM_I2C_OWN_ADDRESS             (0x01UL)    ///< Set Own Slave Address; arg = address 
+#define ARM_I2C_BUS_SPEED               (0x02UL)    ///< Set Bus Speed; arg = speed
+#define ARM_I2C_BUS_CLEAR               (0x03UL)    ///< Execute Bus clear: send nine clock pulses
+#define ARM_I2C_ABORT_TRANSFER          (0x04UL)    ///< Abort Master/Slave Transmit/Receive
+
+/*----- I2C Bus Speed -----*/
+#define ARM_I2C_BUS_SPEED_STANDARD      (0x01UL)    ///< Standard Speed (100kHz)
+#define ARM_I2C_BUS_SPEED_FAST          (0x02UL)    ///< Fast Speed     (400kHz)
+#define ARM_I2C_BUS_SPEED_FAST_PLUS     (0x03UL)    ///< Fast+ Speed    (  1MHz)
+#define ARM_I2C_BUS_SPEED_HIGH          (0x04UL)    ///< High Speed     (3.4MHz)
+
+
+/****** I2C Address Flags *****/
+
+#define ARM_I2C_ADDRESS_10BIT           (0x0400UL)  ///< 10-bit address flag
+#define ARM_I2C_ADDRESS_GC              (0x8000UL)  ///< General Call flag
+
+
+/**
+\brief I2C Status
+*/
+typedef struct _ARM_I2C_STATUS {
+  uint32_t busy             : 1;        ///< Busy flag
+  uint32_t mode             : 1;        ///< Mode: 0=Slave, 1=Master
+  uint32_t direction        : 1;        ///< Direction: 0=Transmitter, 1=Receiver
+  uint32_t general_call     : 1;        ///< General Call indication (cleared on start of next Slave operation)
+  uint32_t arbitration_lost : 1;        ///< Master lost arbitration (cleared on start of next Master operation)
+  uint32_t bus_error        : 1;        ///< Bus error detected (cleared on start of next Master/Slave operation)
+  uint32_t reserved         : 26;
+} ARM_I2C_STATUS;
+
+
+/****** I2C Event *****/
+#define ARM_I2C_EVENT_TRANSFER_DONE       (1UL << 0)  ///< Master/Slave Transmit/Receive finished
+#define ARM_I2C_EVENT_TRANSFER_INCOMPLETE (1UL << 1)  ///< Master/Slave Transmit/Receive incomplete transfer
+#define ARM_I2C_EVENT_SLAVE_TRANSMIT      (1UL << 2)  ///< Addressed as Slave Transmitter but transmit operation is not set.
+#define ARM_I2C_EVENT_SLAVE_RECEIVE       (1UL << 3)  ///< Addressed as Slave Receiver but receive operation is not set.
+#define ARM_I2C_EVENT_ADDRESS_NACK        (1UL << 4)  ///< Address not acknowledged from Slave
+#define ARM_I2C_EVENT_GENERAL_CALL        (1UL << 5)  ///< Slave addressed with general call address
+#define ARM_I2C_EVENT_ARBITRATION_LOST    (1UL << 6)  ///< Master lost arbitration
+#define ARM_I2C_EVENT_BUS_ERROR           (1UL << 7)  ///< Bus error detected (START/STOP at illegal position)
+#define ARM_I2C_EVENT_BUS_CLEAR           (1UL << 8)  ///< Bus clear finished
+
+
+// Function documentation
+/**
+  \fn          ARM_DRIVER_VERSION ARM_I2C_GetVersion (void)
+  \brief       Get driver version.
+  \return      \ref ARM_DRIVER_VERSION
+
+  \fn          ARM_I2C_CAPABILITIES ARM_I2C_GetCapabilities (void)
+  \brief       Get driver capabilities.
+  \return      \ref ARM_I2C_CAPABILITIES
+
+  \fn          int32_t ARM_I2C_Initialize (ARM_I2C_SignalEvent_t cb_event)
+  \brief       Initialize I2C Interface.
+  \param[in]   cb_event  Pointer to \ref ARM_I2C_SignalEvent
+  \return      \ref execution_status
+
+  \fn          int32_t ARM_I2C_Uninitialize (void)
+  \brief       De-initialize I2C Interface.
+  \return      \ref execution_status
+
+  \fn          int32_t ARM_I2C_PowerControl (ARM_POWER_STATE state)
+  \brief       Control I2C Interface Power.
+  \param[in]   state  Power state
+  \return      \ref execution_status
+
+  \fn          int32_t ARM_I2C_MasterTransmit (uint32_t addr, const uint8_t *data, uint32_t num, bool xfer_pending)
+  \brief       Start transmitting data as I2C Master.
+  \param[in]   addr          Slave address (7-bit or 10-bit)
+  \param[in]   data          Pointer to buffer with data to transmit to I2C Slave
+  \param[in]   num           Number of data bytes to transmit
+  \param[in]   xfer_pending  Transfer operation is pending - Stop condition will not be generated
+  \return      \ref execution_status
+
+  \fn          int32_t ARM_I2C_MasterReceive (uint32_t addr, uint8_t *data, uint32_t num, bool xfer_pending)
+  \brief       Start receiving data as I2C Master.
+  \param[in]   addr          Slave address (7-bit or 10-bit)
+  \param[out]  data          Pointer to buffer for data to receive from I2C Slave
+  \param[in]   num           Number of data bytes to receive
+  \param[in]   xfer_pending  Transfer operation is pending - Stop condition will not be generated
+  \return      \ref execution_status
+
+  \fn          int32_t ARM_I2C_SlaveTransmit (const uint8_t *data, uint32_t num)
+  \brief       Start transmitting data as I2C Slave.
+  \param[in]   data  Pointer to buffer with data to transmit to I2C Master
+  \param[in]   num   Number of data bytes to transmit
+  \return      \ref execution_status
+
+  \fn          int32_t ARM_I2C_SlaveReceive (uint8_t *data, uint32_t num)
+  \brief       Start receiving data as I2C Slave.
+  \param[out]  data  Pointer to buffer for data to receive from I2C Master
+  \param[in]   num   Number of data bytes to receive
+  \return      \ref execution_status
+
+  \fn          int32_t ARM_I2C_GetDataCount (void)
+  \brief       Get transferred data count.
+  \return      number of data bytes transferred; -1 when Slave is not addressed by Master
+
+  \fn          int32_t ARM_I2C_Control (uint32_t control, uint32_t arg)
+  \brief       Control I2C Interface.
+  \param[in]   control  Operation
+  \param[in]   arg      Argument of operation (optional)
+  \return      \ref execution_status
+
+  \fn          ARM_I2C_STATUS ARM_I2C_GetStatus (void)
+  \brief       Get I2C status.
+  \return      I2C status \ref ARM_I2C_STATUS
+
+  \fn          void ARM_I2C_SignalEvent (uint32_t event)
+  \brief       Signal I2C Events.
+  \param[in]   event  \ref I2C_events notification mask
+*/
+
+typedef void (*ARM_I2C_SignalEvent_t) (uint32_t event);  ///< Pointer to \ref ARM_I2C_SignalEvent : Signal I2C Event.
+
+
+/**
+\brief I2C Driver Capabilities.
+*/
+typedef struct _ARM_I2C_CAPABILITIES {
+  uint32_t address_10_bit : 1;          ///< supports 10-bit addressing
+  uint32_t reserved       : 31;         ///< Reserved (must be zero)
+} ARM_I2C_CAPABILITIES;
+
+
+/**
+\brief Access structure of the I2C Driver.
+*/
+typedef struct _ARM_DRIVER_I2C {
+  ARM_DRIVER_VERSION   (*GetVersion)     (void);                                                                ///< Pointer to \ref ARM_I2C_GetVersion : Get driver version.
+  ARM_I2C_CAPABILITIES (*GetCapabilities)(void);                                                                ///< Pointer to \ref ARM_I2C_GetCapabilities : Get driver capabilities.
+  int32_t              (*Initialize)     (ARM_I2C_SignalEvent_t cb_event);                                      ///< Pointer to \ref ARM_I2C_Initialize : Initialize I2C Interface.
+  int32_t              (*Uninitialize)   (void);                                                                ///< Pointer to \ref ARM_I2C_Uninitialize : De-initialize I2C Interface.
+  int32_t              (*PowerControl)   (ARM_POWER_STATE state);                                               ///< Pointer to \ref ARM_I2C_PowerControl : Control I2C Interface Power.
+  int32_t              (*MasterTransmit) (uint32_t addr, const uint8_t *data, uint32_t num, bool xfer_pending); ///< Pointer to \ref ARM_I2C_MasterTransmit : Start transmitting data as I2C Master.
+  int32_t              (*MasterReceive)  (uint32_t addr,       uint8_t *data, uint32_t num, bool xfer_pending); ///< Pointer to \ref ARM_I2C_MasterReceive : Start receiving data as I2C Master.
+  int32_t              (*SlaveTransmit)  (               const uint8_t *data, uint32_t num);                    ///< Pointer to \ref ARM_I2C_SlaveTransmit : Start transmitting data as I2C Slave.
+  int32_t              (*SlaveReceive)   (                     uint8_t *data, uint32_t num);                    ///< Pointer to \ref ARM_I2C_SlaveReceive : Start receiving data as I2C Slave.
+  int32_t              (*GetDataCount)   (void);                                                                ///< Pointer to \ref ARM_I2C_GetDataCount : Get transferred data count.
+  int32_t              (*Control)        (uint32_t control, uint32_t arg);                                      ///< Pointer to \ref ARM_I2C_Control : Control I2C Interface.
+  ARM_I2C_STATUS       (*GetStatus)      (void);                                                                ///< Pointer to \ref ARM_I2C_GetStatus : Get I2C status.
+} const ARM_DRIVER_I2C;
+
+#ifdef  __cplusplus
+}
+#endif
+
+#endif /* DRIVER_I2C_H_ */

--- a/platform/ext/cmsis/CMSIS/Driver/Include/Driver_MCI.h
+++ b/platform/ext/cmsis/CMSIS/Driver/Include/Driver_MCI.h
@@ -1,0 +1,365 @@
+/*
+ * Copyright (c) 2013-2020 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * $Date:        31. March 2020
+ * $Revision:    V2.4
+ *
+ * Project:      MCI (Memory Card Interface) Driver definitions
+ */
+
+/* History:
+ *  Version 2.4
+ *    Removed volatile from ARM_MCI_STATUS
+ *  Version 2.3
+ *    ARM_MCI_STATUS made volatile
+ *  Version 2.2
+ *    Added timeout and error flags to ARM_MCI_STATUS
+ *    Added support for controlling optional RST_n pin (eMMC)
+ *    Removed explicit Clock Control (ARM_MCI_CONTROL_CLOCK)
+ *    Removed event ARM_MCI_EVENT_BOOT_ACK_TIMEOUT
+ *  Version 2.1
+ *    Decoupled SPI mode from MCI driver
+ *    Replaced function ARM_MCI_CardSwitchRead with ARM_MCI_ReadCD and ARM_MCI_ReadWP
+ *  Version 2.0
+ *    Added support for:
+ *      SD UHS-I (Ultra High Speed)
+ *      SD I/O Interrupt
+ *      Read Wait (SD I/O)
+ *      Suspend/Resume (SD I/O)
+ *      MMC Interrupt
+ *      MMC Boot
+ *      Stream Data transfer (MMC)
+ *      VCCQ Power Supply Control (eMMC)
+ *      Command Completion Signal (CCS) for CE-ATA
+ *    Added ARM_MCI_Control function
+ *    Added ARM_MCI_GetStatus function
+ *    Removed ARM_MCI_BusMode, ARM_MCI_BusDataWidth, ARM_MCI_BusSingaling functions
+ *      (replaced by ARM_MCI_Control)
+ *    Changed ARM_MCI_CardPower function (voltage parameter)
+ *    Changed ARM_MCI_SendCommnad function (flags parameter)
+ *    Changed ARM_MCI_SetupTransfer function (mode parameter)
+ *    Removed ARM_MCI_ReadTransfer and ARM_MCI_WriteTransfer functions
+ *    Changed prefix ARM_DRV -> ARM_DRIVER
+ *    Changed return values of some functions to int32_t
+ *  Version 1.10
+ *    Namespace prefix ARM_ added
+ *  Version 1.00
+ *    Initial release
+ */
+
+#ifndef DRIVER_MCI_H_
+#define DRIVER_MCI_H_
+
+#ifdef  __cplusplus
+extern "C"
+{
+#endif
+
+#include "Driver_Common.h"
+
+#define ARM_MCI_API_VERSION ARM_DRIVER_VERSION_MAJOR_MINOR(2,4)  /* API version */
+
+
+#define _ARM_Driver_MCI_(n)      Driver_MCI##n
+#define  ARM_Driver_MCI_(n) _ARM_Driver_MCI_(n)
+
+
+/****** MCI Send Command Flags *****/
+#define ARM_MCI_RESPONSE_Pos             0
+#define ARM_MCI_RESPONSE_Msk            (3UL << ARM_MCI_RESPONSE_Pos)
+#define ARM_MCI_RESPONSE_NONE           (0UL << ARM_MCI_RESPONSE_Pos)   ///< No response expected (default)
+#define ARM_MCI_RESPONSE_SHORT          (1UL << ARM_MCI_RESPONSE_Pos)   ///< Short response (48-bit)
+#define ARM_MCI_RESPONSE_SHORT_BUSY     (2UL << ARM_MCI_RESPONSE_Pos)   ///< Short response with busy signal (48-bit)
+#define ARM_MCI_RESPONSE_LONG           (3UL << ARM_MCI_RESPONSE_Pos)   ///< Long response (136-bit)
+
+#define ARM_MCI_RESPONSE_INDEX          (1UL << 2)  ///< Check command index in response
+#define ARM_MCI_RESPONSE_CRC            (1UL << 3)  ///< Check CRC in response
+
+#define ARM_MCI_WAIT_BUSY               (1UL << 4)  ///< Wait until busy before sending the command
+
+#define ARM_MCI_TRANSFER_DATA           (1UL << 5)  ///< Activate Data transfer
+
+#define ARM_MCI_CARD_INITIALIZE         (1UL << 6)  ///< Execute Memory Card initialization sequence
+
+#define ARM_MCI_INTERRUPT_COMMAND       (1UL << 7)  ///< Send Interrupt command (CMD40 - MMC only)
+#define ARM_MCI_INTERRUPT_RESPONSE      (1UL << 8)  ///< Send Interrupt response (CMD40 - MMC only)
+
+#define ARM_MCI_BOOT_OPERATION          (1UL << 9)  ///< Execute Boot operation (MMC only)
+#define ARM_MCI_BOOT_ALTERNATIVE        (1UL << 10) ///< Execute Alternative Boot operation (MMC only)
+#define ARM_MCI_BOOT_ACK                (1UL << 11) ///< Expect Boot Acknowledge (MMC only)
+
+#define ARM_MCI_CCSD                    (1UL << 12) ///< Send Command Completion Signal Disable (CCSD) for CE-ATA device
+#define ARM_MCI_CCS                     (1UL << 13) ///< Expect Command Completion Signal (CCS) for CE-ATA device
+
+
+/****** MCI Setup Transfer Mode *****/
+#define ARM_MCI_TRANSFER_READ           (0UL << 0)  ///< Data Read Transfer (from MCI)
+#define ARM_MCI_TRANSFER_WRITE          (1UL << 0)  ///< Data Write Transfer (to MCI)
+#define ARM_MCI_TRANSFER_BLOCK          (0UL << 1)  ///< Block Data transfer (default)
+#define ARM_MCI_TRANSFER_STREAM         (1UL << 1)  ///< Stream Data transfer (MMC only)
+
+
+/****** MCI Control Codes *****/
+#define ARM_MCI_BUS_SPEED               (0x01UL)    ///< Set Bus Speed; arg = requested speed in bits/s; returns configured speed in bits/s
+#define ARM_MCI_BUS_SPEED_MODE          (0x02UL)    ///< Set Bus Speed Mode as specified with arg
+#define ARM_MCI_BUS_CMD_MODE            (0x03UL)    ///< Set CMD Line Mode as specified with arg
+#define ARM_MCI_BUS_DATA_WIDTH          (0x04UL)    ///< Set Bus Data Width as specified with arg
+#define ARM_MCI_DRIVER_STRENGTH         (0x05UL)    ///< Set SD UHS-I Driver Strength as specified with arg 
+#define ARM_MCI_CONTROL_RESET           (0x06UL)    ///< Control optional RST_n Pin (eMMC); arg: 0=inactive, 1=active 
+#define ARM_MCI_CONTROL_CLOCK_IDLE      (0x07UL)    ///< Control Clock generation on CLK Pin when idle; arg: 0=disabled, 1=enabled
+#define ARM_MCI_UHS_TUNING_OPERATION    (0x08UL)    ///< Sampling clock Tuning operation (SD UHS-I); arg: 0=reset, 1=execute
+#define ARM_MCI_UHS_TUNING_RESULT       (0x09UL)    ///< Sampling clock Tuning result (SD UHS-I); returns: 0=done, 1=in progress, -1=error
+#define ARM_MCI_DATA_TIMEOUT            (0x0AUL)    ///< Set Data timeout; arg = timeout in bus cycles
+#define ARM_MCI_CSS_TIMEOUT             (0x0BUL)    ///< Set Command Completion Signal (CCS) timeout; arg = timeout in bus cycles
+#define ARM_MCI_MONITOR_SDIO_INTERRUPT  (0x0CUL)    ///< Monitor SD I/O interrupt: arg: 0=disabled, 1=enabled
+#define ARM_MCI_CONTROL_READ_WAIT       (0x0DUL)    ///< Control Read/Wait for SD I/O; arg: 0=disabled, 1=enabled
+#define ARM_MCI_SUSPEND_TRANSFER        (0x0EUL)    ///< Suspend Data transfer (SD I/O); returns number of remaining bytes to transfer
+#define ARM_MCI_RESUME_TRANSFER         (0x0FUL)    ///< Resume Data transfer (SD I/O)
+
+/*----- MCI Bus Speed Mode -----*/
+#define ARM_MCI_BUS_DEFAULT_SPEED       (0x00UL)    ///< SD/MMC: Default Speed mode up to 25/26MHz
+#define ARM_MCI_BUS_HIGH_SPEED          (0x01UL)    ///< SD/MMC: High    Speed mode up to 50/52MHz
+#define ARM_MCI_BUS_UHS_SDR12           (0x02UL)    ///< SD: SDR12  (Single Data Rate) up to  25MHz,  12.5MB/s: UHS-I (Ultra High Speed) 1.8V signaling
+#define ARM_MCI_BUS_UHS_SDR25           (0x03UL)    ///< SD: SDR25  (Single Data Rate) up to  50MHz,  25  MB/s: UHS-I (Ultra High Speed) 1.8V signaling
+#define ARM_MCI_BUS_UHS_SDR50           (0x04UL)    ///< SD: SDR50  (Single Data Rate) up to 100MHz,  50  MB/s: UHS-I (Ultra High Speed) 1.8V signaling
+#define ARM_MCI_BUS_UHS_SDR104          (0x05UL)    ///< SD: SDR104 (Single Data Rate) up to 208MHz, 104  MB/s: UHS-I (Ultra High Speed) 1.8V signaling
+#define ARM_MCI_BUS_UHS_DDR50           (0x06UL)    ///< SD: DDR50  (Dual Data Rate)   up to  50MHz,  50  MB/s: UHS-I (Ultra High Speed) 1.8V signaling
+
+/*----- MCI CMD Line Mode -----*/
+#define ARM_MCI_BUS_CMD_PUSH_PULL       (0x00UL)    ///< Push-Pull CMD line (default)
+#define ARM_MCI_BUS_CMD_OPEN_DRAIN      (0x01UL)    ///< Open Drain CMD line (MMC only)
+
+/*----- MCI Bus Data Width -----*/
+#define ARM_MCI_BUS_DATA_WIDTH_1        (0x00UL)    ///< Bus data width: 1 bit (default)
+#define ARM_MCI_BUS_DATA_WIDTH_4        (0x01UL)    ///< Bus data width: 4 bits
+#define ARM_MCI_BUS_DATA_WIDTH_8        (0x02UL)    ///< Bus data width: 8 bits
+#define ARM_MCI_BUS_DATA_WIDTH_4_DDR    (0x03UL)    ///< Bus data width: 4 bits, DDR (Dual Data Rate) - MMC only
+#define ARM_MCI_BUS_DATA_WIDTH_8_DDR    (0x04UL)    ///< Bus data width: 8 bits, DDR (Dual Data Rate) - MMC only
+
+/*----- MCI Driver Strength -----*/
+#define ARM_MCI_DRIVER_TYPE_A           (0x01UL)    ///< SD UHS-I Driver Type A
+#define ARM_MCI_DRIVER_TYPE_B           (0x00UL)    ///< SD UHS-I Driver Type B (default)
+#define ARM_MCI_DRIVER_TYPE_C           (0x02UL)    ///< SD UHS-I Driver Type C
+#define ARM_MCI_DRIVER_TYPE_D           (0x03UL)    ///< SD UHS-I Driver Type D
+
+
+/****** MCI Card Power *****/
+#define ARM_MCI_POWER_VDD_Pos            0
+#define ARM_MCI_POWER_VDD_Msk           (0x0FUL << ARM_MCI_POWER_VDD_Pos)
+#define ARM_MCI_POWER_VDD_OFF           (0x01UL << ARM_MCI_POWER_VDD_Pos)   ///< VDD (VCC) turned off
+#define ARM_MCI_POWER_VDD_3V3           (0x02UL << ARM_MCI_POWER_VDD_Pos)   ///< VDD (VCC) = 3.3V
+#define ARM_MCI_POWER_VDD_1V8           (0x03UL << ARM_MCI_POWER_VDD_Pos)   ///< VDD (VCC) = 1.8V
+#define ARM_MCI_POWER_VCCQ_Pos           4
+#define ARM_MCI_POWER_VCCQ_Msk          (0x0FUL << ARM_MCI_POWER_VCCQ_Pos)
+#define ARM_MCI_POWER_VCCQ_OFF          (0x01UL << ARM_MCI_POWER_VCCQ_Pos)  ///< eMMC VCCQ turned off
+#define ARM_MCI_POWER_VCCQ_3V3          (0x02UL << ARM_MCI_POWER_VCCQ_Pos)  ///< eMMC VCCQ = 3.3V
+#define ARM_MCI_POWER_VCCQ_1V8          (0x03UL << ARM_MCI_POWER_VCCQ_Pos)  ///< eMMC VCCQ = 1.8V
+#define ARM_MCI_POWER_VCCQ_1V2          (0x04UL << ARM_MCI_POWER_VCCQ_Pos)  ///< eMMC VCCQ = 1.2V
+
+
+/**
+\brief MCI Status
+*/
+typedef struct _ARM_MCI_STATUS {
+  uint32_t command_active   : 1;        ///< Command active flag
+  uint32_t command_timeout  : 1;        ///< Command timeout flag (cleared on start of next command)
+  uint32_t command_error    : 1;        ///< Command error flag (cleared on start of next command)
+  uint32_t transfer_active  : 1;        ///< Transfer active flag
+  uint32_t transfer_timeout : 1;        ///< Transfer timeout flag (cleared on start of next command)
+  uint32_t transfer_error   : 1;        ///< Transfer error flag (cleared on start of next command)
+  uint32_t sdio_interrupt   : 1;        ///< SD I/O Interrupt flag (cleared on start of monitoring)
+  uint32_t ccs              : 1;        ///< CCS flag (cleared on start of next command)
+  uint32_t reserved         : 24;
+} ARM_MCI_STATUS;
+
+
+/****** MCI Card Event *****/
+#define ARM_MCI_EVENT_CARD_INSERTED     (1UL << 0)  ///< Memory Card inserted
+#define ARM_MCI_EVENT_CARD_REMOVED      (1UL << 1)  ///< Memory Card removed
+#define ARM_MCI_EVENT_COMMAND_COMPLETE  (1UL << 2)  ///< Command completed
+#define ARM_MCI_EVENT_COMMAND_TIMEOUT   (1UL << 3)  ///< Command timeout
+#define ARM_MCI_EVENT_COMMAND_ERROR     (1UL << 4)  ///< Command response error (CRC error or invalid response)
+#define ARM_MCI_EVENT_TRANSFER_COMPLETE (1UL << 5)  ///< Data transfer completed
+#define ARM_MCI_EVENT_TRANSFER_TIMEOUT  (1UL << 6)  ///< Data transfer timeout
+#define ARM_MCI_EVENT_TRANSFER_ERROR    (1UL << 7)  ///< Data transfer CRC failed
+#define ARM_MCI_EVENT_SDIO_INTERRUPT    (1UL << 8)  ///< SD I/O Interrupt
+#define ARM_MCI_EVENT_CCS               (1UL << 9)  ///< Command Completion Signal (CCS)
+#define ARM_MCI_EVENT_CCS_TIMEOUT       (1UL << 10) ///< Command Completion Signal (CCS) Timeout
+
+
+// Function documentation
+/**
+  \fn            ARM_DRIVER_VERSION ARM_MCI_GetVersion (void)
+  \brief         Get driver version.
+  \return        \ref ARM_DRIVER_VERSION
+*/
+/**
+  \fn            ARM_MCI_CAPABILITIES ARM_MCI_GetCapabilities (void)
+  \brief         Get driver capabilities.
+  \return        \ref ARM_MCI_CAPABILITIES
+*/
+/**
+  \fn            int32_t ARM_MCI_Initialize (ARM_MCI_SignalEvent_t cb_event)
+  \brief         Initialize the Memory Card Interface
+  \param[in]     cb_event  Pointer to \ref ARM_MCI_SignalEvent
+  \return        \ref execution_status
+*/
+/**
+  \fn            int32_t ARM_MCI_Uninitialize (void)
+  \brief         De-initialize Memory Card Interface.
+  \return        \ref execution_status
+*/
+/**
+  \fn            int32_t ARM_MCI_PowerControl (ARM_POWER_STATE state)
+  \brief         Control Memory Card Interface Power.
+  \param[in]     state   Power state \ref ARM_POWER_STATE
+  \return        \ref execution_status
+*/
+/**
+  \fn            int32_t ARM_MCI_CardPower (uint32_t voltage)
+  \brief         Set Memory Card Power supply voltage.
+  \param[in]     voltage  Memory Card Power supply voltage
+  \return        \ref execution_status
+*/
+/**
+  \fn            int32_t ARM_MCI_ReadCD (void)
+  \brief         Read Card Detect (CD) state.
+  \return        1:card detected, 0:card not detected, or error
+*/
+/**
+  \fn            int32_t ARM_MCI_ReadWP (void)
+  \brief         Read Write Protect (WP) state.
+  \return        1:write protected, 0:not write protected, or error
+*/
+/**
+  \fn            int32_t ARM_MCI_SendCommand (uint32_t  cmd,
+                                              uint32_t  arg,
+                                              uint32_t  flags,
+                                              uint32_t *response)
+  \brief         Send Command to card and get the response.
+  \param[in]     cmd       Memory Card command
+  \param[in]     arg       Command argument
+  \param[in]     flags     Command flags
+  \param[out]    response  Pointer to buffer for response
+  \return        \ref execution_status
+*/
+/**
+  \fn            int32_t ARM_MCI_SetupTransfer (uint8_t *data,
+                                                uint32_t block_count,
+                                                uint32_t block_size,
+                                                uint32_t mode)
+  \brief         Setup read or write transfer operation.
+  \param[in,out] data         Pointer to data block(s) to be written or read
+  \param[in]     block_count  Number of blocks
+  \param[in]     block_size   Size of a block in bytes
+  \param[in]     mode         Transfer mode
+  \return        \ref execution_status
+*/
+/**
+  \fn            int32_t ARM_MCI_AbortTransfer (void)
+  \brief         Abort current read/write data transfer.
+  \return        \ref execution_status
+*/
+/**
+  \fn            int32_t ARM_MCI_Control (uint32_t control, uint32_t arg)
+  \brief         Control MCI Interface.
+  \param[in]     control  Operation
+  \param[in]     arg      Argument of operation (optional)
+  \return        \ref execution_status
+*/
+/**
+  \fn            ARM_MCI_STATUS ARM_MCI_GetStatus (void)
+  \brief         Get MCI status.
+  \return        MCI status \ref ARM_MCI_STATUS
+*/
+
+/**
+  \fn            void ARM_MCI_SignalEvent (uint32_t event)
+  \brief         Callback function that signals a MCI Card Event.
+  \param[in]     event \ref mci_event_gr
+*/
+
+typedef void (*ARM_MCI_SignalEvent_t) (uint32_t event);  ///< Pointer to \ref ARM_MCI_SignalEvent : Signal MCI Card Event.
+
+
+/**
+\brief  MCI Driver Capabilities.
+*/
+typedef struct _ARM_MCI_CAPABILITIES {
+  uint32_t cd_state          : 1;       ///< Card Detect State available
+  uint32_t cd_event          : 1;       ///< Signal Card Detect change event
+  uint32_t wp_state          : 1;       ///< Write Protect State available
+  uint32_t vdd               : 1;       ///< Supports VDD Card Power Supply Control
+  uint32_t vdd_1v8           : 1;       ///< Supports 1.8 VDD Card Power Supply
+  uint32_t vccq              : 1;       ///< Supports VCCQ Card Power Supply Control (eMMC)
+  uint32_t vccq_1v8          : 1;       ///< Supports 1.8 VCCQ Card Power Supply (eMMC)
+  uint32_t vccq_1v2          : 1;       ///< Supports 1.2 VCCQ Card Power Supply (eMMC)
+  uint32_t data_width_4      : 1;       ///< Supports 4-bit data
+  uint32_t data_width_8      : 1;       ///< Supports 8-bit data
+  uint32_t data_width_4_ddr  : 1;       ///< Supports 4-bit data, DDR (Dual Data Rate) - MMC only
+  uint32_t data_width_8_ddr  : 1;       ///< Supports 8-bit data, DDR (Dual Data Rate) - MMC only
+  uint32_t high_speed        : 1;       ///< Supports SD/MMC High Speed Mode
+  uint32_t uhs_signaling     : 1;       ///< Supports SD UHS-I (Ultra High Speed) 1.8V signaling 
+  uint32_t uhs_tuning        : 1;       ///< Supports SD UHS-I tuning 
+  uint32_t uhs_sdr50         : 1;       ///< Supports SD UHS-I SDR50  (Single Data Rate) up to  50MB/s
+  uint32_t uhs_sdr104        : 1;       ///< Supports SD UHS-I SDR104 (Single Data Rate) up to 104MB/s
+  uint32_t uhs_ddr50         : 1;       ///< Supports SD UHS-I DDR50  (Dual   Data Rate) up to  50MB/s
+  uint32_t uhs_driver_type_a : 1;       ///< Supports SD UHS-I Driver Type A
+  uint32_t uhs_driver_type_c : 1;       ///< Supports SD UHS-I Driver Type C
+  uint32_t uhs_driver_type_d : 1;       ///< Supports SD UHS-I Driver Type D 
+  uint32_t sdio_interrupt    : 1;       ///< Supports SD I/O Interrupt 
+  uint32_t read_wait         : 1;       ///< Supports Read Wait (SD I/O)
+  uint32_t suspend_resume    : 1;       ///< Supports Suspend/Resume (SD I/O)
+  uint32_t mmc_interrupt     : 1;       ///< Supports MMC Interrupt 
+  uint32_t mmc_boot          : 1;       ///< Supports MMC Boot 
+  uint32_t rst_n             : 1;       ///< Supports RST_n Pin Control (eMMC)
+  uint32_t ccs               : 1;       ///< Supports Command Completion Signal (CCS) for CE-ATA
+  uint32_t ccs_timeout       : 1;       ///< Supports Command Completion Signal (CCS) timeout for CE-ATA
+  uint32_t reserved          : 3;       ///< Reserved (must be zero)
+} ARM_MCI_CAPABILITIES;
+
+
+/**
+\brief  Access structure of the MCI Driver.
+*/
+typedef struct _ARM_DRIVER_MCI {
+  ARM_DRIVER_VERSION   (*GetVersion)     (void);                           ///< Pointer to \ref ARM_MCI_GetVersion : Get driver version.
+  ARM_MCI_CAPABILITIES (*GetCapabilities)(void);                           ///< Pointer to \ref ARM_MCI_GetCapabilities : Get driver capabilities.
+  int32_t              (*Initialize)     (ARM_MCI_SignalEvent_t cb_event); ///< Pointer to \ref ARM_MCI_Initialize : Initialize MCI Interface.
+  int32_t              (*Uninitialize)   (void);                           ///< Pointer to \ref ARM_MCI_Uninitialize : De-initialize MCI Interface.
+  int32_t              (*PowerControl)   (ARM_POWER_STATE state);          ///< Pointer to \ref ARM_MCI_PowerControl : Control MCI Interface Power.
+  int32_t              (*CardPower)      (uint32_t voltage);               ///< Pointer to \ref ARM_MCI_CardPower : Set card power supply voltage.
+  int32_t              (*ReadCD)         (void);                           ///< Pointer to \ref ARM_MCI_ReadCD : Read Card Detect (CD) state.
+  int32_t              (*ReadWP)         (void);                           ///< Pointer to \ref ARM_MCI_ReadWP : Read Write Protect (WP) state.
+  int32_t              (*SendCommand)    (uint32_t cmd, 
+                                          uint32_t arg, 
+                                          uint32_t flags,
+                                          uint32_t *response);             ///< Pointer to \ref ARM_MCI_SendCommand : Send Command to card and get the response.
+  int32_t              (*SetupTransfer)  (uint8_t *data,
+                                          uint32_t block_count,
+                                          uint32_t block_size,
+                                          uint32_t mode);                  ///< Pointer to \ref ARM_MCI_SetupTransfer : Setup data transfer operation.
+  int32_t              (*AbortTransfer)  (void);                           ///< Pointer to \ref ARM_MCI_AbortTransfer : Abort current data transfer.
+  int32_t              (*Control)        (uint32_t control, uint32_t arg); ///< Pointer to \ref ARM_MCI_Control : Control MCI Interface.
+  ARM_MCI_STATUS       (*GetStatus)      (void);                           ///< Pointer to \ref ARM_MCI_GetStatus : Get MCI status.
+} const ARM_DRIVER_MCI;
+
+#ifdef  __cplusplus
+}
+#endif
+
+#endif /* DRIVER_MCI_H_ */

--- a/platform/ext/cmsis/CMSIS/Driver/Include/Driver_NAND.h
+++ b/platform/ext/cmsis/CMSIS/Driver/Include/Driver_NAND.h
@@ -1,0 +1,425 @@
+/*
+ * Copyright (c) 2013-2020 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * $Date:        31. March 2020
+ * $Revision:    V2.4
+ *
+ * Project:      NAND Flash Driver definitions
+ */
+
+/* History:
+ *  Version 2.4
+ *    Removed volatile from ARM_NAND_STATUS
+ *  Version 2.3
+ *    Extended ARM_NAND_ECC_INFO structure
+ *  Version 2.2
+ *    ARM_NAND_STATUS made volatile
+ *  Version 2.1
+ *    Updated ARM_NAND_ECC_INFO structure and ARM_NAND_ECC_xxx definitions
+ *  Version 2.0
+ *    New simplified driver:
+ *      complexity moved to upper layer (command agnostic)
+ *    Added support for:
+ *      NV-DDR & NV-DDR2 Interface (ONFI specification)
+ *      VCC, VCCQ and VPP Power Supply Control
+ *      WP (Write Protect) Control
+ *  Version 1.11
+ *    Changed prefix ARM_DRV -> ARM_DRIVER
+ *  Version 1.10
+ *    Namespace prefix ARM_ added
+ *  Version 1.00
+ *    Initial release
+ */
+
+#ifndef DRIVER_NAND_H_
+#define DRIVER_NAND_H_
+
+#ifdef  __cplusplus
+extern "C"
+{
+#endif
+
+#include "Driver_Common.h"
+
+#define ARM_NAND_API_VERSION ARM_DRIVER_VERSION_MAJOR_MINOR(2,4)  /* API version */
+
+
+#define _ARM_Driver_NAND_(n)      Driver_NAND##n
+#define  ARM_Driver_NAND_(n) _ARM_Driver_NAND_(n)
+
+
+/****** NAND Device Power *****/
+#define ARM_NAND_POWER_VCC_Pos           0
+#define ARM_NAND_POWER_VCC_Msk          (0x07UL << ARM_NAND_POWER_VCC_Pos)
+#define ARM_NAND_POWER_VCC_OFF          (0x01UL << ARM_NAND_POWER_VCC_Pos)  ///< VCC Power off
+#define ARM_NAND_POWER_VCC_3V3          (0x02UL << ARM_NAND_POWER_VCC_Pos)  ///< VCC = 3.3V
+#define ARM_NAND_POWER_VCC_1V8          (0x03UL << ARM_NAND_POWER_VCC_Pos)  ///< VCC = 1.8V
+#define ARM_NAND_POWER_VCCQ_Pos          3
+#define ARM_NAND_POWER_VCCQ_Msk         (0x07UL << ARM_NAND_POWER_VCCQ_Pos)
+#define ARM_NAND_POWER_VCCQ_OFF         (0x01UL << ARM_NAND_POWER_VCCQ_Pos) ///< VCCQ I/O Power off
+#define ARM_NAND_POWER_VCCQ_3V3         (0x02UL << ARM_NAND_POWER_VCCQ_Pos) ///< VCCQ = 3.3V
+#define ARM_NAND_POWER_VCCQ_1V8         (0x03UL << ARM_NAND_POWER_VCCQ_Pos) ///< VCCQ = 1.8V
+#define ARM_NAND_POWER_VPP_OFF          (1UL << 6)                          ///< VPP off
+#define ARM_NAND_POWER_VPP_ON           (1UL << 7)                          ///< VPP on
+
+
+/****** NAND Control Codes *****/
+#define ARM_NAND_BUS_MODE               (0x01UL)    ///< Set Bus Mode as specified with arg
+#define ARM_NAND_BUS_DATA_WIDTH         (0x02UL)    ///< Set Bus Data Width as specified with arg
+#define ARM_NAND_DRIVER_STRENGTH        (0x03UL)    ///< Set Driver Strength as specified with arg
+#define ARM_NAND_DEVICE_READY_EVENT     (0x04UL)    ///< Generate \ref ARM_NAND_EVENT_DEVICE_READY; arg: 0=disabled (default), 1=enabled 
+#define ARM_NAND_DRIVER_READY_EVENT     (0x05UL)    ///< Generate \ref ARM_NAND_EVENT_DRIVER_READY; arg: 0=disabled (default), 1=enabled 
+
+/*----- NAND Bus Mode (ONFI - Open NAND Flash Interface) -----*/
+#define ARM_NAND_BUS_INTERFACE_Pos       4
+#define ARM_NAND_BUS_INTERFACE_Msk      (0x03UL << ARM_NAND_BUS_INTERFACE_Pos)
+#define ARM_NAND_BUS_SDR                (0x00UL << ARM_NAND_BUS_INTERFACE_Pos)    ///< Data Interface:    SDR  (Single Data Rate) - Traditional interface (default)
+#define ARM_NAND_BUS_DDR                (0x01UL << ARM_NAND_BUS_INTERFACE_Pos)    ///< Data Interface: NV-DDR  (Double Data Rate)
+#define ARM_NAND_BUS_DDR2               (0x02UL << ARM_NAND_BUS_INTERFACE_Pos)    ///< Data Interface: NV-DDR2 (Double Data Rate)
+#define ARM_NAND_BUS_TIMING_MODE_Pos     0
+#define ARM_NAND_BUS_TIMING_MODE_Msk    (0x0FUL << ARM_NAND_BUS_TIMING_MODE_Pos)
+#define ARM_NAND_BUS_TIMING_MODE_0      (0x00UL << ARM_NAND_BUS_TIMING_MODE_Pos)  ///< Timing Mode 0 (default)
+#define ARM_NAND_BUS_TIMING_MODE_1      (0x01UL << ARM_NAND_BUS_TIMING_MODE_Pos)  ///< Timing Mode 1
+#define ARM_NAND_BUS_TIMING_MODE_2      (0x02UL << ARM_NAND_BUS_TIMING_MODE_Pos)  ///< Timing Mode 2
+#define ARM_NAND_BUS_TIMING_MODE_3      (0x03UL << ARM_NAND_BUS_TIMING_MODE_Pos)  ///< Timing Mode 3
+#define ARM_NAND_BUS_TIMING_MODE_4      (0x04UL << ARM_NAND_BUS_TIMING_MODE_Pos)  ///< Timing Mode 4 (SDR EDO capable)
+#define ARM_NAND_BUS_TIMING_MODE_5      (0x05UL << ARM_NAND_BUS_TIMING_MODE_Pos)  ///< Timing Mode 5 (SDR EDO capable)
+#define ARM_NAND_BUS_TIMING_MODE_6      (0x06UL << ARM_NAND_BUS_TIMING_MODE_Pos)  ///< Timing Mode 6 (NV-DDR2 only)
+#define ARM_NAND_BUS_TIMING_MODE_7      (0x07UL << ARM_NAND_BUS_TIMING_MODE_Pos)  ///< Timing Mode 7 (NV-DDR2 only)
+#define ARM_NAND_BUS_DDR2_DO_WCYC_Pos    8
+#define ARM_NAND_BUS_DDR2_DO_WCYC_Msk   (0x0FUL << ARM_NAND_BUS_DDR2_DO_WCYC_Pos)
+#define ARM_NAND_BUS_DDR2_DO_WCYC_0     (0x00UL << ARM_NAND_BUS_DDR2_DO_WCYC_Pos) ///< DDR2 Data Output Warm-up cycles: 0 (default)
+#define ARM_NAND_BUS_DDR2_DO_WCYC_1     (0x01UL << ARM_NAND_BUS_DDR2_DO_WCYC_Pos) ///< DDR2 Data Output Warm-up cycles: 1
+#define ARM_NAND_BUS_DDR2_DO_WCYC_2     (0x02UL << ARM_NAND_BUS_DDR2_DO_WCYC_Pos) ///< DDR2 Data Output Warm-up cycles: 2
+#define ARM_NAND_BUS_DDR2_DO_WCYC_4     (0x03UL << ARM_NAND_BUS_DDR2_DO_WCYC_Pos) ///< DDR2 Data Output Warm-up cycles: 4
+#define ARM_NAND_BUS_DDR2_DI_WCYC_Pos    12
+#define ARM_NAND_BUS_DDR2_DI_WCYC_Msk   (0x0FUL << ARM_NAND_BUS_DDR2_DI_WCYC_Pos)
+#define ARM_NAND_BUS_DDR2_DI_WCYC_0     (0x00UL << ARM_NAND_BUS_DDR2_DI_WCYC_Pos) ///< DDR2 Data Input Warm-up cycles: 0 (default)
+#define ARM_NAND_BUS_DDR2_DI_WCYC_1     (0x01UL << ARM_NAND_BUS_DDR2_DI_WCYC_Pos) ///< DDR2 Data Input Warm-up cycles: 1
+#define ARM_NAND_BUS_DDR2_DI_WCYC_2     (0x02UL << ARM_NAND_BUS_DDR2_DI_WCYC_Pos) ///< DDR2 Data Input Warm-up cycles: 2
+#define ARM_NAND_BUS_DDR2_DI_WCYC_4     (0x03UL << ARM_NAND_BUS_DDR2_DI_WCYC_Pos) ///< DDR2 Data Input Warm-up cycles: 4
+#define ARM_NAND_BUS_DDR2_VEN           (1UL << 16)                               ///< DDR2 Enable external VREFQ as reference
+#define ARM_NAND_BUS_DDR2_CMPD          (1UL << 17)                               ///< DDR2 Enable complementary DQS (DQS_c) signal
+#define ARM_NAND_BUS_DDR2_CMPR          (1UL << 18)                               ///< DDR2 Enable complementary RE_n (RE_c) signal
+
+/*----- NAND Data Bus Width -----*/
+#define ARM_NAND_BUS_DATA_WIDTH_8       (0x00UL)   ///< Bus Data Width:  8 bit (default)
+#define ARM_NAND_BUS_DATA_WIDTH_16      (0x01UL)   ///< Bus Data Width: 16 bit
+
+/*----- NAND Driver Strength (ONFI - Open NAND Flash Interface) -----*/
+#define ARM_NAND_DRIVER_STRENGTH_18     (0x00UL)   ///< Driver Strength 2.0x = 18 Ohms
+#define ARM_NAND_DRIVER_STRENGTH_25     (0x01UL)   ///< Driver Strength 1.4x = 25 Ohms
+#define ARM_NAND_DRIVER_STRENGTH_35     (0x02UL)   ///< Driver Strength 1.0x = 35 Ohms (default)
+#define ARM_NAND_DRIVER_STRENGTH_50     (0x03UL)   ///< Driver Strength 0.7x = 50 Ohms
+
+
+/****** NAND ECC for Read/Write Data Mode and Sequence Execution Code *****/
+#define ARM_NAND_ECC_INDEX_Pos           0
+#define ARM_NAND_ECC_INDEX_Msk          (0xFFUL << ARM_NAND_ECC_INDEX_Pos)
+#define ARM_NAND_ECC(n)                 ((n) & ARM_NAND_ECC_INDEX_Msk)     ///< Select ECC
+#define ARM_NAND_ECC0                   (1UL << 8)                         ///< Use ECC0 of selected ECC
+#define ARM_NAND_ECC1                   (1UL << 9)                         ///< Use ECC1 of selected ECC
+
+/****** NAND Flag for Read/Write Data Mode and Sequence Execution Code *****/
+#define ARM_NAND_DRIVER_DONE_EVENT      (1UL << 16) ///< Generate \ref ARM_NAND_EVENT_DRIVER_DONE
+
+/****** NAND Sequence Execution Code *****/
+#define ARM_NAND_CODE_SEND_CMD1         (1UL << 17) ///< Send Command 1
+#define ARM_NAND_CODE_SEND_ADDR_COL1    (1UL << 18) ///< Send Column Address 1
+#define ARM_NAND_CODE_SEND_ADDR_COL2    (1UL << 19) ///< Send Column Address 2
+#define ARM_NAND_CODE_SEND_ADDR_ROW1    (1UL << 20) ///< Send Row Address 1
+#define ARM_NAND_CODE_SEND_ADDR_ROW2    (1UL << 21) ///< Send Row Address 2
+#define ARM_NAND_CODE_SEND_ADDR_ROW3    (1UL << 22) ///< Send Row Address 3
+#define ARM_NAND_CODE_INC_ADDR_ROW      (1UL << 23) ///< Auto-increment Row Address
+#define ARM_NAND_CODE_WRITE_DATA        (1UL << 24) ///< Write Data
+#define ARM_NAND_CODE_SEND_CMD2         (1UL << 25) ///< Send Command 2
+#define ARM_NAND_CODE_WAIT_BUSY         (1UL << 26) ///< Wait while R/Bn busy
+#define ARM_NAND_CODE_READ_DATA         (1UL << 27) ///< Read Data
+#define ARM_NAND_CODE_SEND_CMD3         (1UL << 28) ///< Send Command 3
+#define ARM_NAND_CODE_READ_STATUS       (1UL << 29) ///< Read Status byte and check FAIL bit (bit 0)
+
+/*----- NAND Sequence Execution Code: Command -----*/
+#define ARM_NAND_CODE_CMD1_Pos           0
+#define ARM_NAND_CODE_CMD1_Msk          (0xFFUL << ARM_NAND_CODE_CMD1_Pos)
+#define ARM_NAND_CODE_CMD2_Pos           8
+#define ARM_NAND_CODE_CMD2_Msk          (0xFFUL << ARM_NAND_CODE_CMD2_Pos)
+#define ARM_NAND_CODE_CMD3_Pos           16
+#define ARM_NAND_CODE_CMD3_Msk          (0xFFUL << ARM_NAND_CODE_CMD3_Pos)
+
+/*----- NAND Sequence Execution Code: Column Address -----*/
+#define ARM_NAND_CODE_ADDR_COL1_Pos      0
+#define ARM_NAND_CODE_ADDR_COL1_Msk     (0xFFUL << ARM_NAND_CODE_ADDR_COL1_Pos)
+#define ARM_NAND_CODE_ADDR_COL2_Pos      8
+#define ARM_NAND_CODE_ADDR_COL2_Msk     (0xFFUL << ARM_NAND_CODE_ADDR_COL2_Pos)
+
+/*----- NAND Sequence Execution Code: Row Address -----*/
+#define ARM_NAND_CODE_ADDR_ROW1_Pos      0
+#define ARM_NAND_CODE_ADDR_ROW1_Msk     (0xFFUL << ARM_NAND_CODE_ADDR_ROW1_Pos)
+#define ARM_NAND_CODE_ADDR_ROW2_Pos      8
+#define ARM_NAND_CODE_ADDR_ROW2_Msk     (0xFFUL << ARM_NAND_CODE_ADDR_ROW2_Pos)
+#define ARM_NAND_CODE_ADDR_ROW3_Pos      16
+#define ARM_NAND_CODE_ADDR_ROW3_Msk     (0xFFUL << ARM_NAND_CODE_ADDR_ROW3_Pos)
+
+
+/****** NAND specific error codes *****/
+#define ARM_NAND_ERROR_ECC              (ARM_DRIVER_ERROR_SPECIFIC - 1)     ///< ECC generation/correction failed
+
+
+/**
+\brief NAND ECC (Error Correction Code) Information
+*/
+typedef struct _ARM_NAND_ECC_INFO {
+  uint32_t type             :  2;       ///< Type: 1=ECC0 over Main, 2=ECC0 over Main+Spare, 3=ECC0 over Main and ECC1 over Spare
+  uint32_t page_layout      :  1;       ///< Page layout: 0=|Main0|Spare0|...|MainN-1|SpareN-1|, 1=|Main0|...|MainN-1|Spare0|...|SpareN-1|
+  uint32_t page_count       :  3;       ///< Number of virtual pages: N = 2 ^ page_count
+  uint32_t page_size        :  4;       ///< Virtual Page size (Main+Spare): 0=512+16, 1=1k+32, 2=2k+64, 3=4k+128, 4=8k+256, 8=512+28, 9=1k+56, 10=2k+112, 11=4k+224, 12=8k+448, 15=Not used (extended description)
+  uint32_t reserved         : 14;       ///< Reserved (must be zero)
+  uint32_t correctable_bits :  8;       ///< Number of correctable bits (based on 512 byte codeword size)
+  uint16_t codeword_size     [2];       ///< Number of bytes over which ECC is calculated
+  uint16_t ecc_size          [2];       ///< ECC size in bytes (rounded up)
+  uint16_t ecc_offset        [2];       ///< ECC offset in bytes (where ECC starts in Spare)
+  /* Extended description */
+  uint16_t virtual_page_size [2];       ///< Virtual Page size in bytes (Main/Spare)
+  uint16_t codeword_offset   [2];       ///< Codeword offset in bytes (where ECC protected data starts in Main/Spare)
+  uint16_t codeword_gap      [2];       ///< Codeword gap in bytes till next protected data
+  uint16_t ecc_gap           [2];       ///< ECC gap in bytes till next generated ECC
+} ARM_NAND_ECC_INFO;
+
+
+/**
+\brief NAND Status
+*/
+typedef struct _ARM_NAND_STATUS {
+  uint32_t busy      : 1;               ///< Driver busy flag
+  uint32_t ecc_error : 1;               ///< ECC error detected (cleared on next Read/WriteData or ExecuteSequence)
+  uint32_t reserved  : 30;
+} ARM_NAND_STATUS;
+
+
+/****** NAND Event *****/
+#define ARM_NAND_EVENT_DEVICE_READY     (1UL << 0)  ///< Device Ready: R/Bn rising edge
+#define ARM_NAND_EVENT_DRIVER_READY     (1UL << 1)  ///< Driver Ready
+#define ARM_NAND_EVENT_DRIVER_DONE      (1UL << 2)  ///< Driver operation done
+#define ARM_NAND_EVENT_ECC_ERROR        (1UL << 3)  ///< ECC could not correct data
+
+
+// Function documentation
+/**
+  \fn            ARM_DRIVER_VERSION ARM_NAND_GetVersion (void)
+  \brief         Get driver version.
+  \return        \ref ARM_DRIVER_VERSION
+*/
+/**
+  \fn            ARM_NAND_CAPABILITIES ARM_NAND_GetCapabilities (void)
+  \brief         Get driver capabilities.
+  \return        \ref ARM_NAND_CAPABILITIES
+*/
+/**
+  \fn            int32_t ARM_NAND_Initialize (ARM_NAND_SignalEvent_t cb_event)
+  \brief         Initialize the NAND Interface.
+  \param[in]     cb_event  Pointer to \ref ARM_NAND_SignalEvent
+  \return        \ref execution_status
+*/
+/**
+  \fn            int32_t ARM_NAND_Uninitialize (void)
+  \brief         De-initialize the NAND Interface.
+  \return        \ref execution_status
+*/
+/**
+  \fn            int32_t ARM_NAND_PowerControl (ARM_POWER_STATE state)
+  \brief         Control the NAND interface power.
+  \param[in]     state  Power state
+  \return        \ref execution_status
+*/
+/**
+  \fn            int32_t ARM_NAND_DevicePower (uint32_t voltage)
+  \brief         Set device power supply voltage.
+  \param[in]     voltage  NAND Device supply voltage
+  \return        \ref execution_status
+*/
+/**
+  \fn            int32_t ARM_NAND_WriteProtect (uint32_t dev_num, bool enable)
+  \brief         Control WPn (Write Protect).
+  \param[in]     dev_num  Device number
+  \param[in]     enable
+                - \b false Write Protect off
+                - \b true  Write Protect on
+  \return        \ref execution_status
+*/
+/**
+  \fn            int32_t ARM_NAND_ChipEnable (uint32_t dev_num, bool enable)
+  \brief         Control CEn (Chip Enable).
+  \param[in]     dev_num  Device number
+  \param[in]     enable
+                - \b false Chip Enable off
+                - \b true  Chip Enable on
+  \return        \ref execution_status
+*/
+/**
+  \fn            int32_t ARM_NAND_GetDeviceBusy (uint32_t dev_num)
+  \brief         Get Device Busy pin state.
+  \param[in]     dev_num  Device number
+  \return        1=busy, 0=not busy, or error
+*/
+/**
+  \fn            int32_t ARM_NAND_SendCommand (uint32_t dev_num, uint8_t cmd)
+  \brief         Send command to NAND device.
+  \param[in]     dev_num  Device number
+  \param[in]     cmd      Command
+  \return        \ref execution_status
+*/
+/**
+  \fn            int32_t ARM_NAND_SendAddress (uint32_t dev_num, uint8_t addr)
+  \brief         Send address to NAND device.
+  \param[in]     dev_num  Device number
+  \param[in]     addr     Address
+  \return        \ref execution_status
+*/
+/**
+  \fn            int32_t ARM_NAND_ReadData (uint32_t dev_num, void *data, uint32_t cnt, uint32_t mode)
+  \brief         Read data from NAND device.
+  \param[in]     dev_num  Device number
+  \param[out]    data     Pointer to buffer for data to read from NAND device
+  \param[in]     cnt      Number of data items to read
+  \param[in]     mode     Operation mode
+  \return        number of data items read or \ref execution_status
+*/
+/**
+  \fn            int32_t ARM_NAND_WriteData (uint32_t dev_num, const void *data, uint32_t cnt, uint32_t mode)
+  \brief         Write data to NAND device.
+  \param[in]     dev_num  Device number
+  \param[out]    data     Pointer to buffer with data to write to NAND device
+  \param[in]     cnt      Number of data items to write
+  \param[in]     mode     Operation mode
+  \return        number of data items written or \ref execution_status
+*/
+/**
+  \fn            int32_t ARM_NAND_ExecuteSequence (uint32_t dev_num, uint32_t code, uint32_t cmd,
+                                                   uint32_t addr_col, uint32_t addr_row,
+                                                   void *data, uint32_t data_cnt,
+                                                   uint8_t *status, uint32_t *count)
+  \brief         Execute sequence of operations.
+  \param[in]     dev_num  Device number
+  \param[in]     code     Sequence code
+  \param[in]     cmd      Command(s)
+  \param[in]     addr_col Column address
+  \param[in]     addr_row Row address
+  \param[in,out] data     Pointer to data to be written or read 
+  \param[in]     data_cnt Number of data items in one iteration
+  \param[out]    status   Pointer to status read
+  \param[in,out] count    Number of iterations
+  \return        \ref execution_status
+*/
+/**
+  \fn            int32_t ARM_NAND_AbortSequence (uint32_t dev_num)
+  \brief         Abort sequence execution.
+  \param[in]     dev_num  Device number
+  \return        \ref execution_status
+*/
+/**
+  \fn            int32_t ARM_NAND_Control (uint32_t dev_num, uint32_t control, uint32_t arg)
+  \brief         Control NAND Interface.
+  \param[in]     dev_num  Device number
+  \param[in]     control  Operation
+  \param[in]     arg      Argument of operation
+  \return        \ref execution_status
+*/
+/**
+  \fn            ARM_NAND_STATUS ARM_NAND_GetStatus (uint32_t dev_num)
+  \brief         Get NAND status.
+  \param[in]     dev_num  Device number
+  \return        NAND status \ref ARM_NAND_STATUS
+*/
+/**
+  \fn            int32_t ARM_NAND_InquireECC (int32_t index, ARM_NAND_ECC_INFO *info)
+  \brief         Inquire about available ECC.
+  \param[in]     index   Inquire ECC index
+  \param[out]    info    Pointer to ECC information \ref ARM_NAND_ECC_INFO retrieved
+  \return        \ref execution_status
+*/
+
+/**
+  \fn            void ARM_NAND_SignalEvent (uint32_t dev_num, uint32_t event)
+  \brief         Signal NAND event.
+  \param[in]     dev_num  Device number
+  \param[in]     event    Event notification mask
+*/
+
+typedef void (*ARM_NAND_SignalEvent_t) (uint32_t dev_num, uint32_t event);    ///< Pointer to \ref ARM_NAND_SignalEvent : Signal NAND Event.
+
+
+/**
+\brief NAND Driver Capabilities.
+*/
+typedef struct _ARM_NAND_CAPABILITIES {
+  uint32_t event_device_ready  : 1;     ///< Signal Device Ready event (R/Bn rising edge)
+  uint32_t reentrant_operation : 1;     ///< Supports re-entrant operation (SendCommand/Address, Read/WriteData)
+  uint32_t sequence_operation  : 1;     ///< Supports Sequence operation (ExecuteSequence, AbortSequence)
+  uint32_t vcc                 : 1;     ///< Supports VCC Power Supply Control
+  uint32_t vcc_1v8             : 1;     ///< Supports 1.8 VCC Power Supply
+  uint32_t vccq                : 1;     ///< Supports VCCQ I/O Power Supply Control
+  uint32_t vccq_1v8            : 1;     ///< Supports 1.8 VCCQ I/O Power Supply
+  uint32_t vpp                 : 1;     ///< Supports VPP High Voltage Power Supply Control
+  uint32_t wp                  : 1;     ///< Supports WPn (Write Protect) Control
+  uint32_t ce_lines            : 4;     ///< Number of CEn (Chip Enable) lines: ce_lines + 1
+  uint32_t ce_manual           : 1;     ///< Supports manual CEn (Chip Enable) Control
+  uint32_t rb_monitor          : 1;     ///< Supports R/Bn (Ready/Busy) Monitoring
+  uint32_t data_width_16       : 1;     ///< Supports 16-bit data
+  uint32_t ddr                 : 1;     ///< Supports NV-DDR  Data Interface (ONFI)
+  uint32_t ddr2                : 1;     ///< Supports NV-DDR2 Data Interface (ONFI)
+  uint32_t sdr_timing_mode     : 3;     ///< Fastest (highest) SDR     Timing Mode supported (ONFI)
+  uint32_t ddr_timing_mode     : 3;     ///< Fastest (highest) NV_DDR  Timing Mode supported (ONFI)
+  uint32_t ddr2_timing_mode    : 3;     ///< Fastest (highest) NV_DDR2 Timing Mode supported (ONFI)
+  uint32_t driver_strength_18  : 1;     ///< Supports Driver Strength 2.0x = 18 Ohms
+  uint32_t driver_strength_25  : 1;     ///< Supports Driver Strength 1.4x = 25 Ohms
+  uint32_t driver_strength_50  : 1;     ///< Supports Driver Strength 0.7x = 50 Ohms
+  uint32_t reserved            : 2;     ///< Reserved (must be zero)
+} ARM_NAND_CAPABILITIES;
+
+
+/**
+\brief Access structure of the NAND Driver.
+*/
+typedef struct _ARM_DRIVER_NAND {
+  ARM_DRIVER_VERSION    (*GetVersion)     (void);                                                             ///< Pointer to \ref ARM_NAND_GetVersion : Get driver version.
+  ARM_NAND_CAPABILITIES (*GetCapabilities)(void);                                                             ///< Pointer to \ref ARM_NAND_GetCapabilities : Get driver capabilities.
+  int32_t               (*Initialize)     (ARM_NAND_SignalEvent_t cb_event);                                  ///< Pointer to \ref ARM_NAND_Initialize : Initialize NAND Interface.
+  int32_t               (*Uninitialize)   (void);                                                             ///< Pointer to \ref ARM_NAND_Uninitialize : De-initialize NAND Interface.
+  int32_t               (*PowerControl)   (ARM_POWER_STATE state);                                            ///< Pointer to \ref ARM_NAND_PowerControl : Control NAND Interface Power.
+  int32_t               (*DevicePower)    (uint32_t voltage);                                                 ///< Pointer to \ref ARM_NAND_DevicePower : Set device power supply voltage.
+  int32_t               (*WriteProtect)   (uint32_t dev_num, bool enable);                                    ///< Pointer to \ref ARM_NAND_WriteProtect : Control WPn (Write Protect).
+  int32_t               (*ChipEnable)     (uint32_t dev_num, bool enable);                                    ///< Pointer to \ref ARM_NAND_ChipEnable : Control CEn (Chip Enable).
+  int32_t               (*GetDeviceBusy)  (uint32_t dev_num);                                                 ///< Pointer to \ref ARM_NAND_GetDeviceBusy : Get Device Busy pin state.
+  int32_t               (*SendCommand)    (uint32_t dev_num, uint8_t cmd);                                    ///< Pointer to \ref ARM_NAND_SendCommand : Send command to NAND device.
+  int32_t               (*SendAddress)    (uint32_t dev_num, uint8_t addr);                                   ///< Pointer to \ref ARM_NAND_SendAddress : Send address to NAND device.
+  int32_t               (*ReadData)       (uint32_t dev_num,       void *data, uint32_t cnt, uint32_t mode);  ///< Pointer to \ref ARM_NAND_ReadData : Read data from NAND device.
+  int32_t               (*WriteData)      (uint32_t dev_num, const void *data, uint32_t cnt, uint32_t mode);  ///< Pointer to \ref ARM_NAND_WriteData : Write data to NAND device.
+  int32_t               (*ExecuteSequence)(uint32_t dev_num, uint32_t code, uint32_t cmd,
+                                           uint32_t addr_col, uint32_t addr_row,
+                                           void *data, uint32_t data_cnt,
+                                           uint8_t *status, uint32_t *count);                                 ///< Pointer to \ref ARM_NAND_ExecuteSequence : Execute sequence of operations.
+  int32_t               (*AbortSequence)  (uint32_t dev_num);                                                 ///< Pointer to \ref ARM_NAND_AbortSequence : Abort sequence execution. 
+  int32_t               (*Control)        (uint32_t dev_num, uint32_t control, uint32_t arg);                 ///< Pointer to \ref ARM_NAND_Control : Control NAND Interface.
+  ARM_NAND_STATUS       (*GetStatus)      (uint32_t dev_num);                                                 ///< Pointer to \ref ARM_NAND_GetStatus : Get NAND status.
+  int32_t               (*InquireECC)     ( int32_t index, ARM_NAND_ECC_INFO *info);                          ///< Pointer to \ref ARM_NAND_InquireECC : Inquire about available ECC. 
+} const ARM_DRIVER_NAND;
+
+#ifdef  __cplusplus
+}
+#endif
+
+#endif /* DRIVER_NAND_H_ */

--- a/platform/ext/cmsis/CMSIS/Driver/Include/Driver_SAI.h
+++ b/platform/ext/cmsis/CMSIS/Driver/Include/Driver_SAI.h
@@ -1,0 +1,314 @@
+/*
+ * Copyright (c) 2013-2020 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * $Date:        31. March 2020
+ * $Revision:    V1.2
+ *
+ * Project:      SAI (Serial Audio Interface) Driver definitions
+ */
+
+/* History:
+ *  Version 1.2
+ *    Removed volatile from ARM_SAI_STATUS
+ *  Version 1.1
+ *    ARM_SAI_STATUS made volatile
+ *  Version 1.0
+ *    Initial release
+ */
+
+#ifndef DRIVER_SAI_H_
+#define DRIVER_SAI_H_
+
+#ifdef  __cplusplus
+extern "C"
+{
+#endif
+
+#include "Driver_Common.h"
+
+#define ARM_SAI_API_VERSION ARM_DRIVER_VERSION_MAJOR_MINOR(1,2)  /* API version */
+
+
+#define _ARM_Driver_SAI_(n)      Driver_SAI##n
+#define  ARM_Driver_SAI_(n) _ARM_Driver_SAI_(n)
+
+
+/****** SAI Control Codes *****/
+
+#define ARM_SAI_CONTROL_Msk             (0xFFUL)
+#define ARM_SAI_CONFIGURE_TX            (0x01UL)    ///< Configure Transmitter;  arg1 and arg2 provide additional configuration
+#define ARM_SAI_CONFIGURE_RX            (0x02UL)    ///< Configure Receiver;     arg1 and arg2 provide additional configuration
+#define ARM_SAI_CONTROL_TX              (0x03UL)    ///< Control Transmitter;    arg1.0: 0=disable (default), 1=enable; arg1.1: mute
+#define ARM_SAI_CONTROL_RX              (0x04UL)    ///< Control Receiver;       arg1.0: 0=disable (default), 1=enable
+#define ARM_SAI_MASK_SLOTS_TX           (0x05UL)    ///< Mask Transmitter slots; arg1 = mask (bit: 0=active, 1=inactive); all configured slots are active by default
+#define ARM_SAI_MASK_SLOTS_RX           (0x06UL)    ///< Mask Receiver    slots; arg1 = mask (bit: 0=active, 1=inactive); all configured slots are active by default
+#define ARM_SAI_ABORT_SEND              (0x07UL)    ///< Abort \ref ARM_SAI_Send
+#define ARM_SAI_ABORT_RECEIVE           (0x08UL)    ///< Abort \ref ARM_SAI_Receive
+
+/*----- SAI Control Codes: Configuration Parameters: Mode -----*/
+#define ARM_SAI_MODE_Pos                 8
+#define ARM_SAI_MODE_Msk                (1UL << ARM_SAI_MODE_Pos)
+#define ARM_SAI_MODE_MASTER             (1UL << ARM_SAI_MODE_Pos)               ///< Master Mode
+#define ARM_SAI_MODE_SLAVE              (0UL << ARM_SAI_MODE_Pos)               ///< Slave Mode (default)
+
+/*----- SAI Control Codes: Configuration Parameters: Synchronization -----*/
+#define ARM_SAI_SYNCHRONIZATION_Pos      9
+#define ARM_SAI_SYNCHRONIZATION_Msk     (1UL << ARM_SAI_SYNCHRONIZATION_Pos)
+#define ARM_SAI_ASYNCHRONOUS            (0UL << ARM_SAI_SYNCHRONIZATION_Pos)    ///< Asynchronous (default)
+#define ARM_SAI_SYNCHRONOUS             (1UL << ARM_SAI_SYNCHRONIZATION_Pos)    ///< Synchronous
+
+/*----- SAI Control Codes: Configuration Parameters: Protocol -----*/
+#define ARM_SAI_PROTOCOL_Pos             10
+#define ARM_SAI_PROTOCOL_Msk            (7UL << ARM_SAI_PROTOCOL_Pos)
+#define ARM_SAI_PROTOCOL_USER           (0UL << ARM_SAI_PROTOCOL_Pos)           ///< User defined (default) 
+#define ARM_SAI_PROTOCOL_I2S            (1UL << ARM_SAI_PROTOCOL_Pos)           ///< I2S
+#define ARM_SAI_PROTOCOL_MSB_JUSTIFIED  (2UL << ARM_SAI_PROTOCOL_Pos)           ///< MSB (left) justified 
+#define ARM_SAI_PROTOCOL_LSB_JUSTIFIED  (3UL << ARM_SAI_PROTOCOL_Pos)           ///< LSB (right) justified
+#define ARM_SAI_PROTOCOL_PCM_SHORT      (4UL << ARM_SAI_PROTOCOL_Pos)           ///< PCM with short frame
+#define ARM_SAI_PROTOCOL_PCM_LONG       (5UL << ARM_SAI_PROTOCOL_Pos)           ///< PCM with long frame
+#define ARM_SAI_PROTOCOL_AC97           (6UL << ARM_SAI_PROTOCOL_Pos)           ///< AC'97
+
+/*----- SAI Control Codes: Configuration Parameters: Data Size -----*/
+#define ARM_SAI_DATA_SIZE_Pos            13
+#define ARM_SAI_DATA_SIZE_Msk                      (0x1FUL  << ARM_SAI_DATA_SIZE_Pos)
+#define ARM_SAI_DATA_SIZE(n)            ((((n)-1UL)&0x1FUL) << ARM_SAI_DATA_SIZE_Pos) ///< Data size in bits (8..32)
+
+/*----- SAI Control Codes: Configuration Parameters: Bit Order -----*/
+#define ARM_SAI_BIT_ORDER_Pos            18
+#define ARM_SAI_BIT_ORDER_Msk           (1UL << ARM_SAI_BIT_ORDER_Pos)
+#define ARM_SAI_MSB_FIRST               (0UL << ARM_SAI_BIT_ORDER_Pos)          ///< Data is transferred with MSB first (default)
+#define ARM_SAI_LSB_FIRST               (1UL << ARM_SAI_BIT_ORDER_Pos)          ///< Data is transferred with LSB first; User Protocol only (ignored otherwise)
+
+/*----- SAI Control Codes: Configuration Parameters: Mono Mode -----*/
+#define ARM_SAI_MONO_MODE               (1UL << 19)                             ///< Mono Mode (only for I2S, MSB/LSB justified)
+
+/*----- SAI Control Codes:Configuration Parameters: Companding -----*/
+#define ARM_SAI_COMPANDING_Pos           20
+#define ARM_SAI_COMPANDING_Msk          (3UL << ARM_SAI_COMPANDING_Pos)
+#define ARM_SAI_COMPANDING_NONE         (0UL << ARM_SAI_COMPANDING_Pos)         ///< No companding (default)
+#define ARM_SAI_COMPANDING_A_LAW        (2UL << ARM_SAI_COMPANDING_Pos)         ///< A-Law companding
+#define ARM_SAI_COMPANDING_U_LAW        (3UL << ARM_SAI_COMPANDING_Pos)         ///< u-Law companding
+
+/*----- SAI Control Codes: Configuration Parameters: Clock Polarity -----*/
+#define ARM_SAI_CLOCK_POLARITY_Pos       23
+#define ARM_SAI_CLOCK_POLARITY_Msk      (1UL << ARM_SAI_CLOCK_POLARITY_Pos)
+#define ARM_SAI_CLOCK_POLARITY_0        (0UL << ARM_SAI_CLOCK_POLARITY_Pos)     ///< Drive on falling edge, Capture on rising  edge (default)
+#define ARM_SAI_CLOCK_POLARITY_1        (1UL << ARM_SAI_CLOCK_POLARITY_Pos)     ///< Drive on rising  edge, Capture on falling edge
+
+/*----- SAI Control Codes: Configuration Parameters: Master Clock Pin -----*/
+#define ARM_SAI_MCLK_PIN_Pos             24
+#define ARM_SAI_MCLK_PIN_Msk            (3UL << ARM_SAI_MCLK_PIN_Pos)
+#define ARM_SAI_MCLK_PIN_INACTIVE       (0UL << ARM_SAI_MCLK_PIN_Pos)           ///< MCLK not used (default)
+#define ARM_SAI_MCLK_PIN_OUTPUT         (1UL << ARM_SAI_MCLK_PIN_Pos)           ///< MCLK is output (Master only)
+#define ARM_SAI_MCLK_PIN_INPUT          (2UL << ARM_SAI_MCLK_PIN_Pos)           ///< MCLK is input  (Master only)
+
+
+/****** SAI Configuration (arg1) *****/
+
+/*----- SAI Configuration (arg1): Frame Length -----*/
+#define ARM_SAI_FRAME_LENGTH_Pos          0
+#define ARM_SAI_FRAME_LENGTH_Msk                    (0x3FFUL  << ARM_SAI_FRAME_LENGTH_Pos)
+#define ARM_SAI_FRAME_LENGTH(n)          ((((n)-1UL)&0x3FFUL) << ARM_SAI_FRAME_LENGTH_Pos)  ///< Frame length in bits (8..1024); default depends on protocol and data
+
+/*----- SAI Configuration (arg1): Frame Sync Width -----*/
+#define ARM_SAI_FRAME_SYNC_WIDTH_Pos      10
+#define ARM_SAI_FRAME_SYNC_WIDTH_Msk                (0xFFUL  << ARM_SAI_FRAME_SYNC_WIDTH_Pos)
+#define ARM_SAI_FRAME_SYNC_WIDTH(n)      ((((n)-1UL)&0xFFUL) << ARM_SAI_FRAME_SYNC_WIDTH_Pos) ///< Frame Sync width in bits (1..256); default=1; User Protocol only (ignored otherwise)
+
+/*----- SAI Configuration (arg1): Frame Sync Polarity -----*/
+#define ARM_SAI_FRAME_SYNC_POLARITY_Pos   18
+#define ARM_SAI_FRAME_SYNC_POLARITY_Msk  (1UL << ARM_SAI_FRAME_SYNC_POLARITY_Pos)
+#define ARM_SAI_FRAME_SYNC_POLARITY_HIGH (0UL << ARM_SAI_FRAME_SYNC_POLARITY_Pos)           ///< Frame Sync is active high (default); User Protocol only (ignored otherwise)
+#define ARM_SAI_FRAME_SYNC_POLARITY_LOW  (1UL << ARM_SAI_FRAME_SYNC_POLARITY_Pos)           ///< Frame Sync is active low; User Protocol only (ignored otherwise)
+
+/*----- SAI Configuration (arg1): Frame Sync Early -----*/
+#define ARM_SAI_FRAME_SYNC_EARLY         (1UL << 19)                                        ///< Frame Sync one bit before the first bit of the frame; User Protocol only (ignored otherwise)
+
+/*----- SAI Configuration (arg1): Slot Count -----*/
+#define ARM_SAI_SLOT_COUNT_Pos            20
+#define ARM_SAI_SLOT_COUNT_Msk                      (0x1FUL  << ARM_SAI_SLOT_COUNT_Pos)
+#define ARM_SAI_SLOT_COUNT(n)            ((((n)-1UL)&0x1FUL) << ARM_SAI_SLOT_COUNT_Pos)     ///< Number of slots in frame (1..32); default=1; User Protocol only (ignored otherwise)
+
+/*----- SAI Configuration (arg1): Slot Size -----*/
+#define ARM_SAI_SLOT_SIZE_Pos             25
+#define ARM_SAI_SLOT_SIZE_Msk            (3UL << ARM_SAI_SLOT_SIZE_Pos)
+#define ARM_SAI_SLOT_SIZE_DEFAULT        (0UL << ARM_SAI_SLOT_SIZE_Pos)                     ///< Slot size is equal to data size (default)
+#define ARM_SAI_SLOT_SIZE_16             (1UL << ARM_SAI_SLOT_SIZE_Pos)                     ///< Slot size = 16 bits; User Protocol only (ignored otherwise)
+#define ARM_SAI_SLOT_SIZE_32             (3UL << ARM_SAI_SLOT_SIZE_Pos)                     ///< Slot size = 32 bits; User Protocol only (ignored otherwise)
+
+/*----- SAI Configuration (arg1): Slot Offset -----*/
+#define ARM_SAI_SLOT_OFFSET_Pos           27
+#define ARM_SAI_SLOT_OFFSET_Msk               (0x1FUL  << ARM_SAI_SLOT_OFFSET_Pos)
+#define ARM_SAI_SLOT_OFFSET(n)           (((n)&0x1FUL) << ARM_SAI_SLOT_OFFSET_Pos)          ///< Offset of first data bit in slot (0..31); default=0; User Protocol only (ignored otherwise)
+
+/****** SAI Configuration (arg2) *****/
+
+/*----- SAI Control Codes: Configuration Parameters: Audio Frequency (Master only) -----*/
+#define ARM_SAI_AUDIO_FREQ_Msk          (0x0FFFFFUL)                                        ///< Audio frequency mask
+
+/*----- SAI Control Codes: Configuration Parameters: Master Clock Prescaler (Master only and MCLK Pin) -----*/
+#define ARM_SAI_MCLK_PRESCALER_Pos       20
+#define ARM_SAI_MCLK_PRESCALER_Msk      (0xFFFUL << ARM_SAI_MCLK_PRESCALER_Pos)
+#define ARM_SAI_MCLK_PRESCALER(n)       ((((n)-1UL)&0xFFFUL) << ARM_SAI_MCLK_PRESCALER_Pos) ///< MCLK prescaler; Audio_frequency = MCLK/n; n = 1..4096 (default=1)
+
+
+/****** SAI specific error codes *****/
+#define ARM_SAI_ERROR_SYNCHRONIZATION       (ARM_DRIVER_ERROR_SPECIFIC - 1)     ///< Specified Synchronization not supported
+#define ARM_SAI_ERROR_PROTOCOL              (ARM_DRIVER_ERROR_SPECIFIC - 2)     ///< Specified Protocol not supported
+#define ARM_SAI_ERROR_DATA_SIZE             (ARM_DRIVER_ERROR_SPECIFIC - 3)     ///< Specified Data size not supported
+#define ARM_SAI_ERROR_BIT_ORDER             (ARM_DRIVER_ERROR_SPECIFIC - 4)     ///< Specified Bit order not supported
+#define ARM_SAI_ERROR_MONO_MODE             (ARM_DRIVER_ERROR_SPECIFIC - 5)     ///< Specified Mono mode not supported
+#define ARM_SAI_ERROR_COMPANDING            (ARM_DRIVER_ERROR_SPECIFIC - 6)     ///< Specified Companding not supported
+#define ARM_SAI_ERROR_CLOCK_POLARITY        (ARM_DRIVER_ERROR_SPECIFIC - 7)     ///< Specified Clock polarity not supported
+#define ARM_SAI_ERROR_AUDIO_FREQ            (ARM_DRIVER_ERROR_SPECIFIC - 8)     ///< Specified Audio frequency not supported
+#define ARM_SAI_ERROR_MCLK_PIN              (ARM_DRIVER_ERROR_SPECIFIC - 9)     ///< Specified MCLK Pin setting not supported
+#define ARM_SAI_ERROR_MCLK_PRESCALER        (ARM_DRIVER_ERROR_SPECIFIC - 10)    ///< Specified MCLK Prescaler not supported
+#define ARM_SAI_ERROR_FRAME_LENGTH          (ARM_DRIVER_ERROR_SPECIFIC - 11)    ///< Specified Frame length not supported
+#define ARM_SAI_ERROR_FRAME_LENGHT          (ARM_DRIVER_ERROR_SPECIFIC - 11)    ///< Specified Frame length not supported @deprecated use \ref ARM_SAI_ERROR_FRAME_LENGTH instead
+#define ARM_SAI_ERROR_FRAME_SYNC_WIDTH      (ARM_DRIVER_ERROR_SPECIFIC - 12)    ///< Specified Frame Sync width not supported
+#define ARM_SAI_ERROR_FRAME_SYNC_POLARITY   (ARM_DRIVER_ERROR_SPECIFIC - 13)    ///< Specified Frame Sync polarity not supported
+#define ARM_SAI_ERROR_FRAME_SYNC_EARLY      (ARM_DRIVER_ERROR_SPECIFIC - 14)    ///< Specified Frame Sync early not supported
+#define ARM_SAI_ERROR_SLOT_COUNT            (ARM_DRIVER_ERROR_SPECIFIC - 15)    ///< Specified Slot count not supported
+#define ARM_SAI_ERROR_SLOT_SIZE             (ARM_DRIVER_ERROR_SPECIFIC - 16)    ///< Specified Slot size not supported
+#define ARM_SAI_ERROR_SLOT_OFFESET          (ARM_DRIVER_ERROR_SPECIFIC - 17)    ///< Specified Slot offset not supported
+
+
+/**
+\brief SAI Status
+*/
+typedef struct _ARM_SAI_STATUS {
+  uint32_t tx_busy          : 1;        ///< Transmitter busy flag
+  uint32_t rx_busy          : 1;        ///< Receiver busy flag
+  uint32_t tx_underflow     : 1;        ///< Transmit data underflow detected (cleared on start of next send operation)
+  uint32_t rx_overflow      : 1;        ///< Receive data overflow detected (cleared on start of next receive operation)
+  uint32_t frame_error      : 1;        ///< Sync Frame error detected (cleared on start of next send/receive operation)
+  uint32_t reserved         : 27;
+} ARM_SAI_STATUS;
+
+
+/****** SAI Event *****/
+#define ARM_SAI_EVENT_SEND_COMPLETE     (1UL << 0)  ///< Send completed
+#define ARM_SAI_EVENT_RECEIVE_COMPLETE  (1UL << 1)  ///< Receive completed
+#define ARM_SAI_EVENT_TX_UNDERFLOW      (1UL << 2)  ///< Transmit data not available
+#define ARM_SAI_EVENT_RX_OVERFLOW       (1UL << 3)  ///< Receive data overflow
+#define ARM_SAI_EVENT_FRAME_ERROR       (1UL << 4)  ///< Sync Frame error in Slave mode (optional)
+
+
+// Function documentation
+/**
+  \fn          ARM_DRIVER_VERSION ARM_SAI_GetVersion (void)
+  \brief       Get driver version.
+  \return      \ref ARM_DRIVER_VERSION
+
+  \fn          ARM_SAI_CAPABILITIES ARM_SAI_GetCapabilities (void)
+  \brief       Get driver capabilities.
+  \return      \ref ARM_SAI_CAPABILITIES
+
+  \fn          int32_t ARM_SAI_Initialize (ARM_SAI_SignalEvent_t cb_event)
+  \brief       Initialize SAI Interface.
+  \param[in]   cb_event  Pointer to \ref ARM_SAI_SignalEvent
+  \return      \ref execution_status
+
+  \fn          int32_t ARM_SAI_Uninitialize (void)
+  \brief       De-initialize SAI Interface.
+  \return      \ref execution_status
+
+  \fn          int32_t ARM_SAI_PowerControl (ARM_POWER_STATE state)
+  \brief       Control SAI Interface Power.
+  \param[in]   state  Power state
+  \return      \ref execution_status
+
+  \fn          int32_t ARM_SAI_Send (const void *data, uint32_t num)
+  \brief       Start sending data to SAI transmitter.
+  \param[in]   data  Pointer to buffer with data to send to SAI transmitter
+  \param[in]   num   Number of data items to send
+  \return      \ref execution_status
+
+  \fn          int32_t ARM_SAI_Receive (void *data, uint32_t num)
+  \brief       Start receiving data from SAI receiver.
+  \param[out]  data  Pointer to buffer for data to receive from SAI receiver
+  \param[in]   num   Number of data items to receive
+  \return      \ref execution_status
+
+  \fn          uint32_t ARM_SAI_GetTxCount (void)
+  \brief       Get transmitted data count.
+  \return      number of data items transmitted
+
+  \fn          uint32_t ARM_SAI_GetRxCount (void)
+  \brief       Get received data count.
+  \return      number of data items received
+
+  \fn          int32_t ARM_SAI_Control (uint32_t control, uint32_t arg1, uint32_t arg2)
+  \brief       Control SAI Interface.
+  \param[in]   control  Operation
+  \param[in]   arg1     Argument 1 of operation (optional)
+  \param[in]   arg2     Argument 2 of operation (optional)
+  \return      common \ref execution_status and driver specific \ref sai_execution_status
+
+  \fn          ARM_SAI_STATUS ARM_SAI_GetStatus (void)
+  \brief       Get SAI status.
+  \return      SAI status \ref ARM_SAI_STATUS
+
+  \fn          void ARM_SAI_SignalEvent (uint32_t event)
+  \brief       Signal SAI Events.
+  \param[in]   event \ref SAI_events notification mask
+*/
+
+typedef void (*ARM_SAI_SignalEvent_t) (uint32_t event);  ///< Pointer to \ref ARM_SAI_SignalEvent : Signal SAI Event.
+
+
+/**
+\brief SAI Driver Capabilities.
+*/
+typedef struct _ARM_SAI_CAPABILITIES {
+  uint32_t asynchronous          : 1;   ///< supports asynchronous Transmit/Receive
+  uint32_t synchronous           : 1;   ///< supports synchronous Transmit/Receive
+  uint32_t protocol_user         : 1;   ///< supports user defined Protocol
+  uint32_t protocol_i2s          : 1;   ///< supports I2S Protocol
+  uint32_t protocol_justified    : 1;   ///< supports MSB/LSB justified Protocol
+  uint32_t protocol_pcm          : 1;   ///< supports PCM short/long frame Protocol
+  uint32_t protocol_ac97         : 1;   ///< supports AC'97 Protocol
+  uint32_t mono_mode             : 1;   ///< supports Mono mode
+  uint32_t companding            : 1;   ///< supports Companding
+  uint32_t mclk_pin              : 1;   ///< supports MCLK (Master Clock) pin
+  uint32_t event_frame_error     : 1;   ///< supports Frame error event: \ref ARM_SAI_EVENT_FRAME_ERROR
+  uint32_t reserved              : 21;  ///< Reserved (must be zero)
+} ARM_SAI_CAPABILITIES;
+
+
+/**
+\brief Access structure of the SAI Driver.
+*/
+typedef struct _ARM_DRIVER_SAI {
+  ARM_DRIVER_VERSION   (*GetVersion)      (void);                                            ///< Pointer to \ref ARM_SAI_GetVersion : Get driver version.
+  ARM_SAI_CAPABILITIES (*GetCapabilities) (void);                                            ///< Pointer to \ref ARM_SAI_GetCapabilities : Get driver capabilities.
+  int32_t              (*Initialize)      (ARM_SAI_SignalEvent_t cb_event);                  ///< Pointer to \ref ARM_SAI_Initialize : Initialize SAI Interface.
+  int32_t              (*Uninitialize)    (void);                                            ///< Pointer to \ref ARM_SAI_Uninitialize : De-initialize SAI Interface.
+  int32_t              (*PowerControl)    (ARM_POWER_STATE state);                           ///< Pointer to \ref ARM_SAI_PowerControl : Control SAI Interface Power.
+  int32_t              (*Send)            (const void *data, uint32_t num);                  ///< Pointer to \ref ARM_SAI_Send : Start sending data to SAI Interface.
+  int32_t              (*Receive)         (      void *data, uint32_t num);                  ///< Pointer to \ref ARM_SAI_Receive : Start receiving data from SAI Interface.
+  uint32_t             (*GetTxCount)      (void);                                            ///< Pointer to \ref ARM_SAI_GetTxCount : Get transmitted data count.
+  uint32_t             (*GetRxCount)      (void);                                            ///< Pointer to \ref ARM_SAI_GetRxCount : Get received data count.
+  int32_t              (*Control)         (uint32_t control, uint32_t arg1, uint32_t arg2);  ///< Pointer to \ref ARM_SAI_Control : Control SAI Interface.
+  ARM_SAI_STATUS       (*GetStatus)       (void);                                            ///< Pointer to \ref ARM_SAI_GetStatus : Get SAI status.
+} const ARM_DRIVER_SAI;
+
+#ifdef  __cplusplus
+}
+#endif
+
+#endif /* DRIVER_SAI_H_ */

--- a/platform/ext/cmsis/CMSIS/Driver/Include/Driver_SPI.h
+++ b/platform/ext/cmsis/CMSIS/Driver/Include/Driver_SPI.h
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) 2013-2020 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * $Date:        31. March 2020
+ * $Revision:    V2.3
+ *
+ * Project:      SPI (Serial Peripheral Interface) Driver definitions
+ */
+
+/* History:
+ *  Version 2.3
+ *    Removed Simplex Mode (deprecated)
+ *    Removed volatile from ARM_SPI_STATUS
+ *  Version 2.2
+ *    ARM_SPI_STATUS made volatile
+ *  Version 2.1
+ *    Renamed status flag "tx_rx_busy" to "busy"
+ *  Version 2.0
+ *    New simplified driver:
+ *      complexity moved to upper layer (especially data handling)
+ *      more unified API for different communication interfaces
+ *    Added:
+ *      Slave Mode
+ *      Half-duplex Modes
+ *      Configurable number of data bits
+ *      Support for TI Mode and Microwire
+ *    Changed prefix ARM_DRV -> ARM_DRIVER
+ *  Version 1.10
+ *    Namespace prefix ARM_ added
+ *  Version 1.01
+ *    Added "send_done_event" to Capabilities
+ *  Version 1.00
+ *    Initial release
+ */
+
+#ifndef DRIVER_SPI_H_
+#define DRIVER_SPI_H_
+
+#ifdef  __cplusplus
+extern "C"
+{
+#endif
+
+#include "Driver_Common.h"
+
+#define ARM_SPI_API_VERSION ARM_DRIVER_VERSION_MAJOR_MINOR(2,3)  /* API version */
+
+
+#define _ARM_Driver_SPI_(n)      Driver_SPI##n
+#define  ARM_Driver_SPI_(n) _ARM_Driver_SPI_(n)
+
+
+/****** SPI Control Codes *****/
+
+#define ARM_SPI_CONTROL_Pos              0
+#define ARM_SPI_CONTROL_Msk             (0xFFUL << ARM_SPI_CONTROL_Pos)
+
+/*----- SPI Control Codes: Mode -----*/
+#define ARM_SPI_MODE_INACTIVE           (0x00UL << ARM_SPI_CONTROL_Pos)     ///< SPI Inactive
+#define ARM_SPI_MODE_MASTER             (0x01UL << ARM_SPI_CONTROL_Pos)     ///< SPI Master (Output on MOSI, Input on MISO); arg = Bus Speed in bps
+#define ARM_SPI_MODE_SLAVE              (0x02UL << ARM_SPI_CONTROL_Pos)     ///< SPI Slave  (Output on MISO, Input on MOSI)
+#define ARM_SPI_MODE_MASTER_SIMPLEX     (0x03UL << ARM_SPI_CONTROL_Pos)     ///< SPI Master (Output/Input on MOSI); arg = Bus Speed in bps @deprecated Simplex Mode has been removed
+#define ARM_SPI_MODE_SLAVE_SIMPLEX      (0x04UL << ARM_SPI_CONTROL_Pos)     ///< SPI Slave  (Output/Input on MISO) @deprecated Simplex Mode has been removed
+
+/*----- SPI Control Codes: Mode Parameters: Frame Format -----*/
+#define ARM_SPI_FRAME_FORMAT_Pos         8
+#define ARM_SPI_FRAME_FORMAT_Msk        (7UL << ARM_SPI_FRAME_FORMAT_Pos)
+#define ARM_SPI_CPOL0_CPHA0             (0UL << ARM_SPI_FRAME_FORMAT_Pos)   ///< Clock Polarity 0, Clock Phase 0 (default)
+#define ARM_SPI_CPOL0_CPHA1             (1UL << ARM_SPI_FRAME_FORMAT_Pos)   ///< Clock Polarity 0, Clock Phase 1
+#define ARM_SPI_CPOL1_CPHA0             (2UL << ARM_SPI_FRAME_FORMAT_Pos)   ///< Clock Polarity 1, Clock Phase 0
+#define ARM_SPI_CPOL1_CPHA1             (3UL << ARM_SPI_FRAME_FORMAT_Pos)   ///< Clock Polarity 1, Clock Phase 1
+#define ARM_SPI_TI_SSI                  (4UL << ARM_SPI_FRAME_FORMAT_Pos)   ///< Texas Instruments Frame Format
+#define ARM_SPI_MICROWIRE               (5UL << ARM_SPI_FRAME_FORMAT_Pos)   ///< National Semiconductor Microwire Frame Format
+
+/*----- SPI Control Codes: Mode Parameters: Data Bits -----*/
+#define ARM_SPI_DATA_BITS_Pos            12
+#define ARM_SPI_DATA_BITS_Msk           (0x3FUL << ARM_SPI_DATA_BITS_Pos)
+#define ARM_SPI_DATA_BITS(n)            (((n) & 0x3FUL) << ARM_SPI_DATA_BITS_Pos) ///< Number of Data bits
+
+/*----- SPI Control Codes: Mode Parameters: Bit Order -----*/
+#define ARM_SPI_BIT_ORDER_Pos            18
+#define ARM_SPI_BIT_ORDER_Msk           (1UL << ARM_SPI_BIT_ORDER_Pos)
+#define ARM_SPI_MSB_LSB                 (0UL << ARM_SPI_BIT_ORDER_Pos)      ///< SPI Bit order from MSB to LSB (default)
+#define ARM_SPI_LSB_MSB                 (1UL << ARM_SPI_BIT_ORDER_Pos)      ///< SPI Bit order from LSB to MSB
+
+/*----- SPI Control Codes: Mode Parameters: Slave Select Mode -----*/
+#define ARM_SPI_SS_MASTER_MODE_Pos       19
+#define ARM_SPI_SS_MASTER_MODE_Msk      (3UL << ARM_SPI_SS_MASTER_MODE_Pos)
+#define ARM_SPI_SS_MASTER_UNUSED        (0UL << ARM_SPI_SS_MASTER_MODE_Pos) ///< SPI Slave Select when Master: Not used (default)
+#define ARM_SPI_SS_MASTER_SW            (1UL << ARM_SPI_SS_MASTER_MODE_Pos) ///< SPI Slave Select when Master: Software controlled
+#define ARM_SPI_SS_MASTER_HW_OUTPUT     (2UL << ARM_SPI_SS_MASTER_MODE_Pos) ///< SPI Slave Select when Master: Hardware controlled Output
+#define ARM_SPI_SS_MASTER_HW_INPUT      (3UL << ARM_SPI_SS_MASTER_MODE_Pos) ///< SPI Slave Select when Master: Hardware monitored Input
+#define ARM_SPI_SS_SLAVE_MODE_Pos        21
+#define ARM_SPI_SS_SLAVE_MODE_Msk       (1UL << ARM_SPI_SS_SLAVE_MODE_Pos)
+#define ARM_SPI_SS_SLAVE_HW             (0UL << ARM_SPI_SS_SLAVE_MODE_Pos)  ///< SPI Slave Select when Slave: Hardware monitored (default)
+#define ARM_SPI_SS_SLAVE_SW             (1UL << ARM_SPI_SS_SLAVE_MODE_Pos)  ///< SPI Slave Select when Slave: Software controlled
+
+
+/*----- SPI Control Codes: Miscellaneous Controls  -----*/
+#define ARM_SPI_SET_BUS_SPEED           (0x10UL << ARM_SPI_CONTROL_Pos)     ///< Set Bus Speed in bps; arg = value
+#define ARM_SPI_GET_BUS_SPEED           (0x11UL << ARM_SPI_CONTROL_Pos)     ///< Get Bus Speed in bps
+#define ARM_SPI_SET_DEFAULT_TX_VALUE    (0x12UL << ARM_SPI_CONTROL_Pos)     ///< Set default Transmit value; arg = value
+#define ARM_SPI_CONTROL_SS              (0x13UL << ARM_SPI_CONTROL_Pos)     ///< Control Slave Select; arg: 0=inactive, 1=active 
+#define ARM_SPI_ABORT_TRANSFER          (0x14UL << ARM_SPI_CONTROL_Pos)     ///< Abort current data transfer
+
+
+/****** SPI Slave Select Signal definitions *****/
+#define ARM_SPI_SS_INACTIVE              0UL                                ///< SPI Slave Select Signal Inactive
+#define ARM_SPI_SS_ACTIVE                1UL                                ///< SPI Slave Select Signal Active
+
+
+/****** SPI specific error codes *****/
+#define ARM_SPI_ERROR_MODE              (ARM_DRIVER_ERROR_SPECIFIC - 1)     ///< Specified Mode not supported
+#define ARM_SPI_ERROR_FRAME_FORMAT      (ARM_DRIVER_ERROR_SPECIFIC - 2)     ///< Specified Frame Format not supported
+#define ARM_SPI_ERROR_DATA_BITS         (ARM_DRIVER_ERROR_SPECIFIC - 3)     ///< Specified number of Data bits not supported
+#define ARM_SPI_ERROR_BIT_ORDER         (ARM_DRIVER_ERROR_SPECIFIC - 4)     ///< Specified Bit order not supported
+#define ARM_SPI_ERROR_SS_MODE           (ARM_DRIVER_ERROR_SPECIFIC - 5)     ///< Specified Slave Select Mode not supported
+
+
+/**
+\brief SPI Status
+*/
+typedef struct _ARM_SPI_STATUS {
+  uint32_t busy       : 1;              ///< Transmitter/Receiver busy flag
+  uint32_t data_lost  : 1;              ///< Data lost: Receive overflow / Transmit underflow (cleared on start of transfer operation)
+  uint32_t mode_fault : 1;              ///< Mode fault detected; optional (cleared on start of transfer operation)
+  uint32_t reserved   : 29;
+} ARM_SPI_STATUS;
+
+
+/****** SPI Event *****/
+#define ARM_SPI_EVENT_TRANSFER_COMPLETE (1UL << 0)  ///< Data Transfer completed
+#define ARM_SPI_EVENT_DATA_LOST         (1UL << 1)  ///< Data lost: Receive overflow / Transmit underflow
+#define ARM_SPI_EVENT_MODE_FAULT        (1UL << 2)  ///< Master Mode Fault (SS deactivated when Master)
+
+
+// Function documentation
+/**
+  \fn          ARM_DRIVER_VERSION ARM_SPI_GetVersion (void)
+  \brief       Get driver version.
+  \return      \ref ARM_DRIVER_VERSION
+
+  \fn          ARM_SPI_CAPABILITIES ARM_SPI_GetCapabilities (void)
+  \brief       Get driver capabilities.
+  \return      \ref ARM_SPI_CAPABILITIES
+
+  \fn          int32_t ARM_SPI_Initialize (ARM_SPI_SignalEvent_t cb_event)
+  \brief       Initialize SPI Interface.
+  \param[in]   cb_event  Pointer to \ref ARM_SPI_SignalEvent
+  \return      \ref execution_status
+
+  \fn          int32_t ARM_SPI_Uninitialize (void)
+  \brief       De-initialize SPI Interface.
+  \return      \ref execution_status
+
+  \fn          int32_t ARM_SPI_PowerControl (ARM_POWER_STATE state)
+  \brief       Control SPI Interface Power.
+  \param[in]   state  Power state
+  \return      \ref execution_status
+
+  \fn          int32_t ARM_SPI_Send (const void *data, uint32_t num)
+  \brief       Start sending data to SPI transmitter.
+  \param[in]   data  Pointer to buffer with data to send to SPI transmitter
+  \param[in]   num   Number of data items to send
+  \return      \ref execution_status
+
+  \fn          int32_t ARM_SPI_Receive (void *data, uint32_t num)
+  \brief       Start receiving data from SPI receiver.
+  \param[out]  data  Pointer to buffer for data to receive from SPI receiver
+  \param[in]   num   Number of data items to receive
+  \return      \ref execution_status
+
+  \fn          int32_t ARM_SPI_Transfer (const void *data_out,
+                                               void *data_in,
+                                         uint32_t    num)
+  \brief       Start sending/receiving data to/from SPI transmitter/receiver.
+  \param[in]   data_out  Pointer to buffer with data to send to SPI transmitter
+  \param[out]  data_in   Pointer to buffer for data to receive from SPI receiver
+  \param[in]   num       Number of data items to transfer
+  \return      \ref execution_status
+
+  \fn          uint32_t ARM_SPI_GetDataCount (void)
+  \brief       Get transferred data count.
+  \return      number of data items transferred
+
+  \fn          int32_t ARM_SPI_Control (uint32_t control, uint32_t arg)
+  \brief       Control SPI Interface.
+  \param[in]   control  Operation
+  \param[in]   arg      Argument of operation (optional)
+  \return      common \ref execution_status and driver specific \ref spi_execution_status
+
+  \fn          ARM_SPI_STATUS ARM_SPI_GetStatus (void)
+  \brief       Get SPI status.
+  \return      SPI status \ref ARM_SPI_STATUS
+
+  \fn          void ARM_SPI_SignalEvent (uint32_t event)
+  \brief       Signal SPI Events.
+  \param[in]   event \ref SPI_events notification mask
+*/
+
+typedef void (*ARM_SPI_SignalEvent_t) (uint32_t event);  ///< Pointer to \ref ARM_SPI_SignalEvent : Signal SPI Event.
+
+
+/**
+\brief SPI Driver Capabilities.
+*/
+typedef struct _ARM_SPI_CAPABILITIES {
+  uint32_t simplex          : 1;        ///< supports Simplex Mode (Master and Slave) @deprecated Reserved (must be zero)
+  uint32_t ti_ssi           : 1;        ///< supports TI Synchronous Serial Interface
+  uint32_t microwire        : 1;        ///< supports Microwire Interface
+  uint32_t event_mode_fault : 1;        ///< Signal Mode Fault event: \ref ARM_SPI_EVENT_MODE_FAULT
+  uint32_t reserved         : 28;       ///< Reserved (must be zero)
+} ARM_SPI_CAPABILITIES;
+
+
+/**
+\brief Access structure of the SPI Driver.
+*/
+typedef struct _ARM_DRIVER_SPI {
+  ARM_DRIVER_VERSION   (*GetVersion)      (void);                             ///< Pointer to \ref ARM_SPI_GetVersion : Get driver version.
+  ARM_SPI_CAPABILITIES (*GetCapabilities) (void);                             ///< Pointer to \ref ARM_SPI_GetCapabilities : Get driver capabilities.
+  int32_t              (*Initialize)      (ARM_SPI_SignalEvent_t cb_event);   ///< Pointer to \ref ARM_SPI_Initialize : Initialize SPI Interface.
+  int32_t              (*Uninitialize)    (void);                             ///< Pointer to \ref ARM_SPI_Uninitialize : De-initialize SPI Interface.
+  int32_t              (*PowerControl)    (ARM_POWER_STATE state);            ///< Pointer to \ref ARM_SPI_PowerControl : Control SPI Interface Power.
+  int32_t              (*Send)            (const void *data, uint32_t num);   ///< Pointer to \ref ARM_SPI_Send : Start sending data to SPI Interface.
+  int32_t              (*Receive)         (      void *data, uint32_t num);   ///< Pointer to \ref ARM_SPI_Receive : Start receiving data from SPI Interface.
+  int32_t              (*Transfer)        (const void *data_out,
+                                                 void *data_in,
+                                           uint32_t    num);                  ///< Pointer to \ref ARM_SPI_Transfer : Start sending/receiving data to/from SPI.
+  uint32_t             (*GetDataCount)    (void);                             ///< Pointer to \ref ARM_SPI_GetDataCount : Get transferred data count.
+  int32_t              (*Control)         (uint32_t control, uint32_t arg);   ///< Pointer to \ref ARM_SPI_Control : Control SPI Interface.
+  ARM_SPI_STATUS       (*GetStatus)       (void);                             ///< Pointer to \ref ARM_SPI_GetStatus : Get SPI status.
+} const ARM_DRIVER_SPI;
+
+#ifdef  __cplusplus
+}
+#endif
+
+#endif /* DRIVER_SPI_H_ */

--- a/platform/ext/cmsis/CMSIS/Driver/Include/Driver_Storage.h
+++ b/platform/ext/cmsis/CMSIS/Driver/Include/Driver_Storage.h
@@ -1,0 +1,434 @@
+/*
+ * Copyright (c) 2013-2020 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * $Date:        24. January 2020
+ * $Revision:    V1.2
+ *
+ * Project:      Storage Driver definitions
+ */
+
+/* History:
+ *  Version 1.2
+ *    Removed volatile from ARM_STORAGE_STATUS
+ *  Version 1.1
+ *    ARM_STORAGE_STATUS made volatile
+ *  Version 1.00
+ *    Initial release
+ */
+
+#ifndef DRIVER_STORAGE_H_
+#define DRIVER_STORAGE_H_
+
+#ifdef  __cplusplus
+extern "C" {
+#endif
+
+#include "Driver_Common.h"
+
+#define ARM_STORAGE_API_VERSION ARM_DRIVER_VERSION_MAJOR_MINOR(1,2)  /* API version */
+
+
+#define _ARM_Driver_Storage_(n)      Driver_Storage##n
+#define  ARM_Driver_Storage_(n) _ARM_Driver_Storage_(n)
+
+#define ARM_STORAGE_INVALID_OFFSET  (0xFFFFFFFFFFFFFFFFULL) ///< Invalid address (relative to a storage controller's
+                                                            ///  address space). A storage block may never start at this address.
+
+#define ARM_STORAGE_INVALID_ADDRESS (0xFFFFFFFFUL)          ///< Invalid address within the processor's memory address space.
+                                                            ///  Refer to memory-mapped storage, i.e. \ref ARM_DRIVER_STORAGE::ResolveAddress().
+
+/****** Storage specific error codes *****/
+#define ARM_STORAGE_ERROR_NOT_ERASABLE      (ARM_DRIVER_ERROR_SPECIFIC - 1) ///< Part (or all) of the range provided to Erase() isn't erasable.
+#define ARM_STORAGE_ERROR_NOT_PROGRAMMABLE  (ARM_DRIVER_ERROR_SPECIFIC - 2) ///< Part (or all) of the range provided to ProgramData() isn't programmable.
+#define ARM_STORAGE_ERROR_PROTECTED         (ARM_DRIVER_ERROR_SPECIFIC - 3) ///< Part (or all) of the range to Erase() or ProgramData() is protected.
+
+/**
+ * \brief Attributes of the storage range within a storage block.
+ */
+typedef struct _ARM_STORAGE_BLOCK_ATTRIBUTES {
+  uint32_t erasable      :  1;   ///< Erasing blocks is permitted with a minimum granularity of 'erase_unit'.
+                                 ///   @note if 'erasable' is 0 (i.e. the 'erase' operation isn't available) then
+                                 ///   'erase_unit' (see below) is immaterial and should be 0.
+  uint32_t programmable  :  1;   ///< Writing to ranges is permitted with a minimum granularity of 'program_unit'.
+                                 ///    Writes are typically achieved through the ProgramData operation (following an erase);
+                                 ///    if storage isn't erasable (see 'erasable' above) but is memory-mapped
+                                 ///    (i.e. 'memory_mapped'), it can be written directly using memory-store operations.
+  uint32_t executable    :  1;   ///< This storage block can hold program data; the processor can fetch and execute code
+                                 ///    sourced from it. Often this is accompanied with the device being 'memory_mapped' (see \ref ARM_STORAGE_INFO).
+  uint32_t protectable   :  1;   ///< The entire block can be protected from program and erase operations. Once protection
+                                 ///    is enabled for a block, its 'erasable' and 'programmable' bits are turned off.
+  uint32_t reserved      : 28;
+  uint32_t erase_unit;           ///< Minimum erase size in bytes.
+                                 ///    The offset of the start of the erase-range should also be aligned with this value.
+                                 ///    Applicable if the 'erasable' attribute is set for the block.
+                                 ///    @note if 'erasable' (see above) is 0 (i.e. the 'erase' operation isn't available) then
+                                 ///    'erase_unit' is immaterial and should be 0.
+  uint32_t protection_unit;      ///< Minimum protectable size in bytes. Applicable if the 'protectable'
+                                 ///    attribute is set for the block. This should be a divisor of the block's size. A
+                                 ///    block can be considered to be made up of consecutive, individually-protectable fragments.
+} ARM_STORAGE_BLOCK_ATTRIBUTES;
+
+/**
+ * \brief A storage block is a range of memory with uniform attributes.
+ */
+typedef struct _ARM_STORAGE_BLOCK {
+  uint64_t                     addr;       ///< This is the start address of the storage block. It is
+                                           ///    expressed as an offset from the start of the storage map
+                                           ///    maintained by the owning storage controller.
+  uint64_t                     size;       ///< This is the size of the storage block, in units of bytes.
+                                           ///    Together with addr, it describes a range [addr, addr+size).
+  ARM_STORAGE_BLOCK_ATTRIBUTES attributes; ///< Attributes for this block.
+} ARM_STORAGE_BLOCK;
+
+/**
+ * The check for a valid ARM_STORAGE_BLOCK.
+ */
+#define ARM_STORAGE_VALID_BLOCK(BLK) (((BLK)->addr != ARM_STORAGE_INVALID_OFFSET) && ((BLK)->size != 0))
+
+/**
+ * \brief Values for encoding storage memory-types with respect to programmability.
+ *
+ * Please ensure that the maximum of the following memory types doesn't exceed 16; we
+ * encode this in a 4-bit field within ARM_STORAGE_INFO::programmability.
+ */
+#define ARM_STORAGE_PROGRAMMABILITY_RAM       (0U)
+#define ARM_STORAGE_PROGRAMMABILITY_ROM       (1U)  ///< Read-only memory.
+#define ARM_STORAGE_PROGRAMMABILITY_WORM      (2U)  ///< write-once-read-only-memory (WORM).
+#define ARM_STORAGE_PROGRAMMABILITY_ERASABLE  (3U)  ///< re-programmable based on erase. Supports multiple writes.
+
+/**
+ * Values for encoding data-retention levels for storage blocks.
+ *
+ * Please ensure that the maximum of the following retention types doesn't exceed 16; we
+ * encode this in a 4-bit field within ARM_STORAGE_INFO::retention_level.
+ */
+#define ARM_RETENTION_WHILE_DEVICE_ACTIVE     (0U)  ///< Data is retained only during device activity.
+#define ARM_RETENTION_ACROSS_SLEEP            (1U)  ///< Data is retained across processor sleep.
+#define ARM_RETENTION_ACROSS_DEEP_SLEEP       (2U)  ///< Data is retained across processor deep-sleep.
+#define ARM_RETENTION_BATTERY_BACKED          (3U)  ///< Data is battery-backed. Device can be powered off.
+#define ARM_RETENTION_NVM                     (4U)  ///< Data is retained in non-volatile memory.
+
+/**
+ * Device Data Security Protection Features. Applicable mostly to EXTERNAL_NVM.
+ */
+typedef struct _ARM_STORAGE_SECURITY_FEATURES {
+  uint32_t acls                :  1; ///< Protection against internal software attacks using ACLs.
+  uint32_t rollback_protection :  1; ///< Roll-back protection. Set to true if the creator of the storage
+                                     ///    can ensure that an external attacker can't force an
+                                     ///    older firmware to run or to revert back to a previous state.
+  uint32_t tamper_proof        :  1; ///< Tamper-proof memory (will be deleted on tamper-attempts using board level or chip level sensors).
+  uint32_t internal_flash      :  1; ///< Internal flash.
+  uint32_t reserved1           : 12;
+
+  /**
+   * Encode support for hardening against various classes of attacks.
+   */
+  uint32_t software_attacks     :  1; ///< device software (malware running on the device).
+  uint32_t board_level_attacks  :  1; ///< board level attacks (debug probes, copy protection fuses.)
+  uint32_t chip_level_attacks   :  1; ///< chip level attacks (tamper-protection).
+  uint32_t side_channel_attacks :  1; ///< side channel attacks.
+  uint32_t reserved2            : 12;
+} ARM_STORAGE_SECURITY_FEATURES;
+
+#define ARM_STORAGE_PROGRAM_CYCLES_INFINITE (0UL) /**< Infinite or unknown endurance for reprogramming. */
+
+/**
+ * Device level metadata regarding the Storage implementation.
+ */
+typedef struct _ARM_STORAGE_INFO {
+  uint64_t                      total_storage;        ///< Total available storage, in bytes.
+  uint32_t                      program_unit;         ///< Minimum programming size in bytes.
+                                                      ///    The offset of the start of the program-range should also be aligned with this value.
+                                                      ///    Applicable only if the 'programmable' attribute is set for a block.
+                                                      ///    @note setting program_unit to 0 has the effect of disabling the size and alignment
+                                                      ///    restrictions (setting it to 1 also has the same effect).
+  uint32_t                      optimal_program_unit; ///< Optimal programming page-size in bytes. Some storage controllers
+                                                      ///    have internal buffers into which to receive data. Writing in chunks of
+                                                      ///    'optimal_program_unit' would achieve maximum programming speed.
+                                                      ///    Applicable only if the 'programmable' attribute is set for the underlying block(s).
+  uint32_t                      program_cycles;       ///< A measure of endurance for reprogramming.
+                                                      ///    Use ARM_STORAGE_PROGRAM_CYCLES_INFINITE for infinite or unknown endurance.
+  uint32_t                      erased_value    :  1; ///< Contents of erased memory (usually 1 to indicate erased bytes with state 0xFF).
+  uint32_t                      memory_mapped   :  1; ///< This storage device has a mapping onto the processor's memory address space.
+                                                      ///    @note For a memory-mapped block which isn't erasable but is programmable (i.e. if
+                                                      ///    'erasable' is set to 0, but 'programmable' is 1), writes should be possible directly to
+                                                      ///    the memory-mapped storage without going through the ProgramData operation.
+  uint32_t                      programmability :  4; ///< A value to indicate storage programmability.
+  uint32_t                      retention_level :  4;
+  uint32_t                      reserved        : 22;
+  ARM_STORAGE_SECURITY_FEATURES security;             ///< \ref ARM_STORAGE_SECURITY_FEATURES
+} ARM_STORAGE_INFO;
+
+/**
+\brief Operating status of the storage controller.
+*/
+typedef struct _ARM_STORAGE_STATUS {
+  uint32_t busy     : 1;                ///< Controller busy flag
+  uint32_t error    : 1;                ///< Read/Program/Erase error flag (cleared on start of next operation)
+  uint32_t reserved : 30;
+} ARM_STORAGE_STATUS;
+
+/**
+ * \brief Storage Driver API Capabilities.
+ */
+typedef struct _ARM_STORAGE_CAPABILITIES {
+  uint32_t asynchronous_ops :  1; ///< Used to indicate if APIs like initialize,
+                                  ///    read, erase, program, etc. can operate in asynchronous mode.
+                                  ///    Setting this bit to 1 means that the driver is capable
+                                  ///    of launching asynchronous operations; command completion is
+                                  ///    signaled by the invocation of a completion callback. If
+                                  ///    set to 1, drivers may still complete asynchronous
+                                  ///    operations synchronously as necessary (in which case they
+                                  ///    return a positive error code to indicate synchronous completion).
+  uint32_t erase_all        :  1; ///< Supports EraseAll operation.
+  uint32_t reserved         : 30; ///< Reserved (must be zero)
+} ARM_STORAGE_CAPABILITIES;
+
+/**
+ * Command opcodes for Storage.
+ */
+typedef enum _ARM_STORAGE_OPERATION {
+  ARM_STORAGE_OPERATION_GET_VERSION,
+  ARM_STORAGE_OPERATION_GET_CAPABILITIES,
+  ARM_STORAGE_OPERATION_INITIALIZE,
+  ARM_STORAGE_OPERATION_UNINITIALIZE,
+  ARM_STORAGE_OPERATION_POWER_CONTROL,
+  ARM_STORAGE_OPERATION_READ_DATA,
+  ARM_STORAGE_OPERATION_PROGRAM_DATA,
+  ARM_STORAGE_OPERATION_ERASE,
+  ARM_STORAGE_OPERATION_ERASE_ALL,
+  ARM_STORAGE_OPERATION_GET_STATUS,
+  ARM_STORAGE_OPERATION_GET_INFO,
+  ARM_STORAGE_OPERATION_RESOLVE_ADDRESS,
+  ARM_STORAGE_OPERATION_GET_NEXT_BLOCK,
+  ARM_STORAGE_OPERATION_GET_BLOCK
+} ARM_STORAGE_OPERATION;
+
+// Function documentation
+/**
+  \fn          ARM_DRIVER_VERSION ARM_Storage_GetVersion (void)
+  \brief       Get driver version.
+  \return      \ref ARM_DRIVER_VERSION
+*/
+/**
+  \fn          ARM_STORAGE_CAPABILITIES ARM_Storage_GetCapabilities (void)
+  \brief       Get driver capabilities.
+  \return      \ref ARM_STORAGE_CAPABILITIES
+*/
+/**
+  \fn          int32_t ARM_Storage_Initialize (ARM_Storage_Callback_t callback)
+  \brief       Initialize the Storage interface.
+  \param [in]  callback Pointer to \ref ARM_Storage_Callback_t.
+               Caller-defined callback to be invoked upon command completion
+               for asynchronous APIs (including the completion of
+               initialization). Use a NULL pointer when no callback
+               signals are required.
+  \return      If asynchronous activity is launched, invocation
+               ARM_DRIVER_OK, and the caller can expect to receive a callback in the
+               future with a status value of ARM_DRIVER_OK or an error-code. In the
+               case of synchronous execution, control returns after completion with a
+               value of 1. Return values less than ARM_DRIVER_OK (0) signify errors.
+*/
+/**
+  \fn          int32_t ARM_Storage_Uninitialize (void)
+  \brief       De-initialize the Storage Interface.
+  \return      If asynchronous activity is launched, an invocation returns
+               ARM_DRIVER_OK, and the caller can expect to receive a callback in the
+               future with a status value of ARM_DRIVER_OK or an error-code. In the
+               case of synchronous execution, control returns after completion with a
+               value of 1. Return values less than ARM_DRIVER_OK (0) signify errors.
+*/
+/**
+  \fn          int32_t ARM_Storage_PowerControl (ARM_POWER_STATE state)
+  \brief       Control the Storage interface power.
+  \param[in]   state  Power state
+  \return      If asynchronous activity is launched, an invocation returns
+               ARM_DRIVER_OK, and the caller can expect to receive a callback in the
+               future with a status value of ARM_DRIVER_OK or an error-code. In the
+               case of synchronous execution, control returns after completion with a
+               value of 1. Return values less than ARM_DRIVER_OK (0) signify errors.
+*/
+/**
+  \fn          int32_t ARM_Storage_ReadData (uint64_t addr, void *data, uint32_t size)
+  \brief       Read data from Storage.
+  \param[in]   addr  Data address.
+  \param[out]  data  Pointer to a buffer storing the data read from Storage.
+  \param[in]   size  Number of bytes to read. The data buffer
+               should be at least as large as this size.
+  \return      If asynchronous activity is launched, an invocation returns
+               ARM_DRIVER_OK, and the caller can expect to receive a callback in the
+               future with the number of successfully transferred bytes passed in as
+               the 'status' parameter. In the case of synchronous execution, control
+               returns after completion with a positive transfer-count. Return values
+               less than ARM_DRIVER_OK (0) signify errors.
+*/
+/**
+  \fn          int32_t ARM_Storage_ProgramData (uint64_t addr, const void *data, uint32_t size)
+  \brief       Program data to Storage.
+  \param [in] addr This is the start address of the range to be written into. It
+               needs to be aligned to the device's \em program_unit
+               specified in \ref ARM_STORAGE_INFO.
+  \param [in] data The source of the write operation. The buffer is owned by the
+               caller and should remain accessible for the lifetime of this
+               command.
+  \param [in] size The number of bytes requested to be written. The buffer
+               should be at least as large as this size. \note 'size' should
+               be a multiple of the device's 'program_unit' (see \ref
+               ARM_STORAGE_INFO).
+  \return      If asynchronous activity is launched, an invocation returns
+               ARM_DRIVER_OK, and the caller can expect to receive a callback in the
+               future with the number of successfully transferred bytes passed in as
+               the 'status' parameter. In the case of synchronous execution, control
+               returns after completion with a positive transfer-count. Return values
+               less than ARM_DRIVER_OK (0) signify errors.
+*/
+/**
+  \fn          int32_t ARM_Storage_Erase (uint64_t addr, uint32_t size)
+  \brief       Erase Storage range.
+  \param [in]  addr This is the start-address of the range to be erased. It must
+               start at an 'erase_unit' boundary of the underlying block.
+  \param [in]  size Size (in bytes) of the range to be erased. 'addr + size'
+               must be aligned with the 'erase_unit' of the underlying
+               block.
+  \return      If the range to be erased doesn't align with the erase_units of the
+               respective start and end blocks, ARM_DRIVER_ERROR_PARAMETER is
+               returned. If any part of the range is protected,
+               ARM_STORAGE_ERROR_PROTECTED is returned. If any part of the range
+               is not erasable, ARM_STORAGE_ERROR_NOT_ERASABLE is returned. All
+               such sanity-check failures result in the error code being
+               returned synchronously and the storage bytes within the range
+               remain unaffected. Otherwise the function executes in the
+               following ways: If asynchronous activity is launched, an
+               invocation returns ARM_DRIVER_OK, and the caller can expect to
+               receive a callback in the future with the number of successfully
+               erased bytes passed in as the 'status' parameter. In the case of
+               synchronous execution, control returns after completion with a
+               positive erase-count. Return values less than ARM_DRIVER_OK (0)
+               signify errors.
+*/
+/**
+  \fn          int32_t ARM_Storage_EraseAll (void)
+  \brief       Erase complete Storage.
+  \return      If any part of the storage range is protected,
+               ARM_STORAGE_ERROR_PROTECTED is returned. If any part of the
+               storage range is not erasable, ARM_STORAGE_ERROR_NOT_ERASABLE is
+               returned. All such sanity-check failures result in the error code
+               being returned synchronously and the storage bytes within the
+               range remain unaffected. Otherwise the function executes in the
+               following ways: If asynchronous activity is launched, an
+               invocation returns ARM_DRIVER_OK, and the caller can expect to
+               receive a callback in the future with ARM_DRIVER_OK passed in as
+               the 'status' parameter. In the case of synchronous execution,
+               control returns after completion with a value of 1. Return values
+               less than ARM_DRIVER_OK (0) signify errors.
+*/
+/**
+  \fn          ARM_STORAGE_STATUS ARM_Storage_GetStatus (void)
+  \brief       Get Storage status.
+  \return      Storage status \ref ARM_STORAGE_STATUS
+*/
+/**
+  \fn          int32_t ARM_Storage_GetInfo (ARM_STORAGE_INFO *info)
+  \brief       Get Storage information.
+  \param[out]  info  A caller-supplied buffer capable of being filled in with an \ref ARM_STORAGE_INFO.
+  \return      ARM_DRIVER_OK if a ARM_STORAGE_INFO structure containing top level
+               metadata about the storage controller is filled into the supplied
+               buffer, else an appropriate error value.
+*/
+/**
+  \fn          uint32_t ARM_Storage_ResolveAddress(uint64_t addr)
+  \brief       Resolve an address relative to the storage controller into a memory address.
+  \param[in]   addr The address for which we want a resolution to the processor's physical address space. It is an offset from the
+               start of the storage map maintained by the owning storage
+               controller.
+  \return      The resolved address in the processor's address space, else ARM_STORAGE_INVALID_ADDRESS.
+*/
+/**
+  \fn          int32_t ARM_Storage_GetNextBlock(const ARM_STORAGE_BLOCK* prev_block, ARM_STORAGE_BLOCK *next_block);
+  \brief       Advance to the successor of the current block (iterator).
+  \param[in]   prev_block An existing block (iterator) within the same storage
+               controller. The memory buffer holding this block is owned
+               by the caller. This pointer may be NULL; if so, the
+               invocation fills in the first block into the out parameter:
+               'next_block'.
+  \param[out]  next_block A caller-owned buffer large enough to be filled in with
+               the following ARM_STORAGE_BLOCK. It is legal to provide the
+               same buffer using 'next_block' as was passed in with 'prev_block'. It
+               is also legal to pass a NULL into this parameter if the
+               caller isn't interested in populating a buffer with the next
+               block, i.e. if the caller only wishes to establish the
+               presence of a next block.
+  \return      ARM_DRIVER_OK if a valid next block is found (or first block, if
+               prev_block is passed as NULL); upon successful operation, the contents
+               of the next (or first) block are filled into the buffer pointed to by
+               the parameter 'next_block' and ARM_STORAGE_VALID_BLOCK(next_block) is
+               guaranteed to be true. Upon reaching the end of the sequence of blocks
+               (iterators), or in case the driver is unable to fetch information about
+               the next (or first) block, an error (negative) value is returned and an
+               invalid StorageBlock is populated into the supplied buffer. If
+               prev_block is NULL, the first block is returned.
+*/
+/**
+  \fn          int32_t ARM_Storage_GetBlock(uint64_t addr, ARM_STORAGE_BLOCK *block);
+  \brief       Find the storage block (iterator) encompassing a given storage address.
+  \param[in]   addr Storage address in bytes.
+  \param[out]  block A caller-owned buffer large enough to be filled in with the
+               ARM_STORAGE_BLOCK encapsulating the given address. This value
+               can also be passed in as NULL if the caller isn't interested
+               in populating a buffer with the block, if the caller only
+               wishes to establish the presence of a containing storage
+               block.
+  \return      ARM_DRIVER_OK if a containing storage-block is found. In this case,
+               if block is non-NULL, the buffer pointed to by it is populated with
+               the contents of the storage block, i.e. if block is valid and a block is
+               found, ARM_STORAGE_VALID_BLOCK(block) would return true following this
+               call. If there is no storage block containing the given offset, or in
+               case the driver is unable to resolve an address to a storage-block, an
+               error (negative) value is returned and an invalid StorageBlock is
+               populated into the supplied buffer.
+*/
+
+/**
+ * Provides the typedef for the callback function \ref ARM_Storage_Callback_t.
+ */
+typedef void (*ARM_Storage_Callback_t)(int32_t status, ARM_STORAGE_OPERATION operation);
+
+/**
+ * The set of operations constituting the Storage driver.
+ */
+typedef struct _ARM_DRIVER_STORAGE {
+  ARM_DRIVER_VERSION       (*GetVersion)     (void);                                           ///< Pointer to \ref ARM_Storage_GetVersion : Get driver version.
+  ARM_STORAGE_CAPABILITIES (*GetCapabilities)(void);                                           ///< Pointer to \ref ARM_Storage_GetCapabilities : Get driver capabilities.
+  int32_t                  (*Initialize)     (ARM_Storage_Callback_t callback);                ///< Pointer to \ref ARM_Storage_Initialize : Initialize the Storage Interface.
+  int32_t                  (*Uninitialize)   (void);                                           ///< Pointer to \ref ARM_Storage_Uninitialize : De-initialize the Storage Interface.
+  int32_t                  (*PowerControl)   (ARM_POWER_STATE state);                          ///< Pointer to \ref ARM_Storage_PowerControl : Control the Storage interface power.
+  int32_t                  (*ReadData)       (uint64_t addr, void *data, uint32_t size);       ///< Pointer to \ref ARM_Storage_ReadData : Read data from Storage.
+  int32_t                  (*ProgramData)    (uint64_t addr, const void *data, uint32_t size); ///< Pointer to \ref ARM_Storage_ProgramData : Program data to Storage.
+  int32_t                  (*Erase)          (uint64_t addr, uint32_t size);                   ///< Pointer to \ref ARM_Storage_Erase : Erase Storage range.
+  int32_t                  (*EraseAll)       (void);                                           ///< Pointer to \ref ARM_Storage_EraseAll : Erase complete Storage.
+  ARM_STORAGE_STATUS       (*GetStatus)      (void);                                           ///< Pointer to \ref ARM_Storage_GetStatus : Get Storage status.
+  int32_t                  (*GetInfo)        (ARM_STORAGE_INFO *info);                         ///< Pointer to \ref ARM_Storage_GetInfo : Get Storage information.
+  uint32_t                 (*ResolveAddress) (uint64_t addr);                                  ///< Pointer to \ref ARM_Storage_ResolveAddress : Resolve a storage address.
+  int32_t                  (*GetNextBlock)   (const ARM_STORAGE_BLOCK* prev, ARM_STORAGE_BLOCK *next); ///< Pointer to \ref ARM_Storage_GetNextBlock : fetch successor for current block.
+  int32_t                  (*GetBlock)       (uint64_t addr, ARM_STORAGE_BLOCK *block);        ///< Pointer to \ref ARM_Storage_GetBlock :
+} const ARM_DRIVER_STORAGE;
+
+#ifdef  __cplusplus
+}
+#endif
+
+#endif /* DRIVER_STORAGE_H_ */

--- a/platform/ext/cmsis/CMSIS/Driver/Include/Driver_USART.h
+++ b/platform/ext/cmsis/CMSIS/Driver/Include/Driver_USART.h
@@ -1,0 +1,346 @@
+/*
+ * Copyright (c) 2013-2020 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * $Date:        31. March 2020
+ * $Revision:    V2.4
+ *
+ * Project:      USART (Universal Synchronous Asynchronous Receiver Transmitter)
+ *               Driver definitions
+ */
+
+/* History:
+ *  Version 2.4
+ *    Removed volatile from ARM_USART_STATUS and ARM_USART_MODEM_STATUS
+ *  Version 2.3
+ *    ARM_USART_STATUS and ARM_USART_MODEM_STATUS made volatile
+ *  Version 2.2
+ *    Corrected ARM_USART_CPOL_Pos and ARM_USART_CPHA_Pos definitions
+ *  Version 2.1
+ *    Removed optional argument parameter from Signal Event
+ *  Version 2.0
+ *    New simplified driver:
+ *      complexity moved to upper layer (especially data handling)
+ *      more unified API for different communication interfaces
+ *      renamed driver UART -> USART (Asynchronous & Synchronous)
+ *    Added modes:
+ *      Synchronous
+ *      Single-wire
+ *      IrDA
+ *      Smart Card
+ *    Changed prefix ARM_DRV -> ARM_DRIVER
+ *  Version 1.10
+ *    Namespace prefix ARM_ added
+ *  Version 1.01
+ *    Added events:
+ *      ARM_UART_EVENT_TX_EMPTY,     ARM_UART_EVENT_RX_TIMEOUT
+ *      ARM_UART_EVENT_TX_THRESHOLD, ARM_UART_EVENT_RX_THRESHOLD
+ *    Added functions: SetTxThreshold, SetRxThreshold
+ *    Added "rx_timeout_event" to capabilities
+ *  Version 1.00
+ *    Initial release
+ */
+
+#ifndef DRIVER_USART_H_
+#define DRIVER_USART_H_
+
+#ifdef  __cplusplus
+extern "C"
+{
+#endif
+
+#include "Driver_Common.h"
+
+#define ARM_USART_API_VERSION ARM_DRIVER_VERSION_MAJOR_MINOR(2,4)  /* API version */
+
+
+#define _ARM_Driver_USART_(n)      Driver_USART##n
+#define  ARM_Driver_USART_(n) _ARM_Driver_USART_(n)
+
+
+/****** USART Control Codes *****/
+
+#define ARM_USART_CONTROL_Pos                0
+#define ARM_USART_CONTROL_Msk               (0xFFUL << ARM_USART_CONTROL_Pos)
+
+/*----- USART Control Codes: Mode -----*/
+#define ARM_USART_MODE_ASYNCHRONOUS         (0x01UL << ARM_USART_CONTROL_Pos)   ///< UART (Asynchronous); arg = Baudrate
+#define ARM_USART_MODE_SYNCHRONOUS_MASTER   (0x02UL << ARM_USART_CONTROL_Pos)   ///< Synchronous Master (generates clock signal); arg = Baudrate
+#define ARM_USART_MODE_SYNCHRONOUS_SLAVE    (0x03UL << ARM_USART_CONTROL_Pos)   ///< Synchronous Slave (external clock signal)
+#define ARM_USART_MODE_SINGLE_WIRE          (0x04UL << ARM_USART_CONTROL_Pos)   ///< UART Single-wire (half-duplex); arg = Baudrate
+#define ARM_USART_MODE_IRDA                 (0x05UL << ARM_USART_CONTROL_Pos)   ///< UART IrDA; arg = Baudrate
+#define ARM_USART_MODE_SMART_CARD           (0x06UL << ARM_USART_CONTROL_Pos)   ///< UART Smart Card; arg = Baudrate
+
+/*----- USART Control Codes: Mode Parameters: Data Bits -----*/
+#define ARM_USART_DATA_BITS_Pos              8
+#define ARM_USART_DATA_BITS_Msk             (7UL << ARM_USART_DATA_BITS_Pos)
+#define ARM_USART_DATA_BITS_5               (5UL << ARM_USART_DATA_BITS_Pos)    ///< 5 Data bits
+#define ARM_USART_DATA_BITS_6               (6UL << ARM_USART_DATA_BITS_Pos)    ///< 6 Data bit
+#define ARM_USART_DATA_BITS_7               (7UL << ARM_USART_DATA_BITS_Pos)    ///< 7 Data bits
+#define ARM_USART_DATA_BITS_8               (0UL << ARM_USART_DATA_BITS_Pos)    ///< 8 Data bits (default)
+#define ARM_USART_DATA_BITS_9               (1UL << ARM_USART_DATA_BITS_Pos)    ///< 9 Data bits
+
+/*----- USART Control Codes: Mode Parameters: Parity -----*/
+#define ARM_USART_PARITY_Pos                 12
+#define ARM_USART_PARITY_Msk                (3UL << ARM_USART_PARITY_Pos)
+#define ARM_USART_PARITY_NONE               (0UL << ARM_USART_PARITY_Pos)       ///< No Parity (default)
+#define ARM_USART_PARITY_EVEN               (1UL << ARM_USART_PARITY_Pos)       ///< Even Parity
+#define ARM_USART_PARITY_ODD                (2UL << ARM_USART_PARITY_Pos)       ///< Odd Parity
+
+/*----- USART Control Codes: Mode Parameters: Stop Bits -----*/
+#define ARM_USART_STOP_BITS_Pos              14
+#define ARM_USART_STOP_BITS_Msk             (3UL << ARM_USART_STOP_BITS_Pos)
+#define ARM_USART_STOP_BITS_1               (0UL << ARM_USART_STOP_BITS_Pos)    ///< 1 Stop bit (default)
+#define ARM_USART_STOP_BITS_2               (1UL << ARM_USART_STOP_BITS_Pos)    ///< 2 Stop bits
+#define ARM_USART_STOP_BITS_1_5             (2UL << ARM_USART_STOP_BITS_Pos)    ///< 1.5 Stop bits
+#define ARM_USART_STOP_BITS_0_5             (3UL << ARM_USART_STOP_BITS_Pos)    ///< 0.5 Stop bits
+
+/*----- USART Control Codes: Mode Parameters: Flow Control -----*/
+#define ARM_USART_FLOW_CONTROL_Pos           16
+#define ARM_USART_FLOW_CONTROL_Msk          (3UL << ARM_USART_FLOW_CONTROL_Pos)
+#define ARM_USART_FLOW_CONTROL_NONE         (0UL << ARM_USART_FLOW_CONTROL_Pos) ///< No Flow Control (default)
+#define ARM_USART_FLOW_CONTROL_RTS          (1UL << ARM_USART_FLOW_CONTROL_Pos) ///< RTS Flow Control
+#define ARM_USART_FLOW_CONTROL_CTS          (2UL << ARM_USART_FLOW_CONTROL_Pos) ///< CTS Flow Control
+#define ARM_USART_FLOW_CONTROL_RTS_CTS      (3UL << ARM_USART_FLOW_CONTROL_Pos) ///< RTS/CTS Flow Control
+
+/*----- USART Control Codes: Mode Parameters: Clock Polarity (Synchronous mode) -----*/
+#define ARM_USART_CPOL_Pos                   18
+#define ARM_USART_CPOL_Msk                  (1UL << ARM_USART_CPOL_Pos)
+#define ARM_USART_CPOL0                     (0UL << ARM_USART_CPOL_Pos)         ///< CPOL = 0 (default)
+#define ARM_USART_CPOL1                     (1UL << ARM_USART_CPOL_Pos)         ///< CPOL = 1
+
+/*----- USART Control Codes: Mode Parameters: Clock Phase (Synchronous mode) -----*/
+#define ARM_USART_CPHA_Pos                   19
+#define ARM_USART_CPHA_Msk                  (1UL << ARM_USART_CPHA_Pos)
+#define ARM_USART_CPHA0                     (0UL << ARM_USART_CPHA_Pos)         ///< CPHA = 0 (default)
+#define ARM_USART_CPHA1                     (1UL << ARM_USART_CPHA_Pos)         ///< CPHA = 1
+
+
+/*----- USART Control Codes: Miscellaneous Controls  -----*/
+#define ARM_USART_SET_DEFAULT_TX_VALUE      (0x10UL << ARM_USART_CONTROL_Pos)   ///< Set default Transmit value (Synchronous Receive only); arg = value
+#define ARM_USART_SET_IRDA_PULSE            (0x11UL << ARM_USART_CONTROL_Pos)   ///< Set IrDA Pulse in ns; arg: 0=3/16 of bit period
+#define ARM_USART_SET_SMART_CARD_GUARD_TIME (0x12UL << ARM_USART_CONTROL_Pos)   ///< Set Smart Card Guard Time; arg = number of bit periods
+#define ARM_USART_SET_SMART_CARD_CLOCK      (0x13UL << ARM_USART_CONTROL_Pos)   ///< Set Smart Card Clock in Hz; arg: 0=Clock not generated
+#define ARM_USART_CONTROL_SMART_CARD_NACK   (0x14UL << ARM_USART_CONTROL_Pos)   ///< Smart Card NACK generation; arg: 0=disabled, 1=enabled
+#define ARM_USART_CONTROL_TX                (0x15UL << ARM_USART_CONTROL_Pos)   ///< Transmitter; arg: 0=disabled, 1=enabled
+#define ARM_USART_CONTROL_RX                (0x16UL << ARM_USART_CONTROL_Pos)   ///< Receiver; arg: 0=disabled, 1=enabled
+#define ARM_USART_CONTROL_BREAK             (0x17UL << ARM_USART_CONTROL_Pos)   ///< Continuous Break transmission; arg: 0=disabled, 1=enabled
+#define ARM_USART_ABORT_SEND                (0x18UL << ARM_USART_CONTROL_Pos)   ///< Abort \ref ARM_USART_Send
+#define ARM_USART_ABORT_RECEIVE             (0x19UL << ARM_USART_CONTROL_Pos)   ///< Abort \ref ARM_USART_Receive
+#define ARM_USART_ABORT_TRANSFER            (0x1AUL << ARM_USART_CONTROL_Pos)   ///< Abort \ref ARM_USART_Transfer
+
+
+
+/****** USART specific error codes *****/
+#define ARM_USART_ERROR_MODE                (ARM_DRIVER_ERROR_SPECIFIC - 1)     ///< Specified Mode not supported
+#define ARM_USART_ERROR_BAUDRATE            (ARM_DRIVER_ERROR_SPECIFIC - 2)     ///< Specified baudrate not supported
+#define ARM_USART_ERROR_DATA_BITS           (ARM_DRIVER_ERROR_SPECIFIC - 3)     ///< Specified number of Data bits not supported
+#define ARM_USART_ERROR_PARITY              (ARM_DRIVER_ERROR_SPECIFIC - 4)     ///< Specified Parity not supported
+#define ARM_USART_ERROR_STOP_BITS           (ARM_DRIVER_ERROR_SPECIFIC - 5)     ///< Specified number of Stop bits not supported
+#define ARM_USART_ERROR_FLOW_CONTROL        (ARM_DRIVER_ERROR_SPECIFIC - 6)     ///< Specified Flow Control not supported
+#define ARM_USART_ERROR_CPOL                (ARM_DRIVER_ERROR_SPECIFIC - 7)     ///< Specified Clock Polarity not supported
+#define ARM_USART_ERROR_CPHA                (ARM_DRIVER_ERROR_SPECIFIC - 8)     ///< Specified Clock Phase not supported
+
+
+/**
+\brief USART Status
+*/
+typedef struct _ARM_USART_STATUS {
+  uint32_t tx_busy          : 1;        ///< Transmitter busy flag
+  uint32_t rx_busy          : 1;        ///< Receiver busy flag
+  uint32_t tx_underflow     : 1;        ///< Transmit data underflow detected (cleared on start of next send operation)
+  uint32_t rx_overflow      : 1;        ///< Receive data overflow detected (cleared on start of next receive operation)
+  uint32_t rx_break         : 1;        ///< Break detected on receive (cleared on start of next receive operation)
+  uint32_t rx_framing_error : 1;        ///< Framing error detected on receive (cleared on start of next receive operation)
+  uint32_t rx_parity_error  : 1;        ///< Parity error detected on receive (cleared on start of next receive operation)
+  uint32_t reserved         : 25;
+} ARM_USART_STATUS;
+
+/**
+\brief USART Modem Control
+*/
+typedef enum _ARM_USART_MODEM_CONTROL {
+  ARM_USART_RTS_CLEAR,                  ///< Deactivate RTS
+  ARM_USART_RTS_SET,                    ///< Activate RTS
+  ARM_USART_DTR_CLEAR,                  ///< Deactivate DTR
+  ARM_USART_DTR_SET                     ///< Activate DTR
+} ARM_USART_MODEM_CONTROL;
+
+/**
+\brief USART Modem Status
+*/
+typedef struct _ARM_USART_MODEM_STATUS {
+  uint32_t cts      : 1;                ///< CTS state: 1=Active, 0=Inactive
+  uint32_t dsr      : 1;                ///< DSR state: 1=Active, 0=Inactive
+  uint32_t dcd      : 1;                ///< DCD state: 1=Active, 0=Inactive
+  uint32_t ri       : 1;                ///< RI  state: 1=Active, 0=Inactive
+  uint32_t reserved : 28;
+} ARM_USART_MODEM_STATUS;
+
+
+/****** USART Event *****/
+#define ARM_USART_EVENT_SEND_COMPLETE       (1UL << 0)  ///< Send completed; however USART may still transmit data
+#define ARM_USART_EVENT_RECEIVE_COMPLETE    (1UL << 1)  ///< Receive completed
+#define ARM_USART_EVENT_TRANSFER_COMPLETE   (1UL << 2)  ///< Transfer completed
+#define ARM_USART_EVENT_TX_COMPLETE         (1UL << 3)  ///< Transmit completed (optional)
+#define ARM_USART_EVENT_TX_UNDERFLOW        (1UL << 4)  ///< Transmit data not available (Synchronous Slave)
+#define ARM_USART_EVENT_RX_OVERFLOW         (1UL << 5)  ///< Receive data overflow
+#define ARM_USART_EVENT_RX_TIMEOUT          (1UL << 6)  ///< Receive character timeout (optional)
+#define ARM_USART_EVENT_RX_BREAK            (1UL << 7)  ///< Break detected on receive
+#define ARM_USART_EVENT_RX_FRAMING_ERROR    (1UL << 8)  ///< Framing error detected on receive
+#define ARM_USART_EVENT_RX_PARITY_ERROR     (1UL << 9)  ///< Parity error detected on receive
+#define ARM_USART_EVENT_CTS                 (1UL << 10) ///< CTS state changed (optional)
+#define ARM_USART_EVENT_DSR                 (1UL << 11) ///< DSR state changed (optional)
+#define ARM_USART_EVENT_DCD                 (1UL << 12) ///< DCD state changed (optional)
+#define ARM_USART_EVENT_RI                  (1UL << 13) ///< RI  state changed (optional)
+
+
+// Function documentation
+/**
+  \fn          ARM_DRIVER_VERSION ARM_USART_GetVersion (void)
+  \brief       Get driver version.
+  \return      \ref ARM_DRIVER_VERSION
+
+  \fn          ARM_USART_CAPABILITIES ARM_USART_GetCapabilities (void)
+  \brief       Get driver capabilities.
+  \return      \ref ARM_USART_CAPABILITIES
+
+  \fn          int32_t ARM_USART_Initialize (ARM_USART_SignalEvent_t cb_event)
+  \brief       Initialize USART Interface.
+  \param[in]   cb_event  Pointer to \ref ARM_USART_SignalEvent
+  \return      \ref execution_status
+
+  \fn          int32_t ARM_USART_Uninitialize (void)
+  \brief       De-initialize USART Interface.
+  \return      \ref execution_status
+
+  \fn          int32_t ARM_USART_PowerControl (ARM_POWER_STATE state)
+  \brief       Control USART Interface Power.
+  \param[in]   state  Power state
+  \return      \ref execution_status
+
+  \fn          int32_t ARM_USART_Send (const void *data, uint32_t num)
+  \brief       Start sending data to USART transmitter.
+  \param[in]   data  Pointer to buffer with data to send to USART transmitter
+  \param[in]   num   Number of data items to send
+  \return      \ref execution_status
+
+  \fn          int32_t ARM_USART_Receive (void *data, uint32_t num)
+  \brief       Start receiving data from USART receiver.
+  \param[out]  data  Pointer to buffer for data to receive from USART receiver
+  \param[in]   num   Number of data items to receive
+  \return      \ref execution_status
+
+  \fn          int32_t ARM_USART_Transfer (const void *data_out,
+                                                 void *data_in,
+                                           uint32_t    num)
+  \brief       Start sending/receiving data to/from USART transmitter/receiver.
+  \param[in]   data_out  Pointer to buffer with data to send to USART transmitter
+  \param[out]  data_in   Pointer to buffer for data to receive from USART receiver
+  \param[in]   num       Number of data items to transfer
+  \return      \ref execution_status
+
+  \fn          uint32_t ARM_USART_GetTxCount (void)
+  \brief       Get transmitted data count.
+  \return      number of data items transmitted
+
+  \fn          uint32_t ARM_USART_GetRxCount (void)
+  \brief       Get received data count.
+  \return      number of data items received
+
+  \fn          int32_t ARM_USART_Control (uint32_t control, uint32_t arg)
+  \brief       Control USART Interface.
+  \param[in]   control  Operation
+  \param[in]   arg      Argument of operation (optional)
+  \return      common \ref execution_status and driver specific \ref usart_execution_status
+
+  \fn          ARM_USART_STATUS ARM_USART_GetStatus (void)
+  \brief       Get USART status.
+  \return      USART status \ref ARM_USART_STATUS
+
+  \fn          int32_t ARM_USART_SetModemControl (ARM_USART_MODEM_CONTROL control)
+  \brief       Set USART Modem Control line state.
+  \param[in]   control  \ref ARM_USART_MODEM_CONTROL
+  \return      \ref execution_status
+
+  \fn          ARM_USART_MODEM_STATUS ARM_USART_GetModemStatus (void)
+  \brief       Get USART Modem Status lines state.
+  \return      modem status \ref ARM_USART_MODEM_STATUS
+
+  \fn          void ARM_USART_SignalEvent (uint32_t event)
+  \brief       Signal USART Events.
+  \param[in]   event  \ref USART_events notification mask
+*/
+
+typedef void (*ARM_USART_SignalEvent_t) (uint32_t event);  ///< Pointer to \ref ARM_USART_SignalEvent : Signal USART Event.
+
+
+/**
+\brief USART Device Driver Capabilities.
+*/
+typedef struct _ARM_USART_CAPABILITIES {
+  uint32_t asynchronous       : 1;      ///< supports UART (Asynchronous) mode
+  uint32_t synchronous_master : 1;      ///< supports Synchronous Master mode
+  uint32_t synchronous_slave  : 1;      ///< supports Synchronous Slave mode
+  uint32_t single_wire        : 1;      ///< supports UART Single-wire mode
+  uint32_t irda               : 1;      ///< supports UART IrDA mode
+  uint32_t smart_card         : 1;      ///< supports UART Smart Card mode
+  uint32_t smart_card_clock   : 1;      ///< Smart Card Clock generator available
+  uint32_t flow_control_rts   : 1;      ///< RTS Flow Control available
+  uint32_t flow_control_cts   : 1;      ///< CTS Flow Control available
+  uint32_t event_tx_complete  : 1;      ///< Transmit completed event: \ref ARM_USART_EVENT_TX_COMPLETE
+  uint32_t event_rx_timeout   : 1;      ///< Signal receive character timeout event: \ref ARM_USART_EVENT_RX_TIMEOUT
+  uint32_t rts                : 1;      ///< RTS Line: 0=not available, 1=available
+  uint32_t cts                : 1;      ///< CTS Line: 0=not available, 1=available
+  uint32_t dtr                : 1;      ///< DTR Line: 0=not available, 1=available
+  uint32_t dsr                : 1;      ///< DSR Line: 0=not available, 1=available
+  uint32_t dcd                : 1;      ///< DCD Line: 0=not available, 1=available
+  uint32_t ri                 : 1;      ///< RI Line: 0=not available, 1=available
+  uint32_t event_cts          : 1;      ///< Signal CTS change event: \ref ARM_USART_EVENT_CTS
+  uint32_t event_dsr          : 1;      ///< Signal DSR change event: \ref ARM_USART_EVENT_DSR
+  uint32_t event_dcd          : 1;      ///< Signal DCD change event: \ref ARM_USART_EVENT_DCD
+  uint32_t event_ri           : 1;      ///< Signal RI change event: \ref ARM_USART_EVENT_RI
+  uint32_t reserved           : 11;     ///< Reserved (must be zero)
+} ARM_USART_CAPABILITIES;
+
+
+/**
+\brief Access structure of the USART Driver.
+*/
+typedef struct _ARM_DRIVER_USART {
+  ARM_DRIVER_VERSION     (*GetVersion)      (void);                              ///< Pointer to \ref ARM_USART_GetVersion : Get driver version.
+  ARM_USART_CAPABILITIES (*GetCapabilities) (void);                              ///< Pointer to \ref ARM_USART_GetCapabilities : Get driver capabilities.
+  int32_t                (*Initialize)      (ARM_USART_SignalEvent_t cb_event);  ///< Pointer to \ref ARM_USART_Initialize : Initialize USART Interface.
+  int32_t                (*Uninitialize)    (void);                              ///< Pointer to \ref ARM_USART_Uninitialize : De-initialize USART Interface.
+  int32_t                (*PowerControl)    (ARM_POWER_STATE state);             ///< Pointer to \ref ARM_USART_PowerControl : Control USART Interface Power.
+  int32_t                (*Send)            (const void *data, uint32_t num);    ///< Pointer to \ref ARM_USART_Send : Start sending data to USART transmitter.
+  int32_t                (*Receive)         (      void *data, uint32_t num);    ///< Pointer to \ref ARM_USART_Receive : Start receiving data from USART receiver.
+  int32_t                (*Transfer)        (const void *data_out,
+                                                   void *data_in,
+                                             uint32_t    num);                   ///< Pointer to \ref ARM_USART_Transfer : Start sending/receiving data to/from USART.
+  uint32_t               (*GetTxCount)      (void);                              ///< Pointer to \ref ARM_USART_GetTxCount : Get transmitted data count.
+  uint32_t               (*GetRxCount)      (void);                              ///< Pointer to \ref ARM_USART_GetRxCount : Get received data count.
+  int32_t                (*Control)         (uint32_t control, uint32_t arg);    ///< Pointer to \ref ARM_USART_Control : Control USART Interface.
+  ARM_USART_STATUS       (*GetStatus)       (void);                              ///< Pointer to \ref ARM_USART_GetStatus : Get USART status.
+  int32_t                (*SetModemControl) (ARM_USART_MODEM_CONTROL control);   ///< Pointer to \ref ARM_USART_SetModemControl : Set USART Modem Control line state.
+  ARM_USART_MODEM_STATUS (*GetModemStatus)  (void);                              ///< Pointer to \ref ARM_USART_GetModemStatus : Get USART Modem Status lines state.
+} const ARM_DRIVER_USART;
+
+#ifdef  __cplusplus
+}
+#endif
+
+#endif /* DRIVER_USART_H_ */

--- a/platform/ext/cmsis/CMSIS/Driver/Include/Driver_USB.h
+++ b/platform/ext/cmsis/CMSIS/Driver/Include/Driver_USB.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2013-2020 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * $Date:        24. January 2020
+ * $Revision:    V2.0
+ *
+ * Project:      USB Driver common definitions
+ */
+
+/* History:
+ *  Version 2.0
+ *  Version 1.10
+ *    Namespace prefix ARM_ added
+ *  Version 1.01
+ *    Added PID Types
+ *  Version 1.00
+ *    Initial release
+ */
+
+#ifndef DRIVER_USB_H_
+#define DRIVER_USB_H_
+
+#include "Driver_Common.h"
+
+/* USB Role */
+#define ARM_USB_ROLE_NONE               (0U)
+#define ARM_USB_ROLE_HOST               (1U)
+#define ARM_USB_ROLE_DEVICE             (2U)
+
+/* USB Pins */
+#define ARM_USB_PIN_DP                  (1U << 0) ///< USB D+ pin
+#define ARM_USB_PIN_DM                  (1U << 1) ///< USB D- pin
+#define ARM_USB_PIN_VBUS                (1U << 2) ///< USB VBUS pin
+#define ARM_USB_PIN_OC                  (1U << 3) ///< USB OverCurrent pin
+#define ARM_USB_PIN_ID                  (1U << 4) ///< USB ID pin
+
+/* USB Speed */
+#define ARM_USB_SPEED_LOW               (0U)      ///< Low-speed USB
+#define ARM_USB_SPEED_FULL              (1U)      ///< Full-speed USB
+#define ARM_USB_SPEED_HIGH              (2U)      ///< High-speed USB
+
+/* USB PID Types */
+#define ARM_USB_PID_OUT                 (1U)
+#define ARM_USB_PID_IN                  (9U)
+#define ARM_USB_PID_SOF                 (5U)
+#define ARM_USB_PID_SETUP               (13U)
+#define ARM_USB_PID_DATA0               (3U)
+#define ARM_USB_PID_DATA1               (11U)
+#define ARM_USB_PID_DATA2               (7U)
+#define ARM_USB_PID_MDATA               (15U)
+#define ARM_USB_PID_ACK                 (2U)
+#define ARM_USB_PID_NAK                 (10U)
+#define ARM_USB_PID_STALL               (14U)
+#define ARM_USB_PID_NYET                (6U)
+#define ARM_USB_PID_PRE                 (12U)
+#define ARM_USB_PID_ERR                 (12U)
+#define ARM_USB_PID_SPLIT               (8U)
+#define ARM_USB_PID_PING                (4U)
+#define ARM_USB_PID_RESERVED            (0U)
+
+/* USB Endpoint Address (bEndpointAddress) */
+#define ARM_USB_ENDPOINT_NUMBER_MASK    (0x0FU)
+#define ARM_USB_ENDPOINT_DIRECTION_MASK (0x80U)
+
+/* USB Endpoint Type */
+#define ARM_USB_ENDPOINT_CONTROL        (0U)     ///< Control Endpoint
+#define ARM_USB_ENDPOINT_ISOCHRONOUS    (1U)     ///< Isochronous Endpoint
+#define ARM_USB_ENDPOINT_BULK           (2U)     ///< Bulk Endpoint
+#define ARM_USB_ENDPOINT_INTERRUPT      (3U)     ///< Interrupt Endpoint
+
+/* USB Endpoint Maximum Packet Size (wMaxPacketSize) */
+#define ARM_USB_ENDPOINT_MAX_PACKET_SIZE_MASK           (0x07FFU)
+#define ARM_USB_ENDPOINT_MICROFRAME_TRANSACTIONS_MASK   (0x1800U)
+#define ARM_USB_ENDPOINT_MICROFRAME_TRANSACTIONS_1      (0x0000U)
+#define ARM_USB_ENDPOINT_MICROFRAME_TRANSACTIONS_2      (0x0800U)
+#define ARM_USB_ENDPOINT_MICROFRAME_TRANSACTIONS_3      (0x1000U)
+
+#endif /* DRIVER_USB_H_ */

--- a/platform/ext/cmsis/CMSIS/Driver/Include/Driver_USBD.h
+++ b/platform/ext/cmsis/CMSIS/Driver/Include/Driver_USBD.h
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) 2013-2020 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * $Date:        31. March 2020
+ * $Revision:    V2.3
+ *
+ * Project:      USB Device Driver definitions
+ */
+
+/* History:
+ *  Version 2.3
+ *    Removed volatile from ARM_USBD_STATE
+ *  Version 2.2
+ *    ARM_USBD_STATE made volatile
+ *  Version 2.1
+ *    Added ARM_USBD_ReadSetupPacket function
+ *  Version 2.0
+ *    Removed ARM_USBD_DeviceConfigure function
+ *    Removed ARM_USBD_SET_ADDRESS_STAGE parameter from ARM_USBD_DeviceSetAddress function
+ *    Removed ARM_USBD_EndpointReadStart function
+ *    Replaced ARM_USBD_EndpointRead and ARM_USBD_EndpointWrite functions with ARM_USBD_EndpointTransfer
+ *    Added ARM_USBD_EndpointTransferGetResult function
+ *    Renamed ARM_USBD_EndpointAbort function to ARM_USBD_EndpointTransferAbort
+ *    Changed prefix ARM_DRV -> ARM_DRIVER
+ *    Changed return values of some functions to int32_t
+ *  Version 1.10
+ *    Namespace prefix ARM_ added
+ *  Version 1.00
+ *    Initial release
+ */
+
+#ifndef DRIVER_USBD_H_
+#define DRIVER_USBD_H_
+
+#ifdef  __cplusplus
+extern "C"
+{
+#endif
+
+#include "Driver_USB.h"
+
+#define ARM_USBD_API_VERSION ARM_DRIVER_VERSION_MAJOR_MINOR(2,3)  /* API version */
+
+
+#define _ARM_Driver_USBD_(n)      Driver_USBD##n
+#define  ARM_Driver_USBD_(n) _ARM_Driver_USBD_(n)
+
+
+/**
+\brief USB Device State
+*/
+typedef struct _ARM_USBD_STATE {
+  uint32_t vbus     : 1;                ///< USB Device VBUS flag
+  uint32_t speed    : 2;                ///< USB Device speed setting (ARM_USB_SPEED_xxx)
+  uint32_t active   : 1;                ///< USB Device active flag
+  uint32_t reserved : 28;
+} ARM_USBD_STATE;
+
+
+/****** USB Device Event *****/
+#define ARM_USBD_EVENT_VBUS_ON          (1UL << 0)      ///< USB Device VBUS On
+#define ARM_USBD_EVENT_VBUS_OFF         (1UL << 1)      ///< USB Device VBUS Off
+#define ARM_USBD_EVENT_RESET            (1UL << 2)      ///< USB Reset occurred
+#define ARM_USBD_EVENT_HIGH_SPEED       (1UL << 3)      ///< USB switch to High Speed occurred
+#define ARM_USBD_EVENT_SUSPEND          (1UL << 4)      ///< USB Suspend occurred
+#define ARM_USBD_EVENT_RESUME           (1UL << 5)      ///< USB Resume occurred
+
+/****** USB Endpoint Event *****/
+#define ARM_USBD_EVENT_SETUP            (1UL << 0)      ///< SETUP Packet
+#define ARM_USBD_EVENT_OUT              (1UL << 1)      ///< OUT Packet(s)
+#define ARM_USBD_EVENT_IN               (1UL << 2)      ///< IN Packet(s)
+
+
+#ifndef __DOXYGEN_MW__                  // exclude from middleware documentation
+
+// Function documentation
+/**
+  \fn          ARM_DRIVER_VERSION ARM_USBD_GetVersion (void)
+  \brief       Get driver version.
+  \return      \ref ARM_DRIVER_VERSION
+*/
+/**
+  \fn          ARM_USBD_CAPABILITIES ARM_USBD_GetCapabilities (void)
+  \brief       Get driver capabilities.
+  \return      \ref ARM_USBD_CAPABILITIES
+*/
+/**
+  \fn          int32_t ARM_USBD_Initialize (ARM_USBD_SignalDeviceEvent_t   cb_device_event,
+                                            ARM_USBD_SignalEndpointEvent_t cb_endpoint_event)
+  \brief       Initialize USB Device Interface.
+  \param[in]   cb_device_event    Pointer to \ref ARM_USBD_SignalDeviceEvent
+  \param[in]   cb_endpoint_event  Pointer to \ref ARM_USBD_SignalEndpointEvent
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_USBD_Uninitialize (void)
+  \brief       De-initialize USB Device Interface.
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_USBD_PowerControl (ARM_POWER_STATE state)
+  \brief       Control USB Device Interface Power.
+  \param[in]   state  Power state
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_USBD_DeviceConnect (void)
+  \brief       Connect USB Device.
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_USBD_DeviceDisconnect (void)
+  \brief       Disconnect USB Device.
+  \return      \ref execution_status
+*/
+/**
+  \fn          ARM_USBD_STATE ARM_USBD_DeviceGetState (void)
+  \brief       Get current USB Device State.
+  \return      Device State \ref ARM_USBD_STATE
+*/
+/**
+  \fn          int32_t ARM_USBD_DeviceRemoteWakeup (void)
+  \brief       Trigger USB Remote Wakeup.
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_USBD_DeviceSetAddress (uint8_t dev_addr)
+  \brief       Set USB Device Address.
+  \param[in]   dev_addr  Device Address
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_USBD_ReadSetupPacket (uint8_t *setup)
+  \brief       Read setup packet received over Control Endpoint.
+  \param[out]  setup  Pointer to buffer for setup packet
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_USBD_EndpointConfigure (uint8_t  ep_addr,
+                                                   uint8_t  ep_type,
+                                                   uint16_t ep_max_packet_size)
+  \brief       Configure USB Endpoint.
+  \param[in]   ep_addr  Endpoint Address
+                - ep_addr.0..3: Address
+                - ep_addr.7:    Direction
+  \param[in]   ep_type  Endpoint Type (ARM_USB_ENDPOINT_xxx)
+  \param[in]   ep_max_packet_size Endpoint Maximum Packet Size
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_USBD_EndpointUnconfigure (uint8_t ep_addr)
+  \brief       Unconfigure USB Endpoint.
+  \param[in]   ep_addr  Endpoint Address
+                - ep_addr.0..3: Address
+                - ep_addr.7:    Direction
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_USBD_EndpointStall (uint8_t ep_addr, bool stall)
+  \brief       Set/Clear Stall for USB Endpoint.
+  \param[in]   ep_addr  Endpoint Address
+                - ep_addr.0..3: Address
+                - ep_addr.7:    Direction
+  \param[in]   stall  Operation
+                - \b false Clear
+                - \b true Set
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_USBD_EndpointTransfer (uint8_t ep_addr, uint8_t *data, uint32_t num)
+  \brief       Read data from or Write data to USB Endpoint.
+  \param[in]   ep_addr  Endpoint Address
+                - ep_addr.0..3: Address
+                - ep_addr.7:    Direction
+  \param[out]  data Pointer to buffer for data to read or with data to write
+  \param[in]   num  Number of data bytes to transfer
+  \return      \ref execution_status
+*/
+/**
+  \fn          uint32_t ARM_USBD_EndpointTransferGetResult (uint8_t ep_addr)
+  \brief       Get result of USB Endpoint transfer.
+  \param[in]   ep_addr  Endpoint Address
+                - ep_addr.0..3: Address
+                - ep_addr.7:    Direction
+  \return      number of successfully transferred data bytes
+*/
+/**
+  \fn          int32_t ARM_USBD_EndpointTransferAbort (uint8_t ep_addr)
+  \brief       Abort current USB Endpoint transfer.
+  \param[in]   ep_addr  Endpoint Address
+                - ep_addr.0..3: Address
+                - ep_addr.7:    Direction
+  \return      \ref execution_status
+*/
+/**
+  \fn          uint16_t ARM_USBD_GetFrameNumber (void)
+  \brief       Get current USB Frame Number.
+  \return      Frame Number
+*/
+
+/**
+  \fn          void ARM_USBD_SignalDeviceEvent (uint32_t event)
+  \brief       Signal USB Device Event.
+  \param[in]   event \ref USBD_dev_events
+*/
+/**
+  \fn          void ARM_USBD_SignalEndpointEvent (uint8_t ep_addr, uint32_t event)
+  \brief       Signal USB Endpoint Event.
+  \param[in]   ep_addr  Endpoint Address
+                - ep_addr.0..3: Address
+                - ep_addr.7:    Direction
+  \param[in]   event \ref USBD_ep_events
+*/
+
+typedef void (*ARM_USBD_SignalDeviceEvent_t)   (uint32_t event);                    ///< Pointer to \ref ARM_USBD_SignalDeviceEvent : Signal USB Device Event.
+typedef void (*ARM_USBD_SignalEndpointEvent_t) (uint8_t ep_addr, uint32_t event);   ///< Pointer to \ref ARM_USBD_SignalEndpointEvent : Signal USB Endpoint Event.
+
+
+/**
+\brief USB Device Driver Capabilities.
+*/
+typedef struct _ARM_USBD_CAPABILITIES {
+  uint32_t vbus_detection  : 1;         ///< VBUS detection
+  uint32_t event_vbus_on   : 1;         ///< Signal VBUS On event
+  uint32_t event_vbus_off  : 1;         ///< Signal VBUS Off event
+  uint32_t reserved        : 29;        ///< Reserved (must be zero)
+} ARM_USBD_CAPABILITIES;
+
+
+/**
+\brief Access structure of the USB Device Driver.
+*/
+typedef struct _ARM_DRIVER_USBD {
+  ARM_DRIVER_VERSION    (*GetVersion)                (void);                                              ///< Pointer to \ref ARM_USBD_GetVersion : Get driver version.
+  ARM_USBD_CAPABILITIES (*GetCapabilities)           (void);                                              ///< Pointer to \ref ARM_USBD_GetCapabilities : Get driver capabilities.
+  int32_t               (*Initialize)                (ARM_USBD_SignalDeviceEvent_t   cb_device_event,                     
+                                                      ARM_USBD_SignalEndpointEvent_t cb_endpoint_event);  ///< Pointer to \ref ARM_USBD_Initialize : Initialize USB Device Interface. 
+  int32_t               (*Uninitialize)              (void);                                              ///< Pointer to \ref ARM_USBD_Uninitialize : De-initialize USB Device Interface.
+  int32_t               (*PowerControl)              (ARM_POWER_STATE state);                             ///< Pointer to \ref ARM_USBD_PowerControl : Control USB Device Interface Power.
+  int32_t               (*DeviceConnect)             (void);                                              ///< Pointer to \ref ARM_USBD_DeviceConnect : Connect USB Device.
+  int32_t               (*DeviceDisconnect)          (void);                                              ///< Pointer to \ref ARM_USBD_DeviceDisconnect : Disconnect USB Device.
+  ARM_USBD_STATE        (*DeviceGetState)            (void);                                              ///< Pointer to \ref ARM_USBD_DeviceGetState : Get current USB Device State.
+  int32_t               (*DeviceRemoteWakeup)        (void);                                              ///< Pointer to \ref ARM_USBD_DeviceRemoteWakeup : Trigger USB Remote Wakeup.
+  int32_t               (*DeviceSetAddress)          (uint8_t dev_addr);                                  ///< Pointer to \ref ARM_USBD_DeviceSetAddress : Set USB Device Address.
+  int32_t               (*ReadSetupPacket)           (uint8_t *setup);                                    ///< Pointer to \ref ARM_USBD_ReadSetupPacket : Read setup packet received over Control Endpoint.
+  int32_t               (*EndpointConfigure)         (uint8_t ep_addr,
+                                                      uint8_t ep_type,
+                                                      uint16_t ep_max_packet_size);                       ///< Pointer to \ref ARM_USBD_EndpointConfigure : Configure USB Endpoint.
+  int32_t               (*EndpointUnconfigure)       (uint8_t ep_addr);                                   ///< Pointer to \ref ARM_USBD_EndpointUnconfigure : Unconfigure USB Endpoint.
+  int32_t               (*EndpointStall)             (uint8_t ep_addr, bool stall);                       ///< Pointer to \ref ARM_USBD_EndpointStall : Set/Clear Stall for USB Endpoint.
+  int32_t               (*EndpointTransfer)          (uint8_t ep_addr, uint8_t *data, uint32_t num);      ///< Pointer to \ref ARM_USBD_EndpointTransfer : Read data from or Write data to USB Endpoint.
+  uint32_t              (*EndpointTransferGetResult) (uint8_t ep_addr);                                   ///< Pointer to \ref ARM_USBD_EndpointTransferGetResult : Get result of USB Endpoint transfer.
+  int32_t               (*EndpointTransferAbort)     (uint8_t ep_addr);                                   ///< Pointer to \ref ARM_USBD_EndpointTransferAbort : Abort current USB Endpoint transfer.
+  uint16_t              (*GetFrameNumber)            (void);                                              ///< Pointer to \ref ARM_USBD_GetFrameNumber : Get current USB Frame Number.
+} const ARM_DRIVER_USBD;
+
+#endif /* __DOXYGEN_MW__ */
+
+#ifdef  __cplusplus
+}
+#endif
+
+#endif /* DRIVER_USBD_H_ */

--- a/platform/ext/cmsis/CMSIS/Driver/Include/Driver_USBH.h
+++ b/platform/ext/cmsis/CMSIS/Driver/Include/Driver_USBH.h
@@ -1,0 +1,420 @@
+/*
+ * Copyright (c) 2013-2020 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+  *
+ * $Date:        31. March 2020
+ * $Revision:    V2.3
+ *
+ * Project:      USB Host Driver definitions
+*/
+
+/* History:
+ *  Version 2.3
+ *    Removed volatile from ARM_USBH_PORT_STATE
+ *  Version 2.2
+ *    ARM_USBH_PORT_STATE made volatile
+ *  Version 2.1
+ *    Renamed structure ARM_USBH_EP_HANDLE to ARM_USBH_PIPE_HANDLE
+ *    Renamed functions ARM_USBH_Endpoint... to ARM_USBH_Pipe...
+ *    Renamed function ARM_USBH_SignalEndpointEvent to ARM_USBH_SignalPipeEvent
+ *  Version 2.0
+ *    Replaced function ARM_USBH_PortPowerOnOff with ARM_USBH_PortVbusOnOff
+ *    Changed function ARM_USBH_EndpointCreate parameters
+ *    Replaced function ARM_USBH_EndpointConfigure with ARM_USBH_EndpointModify
+ *    Replaced function ARM_USBH_EndpointClearHalt with ARM_USBH_EndpointReset
+ *    Replaced function ARM_USBH_URB_Submit with ARM_USBH_EndpointTransfer
+ *    Replaced function ARM_USBH_URB_Abort with ARM_USBH_EndpointTransferAbort
+ *    Added function ARM_USBH_EndpointTransferGetResult
+ *    Added function ARM_USBH_GetFrameNumber
+ *    Changed prefix ARM_DRV -> ARM_DRIVER
+ *  Version 1.20
+ *    Added API for OHCI/EHCI Host Controller Interface (HCI)
+ *  Version 1.10
+ *    Namespace prefix ARM_ added
+ *  Version 1.00
+ *    Initial release
+ */
+
+#ifndef DRIVER_USBH_H_
+#define DRIVER_USBH_H_
+
+#ifdef  __cplusplus
+extern "C"
+{
+#endif
+
+#include "Driver_USB.h"
+
+#define ARM_USBH_API_VERSION ARM_DRIVER_VERSION_MAJOR_MINOR(2,3)  /* API version */
+
+
+#define _ARM_Driver_USBH_(n)      Driver_USBH##n
+#define  ARM_Driver_USBH_(n) _ARM_Driver_USBH_(n)
+
+
+/**
+\brief USB Host Port State
+*/
+typedef struct _ARM_USBH_PORT_STATE {
+  uint32_t connected   : 1;             ///< USB Host Port connected flag
+  uint32_t overcurrent : 1;             ///< USB Host Port overcurrent flag
+  uint32_t speed       : 2;             ///< USB Host Port speed setting (ARM_USB_SPEED_xxx)
+  uint32_t reserved    : 28;
+} ARM_USBH_PORT_STATE;
+
+/**
+\brief USB Host Pipe Handle
+*/
+typedef uint32_t ARM_USBH_PIPE_HANDLE;
+#define ARM_USBH_EP_HANDLE ARM_USBH_PIPE_HANDLE  /* Legacy name */
+
+
+/****** USB Host Packet Information *****/
+#define ARM_USBH_PACKET_TOKEN_Pos         0
+#define ARM_USBH_PACKET_TOKEN_Msk        (0x0FUL << ARM_USBH_PACKET_TOKEN_Pos)
+#define ARM_USBH_PACKET_SETUP            (0x01UL << ARM_USBH_PACKET_TOKEN_Pos)  ///< SETUP Packet
+#define ARM_USBH_PACKET_OUT              (0x02UL << ARM_USBH_PACKET_TOKEN_Pos)  ///< OUT Packet
+#define ARM_USBH_PACKET_IN               (0x03UL << ARM_USBH_PACKET_TOKEN_Pos)  ///< IN Packet
+#define ARM_USBH_PACKET_PING             (0x04UL << ARM_USBH_PACKET_TOKEN_Pos)  ///< PING Packet
+
+#define ARM_USBH_PACKET_DATA_Pos          4
+#define ARM_USBH_PACKET_DATA_Msk         (0x0FUL << ARM_USBH_PACKET_DATA_Pos)
+#define ARM_USBH_PACKET_DATA0            (0x01UL << ARM_USBH_PACKET_DATA_Pos)   ///< DATA0 PID
+#define ARM_USBH_PACKET_DATA1            (0x02UL << ARM_USBH_PACKET_DATA_Pos)   ///< DATA1 PID
+
+#define ARM_USBH_PACKET_SPLIT_Pos         8
+#define ARM_USBH_PACKET_SPLIT_Msk        (0x0FUL << ARM_USBH_PACKET_SPLIT_Pos)
+#define ARM_USBH_PACKET_SSPLIT           (0x08UL << ARM_USBH_PACKET_SPLIT_Pos)  ///< SSPLIT Packet
+#define ARM_USBH_PACKET_SSPLIT_S         (0x09UL << ARM_USBH_PACKET_SPLIT_Pos)  ///< SSPLIT Packet: Data Start
+#define ARM_USBH_PACKET_SSPLIT_E         (0x0AUL << ARM_USBH_PACKET_SPLIT_Pos)  ///< SSPLIT Packet: Data End
+#define ARM_USBH_PACKET_SSPLIT_S_E       (0x0BUL << ARM_USBH_PACKET_SPLIT_Pos)  ///< SSPLIT Packet: Data All
+#define ARM_USBH_PACKET_CSPLIT           (0x0CUL << ARM_USBH_PACKET_SPLIT_Pos)  ///< CSPLIT Packet
+
+#define ARM_USBH_PACKET_PRE              (1UL << 12)                            ///< PRE Token
+
+
+/****** USB Host Port Event *****/
+#define ARM_USBH_EVENT_CONNECT           (1UL << 0)     ///< USB Device Connected to Port
+#define ARM_USBH_EVENT_DISCONNECT        (1UL << 1)     ///< USB Device Disconnected from Port
+#define ARM_USBH_EVENT_OVERCURRENT       (1UL << 2)     ///< USB Device caused Overcurrent
+#define ARM_USBH_EVENT_RESET             (1UL << 3)     ///< USB Reset completed
+#define ARM_USBH_EVENT_SUSPEND           (1UL << 4)     ///< USB Suspend occurred
+#define ARM_USBH_EVENT_RESUME            (1UL << 5)     ///< USB Resume occurred
+#define ARM_USBH_EVENT_REMOTE_WAKEUP     (1UL << 6)     ///< USB Device activated Remote Wakeup
+
+/****** USB Host Pipe Event *****/
+#define ARM_USBH_EVENT_TRANSFER_COMPLETE (1UL << 0)     ///< Transfer completed
+#define ARM_USBH_EVENT_HANDSHAKE_NAK     (1UL << 1)     ///< NAK Handshake received
+#define ARM_USBH_EVENT_HANDSHAKE_NYET    (1UL << 2)     ///< NYET Handshake received
+#define ARM_USBH_EVENT_HANDSHAKE_MDATA   (1UL << 3)     ///< MDATA Handshake received
+#define ARM_USBH_EVENT_HANDSHAKE_STALL   (1UL << 4)     ///< STALL Handshake received
+#define ARM_USBH_EVENT_HANDSHAKE_ERR     (1UL << 5)     ///< ERR Handshake received
+#define ARM_USBH_EVENT_BUS_ERROR         (1UL << 6)     ///< Bus Error detected
+
+
+#ifndef __DOXYGEN_MW__                  // exclude from middleware documentation
+
+// Function documentation
+/**
+  \fn          ARM_DRIVER_VERSION ARM_USBH_GetVersion (void)
+  \brief       Get driver version.
+  \return      \ref ARM_DRIVER_VERSION
+*/
+/**
+  \fn          ARM_USBH_CAPABILITIES ARM_USBH_GetCapabilities (void)
+  \brief       Get driver capabilities.
+  \return      \ref ARM_USBH_CAPABILITIES
+*/
+/**
+  \fn          int32_t ARM_USBH_Initialize (ARM_USBH_SignalPortEvent_t cb_port_event,
+                                            ARM_USBH_SignalPipeEvent_t cb_pipe_event)
+  \brief       Initialize USB Host Interface.
+  \param[in]   cb_port_event  Pointer to \ref ARM_USBH_SignalPortEvent
+  \param[in]   cb_pipe_event  Pointer to \ref ARM_USBH_SignalPipeEvent
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_USBH_Uninitialize (void)
+  \brief       De-initialize USB Host Interface.
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_USBH_PowerControl (ARM_POWER_STATE state)
+  \brief       Control USB Host Interface Power.
+  \param[in]   state  Power state
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_USBH_PortVbusOnOff (uint8_t port, bool vbus)
+  \brief       Root HUB Port VBUS on/off.
+  \param[in]   port  Root HUB Port Number
+  \param[in]   vbus
+                - \b false VBUS off
+                - \b true  VBUS on
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_USBH_PortReset (uint8_t port)
+  \brief       Do Root HUB Port Reset.
+  \param[in]   port  Root HUB Port Number
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_USBH_PortSuspend (uint8_t port)
+  \brief       Suspend Root HUB Port (stop generating SOFs).
+  \param[in]   port  Root HUB Port Number
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_USBH_PortResume (uint8_t port)
+  \brief       Resume Root HUB Port (start generating SOFs).
+  \param[in]   port  Root HUB Port Number
+  \return      \ref execution_status
+*/
+/**
+  \fn          ARM_USBH_PORT_STATE ARM_USBH_PortGetState (uint8_t port)
+  \brief       Get current Root HUB Port State.
+  \param[in]   port  Root HUB Port Number
+  \return      Port State \ref ARM_USBH_PORT_STATE
+*/
+/**
+  \fn          ARM_USBH_PIPE_HANDLE ARM_USBH_PipeCreate (uint8_t  dev_addr,
+                                                         uint8_t  dev_speed,
+                                                         uint8_t  hub_addr,
+                                                         uint8_t  hub_port,
+                                                         uint8_t  ep_addr,
+                                                         uint8_t  ep_type,
+                                                         uint16_t ep_max_packet_size,
+                                                         uint8_t  ep_interval)
+  \brief       Create Pipe in System.
+  \param[in]   dev_addr   Device Address
+  \param[in]   dev_speed  Device Speed
+  \param[in]   hub_addr   Hub Address
+  \param[in]   hub_port   Hub Port
+  \param[in]   ep_addr    Endpoint Address
+                - ep_addr.0..3: Address
+                - ep_addr.7:    Direction
+  \param[in]   ep_type    Endpoint Type (ARM_USB_ENDPOINT_xxx)
+  \param[in]   ep_max_packet_size Endpoint Maximum Packet Size
+  \param[in]   ep_interval        Endpoint Polling Interval
+  \return      Pipe Handle \ref ARM_USBH_PIPE_HANDLE
+*/
+/**
+  \fn          int32_t ARM_USBH_PipeModify (ARM_USBH_PIPE_HANDLE pipe_hndl,
+                                            uint8_t              dev_addr,
+                                            uint8_t              dev_speed,
+                                            uint8_t              hub_addr,
+                                            uint8_t              hub_port,
+                                            uint16_t             ep_max_packet_size)
+  \brief       Modify Pipe in System.
+  \param[in]   pipe_hndl  Pipe Handle
+  \param[in]   dev_addr   Device Address
+  \param[in]   dev_speed  Device Speed
+  \param[in]   hub_addr   Hub Address
+  \param[in]   hub_port   Hub Port
+  \param[in]   ep_max_packet_size Endpoint Maximum Packet Size
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_USBH_PipeDelete (ARM_USBH_PIPE_HANDLE pipe_hndl)
+  \brief       Delete Pipe from System.
+  \param[in]   pipe_hndl  Pipe Handle
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_USBH_PipeReset (ARM_USBH_PIPE_HANDLE pipe_hndl)
+  \brief       Reset Pipe.
+  \param[in]   pipe_hndl  Pipe Handle
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_USBH_PipeTransfer (ARM_USBH_PIPE_HANDLE pipe_hndl,
+                                              uint32_t             packet,
+                                              uint8_t             *data,
+                                              uint32_t             num)
+  \brief       Transfer packets through USB Pipe.
+  \param[in]   pipe_hndl  Pipe Handle
+  \param[in]   packet     Packet information
+  \param[in]   data       Pointer to buffer with data to send or for data to receive
+  \param[in]   num        Number of data bytes to transfer
+  \return      \ref execution_status
+*/
+/**
+  \fn          uint32_t ARM_USBH_PipeTransferGetResult (ARM_USBH_PIPE_HANDLE pipe_hndl)
+  \brief       Get result of USB Pipe transfer.
+  \param[in]   pipe_hndl  Pipe Handle
+  \return      number of successfully transferred data bytes
+*/
+/**
+  \fn          int32_t ARM_USBH_PipeTransferAbort (ARM_USBH_PIPE_HANDLE pipe_hndl)
+  \brief       Abort current USB Pipe transfer.
+  \param[in]   pipe_hndl  Pipe Handle
+  \return      \ref execution_status
+*/
+/**
+  \fn          uint16_t ARM_USBH_GetFrameNumber (void)
+  \brief       Get current USB Frame Number.
+  \return      Frame Number
+*/
+
+/**
+  \fn          void ARM_USBH_SignalPortEvent (uint8_t port, uint32_t event)
+  \brief       Signal Root HUB Port Event.
+  \param[in]   port  Root HUB Port Number
+  \param[in]   event \ref USBH_port_events
+*/
+/**
+  \fn          void ARM_USBH_SignalPipeEvent (ARM_USBH_PIPE_HANDLE pipe_hndl, uint32_t event)
+  \brief       Signal Pipe Event.
+  \param[in]   pipe_hndl  Pipe Handle
+  \param[in]   event  \ref USBH_pipe_events
+*/
+
+typedef void (*ARM_USBH_SignalPortEvent_t) (uint8_t port, uint32_t event);                    ///< Pointer to \ref ARM_USBH_SignalPortEvent : Signal Root HUB Port Event.
+typedef void (*ARM_USBH_SignalPipeEvent_t) (ARM_USBH_PIPE_HANDLE pipe_hndl, uint32_t event);  ///< Pointer to \ref ARM_USBH_SignalPipeEvent : Signal Pipe Event.
+#define ARM_USBH_SignalEndpointEvent_t ARM_USBH_SignalPipeEvent_t  /* Legacy name */
+
+
+/**
+\brief USB Host Driver Capabilities.
+*/
+typedef struct _ARM_USBH_CAPABILITIES {
+  uint32_t port_mask          : 15;     ///< Root HUB available Ports Mask
+  uint32_t auto_split         :  1;     ///< Automatic SPLIT packet handling
+  uint32_t event_connect      :  1;     ///< Signal Connect event
+  uint32_t event_disconnect   :  1;     ///< Signal Disconnect event
+  uint32_t event_overcurrent  :  1;     ///< Signal Overcurrent event
+  uint32_t reserved           : 13;     ///< Reserved (must be zero)
+} ARM_USBH_CAPABILITIES;
+
+
+/**
+\brief Access structure of USB Host Driver.
+*/
+typedef struct _ARM_DRIVER_USBH {
+  ARM_DRIVER_VERSION    (*GetVersion)            (void);                                     ///< Pointer to \ref ARM_USBH_GetVersion : Get driver version.
+  ARM_USBH_CAPABILITIES (*GetCapabilities)       (void);                                     ///< Pointer to \ref ARM_USBH_GetCapabilities : Get driver capabilities.
+  int32_t               (*Initialize)            (ARM_USBH_SignalPortEvent_t cb_port_event,            
+                                                  ARM_USBH_SignalPipeEvent_t cb_pipe_event); ///< Pointer to \ref ARM_USBH_Initialize : Initialize USB Host Interface.
+  int32_t               (*Uninitialize)          (void);                                     ///< Pointer to \ref ARM_USBH_Uninitialize : De-initialize USB Host Interface.
+  int32_t               (*PowerControl)          (ARM_POWER_STATE state);                    ///< Pointer to \ref ARM_USBH_PowerControl : Control USB Host Interface Power.
+  int32_t               (*PortVbusOnOff)         (uint8_t port, bool vbus);                  ///< Pointer to \ref ARM_USBH_PortVbusOnOff : Root HUB Port VBUS on/off.
+  int32_t               (*PortReset)             (uint8_t port);                             ///< Pointer to \ref ARM_USBH_PortReset : Do Root HUB Port Reset.
+  int32_t               (*PortSuspend)           (uint8_t port);                             ///< Pointer to \ref ARM_USBH_PortSuspend : Suspend Root HUB Port (stop generating SOFs).
+  int32_t               (*PortResume)            (uint8_t port);                             ///< Pointer to \ref ARM_USBH_PortResume : Resume Root HUB Port (start generating SOFs).
+  ARM_USBH_PORT_STATE   (*PortGetState)          (uint8_t port);                             ///< Pointer to \ref ARM_USBH_PortGetState : Get current Root HUB Port State.
+  ARM_USBH_PIPE_HANDLE  (*PipeCreate)            (uint8_t dev_addr,
+                                                  uint8_t dev_speed,
+                                                  uint8_t hub_addr,
+                                                  uint8_t hub_port,
+                                                  uint8_t ep_addr,
+                                                  uint8_t ep_type,
+                                                  uint16_t ep_max_packet_size,
+                                                  uint8_t ep_interval);                      ///< Pointer to \ref ARM_USBH_PipeCreate : Create Pipe in System.
+  int32_t               (*PipeModify)            (ARM_USBH_PIPE_HANDLE pipe_hndl,
+                                                  uint8_t dev_addr,
+                                                  uint8_t dev_speed,
+                                                  uint8_t hub_addr,
+                                                  uint8_t hub_port,
+                                                  uint16_t ep_max_packet_size);              ///< Pointer to \ref ARM_USBH_PipeModify : Modify Pipe in System.
+  int32_t               (*PipeDelete)            (ARM_USBH_PIPE_HANDLE pipe_hndl);           ///< Pointer to \ref ARM_USBH_PipeDelete : Delete Pipe from System.
+  int32_t               (*PipeReset)             (ARM_USBH_PIPE_HANDLE pipe_hndl);           ///< Pointer to \ref ARM_USBH_PipeReset : Reset Pipe.
+  int32_t               (*PipeTransfer)          (ARM_USBH_PIPE_HANDLE pipe_hndl, 
+                                                  uint32_t packet,
+                                                  uint8_t *data,
+                                                  uint32_t num);                             ///< Pointer to \ref ARM_USBH_PipeTransfer : Transfer packets through USB Pipe.
+  uint32_t              (*PipeTransferGetResult) (ARM_USBH_PIPE_HANDLE pipe_hndl);           ///< Pointer to \ref ARM_USBH_PipeTransferGetResult : Get result of USB Pipe transfer.
+  int32_t               (*PipeTransferAbort)     (ARM_USBH_PIPE_HANDLE pipe_hndl);           ///< Pointer to \ref ARM_USBH_PipeTransferAbort : Abort current USB Pipe transfer.
+  uint16_t              (*GetFrameNumber)        (void);                                     ///< Pointer to \ref ARM_USBH_GetFrameNumber : Get current USB Frame Number.                    
+} const ARM_DRIVER_USBH;
+
+
+// HCI (OHCI/EHCI)
+
+// Function documentation
+/**
+  \fn          ARM_DRIVER_VERSION ARM_USBH_HCI_GetVersion (void)
+  \brief       Get USB Host HCI (OHCI/EHCI) driver version.
+  \return      \ref ARM_DRIVER_VERSION
+*/
+/**
+  \fn          ARM_USBH_HCI_CAPABILITIES ARM_USBH_HCI_GetCapabilities (void)
+  \brief       Get driver capabilities.
+  \return      \ref ARM_USBH_HCI_CAPABILITIES
+*/
+/**
+  \fn          int32_t ARM_USBH_HCI_Initialize (ARM_USBH_HCI_Interrupt_t *cb_interrupt)
+  \brief       Initialize USB Host HCI (OHCI/EHCI) Interface.
+  \param[in]   cb_interrupt Pointer to Interrupt Handler Routine
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_USBH_HCI_Uninitialize (void)
+  \brief       De-initialize USB Host HCI (OHCI/EHCI) Interface.
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_USBH_HCI_PowerControl (ARM_POWER_STATE state)
+  \brief       Control USB Host HCI (OHCI/EHCI) Interface Power.
+  \param[in]   state Power state
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_USBH_HCI_PortVbusOnOff (uint8_t port, bool vbus)
+  \brief       USB Host HCI (OHCI/EHCI) Root HUB Port VBUS on/off.
+  \param[in]   port  Root HUB Port Number
+  \param[in]   vbus
+                - \b false VBUS off
+                - \b true  VBUS on
+  \return      \ref execution_status
+*/
+
+/**
+  \fn          void ARM_USBH_HCI_Interrupt (void)
+  \brief       USB Host HCI Interrupt Handler.
+*/
+
+typedef void (*ARM_USBH_HCI_Interrupt_t) (void);  ///< Pointer to Interrupt Handler Routine.
+
+
+/**
+\brief USB Host HCI (OHCI/EHCI) Driver Capabilities.
+*/
+typedef struct _ARM_USBH_HCI_CAPABILITIES {
+  uint32_t port_mask : 15;              ///< Root HUB available Ports Mask
+  uint32_t reserved  : 17;              ///< Reserved (must be zero)
+} ARM_USBH_HCI_CAPABILITIES;
+
+
+/**
+  \brief Access structure of USB Host HCI (OHCI/EHCI) Driver.
+*/
+typedef struct _ARM_DRIVER_USBH_HCI {
+  ARM_DRIVER_VERSION        (*GetVersion)      (void);                                  ///< Pointer to \ref ARM_USBH_HCI_GetVersion : Get USB Host HCI (OHCI/EHCI) driver version.
+  ARM_USBH_HCI_CAPABILITIES (*GetCapabilities) (void);                                  ///< Pointer to \ref ARM_USBH_HCI_GetCapabilities : Get driver capabilities.
+  int32_t                   (*Initialize)      (ARM_USBH_HCI_Interrupt_t cb_interrupt); ///< Pointer to \ref ARM_USBH_HCI_Initialize : Initialize USB Host HCI (OHCI/EHCI) Interface.
+  int32_t                   (*Uninitialize)    (void);                                  ///< Pointer to \ref ARM_USBH_HCI_Uninitialize : De-initialize USB Host HCI (OHCI/EHCI) Interface.
+  int32_t                   (*PowerControl)    (ARM_POWER_STATE state);                 ///< Pointer to \ref ARM_USBH_HCI_PowerControl : Control USB Host HCI (OHCI/EHCI) Interface Power.
+  int32_t                   (*PortVbusOnOff)   (uint8_t port, bool vbus);               ///< Pointer to \ref ARM_USBH_HCI_PortVbusOnOff : USB Host HCI (OHCI/EHCI) Root HUB Port VBUS on/off.
+} const ARM_DRIVER_USBH_HCI;
+
+#endif /* __DOXYGEN_MW__ */
+
+#ifdef  __cplusplus
+}
+#endif
+
+#endif /* DRIVER_USBH_H_ */

--- a/platform/ext/cmsis/CMSIS/Driver/Include/Driver_WiFi.h
+++ b/platform/ext/cmsis/CMSIS/Driver/Include/Driver_WiFi.h
@@ -1,0 +1,665 @@
+/*
+ * Copyright (c) 2019-2022 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * $Date:        30. March 2022
+ * $Revision:    V1.1
+ *
+ * Project:      WiFi (Wireless Fidelity Interface) Driver definitions
+ */
+
+/* History:
+ *  Version 1.1
+ *    Extended Socket Receive/RecvFrom/Send/SendTo (support for polling)
+ *  Version 1.0
+ *    Initial release
+ */
+
+#ifndef DRIVER_WIFI_H_
+#define DRIVER_WIFI_H_
+
+#ifdef  __cplusplus
+extern "C"
+{
+#endif
+
+#include "Driver_Common.h"
+
+#define ARM_WIFI_API_VERSION ARM_DRIVER_VERSION_MAJOR_MINOR(1,1)  /* API version */
+
+
+#define _ARM_Driver_WiFi_(n)      Driver_WiFi##n
+#define  ARM_Driver_WiFi_(n) _ARM_Driver_WiFi_(n)
+
+
+/****** WiFi SetOption/GetOption Function Option Codes *****/
+#define ARM_WIFI_BSSID                      1U          ///< Station/AP Set/Get BSSID of AP to connect or of AP;        data = &bssid,    len =  6, uint8_t[6]
+#define ARM_WIFI_TX_POWER                   2U          ///< Station/AP Set/Get transmit power;                         data = &power,    len =  4, uint32_t: 0 .. 20 [dBm]
+#define ARM_WIFI_LP_TIMER                   3U          ///< Station    Set/Get low-power deep-sleep time;              data = &time,     len =  4, uint32_t [seconds]: 0 = disable (default)
+#define ARM_WIFI_DTIM                       4U          ///< Station/AP Set/Get DTIM interval;                          data = &dtim,     len =  4, uint32_t [beacons]
+#define ARM_WIFI_BEACON                     5U          ///<         AP Set/Get beacon interval;                        data = &interval, len =  4, uint32_t [ms]
+#define ARM_WIFI_MAC                        6U          ///< Station/AP Set/Get MAC;                                    data = &mac,      len =  6, uint8_t[6]
+#define ARM_WIFI_IP                         7U          ///< Station/AP Set/Get IPv4 static/assigned address;           data = &ip,       len =  4, uint8_t[4]
+#define ARM_WIFI_IP_SUBNET_MASK             8U          ///< Station/AP Set/Get IPv4 subnet mask;                       data = &mask,     len =  4, uint8_t[4]
+#define ARM_WIFI_IP_GATEWAY                 9U          ///< Station/AP Set/Get IPv4 gateway address;                   data = &ip,       len =  4, uint8_t[4]
+#define ARM_WIFI_IP_DNS1                    10U         ///< Station/AP Set/Get IPv4 primary   DNS address;             data = &ip,       len =  4, uint8_t[4]
+#define ARM_WIFI_IP_DNS2                    11U         ///< Station/AP Set/Get IPv4 secondary DNS address;             data = &ip,       len =  4, uint8_t[4]
+#define ARM_WIFI_IP_DHCP                    12U         ///< Station/AP Set/Get IPv4 DHCP client/server enable/disable; data = &dhcp,     len =  4, uint32_t: 0 = disable, non-zero = enable (default)
+#define ARM_WIFI_IP_DHCP_POOL_BEGIN         13U         ///<         AP Set/Get IPv4 DHCP pool begin address;           data = &ip,       len =  4, uint8_t[4]
+#define ARM_WIFI_IP_DHCP_POOL_END           14U         ///<         AP Set/Get IPv4 DHCP pool end address;             data = &ip,       len =  4, uint8_t[4]
+#define ARM_WIFI_IP_DHCP_LEASE_TIME         15U         ///<         AP Set/Get IPv4 DHCP lease time;                   data = &time,     len =  4, uint32_t [seconds]
+#define ARM_WIFI_IP6_GLOBAL                 16U         ///< Station/AP Set/Get IPv6 global address;                    data = &ip6,      len = 16, uint8_t[16]
+#define ARM_WIFI_IP6_LINK_LOCAL             17U         ///< Station/AP Set/Get IPv6 link local address;                data = &ip6,      len = 16, uint8_t[16]
+#define ARM_WIFI_IP6_SUBNET_PREFIX_LEN      18U         ///< Station/AP Set/Get IPv6 subnet prefix length;              data = &len,      len =  4, uint32_t: 1 .. 127
+#define ARM_WIFI_IP6_GATEWAY                19U         ///< Station/AP Set/Get IPv6 gateway address;                   data = &ip6,      len = 16, uint8_t[16]
+#define ARM_WIFI_IP6_DNS1                   20U         ///< Station/AP Set/Get IPv6 primary   DNS address;             data = &ip6,      len = 16, uint8_t[16]
+#define ARM_WIFI_IP6_DNS2                   21U         ///< Station/AP Set/Get IPv6 secondary DNS address;             data = &ip6,      len = 16, uint8_t[16]
+#define ARM_WIFI_IP6_DHCP_MODE              22U         ///< Station/AP Set/Get IPv6 DHCPv6 client mode;                data = &mode,     len =  4, uint32_t: ARM_WIFI_IP6_DHCP_xxx (default Off)
+
+/****** WiFi Security Type *****/
+#define ARM_WIFI_SECURITY_OPEN              0U          ///< Open
+#define ARM_WIFI_SECURITY_WEP               1U          ///< Wired Equivalent Privacy (WEP) with Pre-Sheared Key (PSK)
+#define ARM_WIFI_SECURITY_WPA               2U          ///< WiFi Protected Access (WPA) with PSK
+#define ARM_WIFI_SECURITY_WPA2              3U          ///< WiFi Protected Access II (WPA2) with PSK
+#define ARM_WIFI_SECURITY_UNKNOWN           255U        ///< Unknown
+
+/****** WiFi Protected Setup (WPS) Method *****/
+#define ARM_WIFI_WPS_METHOD_NONE            0U          ///< Not used
+#define ARM_WIFI_WPS_METHOD_PBC             1U          ///< Push Button Configuration
+#define ARM_WIFI_WPS_METHOD_PIN             2U          ///< PIN
+
+/****** WiFi IPv6 Dynamic Host Configuration Protocol (DHCP) Mode *****/
+#define ARM_WIFI_IP6_DHCP_OFF               0U          ///< Static Host Configuration (default)
+#define ARM_WIFI_IP6_DHCP_STATELESS         1U          ///< Dynamic Host Configuration stateless DHCPv6
+#define ARM_WIFI_IP6_DHCP_STATEFULL         2U          ///< Dynamic Host Configuration statefull DHCPv6
+
+/****** WiFi Event *****/
+#define ARM_WIFI_EVENT_AP_CONNECT          (1UL << 0)   ///< Access Point: Station has connected;           arg = &mac, mac (uint8_t[6])
+#define ARM_WIFI_EVENT_AP_DISCONNECT       (1UL << 1)   ///< Access Point: Station has disconnected;        arg = &mac, mac (uint8_t[6])
+#define ARM_WIFI_EVENT_ETH_RX_FRAME        (1UL << 4)   ///< Ethernet Frame Received (in bypass mode only); arg = interface (0 = Station, 1 = Access Point)
+
+
+/**
+\brief WiFi Configuration
+*/
+typedef struct ARM_WIFI_CONFIG_s {
+  const char   *ssid;                                   ///< Pointer to Service Set Identifier (SSID) null-terminated string
+  const char   *pass;                                   ///< Pointer to Password null-terminated string
+        uint8_t security;                               ///< Security type (ARM_WIFI_SECURITY_xxx)
+        uint8_t ch;                                     ///< WiFi Channel (0 = auto, otherwise = exact channel)
+        uint8_t reserved;                               ///< Reserved
+        uint8_t wps_method;                             ///< WiFi Protected Setup (WPS) method (ARM_WIFI_WPS_METHOD_xxx)
+  const char   *wps_pin;                                ///< Pointer to WiFi Protected Setup (WPS) PIN null-terminated string
+} ARM_WIFI_CONFIG_t;
+
+/**
+\brief WiFi Scan Information
+*/
+typedef struct ARM_WIFI_SCAN_INFO_s {
+  char    ssid[32+1];                                   ///< Service Set Identifier (SSID) null-terminated string
+  uint8_t bssid[6];                                     ///< Basic Service Set Identifier (BSSID)
+  uint8_t security;                                     ///< Security type (ARM_WIFI_SECURITY_xxx)
+  uint8_t ch;                                           ///< WiFi Channel
+  uint8_t rssi;                                         ///< Received Signal Strength Indicator
+} ARM_WIFI_SCAN_INFO_t;
+
+/**
+\brief WiFi Network Information
+*/
+typedef struct ARM_WIFI_NET_INFO_s {
+  char    ssid[32+1];                                   ///< Service Set Identifier (SSID) null-terminated string
+  char    pass[64+1];                                   ///< Password null-terminated string
+  uint8_t security;                                     ///< Security type (ARM_WIFI_SECURITY_xxx)
+  uint8_t ch;                                           ///< WiFi Channel
+  uint8_t rssi;                                         ///< Received Signal Strength Indicator
+} ARM_WIFI_NET_INFO_t;
+
+/****** Socket Address Family definitions *****/
+#define ARM_SOCKET_AF_INET                  1           ///< IPv4
+#define ARM_SOCKET_AF_INET6                 2           ///< IPv6
+
+/****** Socket Type definitions *****/
+#define ARM_SOCKET_SOCK_STREAM              1           ///< Stream socket
+#define ARM_SOCKET_SOCK_DGRAM               2           ///< Datagram socket
+
+/****** Socket Protocol definitions *****/
+#define ARM_SOCKET_IPPROTO_TCP              1           ///< TCP
+#define ARM_SOCKET_IPPROTO_UDP              2           ///< UDP
+
+/****** Socket Option definitions *****/
+#define ARM_SOCKET_IO_FIONBIO               1           ///< Non-blocking I/O (Set only, default = 0); opt_val = &nbio, opt_len = sizeof(nbio), nbio (integer): 0=blocking, non-blocking otherwise
+#define ARM_SOCKET_SO_RCVTIMEO              2           ///< Receive timeout in ms (default = 0); opt_val = &timeout, opt_len = sizeof(timeout)
+#define ARM_SOCKET_SO_SNDTIMEO              3           ///< Send timeout in ms (default = 0); opt_val = &timeout, opt_len = sizeof(timeout)
+#define ARM_SOCKET_SO_KEEPALIVE             4           ///< Keep-alive messages (default = 0); opt_val = &keepalive, opt_len = sizeof(keepalive), keepalive (integer): 0=disabled, enabled otherwise
+#define ARM_SOCKET_SO_TYPE                  5           ///< Socket Type (Get only); opt_val = &socket_type, opt_len = sizeof(socket_type), socket_type (integer): ARM_SOCKET_SOCK_xxx
+
+/****** Socket Function return codes *****/
+#define ARM_SOCKET_ERROR                   (-1)         ///< Unspecified error
+#define ARM_SOCKET_ESOCK                   (-2)         ///< Invalid socket
+#define ARM_SOCKET_EINVAL                  (-3)         ///< Invalid argument
+#define ARM_SOCKET_ENOTSUP                 (-4)         ///< Operation not supported
+#define ARM_SOCKET_ENOMEM                  (-5)         ///< Not enough memory
+#define ARM_SOCKET_EAGAIN                  (-6)         ///< Operation would block or timed out
+#define ARM_SOCKET_EINPROGRESS             (-7)         ///< Operation in progress
+#define ARM_SOCKET_ETIMEDOUT               (-8)         ///< Operation timed out
+#define ARM_SOCKET_EISCONN                 (-9)         ///< Socket is connected
+#define ARM_SOCKET_ENOTCONN                (-10)        ///< Socket is not connected
+#define ARM_SOCKET_ECONNREFUSED            (-11)        ///< Connection rejected by the peer
+#define ARM_SOCKET_ECONNRESET              (-12)        ///< Connection reset by the peer
+#define ARM_SOCKET_ECONNABORTED            (-13)        ///< Connection aborted locally
+#define ARM_SOCKET_EALREADY                (-14)        ///< Connection already in progress
+#define ARM_SOCKET_EADDRINUSE              (-15)        ///< Address in use
+#define ARM_SOCKET_EHOSTNOTFOUND           (-16)        ///< Host not found
+
+
+// Function documentation
+/**
+  \fn            ARM_DRIVER_VERSION ARM_WIFI_GetVersion (void)
+  \brief         Get driver version.
+  \return        \ref ARM_DRIVER_VERSION
+*/
+/**
+  \fn            ARM_WIFI_CAPABILITIES ARM_WIFI_GetCapabilities (void)
+  \brief         Get driver capabilities.
+  \return        \ref ARM_WIFI_CAPABILITIES
+*/
+/**
+  \fn            int32_t ARM_WIFI_Initialize (ARM_WIFI_SignalEvent_t cb_event)
+  \brief         Initialize WiFi Module.
+  \param[in]     cb_event Pointer to \ref ARM_WIFI_SignalEvent_t
+  \return        execution status
+                   - \ref ARM_DRIVER_OK                : Operation successful
+                   - \ref ARM_DRIVER_ERROR             : Operation failed
+*/
+/**
+  \fn            int32_t ARM_WIFI_Uninitialize (void)
+  \brief         De-initialize WiFi Module.
+  \return        execution status
+                   - \ref ARM_DRIVER_OK                : Operation successful
+                   - \ref ARM_DRIVER_ERROR             : Operation failed
+*/
+/**
+  \fn            int32_t ARM_WIFI_PowerControl (ARM_POWER_STATE state)
+  \brief         Control WiFi Module Power.
+  \param[in]     state     Power state
+                   - \ref ARM_POWER_OFF                : Power off: no operation possible
+                   - \ref ARM_POWER_LOW                : Low-power mode: sleep or deep-sleep depending on \ref ARM_WIFI_LP_TIMER option set
+                   - \ref ARM_POWER_FULL               : Power on: full operation at maximum performance
+  \return        execution status
+                   - \ref ARM_DRIVER_OK                : Operation successful
+                   - \ref ARM_DRIVER_ERROR             : Operation failed
+                   - \ref ARM_DRIVER_ERROR_UNSUPPORTED : Operation not supported
+                   - \ref ARM_DRIVER_ERROR_PARAMETER   : Parameter error (invalid state)
+*/
+/**
+  \fn            int32_t ARM_WIFI_GetModuleInfo (char *module_info, uint32_t max_len)
+  \brief         Get Module information.
+  \param[out]    module_info Pointer to character buffer were info string will be returned
+  \param[in]     max_len     Maximum length of string to return (including null terminator)
+  \return        execution status
+                   - \ref ARM_DRIVER_OK                : Operation successful
+                   - \ref ARM_DRIVER_ERROR             : Operation failed
+                   - \ref ARM_DRIVER_ERROR_UNSUPPORTED : Operation not supported
+                   - \ref ARM_DRIVER_ERROR_PARAMETER   : Parameter error (NULL module_info pointer or max_len equals to 0)
+*/
+/**
+  \fn            int32_t ARM_WIFI_SetOption (uint32_t interface, uint32_t option, const void *data, uint32_t len)
+  \brief         Set WiFi Module Options.
+  \param[in]     interface Interface (0 = Station, 1 = Access Point)
+  \param[in]     option    Option to set
+  \param[in]     data      Pointer to data relevant to selected option
+  \param[in]     len       Length of data (in bytes)
+  \return        execution status
+                   - \ref ARM_DRIVER_OK                : Operation successful
+                   - \ref ARM_DRIVER_ERROR             : Operation failed
+                   - \ref ARM_DRIVER_ERROR_UNSUPPORTED : Operation not supported
+                   - \ref ARM_DRIVER_ERROR_PARAMETER   : Parameter error (invalid interface, NULL data pointer or len less than option specifies)
+*/
+/**
+  \fn            int32_t ARM_WIFI_GetOption (uint32_t interface, uint32_t option, void *data, uint32_t *len)
+  \brief         Get WiFi Module Options.
+  \param[in]     interface Interface (0 = Station, 1 = Access Point)
+  \param[in]     option    Option to get
+  \param[out]    data      Pointer to memory where data for selected option will be returned
+  \param[in,out] len       Pointer to length of data (input/output)
+                   - input: maximum length of data that can be returned (in bytes)
+                   - output: length of returned data (in bytes)
+  \return        execution status
+                   - \ref ARM_DRIVER_OK                : Operation successful
+                   - \ref ARM_DRIVER_ERROR             : Operation failed
+                   - \ref ARM_DRIVER_ERROR_UNSUPPORTED : Operation not supported
+                   - \ref ARM_DRIVER_ERROR_PARAMETER   : Parameter error (invalid interface, NULL data or len pointer, or *len less than option specifies)
+*/
+/**
+  \fn            int32_t ARM_WIFI_Scan (ARM_WIFI_SCAN_INFO_t scan_info[], uint32_t max_num)
+  \brief         Scan for available networks in range.
+  \param[out]    scan_info Pointer to array of ARM_WIFI_SCAN_INFO_t structures where available Scan Information will be returned
+  \param[in]     max_num   Maximum number of Network Information structures to return
+  \return        number of ARM_WIFI_SCAN_INFO_t structures returned or error code
+                   - value >= 0                        : Number of ARM_WIFI_SCAN_INFO_t structures returned
+                   - \ref ARM_DRIVER_ERROR             : Operation failed
+                   - \ref ARM_DRIVER_ERROR_PARAMETER   : Parameter error (NULL scan_info pointer or max_num equal to 0)
+*/
+/**
+  \fn            int32_t ARM_WIFI_Activate (uint32_t interface, const ARM_WIFI_CONFIG_t *config)
+  \brief         Activate interface (Connect to a wireless network or activate an access point).
+  \param[in]     interface Interface (0 = Station, 1 = Access Point)
+  \param[in]     config    Pointer to ARM_WIFI_CONFIG_t structure where Configuration parameters are located
+  \return        execution status
+                   - \ref ARM_DRIVER_OK                : Operation successful
+                   - \ref ARM_DRIVER_ERROR             : Operation failed
+                   - \ref ARM_DRIVER_ERROR_TIMEOUT     : Timeout occurred
+                   - \ref ARM_DRIVER_ERROR_UNSUPPORTED : Operation not supported (security type, channel autodetect or WPS not supported)
+                   - \ref ARM_DRIVER_ERROR_PARAMETER   : Parameter error (invalid interface, NULL config pointer or invalid configuration)
+*/
+/**
+  \fn            int32_t ARM_WIFI_Deactivate (uint32_t interface)
+  \brief         Deactivate interface (Disconnect from a wireless network or deactivate an access point).
+  \param[in]     interface Interface (0 = Station, 1 = Access Point)
+  \return        execution status
+                   - \ref ARM_DRIVER_OK                : Operation successful
+                   - \ref ARM_DRIVER_ERROR             : Operation failed
+                   - \ref ARM_DRIVER_ERROR_PARAMETER   : Parameter error (invalid interface)
+*/
+/**
+  \fn            uint32_t ARM_WIFI_IsConnected (void)
+  \brief         Get station connection status.
+  \return        station connection status
+                   - value != 0: Station connected
+                   - value = 0: Station not connected
+*/
+/**
+  \fn            int32_t ARM_WIFI_GetNetInfo (ARM_WIFI_NET_INFO_t *net_info)
+  \brief         Get station Network Information.
+  \param[out]    net_info  Pointer to ARM_WIFI_NET_INFO_t structure where station Network Information will be returned
+  \return        execution status
+                   - \ref ARM_DRIVER_OK                : Operation successful
+                   - \ref ARM_DRIVER_ERROR             : Operation failed (station not connected)
+                   - \ref ARM_DRIVER_ERROR_UNSUPPORTED : Operation not supported
+                   - \ref ARM_DRIVER_ERROR_PARAMETER   : Parameter error (invalid interface or NULL net_info pointer)
+*/
+/**
+  \fn            int32_t ARM_WIFI_BypassControl (uint32_t interface, uint32_t mode)
+  \brief         Enable or disable bypass (pass-through) mode. Transmit and receive Ethernet frames (IP layer bypassed and WiFi/Ethernet translation).
+  \param[in]     interface Interface (0 = Station, 1 = Access Point)
+  \param[in]     mode
+                   - value = 1: all packets bypass internal IP stack
+                   - value = 0: all packets processed by internal IP stack
+  \return        execution status
+                   - \ref ARM_DRIVER_OK                : Operation successful
+                   - \ref ARM_DRIVER_ERROR             : Operation failed
+                   - \ref ARM_DRIVER_ERROR_UNSUPPORTED : Operation not supported
+                   - \ref ARM_DRIVER_ERROR_PARAMETER   : Parameter error (invalid interface or mode)
+*/
+/**
+  \fn            int32_t ARM_WIFI_EthSendFrame (uint32_t interface, const uint8_t *frame, uint32_t len)
+  \brief         Send Ethernet frame (in bypass mode only).
+  \param[in]     interface Interface (0 = Station, 1 = Access Point)
+  \param[in]     frame    Pointer to frame buffer with data to send
+  \param[in]     len      Frame buffer length in bytes
+  \return        execution status
+                   - \ref ARM_DRIVER_OK                : Operation successful
+                   - \ref ARM_DRIVER_ERROR             : Operation failed
+                   - \ref ARM_DRIVER_ERROR_BUSY        : Driver is busy
+                   - \ref ARM_DRIVER_ERROR_UNSUPPORTED : Operation not supported
+                   - \ref ARM_DRIVER_ERROR_PARAMETER   : Parameter error (invalid interface or NULL frame pointer)
+*/
+/**
+  \fn            int32_t ARM_WIFI_EthReadFrame (uint32_t interface, uint8_t *frame, uint32_t len)
+  \brief         Read data of received Ethernet frame (in bypass mode only).
+  \param[in]     interface Interface (0 = Station, 1 = Access Point)
+  \param[in]     frame    Pointer to frame buffer for data to read into
+  \param[in]     len      Frame buffer length in bytes
+  \return        number of data bytes read or error code
+                   - value >= 0                        : Number of data bytes read
+                   - \ref ARM_DRIVER_ERROR             : Operation failed
+                   - \ref ARM_DRIVER_ERROR_UNSUPPORTED : Operation not supported
+                   - \ref ARM_DRIVER_ERROR_PARAMETER   : Parameter error (invalid interface or NULL frame pointer)
+*/
+/**
+  \fn            uint32_t ARM_WIFI_EthGetRxFrameSize (uint32_t interface)
+  \brief         Get size of received Ethernet frame (in bypass mode only).
+  \param[in]     interface Interface (0 = Station, 1 = Access Point)
+  \return        number of bytes in received frame
+*/
+/**
+  \fn            int32_t ARM_WIFI_SocketCreate (int32_t af, int32_t type, int32_t protocol)
+  \brief         Create a communication socket.
+  \param[in]     af       Address family
+  \param[in]     type     Socket type
+  \param[in]     protocol Socket protocol
+  \return        status information
+                   - Socket identification number (>=0)
+                   - \ref ARM_SOCKET_EINVAL            : Invalid argument
+                   - \ref ARM_SOCKET_ENOTSUP           : Operation not supported
+                   - \ref ARM_SOCKET_ENOMEM            : Not enough memory
+                   - \ref ARM_SOCKET_ERROR             : Unspecified error
+*/
+/**
+  \fn            int32_t ARM_WIFI_SocketBind (int32_t socket, const uint8_t *ip, uint32_t ip_len, uint16_t port)
+  \brief         Assign a local address to a socket.
+  \param[in]     socket   Socket identification number
+  \param[in]     ip       Pointer to local IP address
+  \param[in]     ip_len   Length of 'ip' address in bytes
+  \param[in]     port     Local port number
+  \return        status information
+                   - 0                                 : Operation successful
+                   - \ref ARM_SOCKET_ESOCK             : Invalid socket
+                   - \ref ARM_SOCKET_EINVAL            : Invalid argument (address or socket already bound)
+                   - \ref ARM_SOCKET_EADDRINUSE        : Address already in use
+                   - \ref ARM_SOCKET_ERROR             : Unspecified error
+*/
+/**
+  \fn            int32_t ARM_WIFI_SocketListen (int32_t socket, int32_t backlog)
+  \brief         Listen for socket connections.
+  \param[in]     socket   Socket identification number
+  \param[in]     backlog  Number of connection requests that can be queued
+  \return        status information
+                   - 0                                 : Operation successful
+                   - \ref ARM_SOCKET_ESOCK             : Invalid socket
+                   - \ref ARM_SOCKET_EINVAL            : Invalid argument (socket not bound)
+                   - \ref ARM_SOCKET_ENOTSUP           : Operation not supported
+                   - \ref ARM_SOCKET_EISCONN           : Socket is already connected
+                   - \ref ARM_SOCKET_ERROR             : Unspecified error
+*/
+/**
+  \fn            int32_t ARM_WIFI_SocketAccept (int32_t socket, uint8_t *ip, uint32_t *ip_len, uint16_t *port)
+  \brief         Accept a new connection on a socket.
+  \param[in]     socket   Socket identification number
+  \param[out]    ip       Pointer to buffer where address of connecting socket shall be returned (NULL for none)
+  \param[in,out] ip_len   Pointer to length of 'ip' (or NULL if 'ip' is NULL)
+                   - length of supplied 'ip' on input
+                   - length of stored 'ip' on output
+  \param[out]    port     Pointer to buffer where port of connecting socket shall be returned (NULL for none)
+  \return        status information
+                   - socket identification number of accepted socket (>=0)
+                   - \ref ARM_SOCKET_ESOCK             : Invalid socket
+                   - \ref ARM_SOCKET_EINVAL            : Invalid argument (socket not in listen mode)
+                   - \ref ARM_SOCKET_ENOTSUP           : Operation not supported (socket type does not support accepting connections)
+                   - \ref ARM_SOCKET_ECONNRESET        : Connection reset by the peer
+                   - \ref ARM_SOCKET_ECONNABORTED      : Connection aborted locally
+                   - \ref ARM_SOCKET_EAGAIN            : Operation would block or timed out (may be called again)
+                   - \ref ARM_SOCKET_ERROR             : Unspecified error
+*/
+/**
+  \fn            int32_t ARM_WIFI_SocketConnect (int32_t socket, const uint8_t *ip, uint32_t ip_len, uint16_t port)
+  \brief         Connect a socket to a remote host.
+  \param[in]     socket   Socket identification number
+  \param[in]     ip       Pointer to remote IP address
+  \param[in]     ip_len   Length of 'ip' address in bytes
+  \param[in]     port     Remote port number
+  \return        status information
+                   - 0                                 : Operation successful
+                   - \ref ARM_SOCKET_ESOCK             : Invalid socket
+                   - \ref ARM_SOCKET_EINVAL            : Invalid argument
+                   - \ref ARM_SOCKET_EALREADY          : Connection already in progress
+                   - \ref ARM_SOCKET_EINPROGRESS       : Operation in progress
+                   - \ref ARM_SOCKET_EISCONN           : Socket is connected
+                   - \ref ARM_SOCKET_ECONNREFUSED      : Connection rejected by the peer
+                   - \ref ARM_SOCKET_ECONNABORTED      : Connection aborted locally
+                   - \ref ARM_SOCKET_EADDRINUSE        : Address already in use
+                   - \ref ARM_SOCKET_ETIMEDOUT         : Operation timed out
+                   - \ref ARM_SOCKET_ERROR             : Unspecified error
+*/
+/**
+  \fn            int32_t ARM_WIFI_SocketRecv (int32_t socket, void *buf, uint32_t len)
+  \brief         Receive data or check if data is available on a connected socket.
+  \param[in]     socket   Socket identification number
+  \param[out]    buf      Pointer to buffer where data should be stored
+  \param[in]     len      Length of buffer (in bytes), set len = 0 to check if data is available
+  \return        status information
+                   - number of bytes received (>=0), if len != 0
+                   - 0                                 : Data is available (len = 0)
+                   - \ref ARM_SOCKET_ESOCK             : Invalid socket
+                   - \ref ARM_SOCKET_EINVAL            : Invalid argument (pointer to buffer or length)
+                   - \ref ARM_SOCKET_ENOTCONN          : Socket is not connected
+                   - \ref ARM_SOCKET_ECONNRESET        : Connection reset by the peer
+                   - \ref ARM_SOCKET_ECONNABORTED      : Connection aborted locally
+                   - \ref ARM_SOCKET_EAGAIN            : Operation would block or timed out (may be called again)
+                   - \ref ARM_SOCKET_ERROR             : Unspecified error
+*/
+/**
+  \fn            int32_t ARM_WIFI_SocketRecvFrom (int32_t socket, void *buf, uint32_t len, uint8_t *ip, uint32_t *ip_len, uint16_t *port)
+  \brief         Receive data or check if data is available on a socket.
+  \param[in]     socket   Socket identification number
+  \param[out]    buf      Pointer to buffer where data should be stored
+  \param[in]     len      Length of buffer (in bytes), set len = 0 to check if data is available
+  \param[out]    ip       Pointer to buffer where remote source address shall be returned (NULL for none)
+  \param[in,out] ip_len   Pointer to length of 'ip' (or NULL if 'ip' is NULL)
+                   - length of supplied 'ip' on input
+                   - length of stored 'ip' on output
+  \param[out]    port     Pointer to buffer where remote source port shall be returned (NULL for none)
+  \return        status information
+                   - number of bytes received (>=0), if len != 0
+                   - 0                                 : Data is available (len = 0)
+                   - \ref ARM_SOCKET_ESOCK             : Invalid socket
+                   - \ref ARM_SOCKET_EINVAL            : Invalid argument (pointer to buffer or length)
+                   - \ref ARM_SOCKET_ENOTCONN          : Socket is not connected
+                   - \ref ARM_SOCKET_ECONNRESET        : Connection reset by the peer
+                   - \ref ARM_SOCKET_ECONNABORTED      : Connection aborted locally
+                   - \ref ARM_SOCKET_EAGAIN            : Operation would block or timed out (may be called again)
+                   - \ref ARM_SOCKET_ERROR             : Unspecified error
+*/
+/**
+  \fn            int32_t ARM_WIFI_SocketSend (int32_t socket, const void *buf, uint32_t len)
+  \brief         Send data or check if data can be sent on a connected socket.
+  \param[in]     socket   Socket identification number
+  \param[in]     buf      Pointer to buffer containing data to send
+  \param[in]     len      Length of data (in bytes), set len = 0 to check if data can be sent
+  \return        status information
+                   - number of bytes sent (>=0), if len != 0
+                   - 0                                 : Data can be sent (len = 0)
+                   - \ref ARM_SOCKET_ESOCK             : Invalid socket
+                   - \ref ARM_SOCKET_EINVAL            : Invalid argument (pointer to buffer or length)
+                   - \ref ARM_SOCKET_ENOTCONN          : Socket is not connected
+                   - \ref ARM_SOCKET_ECONNRESET        : Connection reset by the peer
+                   - \ref ARM_SOCKET_ECONNABORTED      : Connection aborted locally
+                   - \ref ARM_SOCKET_EAGAIN            : Operation would block or timed out (may be called again)
+                   - \ref ARM_SOCKET_ERROR             : Unspecified error
+*/
+/**
+  \fn            int32_t ARM_WIFI_SocketSendTo (int32_t socket, const void *buf, uint32_t len, const uint8_t *ip, uint32_t ip_len, uint16_t port)
+  \brief         Send data or check if data can be sent on a socket.
+  \param[in]     socket   Socket identification number
+  \param[in]     buf      Pointer to buffer containing data to send
+  \param[in]     len      Length of data (in bytes), set len = 0 to check if data can be sent
+  \param[in]     ip       Pointer to remote destination IP address
+  \param[in]     ip_len   Length of 'ip' address in bytes
+  \param[in]     port     Remote destination port number
+  \return        status information
+                   - number of bytes sent (>=0), if len != 0
+                   - 0                                 : Data can be sent (len = 0)
+                   - \ref ARM_SOCKET_ESOCK             : Invalid socket
+                   - \ref ARM_SOCKET_EINVAL            : Invalid argument (pointer to buffer or length)
+                   - \ref ARM_SOCKET_ENOTCONN          : Socket is not connected
+                   - \ref ARM_SOCKET_ECONNRESET        : Connection reset by the peer
+                   - \ref ARM_SOCKET_ECONNABORTED      : Connection aborted locally
+                   - \ref ARM_SOCKET_EAGAIN            : Operation would block or timed out (may be called again)
+                   - \ref ARM_SOCKET_ERROR             : Unspecified error
+*/
+/**
+  \fn            int32_t ARM_WIFI_SocketGetSockName (int32_t socket, uint8_t *ip, uint32_t *ip_len, uint16_t *port)
+  \brief         Retrieve local IP address and port of a socket.
+  \param[in]     socket   Socket identification number
+  \param[out]    ip       Pointer to buffer where local address shall be returned (NULL for none)
+  \param[in,out] ip_len   Pointer to length of 'ip' (or NULL if 'ip' is NULL)
+                   - length of supplied 'ip' on input
+                   - length of stored 'ip' on output
+  \param[out]    port     Pointer to buffer where local port shall be returned (NULL for none)
+  \return        status information
+                   - 0                                 : Operation successful
+                   - \ref ARM_SOCKET_ESOCK             : Invalid socket
+                   - \ref ARM_SOCKET_EINVAL            : Invalid argument (pointer to buffer or length)
+                   - \ref ARM_SOCKET_ERROR             : Unspecified error
+*/
+/**
+  \fn            int32_t ARM_WIFI_SocketGetPeerName (int32_t socket, uint8_t *ip, uint32_t *ip_len, uint16_t *port)
+  \brief         Retrieve remote IP address and port of a socket.
+  \param[in]     socket   Socket identification number
+  \param[out]    ip       Pointer to buffer where remote address shall be returned (NULL for none)
+  \param[in,out] ip_len   Pointer to length of 'ip' (or NULL if 'ip' is NULL)
+                   - length of supplied 'ip' on input
+                   - length of stored 'ip' on output
+  \param[out]    port     Pointer to buffer where remote port shall be returned (NULL for none)
+  \return        status information
+                   - 0                                 : Operation successful
+                   - \ref ARM_SOCKET_ESOCK             : Invalid socket
+                   - \ref ARM_SOCKET_EINVAL            : Invalid argument (pointer to buffer or length)
+                   - \ref ARM_SOCKET_ENOTCONN          : Socket is not connected
+                   - \ref ARM_SOCKET_ERROR             : Unspecified error
+*/
+/**
+  \fn            int32_t ARM_WIFI_SocketGetOpt (int32_t socket, int32_t opt_id, void *opt_val, uint32_t *opt_len)
+  \brief         Get socket option.
+  \param[in]     socket   Socket identification number
+  \param[in]     opt_id   Option identifier
+  \param[out]    opt_val  Pointer to the buffer that will receive the option value
+  \param[in,out] opt_len  Pointer to length of the option value
+                   - length of buffer on input
+                   - length of data on output
+  \return        status information
+                   - 0                                 : Operation successful
+                   - \ref ARM_SOCKET_ESOCK             : Invalid socket
+                   - \ref ARM_SOCKET_EINVAL            : Invalid argument
+                   - \ref ARM_SOCKET_ENOTSUP           : Operation not supported
+                   - \ref ARM_SOCKET_ERROR             : Unspecified error
+*/
+/**
+  \fn            int32_t ARM_WIFI_SocketSetOpt (int32_t socket, int32_t opt_id, const void *opt_val, uint32_t opt_len)
+  \brief         Set socket option.
+  \param[in]     socket   Socket identification number
+  \param[in]     opt_id   Option identifier
+  \param[in]     opt_val  Pointer to the option value
+  \param[in]     opt_len  Length of the option value in bytes
+  \return        status information
+                   - 0                                 : Operation successful
+                   - \ref ARM_SOCKET_ESOCK             : Invalid socket
+                   - \ref ARM_SOCKET_EINVAL            : Invalid argument
+                   - \ref ARM_SOCKET_ENOTSUP           : Operation not supported
+                   - \ref ARM_SOCKET_ERROR             : Unspecified error
+*/
+/**
+  \fn            int32_t ARM_WIFI_SocketClose (int32_t socket)
+  \brief         Close and release a socket.
+  \param[in]     socket   Socket identification number
+  \return        status information
+                   - 0                                 : Operation successful
+                   - \ref ARM_SOCKET_ESOCK             : Invalid socket
+                   - \ref ARM_SOCKET_EAGAIN            : Operation would block (may be called again)
+                   - \ref ARM_SOCKET_ERROR             : Unspecified error
+*/
+/**
+  \fn            int32_t ARM_WIFI_SocketGetHostByName (const char *name, int32_t af, uint8_t *ip, uint32_t *ip_len)
+  \brief         Retrieve host IP address from host name.
+  \param[in]     name     Host name
+  \param[in]     af       Address family
+  \param[out]    ip       Pointer to buffer where resolved IP address shall be returned
+  \param[in,out] ip_len   Pointer to length of 'ip'
+                   - length of supplied 'ip' on input
+                   - length of stored 'ip' on output
+  \return        status information
+                   - 0                                 : Operation successful
+                   - \ref ARM_SOCKET_EINVAL            : Invalid argument
+                   - \ref ARM_SOCKET_ENOTSUP           : Operation not supported
+                   - \ref ARM_SOCKET_ETIMEDOUT         : Operation timed out
+                   - \ref ARM_SOCKET_EHOSTNOTFOUND     : Host not found
+                   - \ref ARM_SOCKET_ERROR             : Unspecified error
+*/
+/**
+  \fn            int32_t ARM_WIFI_Ping (const uint8_t *ip, uint32_t ip_len)
+  \brief         Probe remote host with Ping command.
+  \param[in]     ip       Pointer to remote host IP address
+  \param[in]     ip_len   Length of 'ip' address in bytes
+  \return        execution status
+                   - \ref ARM_DRIVER_OK                : Operation successful
+                   - \ref ARM_DRIVER_ERROR             : Operation failed
+                   - \ref ARM_DRIVER_ERROR_TIMEOUT     : Timeout occurred
+                   - \ref ARM_DRIVER_ERROR_UNSUPPORTED : Operation not supported
+                   - \ref ARM_DRIVER_ERROR_PARAMETER   : Parameter error (NULL ip pointer or ip_len different than 4 or 16)
+*/
+/**
+  \fn            void ARM_WIFI_SignalEvent (uint32_t event, void *arg)
+  \brief         Signal WiFi Events.
+  \param[in]     event    \ref wifi_event notification mask
+  \param[in]     arg      Pointer to argument of signaled event
+*/
+
+typedef void (*ARM_WIFI_SignalEvent_t) (uint32_t event, void *arg); ///< Pointer to \ref ARM_WIFI_SignalEvent : Signal WiFi Event.
+
+
+/**
+\brief WiFi Driver Capabilities.
+*/
+typedef struct _ARM_WIFI_CAPABILITIES {
+  uint32_t station               : 1;   ///< Station
+  uint32_t ap                    : 1;   ///< Access Point
+  uint32_t station_ap            : 1;   ///< Concurrent Station and Access Point
+  uint32_t wps_station           : 1;   ///< WiFi Protected Setup (WPS) for Station
+  uint32_t wps_ap                : 1;   ///< WiFi Protected Setup (WPS) for Access Point
+  uint32_t event_ap_connect      : 1;   ///< Access Point: event generated on Station connect
+  uint32_t event_ap_disconnect   : 1;   ///< Access Point: event generated on Station disconnect
+  uint32_t event_eth_rx_frame    : 1;   ///< Event generated on Ethernet frame reception in bypass mode
+  uint32_t bypass_mode           : 1;   ///< Bypass or pass-through mode (Ethernet interface)
+  uint32_t ip                    : 1;   ///< IP (UDP/TCP) (Socket interface)
+  uint32_t ip6                   : 1;   ///< IPv6 (Socket interface)
+  uint32_t ping                  : 1;   ///< Ping (ICMP)
+  uint32_t reserved              : 20;  ///< Reserved (must be zero)
+} ARM_WIFI_CAPABILITIES;
+
+/**
+\brief Access structure of the WiFi Driver.
+*/
+typedef struct _ARM_DRIVER_WIFI {
+  ARM_DRIVER_VERSION    (*GetVersion)                  (void);
+  ARM_WIFI_CAPABILITIES (*GetCapabilities)             (void);
+  int32_t               (*Initialize)                  (ARM_WIFI_SignalEvent_t cb_event);
+  int32_t               (*Uninitialize)                (void);
+  int32_t               (*PowerControl)                (ARM_POWER_STATE state);
+  int32_t               (*GetModuleInfo)               (char *module_info, uint32_t max_len);
+  int32_t               (*SetOption)                   (uint32_t interface, uint32_t option, const void *data, uint32_t  len);
+  int32_t               (*GetOption)                   (uint32_t interface, uint32_t option,       void *data, uint32_t *len);
+  int32_t               (*Scan)                        (ARM_WIFI_SCAN_INFO_t scan_info[], uint32_t max_num);
+  int32_t               (*Activate)                    (uint32_t interface, const ARM_WIFI_CONFIG_t *config);
+  int32_t               (*Deactivate)                  (uint32_t interface);
+  uint32_t              (*IsConnected)                 (void);
+  int32_t               (*GetNetInfo)                  (ARM_WIFI_NET_INFO_t *net_info);
+  int32_t               (*BypassControl)               (uint32_t interface, uint32_t mode);
+  int32_t               (*EthSendFrame)                (uint32_t interface, const uint8_t *frame, uint32_t len);
+  int32_t               (*EthReadFrame)                (uint32_t interface,       uint8_t *frame, uint32_t len);
+  uint32_t              (*EthGetRxFrameSize)           (uint32_t interface);
+  int32_t               (*SocketCreate)                (int32_t af, int32_t type, int32_t protocol);
+  int32_t               (*SocketBind)                  (int32_t socket, const uint8_t *ip, uint32_t  ip_len, uint16_t  port);
+  int32_t               (*SocketListen)                (int32_t socket, int32_t backlog);
+  int32_t               (*SocketAccept)                (int32_t socket,       uint8_t *ip, uint32_t *ip_len, uint16_t *port);
+  int32_t               (*SocketConnect)               (int32_t socket, const uint8_t *ip, uint32_t  ip_len, uint16_t  port);
+  int32_t               (*SocketRecv)                  (int32_t socket, void *buf, uint32_t len);
+  int32_t               (*SocketRecvFrom)              (int32_t socket, void *buf, uint32_t len, uint8_t *ip, uint32_t *ip_len, uint16_t *port);
+  int32_t               (*SocketSend)                  (int32_t socket, const void *buf, uint32_t len);
+  int32_t               (*SocketSendTo)                (int32_t socket, const void *buf, uint32_t len, const uint8_t *ip, uint32_t ip_len, uint16_t port);
+  int32_t               (*SocketGetSockName)           (int32_t socket, uint8_t *ip, uint32_t *ip_len, uint16_t *port);
+  int32_t               (*SocketGetPeerName)           (int32_t socket, uint8_t *ip, uint32_t *ip_len, uint16_t *port);
+  int32_t               (*SocketGetOpt)                (int32_t socket, int32_t opt_id,       void *opt_val, uint32_t *opt_len);
+  int32_t               (*SocketSetOpt)                (int32_t socket, int32_t opt_id, const void *opt_val, uint32_t  opt_len);
+  int32_t               (*SocketClose)                 (int32_t socket);
+  int32_t               (*SocketGetHostByName)         (const char *name, int32_t af, uint8_t *ip, uint32_t *ip_len);
+  int32_t               (*Ping)                        (const uint8_t *ip, uint32_t ip_len);
+} const ARM_DRIVER_WIFI;
+
+#ifdef  __cplusplus
+}
+#endif
+
+#endif /* DRIVER_WIFI_H_ */

--- a/platform/ext/cmsis/CMSIS/Driver/VIO/Include/cmsis_vio.h
+++ b/platform/ext/cmsis/CMSIS/Driver/VIO/Include/cmsis_vio.h
@@ -1,0 +1,104 @@
+/******************************************************************************
+ * @file     cmsis_vio.h
+ * @brief    CMSIS Virtual I/O header file
+ * @version  V1.0.0
+ * @date     24. May 2023
+ ******************************************************************************/
+/*
+ * Copyright (c) 2019-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __CMSIS_VIO_H
+#define __CMSIS_VIO_H
+
+#include <stdint.h>
+
+/*******************************************************************************
+ * Generic I/O mapping recommended for CMSIS-VIO
+ * Note: not every I/O must be physically available
+ */
+ 
+// vioSetSignal: mask values 
+#define vioLED0             (1U << 0)   ///< \ref vioSetSignal \a mask parameter: LED 0 (for 3-color: red)
+#define vioLED1             (1U << 1)   ///< \ref vioSetSignal \a mask parameter: LED 1 (for 3-color: green)
+#define vioLED2             (1U << 2)   ///< \ref vioSetSignal \a mask parameter: LED 2 (for 3-color: blue)
+#define vioLED3             (1U << 3)   ///< \ref vioSetSignal \a mask parameter: LED 3
+#define vioLED4             (1U << 4)   ///< \ref vioSetSignal \a mask parameter: LED 4
+#define vioLED5             (1U << 5)   ///< \ref vioSetSignal \a mask parameter: LED 5
+#define vioLED6             (1U << 6)   ///< \ref vioSetSignal \a mask parameter: LED 6
+#define vioLED7             (1U << 7)   ///< \ref vioSetSignal \a mask parameter: LED 7
+
+// vioSetSignal: signal values
+#define vioLEDon            (0xFFU)     ///< \ref vioSetSignal \a signal parameter: pattern to turn any LED on
+#define vioLEDoff           (0x00U)     ///< \ref vioSetSignal \a signal parameter: pattern to turn any LED off
+
+// vioGetSignal: mask values and return values
+#define vioBUTTON0          (1U << 0)   ///< \ref vioGetSignal \a mask parameter: Push button 0
+#define vioBUTTON1          (1U << 1)   ///< \ref vioGetSignal \a mask parameter: Push button 1
+#define vioBUTTON2          (1U << 2)   ///< \ref vioGetSignal \a mask parameter: Push button 2
+#define vioBUTTON3          (1U << 3)   ///< \ref vioGetSignal \a mask parameter: Push button 3
+#define vioJOYup            (1U << 4)   ///< \ref vioGetSignal \a mask parameter: Joystick button: up
+#define vioJOYdown          (1U << 5)   ///< \ref vioGetSignal \a mask parameter: Joystick button: down
+#define vioJOYleft          (1U << 6)   ///< \ref vioGetSignal \a mask parameter: Joystick button: left
+#define vioJOYright         (1U << 7)   ///< \ref vioGetSignal \a mask parameter: Joystick button: right
+#define vioJOYselect        (1U << 8)   ///< \ref vioGetSignal \a mask parameter: Joystick button: select
+#define vioJOYall           (vioJOYup    | \
+                             vioJOYdown  | \
+                             vioJOYleft  | \
+                             vioJOYright | \
+                             vioJOYselect)  ///< \ref vioGetSignal \a mask Joystick button: all
+
+// vioSetValue / vioGetValue: id values
+#define vioAIN0             (0U)        ///< \ref vioSetValue / \ref vioGetValue \a id parameter: Analog input value 0
+#define vioAIN1             (1U)        ///< \ref vioSetValue / \ref vioGetValue \a id parameter: Analog input value 1
+#define vioAIN2             (2U)        ///< \ref vioSetValue / \ref vioGetValue \a id parameter: Analog input value 2
+#define vioAIN3             (3U)        ///< \ref vioSetValue / \ref vioGetValue \a id parameter: Analog input value 3
+#define vioAOUT0            (4U)        ///< \ref vioSetValue / \ref vioGetValue \a id parameter: Analog output value 0
+
+#ifdef  __cplusplus
+extern "C"
+{
+#endif
+
+/// Initialize test input, output.
+void vioInit (void);
+
+/// Set signal output.
+/// \param[in]     mask         bit mask of signals to set.
+/// \param[in]     signal       signal value to set.
+void vioSetSignal (uint32_t mask, uint32_t signal);
+
+/// Get signal input.
+/// \param[in]     mask         bit mask of signals to read.
+/// \return signal value.
+uint32_t vioGetSignal (uint32_t mask);
+
+/// Set value output.
+/// \param[in]     id           output identifier.
+/// \param[in]     value        value to set.
+void vioSetValue (uint32_t id, int32_t value);
+
+/// Get value input.
+/// \param[in]     id           input identifier.
+/// \return  value retrieved from input.
+int32_t vioGetValue (uint32_t id);
+
+#ifdef  __cplusplus
+}
+#endif
+
+#endif /* __CMSIS_VIO_H */

--- a/platform/ext/cmsis/CMSIS/Driver/VIO/Source/vio.c
+++ b/platform/ext/cmsis/CMSIS/Driver/VIO/Source/vio.c
@@ -1,0 +1,158 @@
+/******************************************************************************
+ * @file     vio.c
+ * @brief    Virtual I/O implementation template
+ * @version  V1.0.0
+ * @date     24. May 2023
+ ******************************************************************************/
+/*
+ * Copyright (c) 2019-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <string.h>
+#include "cmsis_vio.h"
+
+#include "RTE_Components.h"                 // Component selection
+#include CMSIS_device_header
+
+#if !defined CMSIS_VOUT || !defined CMSIS_VIN
+// Add user includes here:
+
+#endif
+
+// VIO input, output definitions
+#define VIO_VALUE_NUM           5U          // Number of values
+
+// VIO input, output variables
+__USED uint32_t vioSignalIn;                // Memory for incoming signal
+__USED uint32_t vioSignalOut;               // Memory for outgoing signal
+__USED int32_t  vioValue[VIO_VALUE_NUM];    // Memory for value used in vioGetValue/vioSetValue
+
+#if !defined CMSIS_VOUT
+// Add global user types, variables, functions here:
+
+#endif
+
+#if !defined CMSIS_VIN
+// Add global user types, variables, functions here:
+
+#endif
+
+// Initialize test input, output.
+void vioInit (void) {
+#if !defined CMSIS_VOUT
+// Add user variables here:
+
+#endif
+#if !defined CMSIS_VIN
+// Add user variables here:
+
+#endif
+
+  vioSignalIn  = 0U;
+  vioSignalOut = 0U;
+
+  memset(vioValue, 0, sizeof(vioValue));
+
+#if !defined CMSIS_VOUT
+// Add user code here:
+
+#endif
+
+#if !defined CMSIS_VIN
+// Add user code here:
+
+#endif
+}
+
+// Set signal output.
+void vioSetSignal (uint32_t mask, uint32_t signal) {
+#if !defined CMSIS_VOUT
+// Add user variables here:
+
+#endif
+
+  vioSignalOut &= ~mask;
+  vioSignalOut |=  mask & signal;
+
+#if !defined CMSIS_VOUT
+// Add user code here:
+
+#endif
+}
+
+// Get signal input.
+uint32_t vioGetSignal (uint32_t mask) {
+  uint32_t signal;
+#if !defined CMSIS_VIN
+// Add user variables here:
+
+#endif
+
+#if !defined CMSIS_VIN
+// Add user code here:
+
+//   vioSignalIn = ...;
+#endif
+
+  signal = vioSignalIn & mask;
+
+  return signal;
+}
+
+// Set value output.
+void vioSetValue (uint32_t id, int32_t value) {
+  uint32_t index = id;
+#if !defined CMSIS_VOUT
+// Add user variables here:
+
+#endif
+
+  if (index >= VIO_VALUE_NUM) {
+    return;                             /* return in case of out-of-range index */
+  }
+
+  vioValue[index] = value;
+
+#if !defined CMSIS_VOUT
+// Add user code here:
+
+#endif
+}
+
+// Get value input.
+int32_t vioGetValue (uint32_t id) {
+  uint32_t index = id;
+  int32_t  value = 0;
+#if !defined CMSIS_VIN
+// Add user variables here:
+
+#endif
+
+  if (index >= VIO_VALUE_NUM) {
+    return value;                       /* return default in case of out-of-range index */
+  }
+
+#if !defined CMSIS_VIN
+// Add user code here:
+
+//   vioValue[index] = ...;
+#endif
+
+  value = vioValue[index];
+
+  return value;
+}

--- a/platform/ext/cmsis/CMSIS/Driver/VIO/Source/vio_memory.c
+++ b/platform/ext/cmsis/CMSIS/Driver/VIO/Source/vio_memory.c
@@ -1,0 +1,89 @@
+/******************************************************************************
+ * @file     vio_memory.c
+ * @brief    Virtual I/O implementation using memory only
+ * @version  V1.0.0
+ * @date     24. May 2023
+ ******************************************************************************/
+/*
+ * Copyright (c) 2019-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <string.h>
+#include "cmsis_vio.h"
+
+#include "RTE_Components.h"                 // Component selection
+#include CMSIS_device_header
+
+// VIO input, output definitions
+#ifndef VIO_VALUE_NUM
+#define VIO_VALUE_NUM           5U          // Number of values
+#endif
+
+// VIO input, output variables
+__USED uint32_t vioSignalIn;                // Memory for incoming signal
+__USED uint32_t vioSignalOut;               // Memory for outgoing signal
+__USED int32_t  vioValue[VIO_VALUE_NUM];    // Memory for value used in vioGetValue/vioSetValue
+
+// Initialize test input, output.
+void vioInit (void) {
+
+  vioSignalIn  = 0U;
+  vioSignalOut = 0U;
+
+  memset(vioValue, 0, sizeof(vioValue));
+}
+
+// Set signal output.
+void vioSetSignal (uint32_t mask, uint32_t signal) {
+
+  vioSignalOut &= ~mask;
+  vioSignalOut |=  mask & signal;
+}
+
+// Get signal input.
+uint32_t vioGetSignal (uint32_t mask) {
+  uint32_t signal;
+
+  signal = vioSignalIn & mask;
+
+  return signal;
+}
+
+// Set value output.
+void vioSetValue (uint32_t id, int32_t value) {
+  uint32_t index = id;
+
+  if (index >= VIO_VALUE_NUM) {
+    return;                             /* return in case of out-of-range index */
+  }
+
+  vioValue[index] = value;
+}
+
+// Get value input.
+int32_t vioGetValue (uint32_t id) {
+  uint32_t index = id;
+  int32_t  value = 0;
+
+  if (index >= VIO_VALUE_NUM) {
+    return value;                       /* return default in case of out-of-range index */
+  }
+
+  value = vioValue[index];
+
+  return value;
+}

--- a/platform/ext/cmsis/CMSIS/Driver/VIO/cmsis_vio.scvd
+++ b/platform/ext/cmsis/CMSIS/Driver/VIO/cmsis_vio.scvd
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<component_viewer schemaVersion="1.2.0" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="Component_Viewer.xsd">
+<component name="CMSIS-Driver VIO" version="1.0.0"/>
+
+  <objects>
+    <object name="VIO Object">
+      <var name="i" type="int32_t" value="0"/>
+
+      <read name="SignalIn"  type="uint32_t" symbol="vioSignalIn"/>
+      <read name="SignalOut" type="uint32_t" symbol="vioSignalOut"/>
+      <read name="Value"     type="int32_t"  symbol="vioValue" size="__size_of(&quot;vioValue&quot;)"/>
+
+      <out name="CMSIS-Driver VIO">
+        <item property="Signal Bits (Input)"  value="%x[SignalIn]"/>
+        <item property="Signal Bits (Output)" value="%x[SignalOut]"/>
+        <item property="Value Array">
+           <list name="i" start="0" limit="Value._count">
+             <item property="Value[%d[i]]"  value="%d[Value[i]]"/>
+           </list>
+        </item>
+      </out>
+
+    </object>
+
+  </objects>
+
+</component_viewer>

--- a/platform/ext/cmsis/CMSIS/RTOS2/Include/cmsis_os2.h
+++ b/platform/ext/cmsis/CMSIS/RTOS2/Include/cmsis_os2.h
@@ -1,0 +1,882 @@
+/*
+ * Copyright (c) 2013-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ----------------------------------------------------------------------
+ *
+ * $Date:        30. June 2023
+ * $Revision:    V2.3.0
+ *
+ * Project:      CMSIS-RTOS2 API
+ * Title:        cmsis_os2.h header file
+ *
+ * Version 2.3.0
+ *    Added provisional support for processor affinity in SMP systems:
+      - osThreadAttr_t: affinity_mask
+ *    - osThreadSetAffinityMask, osThreadGetAffinityMask
+ * Version 2.2.0
+ *    Added support for Process Isolation (Functional Safety):
+ *    - Kernel Management: osKernelProtect, osKernelDestroyClass
+ *    - Thread Management: osThreadGetClass, osThreadGetZone,
+ *                         osThreadSuspendClass, osThreadResumeClass
+ *                         osThreadTerminateZone,
+ *                         osThreadFeedWatchdog,
+ *                         osThreadProtectPrivileged
+ *    - Thread attributes: osThreadZone, osThreadUnprivileged/osThreadPrivileged
+ *    - Object attributes: osSafetyClass
+ *    - Handler functions: osWatchdogAlarm_Handler
+ *    - Zone Management: osZoneSetup_Callback
+ *    - Exception Faults: osFaultResume
+ *    Additional functions allowed to be called from Interrupt Service Routines:
+ *    - osThreadGetName, osTimerGetName, osEventFlagsGetName, osMutexGetName,
+ *      osSemaphoreGetName, osMemoryPoolGetName, osMessageQueueGetName
+ * Version 2.1.3
+ *    Additional functions allowed to be called from Interrupt Service Routines:
+ *    - osThreadGetId
+ * Version 2.1.2
+ *    Additional functions allowed to be called from Interrupt Service Routines:
+ *    - osKernelGetInfo, osKernelGetState
+ * Version 2.1.1
+ *    Additional functions allowed to be called from Interrupt Service Routines:
+ *    - osKernelGetTickCount, osKernelGetTickFreq
+ *    Changed Kernel Tick type to uint32_t:
+ *    - updated: osKernelGetTickCount, osDelayUntil
+ * Version 2.1.0
+ *    Support for critical and uncritical sections (nesting safe):
+ *    - updated: osKernelLock, osKernelUnlock
+ *    - added: osKernelRestoreLock
+ *    Updated Thread and Event Flags:
+ *    - changed flags parameter and return type from int32_t to uint32_t
+ * Version 2.0.0
+ *    Initial Release
+ *---------------------------------------------------------------------------*/
+ 
+#ifndef CMSIS_OS2_H_
+#define CMSIS_OS2_H_
+ 
+#ifndef __NO_RETURN
+#if   defined(__CC_ARM)
+#define __NO_RETURN __declspec(noreturn)
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#define __NO_RETURN __attribute__((__noreturn__))
+#elif defined(__GNUC__)
+#define __NO_RETURN __attribute__((__noreturn__))
+#elif defined(__ICCARM__)
+#define __NO_RETURN __noreturn
+#else
+#define __NO_RETURN
+#endif
+#endif
+ 
+#include <stdint.h>
+#include <stddef.h>
+ 
+#ifdef  __cplusplus
+extern "C"
+{
+#endif
+ 
+ 
+//  ==== Enumerations, structures, defines ====
+ 
+/// Version information.
+typedef struct {
+  uint32_t                       api;   ///< API version (major.minor.rev: mmnnnrrrr dec).
+  uint32_t                    kernel;   ///< Kernel version (major.minor.rev: mmnnnrrrr dec).
+} osVersion_t;
+ 
+/// Kernel state.
+typedef enum {
+  osKernelInactive        =  0,         ///< Inactive.
+  osKernelReady           =  1,         ///< Ready.
+  osKernelRunning         =  2,         ///< Running.
+  osKernelLocked          =  3,         ///< Locked.
+  osKernelSuspended       =  4,         ///< Suspended.
+  osKernelError           = -1,         ///< Error.
+  osKernelReserved        = 0x7FFFFFFF  ///< Prevents enum down-size compiler optimization.
+} osKernelState_t;
+ 
+/// Thread state.
+typedef enum {
+  osThreadInactive        =  0,         ///< Inactive.
+  osThreadReady           =  1,         ///< Ready.
+  osThreadRunning         =  2,         ///< Running.
+  osThreadBlocked         =  3,         ///< Blocked.
+  osThreadTerminated      =  4,         ///< Terminated.
+  osThreadError           = -1,         ///< Error.
+  osThreadReserved        = 0x7FFFFFFF  ///< Prevents enum down-size compiler optimization.
+} osThreadState_t;
+ 
+/// Priority values.
+typedef enum {
+  osPriorityNone          =  0,         ///< No priority (not initialized).
+  osPriorityIdle          =  1,         ///< Reserved for Idle thread.
+  osPriorityLow           =  8,         ///< Priority: low
+  osPriorityLow1          =  8+1,       ///< Priority: low + 1
+  osPriorityLow2          =  8+2,       ///< Priority: low + 2
+  osPriorityLow3          =  8+3,       ///< Priority: low + 3
+  osPriorityLow4          =  8+4,       ///< Priority: low + 4
+  osPriorityLow5          =  8+5,       ///< Priority: low + 5
+  osPriorityLow6          =  8+6,       ///< Priority: low + 6
+  osPriorityLow7          =  8+7,       ///< Priority: low + 7
+  osPriorityBelowNormal   = 16,         ///< Priority: below normal
+  osPriorityBelowNormal1  = 16+1,       ///< Priority: below normal + 1
+  osPriorityBelowNormal2  = 16+2,       ///< Priority: below normal + 2
+  osPriorityBelowNormal3  = 16+3,       ///< Priority: below normal + 3
+  osPriorityBelowNormal4  = 16+4,       ///< Priority: below normal + 4
+  osPriorityBelowNormal5  = 16+5,       ///< Priority: below normal + 5
+  osPriorityBelowNormal6  = 16+6,       ///< Priority: below normal + 6
+  osPriorityBelowNormal7  = 16+7,       ///< Priority: below normal + 7
+  osPriorityNormal        = 24,         ///< Priority: normal
+  osPriorityNormal1       = 24+1,       ///< Priority: normal + 1
+  osPriorityNormal2       = 24+2,       ///< Priority: normal + 2
+  osPriorityNormal3       = 24+3,       ///< Priority: normal + 3
+  osPriorityNormal4       = 24+4,       ///< Priority: normal + 4
+  osPriorityNormal5       = 24+5,       ///< Priority: normal + 5
+  osPriorityNormal6       = 24+6,       ///< Priority: normal + 6
+  osPriorityNormal7       = 24+7,       ///< Priority: normal + 7
+  osPriorityAboveNormal   = 32,         ///< Priority: above normal
+  osPriorityAboveNormal1  = 32+1,       ///< Priority: above normal + 1
+  osPriorityAboveNormal2  = 32+2,       ///< Priority: above normal + 2
+  osPriorityAboveNormal3  = 32+3,       ///< Priority: above normal + 3
+  osPriorityAboveNormal4  = 32+4,       ///< Priority: above normal + 4
+  osPriorityAboveNormal5  = 32+5,       ///< Priority: above normal + 5
+  osPriorityAboveNormal6  = 32+6,       ///< Priority: above normal + 6
+  osPriorityAboveNormal7  = 32+7,       ///< Priority: above normal + 7
+  osPriorityHigh          = 40,         ///< Priority: high
+  osPriorityHigh1         = 40+1,       ///< Priority: high + 1
+  osPriorityHigh2         = 40+2,       ///< Priority: high + 2
+  osPriorityHigh3         = 40+3,       ///< Priority: high + 3
+  osPriorityHigh4         = 40+4,       ///< Priority: high + 4
+  osPriorityHigh5         = 40+5,       ///< Priority: high + 5
+  osPriorityHigh6         = 40+6,       ///< Priority: high + 6
+  osPriorityHigh7         = 40+7,       ///< Priority: high + 7
+  osPriorityRealtime      = 48,         ///< Priority: realtime
+  osPriorityRealtime1     = 48+1,       ///< Priority: realtime + 1
+  osPriorityRealtime2     = 48+2,       ///< Priority: realtime + 2
+  osPriorityRealtime3     = 48+3,       ///< Priority: realtime + 3
+  osPriorityRealtime4     = 48+4,       ///< Priority: realtime + 4
+  osPriorityRealtime5     = 48+5,       ///< Priority: realtime + 5
+  osPriorityRealtime6     = 48+6,       ///< Priority: realtime + 6
+  osPriorityRealtime7     = 48+7,       ///< Priority: realtime + 7
+  osPriorityISR           = 56,         ///< Reserved for ISR deferred thread.
+  osPriorityError         = -1,         ///< System cannot determine priority or illegal priority.
+  osPriorityReserved      = 0x7FFFFFFF  ///< Prevents enum down-size compiler optimization.
+} osPriority_t;
+ 
+/// Entry point of a thread.
+typedef void (*osThreadFunc_t) (void *argument);
+ 
+/// Timer callback function.
+typedef void (*osTimerFunc_t) (void *argument);
+ 
+/// Timer type.
+typedef enum {
+  osTimerOnce             = 0,          ///< One-shot timer.
+  osTimerPeriodic         = 1           ///< Repeating timer.
+} osTimerType_t;
+ 
+// Timeout value.
+#define osWaitForever           0xFFFFFFFFU ///< Wait forever timeout value.
+ 
+// Flags options (\ref osThreadFlagsWait and \ref osEventFlagsWait).
+#define osFlagsWaitAny          0x00000000U ///< Wait for any flag (default).
+#define osFlagsWaitAll          0x00000001U ///< Wait for all flags.
+#define osFlagsNoClear          0x00000002U ///< Do not clear flags which have been specified to wait for.
+ 
+// Flags errors (returned by osThreadFlagsXxxx and osEventFlagsXxxx).
+#define osFlagsError            0x80000000U ///< Error indicator.
+#define osFlagsErrorUnknown     0xFFFFFFFFU ///< osError (-1).
+#define osFlagsErrorTimeout     0xFFFFFFFEU ///< osErrorTimeout (-2).
+#define osFlagsErrorResource    0xFFFFFFFDU ///< osErrorResource (-3).
+#define osFlagsErrorParameter   0xFFFFFFFCU ///< osErrorParameter (-4).
+#define osFlagsErrorISR         0xFFFFFFFAU ///< osErrorISR (-6).
+#define osFlagsErrorSafetyClass 0xFFFFFFF9U ///< osErrorSafetyClass (-7).
+ 
+// Thread attributes (attr_bits in \ref osThreadAttr_t).
+#define osThreadDetached        0x00000000U ///< Thread created in detached mode (default)
+#define osThreadJoinable        0x00000001U ///< Thread created in joinable mode
+#define osThreadUnprivileged    0x00000002U ///< Thread runs in unprivileged mode
+#define osThreadPrivileged      0x00000004U ///< Thread runs in privileged mode
+ 
+#define osThreadZone_Pos        8U                            ///< MPU protected zone position
+#define osThreadZone_Msk        (0x3FUL << osThreadZone_Pos)  ///< MPU protected zone mask
+#define osThreadZone_Valid      (0x80UL << osThreadZone_Pos)  ///< MPU protected zone valid flag
+#define osThreadZone(n)         ((((n) << osThreadZone_Pos) & osThreadZone_Msk) | \
+                                 osThreadZone_Valid)          ///< MPU zone value in attribute bit field format
+ 
+// Thread processor affinity (affinity_mask in \ref osThreadAttr_t).
+#define osThreadProcessor(n)    (1UL << (n))    ///< Thread processor number for SMP systems
+ 
+// Mutex attributes (attr_bits in \ref osMutexAttr_t).
+#define osMutexRecursive        0x00000001U ///< Recursive mutex.
+#define osMutexPrioInherit      0x00000002U ///< Priority inherit protocol.
+#define osMutexRobust           0x00000008U ///< Robust mutex.
+ 
+// Object attributes (attr_bits in all objects).
+#define osSafetyClass_Pos       16U                           ///< Safety class position
+#define osSafetyClass_Msk       (0x0FUL << osSafetyClass_Pos) ///< Safety class mask
+#define osSafetyClass_Valid     (0x10UL << osSafetyClass_Pos) ///< Safety class valid flag
+#define osSafetyClass(n)        ((((n) << osSafetyClass_Pos) & osSafetyClass_Msk) | \
+                                 osSafetyClass_Valid)         ///< Safety class
+ 
+// Safety mode (\ref osThreadSuspendClass, \ref osThreadResumeClass and \ref osKernelDestroyClass).
+#define osSafetyWithSameClass   0x00000001U ///< Objects with same safety class.
+#define osSafetyWithLowerClass  0x00000002U ///< Objects with lower safety class.
+ 
+// Error indication (returned by \ref osThreadGetClass and \ref osThreadGetZone).
+#define osErrorId               0xFFFFFFFFU ///< osError (-1).
+ 
+/// Status code values returned by CMSIS-RTOS functions.
+typedef enum {
+  osOK                    =  0,         ///< Operation completed successfully.
+  osError                 = -1,         ///< Unspecified RTOS error: run-time error but no other error message fits.
+  osErrorTimeout          = -2,         ///< Operation not completed within the timeout period.
+  osErrorResource         = -3,         ///< Resource not available.
+  osErrorParameter        = -4,         ///< Parameter error.
+  osErrorNoMemory         = -5,         ///< System is out of memory: it was impossible to allocate or reserve memory for the operation.
+  osErrorISR              = -6,         ///< Not allowed in ISR context: the function cannot be called from interrupt service routines.
+  osErrorSafetyClass      = -7,         ///< Operation denied because of safety class violation.
+  osStatusReserved        = 0x7FFFFFFF  ///< Prevents enum down-size compiler optimization.
+} osStatus_t;
+ 
+ 
+/// \details Thread ID identifies the thread.
+typedef void *osThreadId_t;
+ 
+/// \details Timer ID identifies the timer.
+typedef void *osTimerId_t;
+ 
+/// \details Event Flags ID identifies the event flags.
+typedef void *osEventFlagsId_t;
+ 
+/// \details Mutex ID identifies the mutex.
+typedef void *osMutexId_t;
+ 
+/// \details Semaphore ID identifies the semaphore.
+typedef void *osSemaphoreId_t;
+ 
+/// \details Memory Pool ID identifies the memory pool.
+typedef void *osMemoryPoolId_t;
+ 
+/// \details Message Queue ID identifies the message queue.
+typedef void *osMessageQueueId_t;
+ 
+ 
+#ifndef TZ_MODULEID_T
+#define TZ_MODULEID_T
+/// \details Data type that identifies secure software modules called by a process.
+typedef uint32_t TZ_ModuleId_t;
+#endif
+ 
+ 
+/// Attributes structure for thread.
+typedef struct {
+  const char                   *name;   ///< name of the thread
+  uint32_t                 attr_bits;   ///< attribute bits
+  void                      *cb_mem;    ///< memory for control block
+  uint32_t                   cb_size;   ///< size of provided memory for control block
+  void                   *stack_mem;    ///< memory for stack
+  uint32_t                stack_size;   ///< size of stack
+  osPriority_t              priority;   ///< initial thread priority (default: osPriorityNormal)
+  TZ_ModuleId_t            tz_module;   ///< TrustZone module identifier
+  uint32_t             affinity_mask;   ///< processor affinity mask for binding the thread to a CPU in a SMP system (0 when not used)
+} osThreadAttr_t;
+ 
+/// Attributes structure for timer.
+typedef struct {
+  const char                   *name;   ///< name of the timer
+  uint32_t                 attr_bits;   ///< attribute bits
+  void                      *cb_mem;    ///< memory for control block
+  uint32_t                   cb_size;   ///< size of provided memory for control block
+} osTimerAttr_t;
+ 
+/// Attributes structure for event flags.
+typedef struct {
+  const char                   *name;   ///< name of the event flags
+  uint32_t                 attr_bits;   ///< attribute bits
+  void                      *cb_mem;    ///< memory for control block
+  uint32_t                   cb_size;   ///< size of provided memory for control block
+} osEventFlagsAttr_t;
+ 
+/// Attributes structure for mutex.
+typedef struct {
+  const char                   *name;   ///< name of the mutex
+  uint32_t                 attr_bits;   ///< attribute bits
+  void                      *cb_mem;    ///< memory for control block
+  uint32_t                   cb_size;   ///< size of provided memory for control block
+} osMutexAttr_t;
+ 
+/// Attributes structure for semaphore.
+typedef struct {
+  const char                   *name;   ///< name of the semaphore
+  uint32_t                 attr_bits;   ///< attribute bits
+  void                      *cb_mem;    ///< memory for control block
+  uint32_t                   cb_size;   ///< size of provided memory for control block
+} osSemaphoreAttr_t;
+ 
+/// Attributes structure for memory pool.
+typedef struct {
+  const char                   *name;   ///< name of the memory pool
+  uint32_t                 attr_bits;   ///< attribute bits
+  void                      *cb_mem;    ///< memory for control block
+  uint32_t                   cb_size;   ///< size of provided memory for control block
+  void                      *mp_mem;    ///< memory for data storage
+  uint32_t                   mp_size;   ///< size of provided memory for data storage 
+} osMemoryPoolAttr_t;
+ 
+/// Attributes structure for message queue.
+typedef struct {
+  const char                   *name;   ///< name of the message queue
+  uint32_t                 attr_bits;   ///< attribute bits
+  void                      *cb_mem;    ///< memory for control block
+  uint32_t                   cb_size;   ///< size of provided memory for control block
+  void                      *mq_mem;    ///< memory for data storage
+  uint32_t                   mq_size;   ///< size of provided memory for data storage 
+} osMessageQueueAttr_t;
+ 
+ 
+//  ==== Kernel Management Functions ====
+ 
+/// Initialize the RTOS Kernel.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osKernelInitialize (void);
+ 
+///  Get RTOS Kernel Information.
+/// \param[out]    version       pointer to buffer for retrieving version information.
+/// \param[out]    id_buf        pointer to buffer for retrieving kernel identification string.
+/// \param[in]     id_size       size of buffer for kernel identification string.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osKernelGetInfo (osVersion_t *version, char *id_buf, uint32_t id_size);
+ 
+/// Get the current RTOS Kernel state.
+/// \return current RTOS Kernel state.
+osKernelState_t osKernelGetState (void);
+ 
+/// Start the RTOS Kernel scheduler.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osKernelStart (void);
+ 
+/// Lock the RTOS Kernel scheduler.
+/// \return previous lock state (1 - locked, 0 - not locked, error code if negative).
+int32_t osKernelLock (void);
+ 
+/// Unlock the RTOS Kernel scheduler.
+/// \return previous lock state (1 - locked, 0 - not locked, error code if negative).
+int32_t osKernelUnlock (void);
+ 
+/// Restore the RTOS Kernel scheduler lock state.
+/// \param[in]     lock          lock state obtained by \ref osKernelLock or \ref osKernelUnlock.
+/// \return new lock state (1 - locked, 0 - not locked, error code if negative).
+int32_t osKernelRestoreLock (int32_t lock);
+ 
+/// Suspend the RTOS Kernel scheduler.
+/// \return time in ticks, for how long the system can sleep or power-down.
+uint32_t osKernelSuspend (void);
+ 
+/// Resume the RTOS Kernel scheduler.
+/// \param[in]     sleep_ticks   time in ticks for how long the system was in sleep or power-down mode.
+void osKernelResume (uint32_t sleep_ticks);
+ 
+/// Protect the RTOS Kernel scheduler access.
+/// \param[in]     safety_class  safety class.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osKernelProtect (uint32_t safety_class);
+ 
+/// Destroy objects for specified safety classes.
+/// \param[in]     safety_class  safety class.
+/// \param[in]     mode          safety mode.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osKernelDestroyClass (uint32_t safety_class, uint32_t mode); 
+ 
+/// Get the RTOS kernel tick count.
+/// \return RTOS kernel current tick count.
+uint32_t osKernelGetTickCount (void);
+ 
+/// Get the RTOS kernel tick frequency.
+/// \return frequency of the kernel tick in hertz, i.e. kernel ticks per second.
+uint32_t osKernelGetTickFreq (void);
+ 
+/// Get the RTOS kernel system timer count.
+/// \return RTOS kernel current system timer count as 32-bit value.
+uint32_t osKernelGetSysTimerCount (void);
+ 
+/// Get the RTOS kernel system timer frequency.
+/// \return frequency of the system timer in hertz, i.e. timer ticks per second.
+uint32_t osKernelGetSysTimerFreq (void);
+ 
+ 
+//  ==== Thread Management Functions ====
+ 
+/// Create a thread and add it to Active Threads.
+/// \param[in]     func          thread function.
+/// \param[in]     argument      pointer that is passed to the thread function as start argument.
+/// \param[in]     attr          thread attributes; NULL: default values.
+/// \return thread ID for reference by other functions or NULL in case of error.
+osThreadId_t osThreadNew (osThreadFunc_t func, void *argument, const osThreadAttr_t *attr);
+ 
+/// Get name of a thread.
+/// \param[in]     thread_id     thread ID obtained by \ref osThreadNew or \ref osThreadGetId.
+/// \return name as null-terminated string.
+const char *osThreadGetName (osThreadId_t thread_id);
+ 
+/// Get safety class of a thread.
+/// \param[in]     thread_id     thread ID obtained by \ref osThreadNew or \ref osThreadGetId.
+/// \return safety class of the specified thread.
+uint32_t osThreadGetClass (osThreadId_t thread_id);
+ 
+/// Get MPU protected zone of a thread.
+/// \param[in]     thread_id     thread ID obtained by \ref osThreadNew or \ref osThreadGetId.
+/// \return MPU protected zone of the specified thread.
+uint32_t osThreadGetZone (osThreadId_t thread_id);
+ 
+/// Return the thread ID of the current running thread.
+/// \return thread ID for reference by other functions or NULL in case of error.
+osThreadId_t osThreadGetId (void);
+ 
+/// Get current thread state of a thread.
+/// \param[in]     thread_id     thread ID obtained by \ref osThreadNew or \ref osThreadGetId.
+/// \return current thread state of the specified thread.
+osThreadState_t osThreadGetState (osThreadId_t thread_id);
+ 
+/// Get stack size of a thread.
+/// \param[in]     thread_id     thread ID obtained by \ref osThreadNew or \ref osThreadGetId.
+/// \return stack size in bytes.
+uint32_t osThreadGetStackSize (osThreadId_t thread_id);
+ 
+/// Get available stack space of a thread based on stack watermark recording during execution.
+/// \param[in]     thread_id     thread ID obtained by \ref osThreadNew or \ref osThreadGetId.
+/// \return remaining stack space in bytes.
+uint32_t osThreadGetStackSpace (osThreadId_t thread_id);
+ 
+/// Change priority of a thread.
+/// \param[in]     thread_id     thread ID obtained by \ref osThreadNew or \ref osThreadGetId.
+/// \param[in]     priority      new priority value for the thread function.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osThreadSetPriority (osThreadId_t thread_id, osPriority_t priority);
+ 
+/// Get current priority of a thread.
+/// \param[in]     thread_id     thread ID obtained by \ref osThreadNew or \ref osThreadGetId.
+/// \return current priority value of the specified thread.
+osPriority_t osThreadGetPriority (osThreadId_t thread_id);
+ 
+/// Pass control to next thread that is in state \b READY.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osThreadYield (void);
+ 
+/// Suspend execution of a thread.
+/// \param[in]     thread_id     thread ID obtained by \ref osThreadNew or \ref osThreadGetId.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osThreadSuspend (osThreadId_t thread_id);
+ 
+/// Resume execution of a thread.
+/// \param[in]     thread_id     thread ID obtained by \ref osThreadNew or \ref osThreadGetId.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osThreadResume (osThreadId_t thread_id);
+ 
+/// Detach a thread (thread storage can be reclaimed when thread terminates).
+/// \param[in]     thread_id     thread ID obtained by \ref osThreadNew or \ref osThreadGetId.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osThreadDetach (osThreadId_t thread_id);
+ 
+/// Wait for specified thread to terminate.
+/// \param[in]     thread_id     thread ID obtained by \ref osThreadNew or \ref osThreadGetId.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osThreadJoin (osThreadId_t thread_id);
+ 
+/// Terminate execution of current running thread.
+__NO_RETURN void osThreadExit (void);
+ 
+/// Terminate execution of a thread.
+/// \param[in]     thread_id     thread ID obtained by \ref osThreadNew or \ref osThreadGetId.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osThreadTerminate (osThreadId_t thread_id);
+ 
+/// Feed watchdog of the current running thread.
+/// \param[in]     ticks         interval in kernel ticks until the thread watchdog expires, or 0 to stop the watchdog
+/// \return status code that indicates the execution status of the function.
+osStatus_t osThreadFeedWatchdog (uint32_t ticks);
+ 
+/// Protect creation of privileged threads.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osThreadProtectPrivileged (void);
+ 
+/// Suspend execution of threads for specified safety classes.
+/// \param[in]     safety_class  safety class.
+/// \param[in]     mode          safety mode.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osThreadSuspendClass (uint32_t safety_class, uint32_t mode);
+ 
+/// Resume execution of threads for specified safety classes.
+/// \param[in]     safety_class  safety class.
+/// \param[in]     mode          safety mode.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osThreadResumeClass (uint32_t safety_class, uint32_t mode);
+ 
+/// Terminate execution of threads assigned to a specified MPU protected zone.
+/// \param[in]     zone          MPU protected zone.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osThreadTerminateZone (uint32_t zone);
+ 
+/// Set processor affinity mask of a thread.
+/// \param[in]     thread_id     thread ID obtained by \ref osThreadNew or \ref osThreadGetId.
+/// \param[in]     affinity_mask processor affinity mask for the thread.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osThreadSetAffinityMask (osThreadId_t thread_id, uint32_t affinity_mask);
+ 
+/// Get current processor affinity mask of a thread.
+/// \param[in]     thread_id     thread ID obtained by \ref osThreadNew or \ref osThreadGetId.
+/// \return current processor affinity mask of the specified thread.
+uint32_t osThreadGetAffinityMask (osThreadId_t thread_id);
+ 
+/// Get number of active threads.
+/// \return number of active threads.
+uint32_t osThreadGetCount (void);
+ 
+/// Enumerate active threads.
+/// \param[out]    thread_array  pointer to array for retrieving thread IDs.
+/// \param[in]     array_items   maximum number of items in array for retrieving thread IDs.
+/// \return number of enumerated threads.
+uint32_t osThreadEnumerate (osThreadId_t *thread_array, uint32_t array_items);
+ 
+ 
+//  ==== Thread Flags Functions ====
+ 
+/// Set the specified Thread Flags of a thread.
+/// \param[in]     thread_id     thread ID obtained by \ref osThreadNew or \ref osThreadGetId.
+/// \param[in]     flags         specifies the flags of the thread that shall be set.
+/// \return thread flags after setting or error code if highest bit set.
+uint32_t osThreadFlagsSet (osThreadId_t thread_id, uint32_t flags);
+ 
+/// Clear the specified Thread Flags of current running thread.
+/// \param[in]     flags         specifies the flags of the thread that shall be cleared.
+/// \return thread flags before clearing or error code if highest bit set.
+uint32_t osThreadFlagsClear (uint32_t flags);
+ 
+/// Get the current Thread Flags of current running thread.
+/// \return current thread flags.
+uint32_t osThreadFlagsGet (void);
+ 
+/// Wait for one or more Thread Flags of the current running thread to become signaled.
+/// \param[in]     flags         specifies the flags to wait for.
+/// \param[in]     options       specifies flags options (osFlagsXxxx).
+/// \param[in]     timeout       \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out.
+/// \return thread flags before clearing or error code if highest bit set.
+uint32_t osThreadFlagsWait (uint32_t flags, uint32_t options, uint32_t timeout);
+ 
+ 
+//  ==== Generic Wait Functions ====
+ 
+/// Wait for Timeout (Time Delay).
+/// \param[in]     ticks         \ref CMSIS_RTOS_TimeOutValue "time ticks" value
+/// \return status code that indicates the execution status of the function.
+osStatus_t osDelay (uint32_t ticks);
+ 
+/// Wait until specified time.
+/// \param[in]     ticks         absolute time in ticks
+/// \return status code that indicates the execution status of the function.
+osStatus_t osDelayUntil (uint32_t ticks);
+ 
+ 
+//  ==== Timer Management Functions ====
+ 
+/// Create and Initialize a timer.
+/// \param[in]     func          function pointer to callback function.
+/// \param[in]     type          \ref osTimerOnce for one-shot or \ref osTimerPeriodic for periodic behavior.
+/// \param[in]     argument      argument to the timer callback function.
+/// \param[in]     attr          timer attributes; NULL: default values.
+/// \return timer ID for reference by other functions or NULL in case of error.
+osTimerId_t osTimerNew (osTimerFunc_t func, osTimerType_t type, void *argument, const osTimerAttr_t *attr);
+ 
+/// Get name of a timer.
+/// \param[in]     timer_id      timer ID obtained by \ref osTimerNew.
+/// \return name as null-terminated string.
+const char *osTimerGetName (osTimerId_t timer_id);
+ 
+/// Start or restart a timer.
+/// \param[in]     timer_id      timer ID obtained by \ref osTimerNew.
+/// \param[in]     ticks         \ref CMSIS_RTOS_TimeOutValue "time ticks" value of the timer.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osTimerStart (osTimerId_t timer_id, uint32_t ticks);
+ 
+/// Stop a timer.
+/// \param[in]     timer_id      timer ID obtained by \ref osTimerNew.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osTimerStop (osTimerId_t timer_id);
+ 
+/// Check if a timer is running.
+/// \param[in]     timer_id      timer ID obtained by \ref osTimerNew.
+/// \return 0 not running, 1 running.
+uint32_t osTimerIsRunning (osTimerId_t timer_id);
+ 
+/// Delete a timer.
+/// \param[in]     timer_id      timer ID obtained by \ref osTimerNew.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osTimerDelete (osTimerId_t timer_id);
+ 
+ 
+//  ==== Event Flags Management Functions ====
+ 
+/// Create and Initialize an Event Flags object.
+/// \param[in]     attr          event flags attributes; NULL: default values.
+/// \return event flags ID for reference by other functions or NULL in case of error.
+osEventFlagsId_t osEventFlagsNew (const osEventFlagsAttr_t *attr);
+ 
+/// Get name of an Event Flags object.
+/// \param[in]     ef_id         event flags ID obtained by \ref osEventFlagsNew.
+/// \return name as null-terminated string.
+const char *osEventFlagsGetName (osEventFlagsId_t ef_id);
+ 
+/// Set the specified Event Flags.
+/// \param[in]     ef_id         event flags ID obtained by \ref osEventFlagsNew.
+/// \param[in]     flags         specifies the flags that shall be set.
+/// \return event flags after setting or error code if highest bit set.
+uint32_t osEventFlagsSet (osEventFlagsId_t ef_id, uint32_t flags);
+ 
+/// Clear the specified Event Flags.
+/// \param[in]     ef_id         event flags ID obtained by \ref osEventFlagsNew.
+/// \param[in]     flags         specifies the flags that shall be cleared.
+/// \return event flags before clearing or error code if highest bit set.
+uint32_t osEventFlagsClear (osEventFlagsId_t ef_id, uint32_t flags);
+ 
+/// Get the current Event Flags.
+/// \param[in]     ef_id         event flags ID obtained by \ref osEventFlagsNew.
+/// \return current event flags.
+uint32_t osEventFlagsGet (osEventFlagsId_t ef_id);
+ 
+/// Wait for one or more Event Flags to become signaled.
+/// \param[in]     ef_id         event flags ID obtained by \ref osEventFlagsNew.
+/// \param[in]     flags         specifies the flags to wait for.
+/// \param[in]     options       specifies flags options (osFlagsXxxx).
+/// \param[in]     timeout       \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out.
+/// \return event flags before clearing or error code if highest bit set.
+uint32_t osEventFlagsWait (osEventFlagsId_t ef_id, uint32_t flags, uint32_t options, uint32_t timeout);
+ 
+/// Delete an Event Flags object.
+/// \param[in]     ef_id         event flags ID obtained by \ref osEventFlagsNew.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osEventFlagsDelete (osEventFlagsId_t ef_id);
+ 
+ 
+//  ==== Mutex Management Functions ====
+ 
+/// Create and Initialize a Mutex object.
+/// \param[in]     attr          mutex attributes; NULL: default values.
+/// \return mutex ID for reference by other functions or NULL in case of error.
+osMutexId_t osMutexNew (const osMutexAttr_t *attr);
+ 
+/// Get name of a Mutex object.
+/// \param[in]     mutex_id      mutex ID obtained by \ref osMutexNew.
+/// \return name as null-terminated string.
+const char *osMutexGetName (osMutexId_t mutex_id);
+ 
+/// Acquire a Mutex or timeout if it is locked.
+/// \param[in]     mutex_id      mutex ID obtained by \ref osMutexNew.
+/// \param[in]     timeout       \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osMutexAcquire (osMutexId_t mutex_id, uint32_t timeout);
+ 
+/// Release a Mutex that was acquired by \ref osMutexAcquire.
+/// \param[in]     mutex_id      mutex ID obtained by \ref osMutexNew.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osMutexRelease (osMutexId_t mutex_id);
+ 
+/// Get Thread which owns a Mutex object.
+/// \param[in]     mutex_id      mutex ID obtained by \ref osMutexNew.
+/// \return thread ID of owner thread or NULL when mutex was not acquired.
+osThreadId_t osMutexGetOwner (osMutexId_t mutex_id);
+ 
+/// Delete a Mutex object.
+/// \param[in]     mutex_id      mutex ID obtained by \ref osMutexNew.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osMutexDelete (osMutexId_t mutex_id);
+ 
+ 
+//  ==== Semaphore Management Functions ====
+ 
+/// Create and Initialize a Semaphore object.
+/// \param[in]     max_count     maximum number of available tokens.
+/// \param[in]     initial_count initial number of available tokens.
+/// \param[in]     attr          semaphore attributes; NULL: default values.
+/// \return semaphore ID for reference by other functions or NULL in case of error.
+osSemaphoreId_t osSemaphoreNew (uint32_t max_count, uint32_t initial_count, const osSemaphoreAttr_t *attr);
+ 
+/// Get name of a Semaphore object.
+/// \param[in]     semaphore_id  semaphore ID obtained by \ref osSemaphoreNew.
+/// \return name as null-terminated string.
+const char *osSemaphoreGetName (osSemaphoreId_t semaphore_id);
+ 
+/// Acquire a Semaphore token or timeout if no tokens are available.
+/// \param[in]     semaphore_id  semaphore ID obtained by \ref osSemaphoreNew.
+/// \param[in]     timeout       \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osSemaphoreAcquire (osSemaphoreId_t semaphore_id, uint32_t timeout);
+ 
+/// Release a Semaphore token up to the initial maximum count.
+/// \param[in]     semaphore_id  semaphore ID obtained by \ref osSemaphoreNew.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osSemaphoreRelease (osSemaphoreId_t semaphore_id);
+ 
+/// Get current Semaphore token count.
+/// \param[in]     semaphore_id  semaphore ID obtained by \ref osSemaphoreNew.
+/// \return number of tokens available.
+uint32_t osSemaphoreGetCount (osSemaphoreId_t semaphore_id);
+ 
+/// Delete a Semaphore object.
+/// \param[in]     semaphore_id  semaphore ID obtained by \ref osSemaphoreNew.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osSemaphoreDelete (osSemaphoreId_t semaphore_id);
+ 
+ 
+//  ==== Memory Pool Management Functions ====
+ 
+/// Create and Initialize a Memory Pool object.
+/// \param[in]     block_count   maximum number of memory blocks in memory pool.
+/// \param[in]     block_size    memory block size in bytes.
+/// \param[in]     attr          memory pool attributes; NULL: default values.
+/// \return memory pool ID for reference by other functions or NULL in case of error.
+osMemoryPoolId_t osMemoryPoolNew (uint32_t block_count, uint32_t block_size, const osMemoryPoolAttr_t *attr);
+ 
+/// Get name of a Memory Pool object.
+/// \param[in]     mp_id         memory pool ID obtained by \ref osMemoryPoolNew.
+/// \return name as null-terminated string.
+const char *osMemoryPoolGetName (osMemoryPoolId_t mp_id);
+ 
+/// Allocate a memory block from a Memory Pool.
+/// \param[in]     mp_id         memory pool ID obtained by \ref osMemoryPoolNew.
+/// \param[in]     timeout       \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out.
+/// \return address of the allocated memory block or NULL in case of no memory is available.
+void *osMemoryPoolAlloc (osMemoryPoolId_t mp_id, uint32_t timeout);
+ 
+/// Return an allocated memory block back to a Memory Pool.
+/// \param[in]     mp_id         memory pool ID obtained by \ref osMemoryPoolNew.
+/// \param[in]     block         address of the allocated memory block to be returned to the memory pool.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osMemoryPoolFree (osMemoryPoolId_t mp_id, void *block);
+ 
+/// Get maximum number of memory blocks in a Memory Pool.
+/// \param[in]     mp_id         memory pool ID obtained by \ref osMemoryPoolNew.
+/// \return maximum number of memory blocks.
+uint32_t osMemoryPoolGetCapacity (osMemoryPoolId_t mp_id);
+ 
+/// Get memory block size in a Memory Pool.
+/// \param[in]     mp_id         memory pool ID obtained by \ref osMemoryPoolNew.
+/// \return memory block size in bytes.
+uint32_t osMemoryPoolGetBlockSize (osMemoryPoolId_t mp_id);
+ 
+/// Get number of memory blocks used in a Memory Pool.
+/// \param[in]     mp_id         memory pool ID obtained by \ref osMemoryPoolNew.
+/// \return number of memory blocks used.
+uint32_t osMemoryPoolGetCount (osMemoryPoolId_t mp_id);
+ 
+/// Get number of memory blocks available in a Memory Pool.
+/// \param[in]     mp_id         memory pool ID obtained by \ref osMemoryPoolNew.
+/// \return number of memory blocks available.
+uint32_t osMemoryPoolGetSpace (osMemoryPoolId_t mp_id);
+ 
+/// Delete a Memory Pool object.
+/// \param[in]     mp_id         memory pool ID obtained by \ref osMemoryPoolNew.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osMemoryPoolDelete (osMemoryPoolId_t mp_id);
+ 
+ 
+//  ==== Message Queue Management Functions ====
+ 
+/// Create and Initialize a Message Queue object.
+/// \param[in]     msg_count     maximum number of messages in queue.
+/// \param[in]     msg_size      maximum message size in bytes.
+/// \param[in]     attr          message queue attributes; NULL: default values.
+/// \return message queue ID for reference by other functions or NULL in case of error.
+osMessageQueueId_t osMessageQueueNew (uint32_t msg_count, uint32_t msg_size, const osMessageQueueAttr_t *attr);
+ 
+/// Get name of a Message Queue object.
+/// \param[in]     mq_id         message queue ID obtained by \ref osMessageQueueNew.
+/// \return name as null-terminated string.
+const char *osMessageQueueGetName (osMessageQueueId_t mq_id);
+ 
+/// Put a Message into a Queue or timeout if Queue is full.
+/// \param[in]     mq_id         message queue ID obtained by \ref osMessageQueueNew.
+/// \param[in]     msg_ptr       pointer to buffer with message to put into a queue.
+/// \param[in]     msg_prio      message priority.
+/// \param[in]     timeout       \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osMessageQueuePut (osMessageQueueId_t mq_id, const void *msg_ptr, uint8_t msg_prio, uint32_t timeout);
+ 
+/// Get a Message from a Queue or timeout if Queue is empty.
+/// \param[in]     mq_id         message queue ID obtained by \ref osMessageQueueNew.
+/// \param[out]    msg_ptr       pointer to buffer for message to get from a queue.
+/// \param[out]    msg_prio      pointer to buffer for message priority or NULL.
+/// \param[in]     timeout       \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osMessageQueueGet (osMessageQueueId_t mq_id, void *msg_ptr, uint8_t *msg_prio, uint32_t timeout);
+ 
+/// Get maximum number of messages in a Message Queue.
+/// \param[in]     mq_id         message queue ID obtained by \ref osMessageQueueNew.
+/// \return maximum number of messages.
+uint32_t osMessageQueueGetCapacity (osMessageQueueId_t mq_id);
+ 
+/// Get maximum message size in a Message Queue.
+/// \param[in]     mq_id         message queue ID obtained by \ref osMessageQueueNew.
+/// \return maximum message size in bytes.
+uint32_t osMessageQueueGetMsgSize (osMessageQueueId_t mq_id);
+ 
+/// Get number of queued messages in a Message Queue.
+/// \param[in]     mq_id         message queue ID obtained by \ref osMessageQueueNew.
+/// \return number of queued messages.
+uint32_t osMessageQueueGetCount (osMessageQueueId_t mq_id);
+ 
+/// Get number of available slots for messages in a Message Queue.
+/// \param[in]     mq_id         message queue ID obtained by \ref osMessageQueueNew.
+/// \return number of available slots for messages.
+uint32_t osMessageQueueGetSpace (osMessageQueueId_t mq_id);
+ 
+/// Reset a Message Queue to initial empty state.
+/// \param[in]     mq_id         message queue ID obtained by \ref osMessageQueueNew.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osMessageQueueReset (osMessageQueueId_t mq_id);
+ 
+/// Delete a Message Queue object.
+/// \param[in]     mq_id         message queue ID obtained by \ref osMessageQueueNew.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osMessageQueueDelete (osMessageQueueId_t mq_id);
+ 
+ 
+//  ==== Handler Functions ====
+ 
+/// Handler for expired thread watchdogs.
+/// \param[in]     thread_id thread ID obtained by \ref osThreadNew or \ref osThreadGetId.
+/// \return new watchdog reload value or 0 to stop the watchdog.
+uint32_t osWatchdogAlarm_Handler (osThreadId_t thread_id);
+ 
+ 
+// ==== Zone Management Function ====
+ 
+/// Setup MPU protected zone (called when zone changes).
+/// \param[in]     zone          zone number.
+void osZoneSetup_Callback (uint32_t zone);
+ 
+ 
+//  ==== Exception Faults ====
+ 
+/// Resume normal operation when exiting exception faults
+void osFaultResume (void);
+ 
+ 
+#ifdef  __cplusplus
+}
+#endif
+ 
+#endif  // CMSIS_OS2_H_

--- a/platform/ext/cmsis/CMSIS/RTOS2/Include/os_tick.h
+++ b/platform/ext/cmsis/CMSIS/RTOS2/Include/os_tick.h
@@ -1,0 +1,80 @@
+/**************************************************************************//**
+ * @file     os_tick.h
+ * @brief    CMSIS OS Tick header file
+ * @version  V1.0.2
+ * @date     19. March 2021
+ ******************************************************************************/
+/*
+ * Copyright (c) 2017-2021 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OS_TICK_H
+#define OS_TICK_H
+
+#include <stdint.h>
+
+#ifdef  __cplusplus
+extern "C"
+{
+#endif
+
+/// IRQ Handler.
+#ifndef IRQHANDLER_T
+#define IRQHANDLER_T
+typedef void (*IRQHandler_t) (void);
+#endif
+
+/// Setup OS Tick timer to generate periodic RTOS Kernel Ticks
+/// \param[in]     freq         tick frequency in Hz
+/// \param[in]     handler      tick IRQ handler
+/// \return 0 on success, -1 on error.
+int32_t  OS_Tick_Setup (uint32_t freq, IRQHandler_t handler);
+
+/// Enable OS Tick timer interrupt
+void     OS_Tick_Enable (void);
+
+/// Disable OS Tick timer interrupt
+void     OS_Tick_Disable (void);
+
+/// Acknowledge execution of OS Tick timer interrupt
+void     OS_Tick_AcknowledgeIRQ (void);
+
+/// Get OS Tick timer IRQ number
+/// \return OS Tick IRQ number
+int32_t  OS_Tick_GetIRQn (void);
+
+/// Get OS Tick timer clock frequency
+/// \return OS Tick timer clock frequency in Hz
+uint32_t OS_Tick_GetClock (void);
+
+/// Get OS Tick timer interval reload value
+/// \return OS Tick timer interval reload value
+uint32_t OS_Tick_GetInterval (void);
+
+/// Get OS Tick timer counter value
+/// \return OS Tick timer counter value
+uint32_t OS_Tick_GetCount (void);
+
+/// Get OS Tick timer overflow status
+/// \return OS Tick overflow status (1 - overflow, 0 - no overflow).
+uint32_t OS_Tick_GetOverflow (void);
+
+#ifdef  __cplusplus
+}
+#endif
+
+#endif  /* OS_TICK_H */

--- a/platform/ext/cmsis/CMSIS/RTOS2/Source/os_systick.c
+++ b/platform/ext/cmsis/CMSIS/RTOS2/Source/os_systick.c
@@ -1,0 +1,142 @@
+/**************************************************************************//**
+ * @file     os_systick.c
+ * @brief    CMSIS OS Tick SysTick implementation
+ * @version  V1.0.5
+ * @date     16. October 2023
+ ******************************************************************************/
+/*
+ * Copyright (c) 2017-2023 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "os_tick.h"
+
+//lint -emacro((923,9078),SCB,SysTick) "cast from unsigned long to pointer"
+#include "RTE_Components.h"
+#include CMSIS_device_header
+
+#ifdef  SysTick
+
+#ifndef SYSTICK_IRQ_PRIORITY
+#define SYSTICK_IRQ_PRIORITY    0xFFU
+#endif
+
+static uint8_t PendST __attribute__((section(".bss.os")));
+
+// Setup OS Tick.
+__WEAK int32_t OS_Tick_Setup (uint32_t freq, IRQHandler_t handler) {
+  uint32_t load;
+  (void)handler;
+
+  if (freq == 0U) {
+    //lint -e{904} "Return statement before end of function"
+    return (-1);
+  }
+
+  load = (SystemCoreClock / freq) - 1U;
+  if (load > 0x00FFFFFFU) {
+    //lint -e{904} "Return statement before end of function"
+    return (-1);
+  }
+
+  // Set SysTick Interrupt Priority
+#if   ((defined(__ARM_ARCH_8M_MAIN__)   && (__ARM_ARCH_8M_MAIN__   != 0)) || \
+       (defined(__ARM_ARCH_8_1M_MAIN__) && (__ARM_ARCH_8_1M_MAIN__ != 0)) || \
+       (defined(__CORTEX_M)             && (__CORTEX_M             == 7U)))
+  SCB->SHPR[11] = SYSTICK_IRQ_PRIORITY;
+#elif  (defined(__ARM_ARCH_8M_BASE__)   && (__ARM_ARCH_8M_BASE__   != 0))
+  SCB->SHPR[1] |= ((uint32_t)SYSTICK_IRQ_PRIORITY << 24);
+#elif ((defined(__ARM_ARCH_7M__)        && (__ARM_ARCH_7M__        != 0)) || \
+       (defined(__ARM_ARCH_7EM__)       && (__ARM_ARCH_7EM__       != 0)))
+  SCB->SHPR[11]  = SYSTICK_IRQ_PRIORITY;
+#elif  (defined(__ARM_ARCH_6M__)        && (__ARM_ARCH_6M__        != 0))
+  SCB->SHPR[1]  |= ((uint32_t)SYSTICK_IRQ_PRIORITY << 24);
+#else
+#error "Unknown ARM Core!"
+#endif
+
+  SysTick->CTRL =  SysTick_CTRL_CLKSOURCE_Msk | SysTick_CTRL_TICKINT_Msk;
+  SysTick->LOAD =  load;
+  SysTick->VAL  =  0U;
+
+  PendST = 0U;
+
+  return (0);
+}
+
+/// Enable OS Tick.
+__WEAK void OS_Tick_Enable (void) {
+
+  if (PendST != 0U) {
+    PendST = 0U;
+    SCB->ICSR = SCB_ICSR_PENDSTSET_Msk;
+  }
+
+  SysTick->CTRL |=  SysTick_CTRL_ENABLE_Msk;
+}
+
+/// Disable OS Tick.
+__WEAK void OS_Tick_Disable (void) {
+
+  SysTick->CTRL &= ~SysTick_CTRL_ENABLE_Msk;
+
+  if ((SCB->ICSR & SCB_ICSR_PENDSTSET_Msk) != 0U) {
+    SCB->ICSR = SCB_ICSR_PENDSTCLR_Msk;
+    PendST = 1U;
+  }
+}
+
+// Acknowledge OS Tick IRQ.
+__WEAK void OS_Tick_AcknowledgeIRQ (void) {
+  (void)SysTick->CTRL;
+}
+
+// Get OS Tick IRQ number.
+__WEAK int32_t  OS_Tick_GetIRQn (void) {
+  return ((int32_t)SysTick_IRQn);
+}
+
+// Get OS Tick clock.
+__WEAK uint32_t OS_Tick_GetClock (void) {
+  return (SystemCoreClock);
+}
+
+// Get OS Tick interval.
+__WEAK uint32_t OS_Tick_GetInterval (void) {
+  return (SysTick->LOAD + 1U);
+}
+
+// Get OS Tick count value.
+__WEAK uint32_t OS_Tick_GetCount (void) {
+  uint32_t val;
+  uint32_t count;
+
+  val = SysTick->VAL;
+  if (val != 0U) {
+    count = (SysTick->LOAD - val) + 1U;
+  } else {
+    count = 0U;
+  }
+
+  return (count);
+}
+
+// Get OS Tick overflow status.
+__WEAK uint32_t OS_Tick_GetOverflow (void) {
+  return ((SCB->ICSR & SCB_ICSR_PENDSTSET_Msk) >> SCB_ICSR_PENDSTSET_Pos);
+}
+
+#endif  // SysTick

--- a/platform/ext/cmsis/CMSIS/RTOS2/Source/os_tick_gtim.c
+++ b/platform/ext/cmsis/CMSIS/RTOS2/Source/os_tick_gtim.c
@@ -1,0 +1,187 @@
+/**************************************************************************//**
+ * @file     os_tick_gtim.c
+ * @brief    CMSIS OS Tick implementation for Generic Timer
+ * @version  V1.0.1
+ * @date     24. November 2017
+ ******************************************************************************/
+/*
+ * Copyright (c) 2017 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "os_tick.h"
+#include "irq_ctrl.h"
+
+#include "RTE_Components.h"
+#include CMSIS_device_header
+
+#ifndef GTIM_IRQ_PRIORITY
+#define GTIM_IRQ_PRIORITY           0xFFU
+#endif
+
+#ifndef GTIM_IRQ_NUM
+#define GTIM_IRQ_NUM                SecurePhyTimer_IRQn
+#endif
+
+// Timer interrupt pending flag
+static uint8_t GTIM_PendIRQ;
+
+// Timer tick frequency
+static uint32_t GTIM_Clock;
+
+// Timer load value
+static uint32_t GTIM_Load;
+
+// Setup OS Tick.
+int32_t OS_Tick_Setup (uint32_t freq, IRQHandler_t handler) {
+  uint32_t prio, bits;
+
+  if (freq == 0U) {
+    return (-1);
+  }
+
+  GTIM_PendIRQ = 0U;
+
+  // Get timer clock
+#ifdef SCTR_BASE
+  GTIM_Clock = *(uint32_t*)(SCTR_BASE+0x20);
+#else
+  // FVP REFCLK CNTControl 100MHz
+  GTIM_Clock = 100000000UL;
+#endif
+
+  PL1_SetCounterFrequency(GTIM_Clock);
+
+  // Calculate load value
+  GTIM_Load = (GTIM_Clock / freq) - 1U;
+
+  // Disable Generic Timer and set load value
+  PL1_SetControl(0U);
+  PL1_SetLoadValue(GTIM_Load);
+
+  // Disable corresponding IRQ
+  IRQ_Disable(GTIM_IRQ_NUM);
+  IRQ_ClearPending(GTIM_IRQ_NUM);
+
+  // Determine number of implemented priority bits
+  IRQ_SetPriority(GTIM_IRQ_NUM, 0xFFU);
+
+  prio = IRQ_GetPriority(GTIM_IRQ_NUM);
+
+  // At least bits [7:4] must be implemented
+  if ((prio & 0xF0U) == 0U) {
+    return (-1);
+  }
+
+  for (bits = 0; bits < 4; bits++) {
+    if ((prio & 0x01) != 0) {
+      break;
+    }
+    prio >>= 1;
+  }
+  
+  // Adjust configured priority to the number of implemented priority bits
+  prio = (GTIM_IRQ_PRIORITY << bits) & 0xFFUL;
+
+  // Set Private Timer interrupt priority
+  IRQ_SetPriority(GTIM_IRQ_NUM, prio-1U);
+
+  // Set edge-triggered IRQ
+  IRQ_SetMode(GTIM_IRQ_NUM, IRQ_MODE_TRIG_EDGE);
+
+  // Register tick interrupt handler function
+  IRQ_SetHandler(GTIM_IRQ_NUM, handler);
+
+  // Enable corresponding interrupt
+  IRQ_Enable(GTIM_IRQ_NUM);
+
+  // Enable system counter and timer control
+#ifdef SCTR_BASE
+  *(uint32_t*)SCTR_BASE |= 3U;
+#endif
+
+  // Enable timer control
+  PL1_SetControl(1U);
+
+  return (0);
+}
+
+/// Enable OS Tick.
+void OS_Tick_Enable (void) {
+  uint32_t ctrl;
+
+  // Set pending interrupt if flag set
+  if (GTIM_PendIRQ != 0U) {
+    GTIM_PendIRQ = 0U;
+    IRQ_SetPending (GTIM_IRQ_NUM);
+  }
+
+  // Start the Private Timer
+  ctrl = PL1_GetControl();
+  // Set bit: Timer enable
+  ctrl |= 1U;
+  PL1_SetControl(ctrl);
+}
+
+/// Disable OS Tick.
+void OS_Tick_Disable (void) {
+  uint32_t ctrl;
+
+  // Stop the Private Timer
+  ctrl = PL1_GetControl();
+  // Clear bit: Timer enable
+  ctrl &= ~1U;
+  PL1_SetControl(ctrl);
+
+  // Remember pending interrupt flag
+  if (IRQ_GetPending(GTIM_IRQ_NUM) != 0) {
+    IRQ_ClearPending(GTIM_IRQ_NUM);
+    GTIM_PendIRQ = 1U;
+  }
+}
+
+// Acknowledge OS Tick IRQ.
+void OS_Tick_AcknowledgeIRQ (void) {
+  IRQ_ClearPending (GTIM_IRQ_NUM);
+  PL1_SetLoadValue(GTIM_Load);
+}
+
+// Get OS Tick IRQ number.
+int32_t  OS_Tick_GetIRQn (void) {
+  return (GTIM_IRQ_NUM);
+}
+
+// Get OS Tick clock.
+uint32_t OS_Tick_GetClock (void) {
+  return (GTIM_Clock);
+}
+
+// Get OS Tick interval.
+uint32_t OS_Tick_GetInterval (void) {
+  return (GTIM_Load + 1U);
+}
+
+// Get OS Tick count value.
+uint32_t OS_Tick_GetCount (void) {
+  return (GTIM_Load - PL1_GetCurrentValue());
+}
+
+// Get OS Tick overflow status.
+uint32_t OS_Tick_GetOverflow (void) {
+  CNTP_CTL_Type cntp_ctl;
+  cntp_ctl.w = PL1_GetControl();
+  return (cntp_ctl.b.ISTATUS);
+}

--- a/platform/ext/cmsis/CMSIS/RTOS2/Source/os_tick_ptim.c
+++ b/platform/ext/cmsis/CMSIS/RTOS2/Source/os_tick_ptim.c
@@ -1,0 +1,165 @@
+/**************************************************************************//**
+ * @file     os_tick_ptim.c
+ * @brief    CMSIS OS Tick implementation for Private Timer
+ * @version  V1.0.2
+ * @date     02. March 2018
+ ******************************************************************************/
+/*
+ * Copyright (c) 2017-2018 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "RTE_Components.h"
+#include CMSIS_device_header
+
+#if defined(PTIM)
+
+#include "os_tick.h"
+#include "irq_ctrl.h"
+
+#ifndef PTIM_IRQ_PRIORITY
+#define PTIM_IRQ_PRIORITY           0xFFU
+#endif
+
+static uint8_t PTIM_PendIRQ;        // Timer interrupt pending flag
+
+// Setup OS Tick.
+int32_t OS_Tick_Setup (uint32_t freq, IRQHandler_t handler) {
+  uint32_t load;
+  uint32_t prio;
+  uint32_t bits;
+
+  if (freq == 0U) {
+    return (-1);
+  }
+
+  PTIM_PendIRQ = 0U;
+
+  // Private Timer runs with the system frequency
+  load = (SystemCoreClock / freq) - 1U;
+
+  // Disable Private Timer and set load value
+  PTIM_SetControl   (0U);
+  PTIM_SetLoadValue (load);
+
+  // Disable corresponding IRQ
+  IRQ_Disable     (PrivTimer_IRQn);
+  IRQ_ClearPending(PrivTimer_IRQn);
+
+  // Determine number of implemented priority bits
+  IRQ_SetPriority (PrivTimer_IRQn, 0xFFU);
+
+  prio = IRQ_GetPriority (PrivTimer_IRQn);
+
+  // At least bits [7:4] must be implemented
+  if ((prio & 0xF0U) == 0U) {
+    return (-1);
+  }
+
+  for (bits = 0; bits < 4; bits++) {
+    if ((prio & 0x01) != 0) {
+      break;
+    }
+    prio >>= 1;
+  }
+
+  // Adjust configured priority to the number of implemented priority bits
+  prio = (PTIM_IRQ_PRIORITY << bits) & 0xFFUL;
+
+  // Set Private Timer interrupt priority
+  IRQ_SetPriority(PrivTimer_IRQn, prio-1U);
+
+  // Set edge-triggered IRQ
+  IRQ_SetMode(PrivTimer_IRQn, IRQ_MODE_TRIG_EDGE);
+
+  // Register tick interrupt handler function
+  IRQ_SetHandler(PrivTimer_IRQn, handler);
+
+  // Enable corresponding interrupt
+  IRQ_Enable (PrivTimer_IRQn);
+
+  // Set bits: IRQ enable and Auto reload
+  PTIM_SetControl (0x06U);
+
+  return (0);
+}
+
+/// Enable OS Tick.
+void OS_Tick_Enable (void) {
+  uint32_t ctrl;
+
+  // Set pending interrupt if flag set
+  if (PTIM_PendIRQ != 0U) {
+    PTIM_PendIRQ = 0U;
+    IRQ_SetPending (PrivTimer_IRQn);
+  }
+
+  // Start the Private Timer
+  ctrl  = PTIM_GetControl();
+  // Set bit: Timer enable
+  ctrl |= 1U;
+  PTIM_SetControl (ctrl);
+}
+
+/// Disable OS Tick.
+void OS_Tick_Disable (void) {
+  uint32_t ctrl;
+
+  // Stop the Private Timer
+  ctrl  = PTIM_GetControl();
+  // Clear bit: Timer enable
+  ctrl &= ~1U;
+  PTIM_SetControl (ctrl);
+
+  // Remember pending interrupt flag
+  if (IRQ_GetPending(PrivTimer_IRQn) != 0) {
+    IRQ_ClearPending (PrivTimer_IRQn);
+    PTIM_PendIRQ = 1U;
+  }
+}
+
+// Acknowledge OS Tick IRQ.
+void OS_Tick_AcknowledgeIRQ (void) {
+  PTIM_ClearEventFlag();
+}
+
+// Get OS Tick IRQ number.
+int32_t  OS_Tick_GetIRQn (void) {
+  return (PrivTimer_IRQn);
+}
+
+// Get OS Tick clock.
+uint32_t OS_Tick_GetClock (void) {
+  return (SystemCoreClock);
+}
+
+// Get OS Tick interval.
+uint32_t OS_Tick_GetInterval (void) {
+  return (PTIM_GetLoadValue() + 1U);
+}
+
+// Get OS Tick count value.
+uint32_t OS_Tick_GetCount (void) {
+  uint32_t load = PTIM_GetLoadValue();
+  return  (load - PTIM_GetCurrentValue());
+}
+
+// Get OS Tick overflow status.
+uint32_t OS_Tick_GetOverflow (void) {
+  return (PTIM->ISR & 1);
+}
+
+#endif  // PTIM

--- a/platform/ext/cmsis/LICENSE
+++ b/platform/ext/cmsis/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/platform/ext/cmsis/README.md
+++ b/platform/ext/cmsis/README.md
@@ -1,0 +1,88 @@
+[![Version](https://img.shields.io/github/v/release/arm-software/CMSIS_6)](https://github.com/ARM-software/CMSIS_6/releases/latest) [![License](https://img.shields.io/github/license/arm-software/CMSIS_6)](https://github.com/ARM-software/CMSIS_6/blob/main/LICENSE)
+
+# CMSIS Version 6
+
+> **Note:** The branch *main* of this GitHub repository contains our current state of development and gives you contiguous access to the CMSIS development for review, feedback, and contributions via pull requests. For stable versions ready for productive use please refer to tagged releases, like [![Version](https://img.shields.io/github/v/release/arm-software/CMSIS_6?display_name=release&label=%20&sort=semver)](https://github.com/ARM-software/CMSIS_6/releases/latest).
+
+## Useful Links
+
+- [**Documentation of latest release**](https://arm-software.github.io/CMSIS_6/) -  access to the CMSIS user's manual.
+- [**CMSIS Components**](https://arm-software.github.io/CMSIS_6/latest/General/index.html#cmsis_components) - overview of software, tools, and specification.
+- [**Raise Issues**](https://github.com/ARM-software/CMSIS_6#issues-and-labels) - to provide feedback or report problems.
+- [**Documentation of main branch**](https://arm-software.github.io/CMSIS_6/main/General/index.html) - updated from time to time (use [Generate CMSIS Pack for Release](https://github.com/ARM-software/CMSIS_6#generate-cmsis-pack-for-release) for local generation).
+
+## Other related GitHub repositories
+
+| Repository                  | Description                                               |
+|:--------------------------- |:--------------------------------------------------------- |
+| [CMSIS-DSP](https://github.com/ARM-software/CMSIS-DSP)                      | Compute library for various data types: fixed-point (fractional q7, q15, q31) and single precision floating-point (32-bit).
+| [CMSIS-NN](https://github.com/ARM-software/CMSIS-NN)                        | Software library of efficient neural network kernels optimized for Arm Cortex-M processors.
+| [CMSIS-FreeRTOS](https://github.com/arm-software/CMSIS-FreeRTOS)            | CMSIS adoption of FreeRTOS including CMSIS-RTOS2 API layer.
+| [CMSIS-RTX](https://github.com/arm-software/CMSIS-rtx)                      | Keil RTX Real-Time Operating System (CMSIS-RTOS2 native implementation).
+| [CMSIS-Driver](https://github.com/arm-software/CMSIS-Driver)                | Generic MCU driver implementations and templates for Ethernet MAC/PHY and Flash.  |
+| [CMSIS-Driver_Validation](https://github.com/ARM-software/CMSIS-Driver_Validation) | CMSIS-Driver Validation can be used to verify CMSIS-Driver in a user system |
+| [cmsis-pack-eclipse](https://github.com/ARM-software/cmsis-pack-eclipse)    | CMSIS-Pack Management for Eclipse reference implementation Pack support  |
+| [CMSIS-Zone](https://github.com/ARM-software/CMSIS-Zone)                    | CMSIS-Zone Utility along with example projects and FreeMarker templates         |
+| [NXP_LPC](https://github.com/ARM-software/NXP_LPC)                          | CMSIS Driver Implementations for the NXP LPC Microcontroller Series       |
+| [mdk-packs](https://github.com/mdk-packs)                                   | IoT cloud connectors as trail implementations for MDK (help us to make it generic)|
+| [trustedfirmware.org](https://www.trustedfirmware.org/)                     | Arm Trusted Firmware provides a reference implementation of secure world software for Armv8-A and Armv8-M.|
+
+## Directory Structure
+
+Directory                                      | Content
+:----------------------------------------------|:---------------------------------------------------------
+[CMSIS/Core](./CMSIS/Core)                     | CMSIS-Core related files (for release)
+[CMSIS/CoreValidation](./CMSIS/CoreValidation) | Validation for Core(M) and Core(A) (NOT part of pack release)  
+[CMSIS/Driver](./CMSIS/Driver)                 | CMSIS-Driver API headers and template files
+[CMSIS/RTOS2](./CMSIS/RTOS2)                   | RTOS v2 related files (for Cortex-M & Armv8-M)
+[CMSIS/Documentation](./CMSIS/Documentation)   | Doxygen source of the users guide (NOT part of pack release)  
+
+## Generate CMSIS Pack for Release
+
+This GitHub development repository lacks pre-built libraries of various software components (RTOS, RTOS2).
+In order to generate a full pack one needs to have the build environment available to build these libraries.
+This causes some sort of inconvenience. Hence the pre-built libraries may be moved out into separate pack(s)
+in the future.
+
+To build a complete CMSIS pack for installation the following additional tools are required:
+
+- **doxygen.exe**    Version: 1.9.6 (Documentation Generator)
+- **mscgen.exe**     Version: 0.20  (Message Sequence Chart Converter)
+- **7z.exe (7-Zip)** Version: 16.02 (File Archiver)
+
+Using these tools, you can generate on a Windows PC:
+
+- **CMSIS Documentation** using the shell script **gen_doc.sh** (located in ./CMSIS/Documentation/Doxygen).
+- **CMSIS Software Pack** using the shell script **gen_pack.sh**.
+
+## License
+
+Arm CMSIS is licensed under [![License](https://img.shields.io/github/license/arm-software/CMSIS_6?label)](https://github.com/ARM-software/CMSIS_6/blob/main/LICENSE).
+
+## Contributions and Pull Requests
+
+Contributions are accepted under [![License](https://img.shields.io/github/license/arm-software/CMSIS_6?label)](https://github.com/ARM-software/CMSIS_6/blob/main/LICENSE). Only submit contributions where you have authored all of the code.
+
+### Issues and Labels
+
+Please feel free to raise an [issue on GitHub](https://github.com/ARM-software/CMSIS_6/issues)
+to report misbehavior (i.e. bugs) or start discussions about enhancements. This
+is your best way to interact directly with the maintenance team and the community.
+We encourage you to append implementation suggestions as this helps to decrease the
+workload of the very limited maintenance team.
+
+We will be monitoring and responding to issues as best we can.
+Please attempt to avoid filing duplicates of open or closed items when possible.
+In the spirit of openness we will be tagging issues with the following:
+
+- **bug** – We consider this issue to be a bug that will be investigated.
+- **wontfix** - We appreciate this issue but decided not to change the current behavior.
+- **enhancement** – Denotes something that will be implemented soon.
+- **future** - Denotes something not yet schedule for implementation.
+- **out-of-scope** - We consider this issue loosely related to CMSIS. It might by implemented outside of CMSIS. Let us know about your work.
+- **question** – We have further questions to this issue. Please review and provide feedback.
+- **documentation** - This issue is a documentation flaw that will be improved in future.
+- **review** - This issue is under review. Please be patient.
+- **DONE** - We consider this issue as resolved - please review and close it. In case of no further activity this issues will be closed after a week.
+- **duplicate** - This issue is already addressed elsewhere, see comment with provided references.
+- **Important Information** - We provide essential information regarding planned or resolved major enhancements.

--- a/platform/ext/cmsis/gen_pack.sh
+++ b/platform/ext/cmsis/gen_pack.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Version: 3.0
+# Date: 2023-11-06
+# This bash script generates a CMSIS Software Pack:
+#
+
+set -o pipefail
+
+# Set version of gen pack library
+# For available versions see https://github.com/Open-CMSIS-Pack/gen-pack/tags.
+# Use the tag name without the prefix "v", e.g., 0.7.0
+REQUIRED_GEN_PACK_LIB="0.9.1"
+
+# Set default command line arguments
+DEFAULT_ARGS=(-c "v")
+
+# Pack warehouse directory - destination
+# Default: ./output
+#
+# PACK_OUTPUT=./output
+
+# Temporary pack build directory,
+# Default: ./build
+#
+# PACK_BUILD=./build
+
+# Specify directory names to be added to pack base directory
+# An empty list defaults to all folders next to this script.
+# Default: empty (all folders)
+#
+PACK_DIRS="
+  CMSIS/Core
+  CMSIS/Documentation
+  CMSIS/Driver
+  CMSIS/RTOS2
+"
+
+# Specify file names to be added to pack base directory
+# Default: empty
+#
+PACK_BASE_FILES="
+  LICENSE
+"
+
+# Specify file names to be deleted from pack build directory
+# Default: empty
+#
+PACK_DELETE_FILES="
+  CMSIS/Documentation/Doxygen
+  CMSIS/Documentation/README.md
+"
+
+# Specify patches to be applied
+# Default: empty
+#
+# PACK_PATCH_FILES=""
+
+# Specify addition argument to packchk
+# Default: empty
+#
+PACKCHK_ARGS=(-x M336)
+
+# Specify additional dependencies for packchk
+# Default: empty
+#
+PACKCHK_DEPS=" "
+
+# Optional: restrict fallback modes for changelog generation
+# Default: full
+# Values:
+# - full      Tag annotations, release descriptions, or commit messages (in order)
+# - release   Tag annotations, or release descriptions (in order)
+# - tag       Tag annotations only
+#
+PACK_CHANGELOG_MODE="tag"
+
+#
+# custom pre-processing steps
+#
+# usage: preprocess <build>
+#   <build>  The build folder
+#
+function preprocess() {
+  # add custom steps here to be executed
+  # before populating the pack build folder
+  ./CMSIS/Documentation/Doxygen/gen_doc.sh
+  return 0
+}
+
+#
+# custom post-processing steps
+#
+# usage: postprocess <build>
+#   <build>  The build folder
+#
+function postprocess() {
+  # add custom steps here to be executed
+  # after populating the pack build folder
+  # but before archiving the pack into output folder
+  return 0
+}
+
+############ DO NOT EDIT BELOW ###########
+
+# Set GEN_PACK_LIB_PATH to use a specific gen-pack library root
+# ... instead of bootstrap based on REQUIRED_GEN_PACK_LIB
+if [[ -f "${GEN_PACK_LIB_PATH}/gen-pack" ]]; then
+  . "${GEN_PACK_LIB}/gen-pack"
+else
+  . <(curl -sL "https://raw.githubusercontent.com/Open-CMSIS-Pack/gen-pack/main/bootstrap")
+fi
+
+gen_pack "${DEFAULT_ARGS[@]}" "$@"
+
+exit 0


### PR DESCRIPTION
This adds all the files (minus `.git*` and `CMSIS/Documentation/` for saving on size) from the CMSIS v6 repository
(https://github.com/ARM-software/CMSIS_6) at the revision `d0c460c169` as defined in `lib/ext/cmsis/CMakeLists.txt`.
The patch `lib/ext/cmsis/0001-iar-Add-missing-v8.1m-check` is applied on top.

This is because as of v2.1.0 TF-M has updated to CMSIS v6 and switched from hosting the sources to depending on the upstream repository, cloning it at build time.

To prevent a download from happening during the build, CMSIS v6 sources are pushed and the CMSIS_PATH CMake variable is used to point to them.