### PR TITLE
Increase the size of heap memory of the crypto partition to allow RSA 2048-bits signatures

### DIFF
--- a/config/config_base.h
+++ b/config/config_base.h
@@ -123,7 +123,7 @@
 
 /* The stack size of the Crypto Secure Partition */
 #ifndef CRYPTO_STACK_SIZE
-#define CRYPTO_STACK_SIZE                      0x1B00
+#define CRYPTO_STACK_SIZE                      0x1800
 #endif
 
 /* FWU Partition Configs */

--- a/config/config_base.h
+++ b/config/config_base.h
@@ -36,11 +36,12 @@
 /* Crypto Partition Configs */
 
 /*
- * Heap size for the crypto backend
- * CRYPTO_ENGINE_BUF_SIZE needs to be >8KB for EC signing by attest module.
+ * Heap size for the crypto backend. This is statically allocated
+ * inside the Crypto service and used as heap through the default
+ * Mbed TLS allocator
  */
 #ifndef CRYPTO_ENGINE_BUF_SIZE
-#define CRYPTO_ENGINE_BUF_SIZE                 0x2080
+#define CRYPTO_ENGINE_BUF_SIZE                 0x3000
 #endif
 
 /* The max number of concurrent operations that can be active (allocated) at any time in Crypto */

--- a/config/profile/config_profile_large.h
+++ b/config/profile/config_profile_large.h
@@ -125,7 +125,7 @@
 
 /* The stack size of the Crypto Secure Partition */
 #ifndef CRYPTO_STACK_SIZE
-#define CRYPTO_STACK_SIZE                      0x1B00
+#define CRYPTO_STACK_SIZE                      0x1800
 #endif
 
 /* FWU Partition Configs */

--- a/config/profile/config_profile_large.h
+++ b/config/profile/config_profile_large.h
@@ -43,11 +43,12 @@
 #endif
 
 /*
- * Heap size for the crypto backend
- * CRYPTO_ENGINE_BUF_SIZE needs to be >8KB for EC signing by attest module.
+ * Heap size for the crypto backend. This is statically allocated
+ * inside the Crypto service and used as heap through the default
+ * Mbed TLS allocator
  */
 #ifndef CRYPTO_ENGINE_BUF_SIZE
-#define CRYPTO_ENGINE_BUF_SIZE                 0x2380
+#define CRYPTO_ENGINE_BUF_SIZE                 0x3000
 #endif
 
 /* The max number of concurrent operations that can be active (allocated) at any time in Crypto */

--- a/config/profile/config_profile_medium.h
+++ b/config/profile/config_profile_medium.h
@@ -125,7 +125,7 @@
 
 /* The stack size of the Crypto Secure Partition */
 #ifndef CRYPTO_STACK_SIZE
-#define CRYPTO_STACK_SIZE                      0x1B00
+#define CRYPTO_STACK_SIZE                      0x1800
 #endif
 
 /* FWU Partition Configs */

--- a/config/profile/config_profile_medium.h
+++ b/config/profile/config_profile_medium.h
@@ -33,8 +33,9 @@
 /* Crypto Partition Configs */
 
 /*
- * Heap size for the crypto backend
- * CRYPTO_ENGINE_BUF_SIZE needs to be >8KB for EC signing by attest module.
+ * Heap size for the crypto backend. This is statically allocated
+ * inside the Crypto service and used as heap through the default
+ * Mbed TLS allocator
  */
 #ifndef CRYPTO_ENGINE_BUF_SIZE
 #define CRYPTO_ENGINE_BUF_SIZE                 0x2080

--- a/config/profile/config_profile_medium_arotless.h
+++ b/config/profile/config_profile_medium_arotless.h
@@ -125,7 +125,7 @@
 
 /* The stack size of the Crypto Secure Partition */
 #ifndef CRYPTO_STACK_SIZE
-#define CRYPTO_STACK_SIZE                      0x1B00
+#define CRYPTO_STACK_SIZE                      0x1800
 #endif
 
 /* FWU Partition Configs */

--- a/config/profile/config_profile_medium_arotless.h
+++ b/config/profile/config_profile_medium_arotless.h
@@ -33,8 +33,9 @@
 /* Crypto Partition Configs */
 
 /*
- * Heap size for the crypto backend
- * CRYPTO_ENGINE_BUF_SIZE needs to be >8KB for EC signing by attest module.
+ * Heap size for the crypto backend. This is statically allocated
+ * inside the Crypto service and used as heap through the default
+ * Mbed TLS allocator
  */
 #ifndef CRYPTO_ENGINE_BUF_SIZE
 #define CRYPTO_ENGINE_BUF_SIZE                 0x2080

--- a/config/profile/config_profile_small.h
+++ b/config/profile/config_profile_small.h
@@ -32,7 +32,11 @@
 
 /* Crypto Partition Configs */
 
-/* Heap size for the crypto backend */
+/*
+ * Heap size for the crypto backend. This is statically allocated
+ * inside the Crypto service and used as heap through the default
+ * Mbed TLS allocator
+ */
 #ifndef CRYPTO_ENGINE_BUF_SIZE
 #define CRYPTO_ENGINE_BUF_SIZE                 0x400
 #endif

--- a/config/profile/config_profile_small.h
+++ b/config/profile/config_profile_small.h
@@ -122,7 +122,7 @@
 
 /* The stack size of the Crypto Secure Partition */
 #ifndef CRYPTO_STACK_SIZE
-#define CRYPTO_STACK_SIZE                      0x1B00
+#define CRYPTO_STACK_SIZE                      0x1800
 #endif
 
 /* FWU Partition Configs */


### PR DESCRIPTION
This PR cherry-picks:

- https://review.trustedfirmware.org/c/TF-M/trusted-firmware-m/+/33552
- https://review.trustedfirmware.org/c/TF-M/trusted-firmware-m/+/33523

from the upstream TF-M project. The goal is to fix heap memory size for crypto partition (basically Mbed TLS) in order to allow RSA signatures up to 2048-bits (previously only RSA with 1024-bits key size were possible).

At the same time stack size for the crypto partition is reduced because:
- the previous value was too large;
- mitigate the effects of the heap increase.

This fix is required to resolve: https://github.com/zephyrproject-rtos/zephyr/issues/79864 