### PR TITLE
stm32u5 hal dma_ex function not inlined with GCC 11 or 12

### DIFF
--- a/platform/ext/target/stm/common/stm32u5xx/hal/Src/stm32u5xx_hal_dma_ex.c
+++ b/platform/ext/target/stm/common/stm32u5xx/hal/Src/stm32u5xx_hal_dma_ex.c
@@ -535,7 +535,11 @@ static void DMA_List_BuildNode(DMA_NodeConfTypeDef const *const pNodeConfig,
                                DMA_NodeTypeDef *const pNode);
 static void DMA_List_GetNodeConfig(DMA_NodeConfTypeDef *const pNodeConfig,
                                    DMA_NodeTypeDef const *const pNode);
+#if (__GNUC__ == 11) || (__GNUC__ == 12)
+static __attribute__((noinline)) uint32_t DMA_List_CheckNodesBaseAddresses(DMA_NodeTypeDef const *const pNode1,
+#else
 static uint32_t DMA_List_CheckNodesBaseAddresses(DMA_NodeTypeDef const *const pNode1,
+#endif
                                                  DMA_NodeTypeDef const *const pNode2,
                                                  DMA_NodeTypeDef const *const pNode3,
                                                  DMA_NodeTypeDef const *const pNode4);
@@ -4074,7 +4078,11 @@ static void DMA_List_GetNodeConfig(DMA_NodeConfTypeDef *const pNodeConfig,
   * @param  pNode4 : Pointer to a DMA_NodeTypeDef structure that contains linked-list node 4 registers configurations.
   * @retval Return 0 when nodes addresses are compatible, 1 otherwise.
   */
+#if (__GNUC__ == 11) || (__GNUC__ == 12)
+static __attribute__((noinline)) uint32_t DMA_List_CheckNodesBaseAddresses(DMA_NodeTypeDef const *const pNode1,
+#else
 static uint32_t DMA_List_CheckNodesBaseAddresses(DMA_NodeTypeDef const *const pNode1,
+#endif
                                                  DMA_NodeTypeDef const *const pNode2,
                                                  DMA_NodeTypeDef const *const pNode3,
                                                  DMA_NodeTypeDef const *const pNode4)


### PR DESCRIPTION
Fix the Issue linked to compilation of file HAL_DMAEx_List_ReplaceNode_Head.c
using a GCC version comprised between v11.x and v12.x.

and blocking the zephyr CI

Issue is seen only with TF-M build config RelWithDebInfo (With MinSizeRel config, this file is not built).
Issue could be fixed by "adding attribute ((no_inline)) to DMA_List_CheckNodesBaseAddresses allows the build to pass"

Zephyr issue: https://github.com/zephyrproject-rtos/zephyr/issues/80932