### PR TITLE
Use picolibc instead of newlib-nano

### DIFF
--- a/bl1/bl1_1/CMakeLists.txt
+++ b/bl1/bl1_1/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_options(bl1_1
 target_sources(bl1_1
     PRIVATE
         main.c
+        $<$<BOOL:${CONFIG_PICOLIBC}>:${CMAKE_SOURCE_DIR}/platform/ext/common/picolibc.c>
         $<$<BOOL:${CONFIG_GNU_SYSCALL_STUB_ENABLED}>:${CMAKE_SOURCE_DIR}/platform/ext/common/syscalls_stub.c>
 )
 

--- a/bl1/bl1_2/CMakeLists.txt
+++ b/bl1/bl1_2/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_options(bl1_2
 target_sources(bl1_2
     PRIVATE
         main.c
+        $<$<BOOL:${CONFIG_PICOLIBC}>:${CMAKE_SOURCE_DIR}/platform/ext/common/picolibc.c>
         $<$<BOOL:${CONFIG_GNU_SYSCALL_STUB_ENABLED}>:${CMAKE_SOURCE_DIR}/platform/ext/common/syscalls_stub.c>
 )
 

--- a/bl2/CMakeLists.txt
+++ b/bl2/CMakeLists.txt
@@ -141,6 +141,7 @@ add_executable(bl2
     $<$<BOOL:${DEFAULT_MCUBOOT_FLASH_MAP}>:src/default_flash_map.c>
     $<$<BOOL:${MCUBOOT_DATA_SHARING}>:src/shared_data.c>
     $<$<BOOL:${PLATFORM_DEFAULT_PROVISIONING}>:src/provisioning.c>
+    $<$<BOOL:${CONFIG_PICOLIBC}>:${CMAKE_SOURCE_DIR}/platform/ext/common/picolibc.c>
     $<$<BOOL:${CONFIG_GNU_SYSCALL_STUB_ENABLED}>:${CMAKE_SOURCE_DIR}/platform/ext/common/syscalls_stub.c>
 )
 

--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -254,6 +254,11 @@ install(DIRECTORY   $<BUILD_INTERFACE:${CMSIS_PATH}/CMSIS/Core/Include>
                     $<BUILD_INTERFACE:${CMSIS_PATH}/CMSIS/Driver/Include>
         DESTINATION ${INSTALL_PLATFORM_NS_DIR}/ext/cmsis)
 
+if(CONFIG_PICOLIBC)
+    install(FILES       ${PLATFORM_DIR}/ext/common/picolibc.c
+            DESTINATION ${INSTALL_PLATFORM_NS_DIR}/ext/common)
+endif()
+
 if(PLATFORM_DEFAULT_UART_STDOUT)
     install(FILES       ${PLATFORM_DIR}/ext/common/uart_stdout.c
                         ${PLATFORM_DIR}/ext/common/uart_stdout.h

--- a/cmake/spe-CMakeLists.cmake
+++ b/cmake/spe-CMakeLists.cmake
@@ -104,6 +104,7 @@ add_subdirectory(platform)
 
 target_sources(platform_ns
     PRIVATE
+        $<$<BOOL:${CONFIG_PICOLIBC}>:${CMAKE_CURRENT_SOURCE_DIR}/platform/ext/common/picolibc.c>
         $<$<BOOL:${PLATFORM_DEFAULT_UART_STDOUT}>:${CMAKE_CURRENT_SOURCE_DIR}/platform/ext/common/uart_stdout.c>
 )
 

--- a/platform/CMakeLists.txt
+++ b/platform/CMakeLists.txt
@@ -81,6 +81,7 @@ target_sources(platform_s
         $<$<BOOL:${PLATFORM_DEFAULT_PROVISIONING}>:ext/common/provisioning.c>
         $<$<OR:$<BOOL:${TEST_S_FPU}>,$<BOOL:${TEST_NS_FPU}>>:${CMAKE_SOURCE_DIR}/platform/ext/common/test_interrupt.c>
         $<$<BOOL:${TFM_SANITIZE}>:ext/common/tfm_sanitize_handlers.c>
+        $<$<BOOL:${CONFIG_PICOLIBC}>:ext/common/picolibc.c>
         ./ext/common/tfm_fatal_error.c
 )
 
@@ -203,6 +204,7 @@ if(BL2)
             $<$<OR:$<BOOL:${PLATFORM_DEFAULT_NV_COUNTERS}>,$<BOOL:${PLATFORM_DEFAULT_OTP}>>:ext/common/template/flash_otp_nv_counters_backend.c>
             $<$<BOOL:${PLATFORM_DEFAULT_OTP}>:ext/common/template/otp_flash.c>
             $<$<BOOL:${BL2_SANITIZE}>:ext/common/tfm_sanitize_handlers.c>
+            $<$<BOOL:${CONFIG_PICOLIBC}>:ext/common/picolibc.c>
             ./ext/common/tfm_fatal_error.c
     )
 
@@ -304,6 +306,7 @@ if(BL1 AND PLATFORM_DEFAULT_BL1)
             $<$<BOOL:${PLATFORM_DEFAULT_OTP}>:ext/common/template/flash_otp_nv_counters_backend.c>
             $<$<BOOL:${PLATFORM_DEFAULT_OTP}>:ext/common/template/otp_flash.c>
             $<$<OR:$<BOOL:${BL1_1_SANITIZE}>,$<BOOL:${TFM_BL1_2_SANITIZE}>>:ext/common/tfm_sanitize_handlers.c>
+            $<$<BOOL:${CONFIG_PICOLIBC}>:ext/common/picolibc.c>
             ./ext/common/tfm_fatal_error.c
     )
 
@@ -359,6 +362,7 @@ if(BL1 AND PLATFORM_DEFAULT_BL1)
             $<$<BOOL:${PLATFORM_DEFAULT_NV_COUNTERS}>:ext/common/template/nv_counters.c>
             $<$<OR:$<BOOL:${PLATFORM_DEFAULT_NV_COUNTERS}>,$<BOOL:${PLATFORM_DEFAULT_OTP}>>:ext/common/template/flash_otp_nv_counters_backend.c>
             $<$<BOOL:${PLATFORM_DEFAULT_OTP}>:ext/common/template/otp_flash.c>
+            $<$<BOOL:${CONFIG_PICOLIBC}>:ext/common/picolibc.c>
     )
 
     target_link_libraries(platform_bl1_2

--- a/platform/ext/common/gcc/tfm_common_bl2.ld
+++ b/platform/ext/common/gcc/tfm_common_bl2.ld
@@ -60,6 +60,7 @@ SECTIONS
         . = ALIGN(4);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
+        PROVIDE(__bothinit_array_start = __preinit_array_start);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
@@ -69,6 +70,7 @@ SECTIONS
         KEEP(*(SORT(.init_array.*)))
         KEEP(*(.init_array))
         PROVIDE_HIDDEN (__init_array_end = .);
+        PROVIDE(__bothinit_array_end = __init_array_end);
 
         . = ALIGN(4);
         /* finit data */
@@ -212,8 +214,10 @@ SECTIONS
         __end__ = .;
         PROVIDE(end = .);
         __HeapBase = .;
+        PROVIDE(__heap_start = __HeapBase);
         . += __heap_size__;
         __HeapLimit = .;
+        PROVIDE(__heap_end = __HeapLimit);
         __heap_limit = .; /* Add for _sbrk */
     } > RAM
     Image$$ARM_LIB_HEAP$$ZI$$Limit = ADDR(.heap) + SIZEOF(.heap);

--- a/platform/ext/common/gcc/tfm_common_ns.ld
+++ b/platform/ext/common/gcc/tfm_common_ns.ld
@@ -47,6 +47,7 @@ SECTIONS
         . = ALIGN(4);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
+        PROVIDE(__bothinit_array_start = __preinit_array_start);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
@@ -56,6 +57,7 @@ SECTIONS
         KEEP(*(SORT(.init_array.*)))
         KEEP(*(.init_array))
         PROVIDE_HIDDEN (__init_array_end = .);
+        PROVIDE(__bothinit_array_end = __init_array_end);
 
         . = ALIGN(4);
         /* finit data */
@@ -158,8 +160,10 @@ SECTIONS
         __end__ = .;
         PROVIDE(end = .);
         __HeapBase = .;
+        PROVIDE(__heap_start = __HeapBase);
         . += __heap_size__;
         __HeapLimit = .;
+        PROVIDE(__heap_end = __HeapLimit);
         __heap_limit = .; /* Add for _sbrk */
     } > RAM
 

--- a/platform/ext/common/gcc/tfm_common_s.ld.template
+++ b/platform/ext/common/gcc/tfm_common_s.ld.template
@@ -200,6 +200,9 @@ SECTIONS
         . = ALIGN(4); /* This alignment is needed to make the section size 4 bytes aligned */
     } > CODE_RAM AT > FLASH
 
+    /* Reset current position for subsequent sections */
+    . = LOADADDR(.ER_CODE_SRAM) + SIZEOF(.ER_CODE_SRAM);
+
     ASSERT(S_RAM_CODE_START % 4 == 0, "S_RAM_CODE_START must be divisible by 4")
 
     Image$$ER_CODE_SRAM$$RO$$Base = ADDR(.ER_CODE_SRAM);

--- a/platform/ext/common/gcc/tfm_common_s.ld.template
+++ b/platform/ext/common/gcc/tfm_common_s.ld.template
@@ -276,6 +276,9 @@ SECTIONS
         /* .zero.table */
         . = ALIGN(4);
         __zero_table_start__ = .;
+        LONG (ADDR(.TFM_BSS))
+        LONG (SIZEOF(.TFM_BSS) / 4)
+
         LONG (ADDR(.TFM_PSA_ROT_LINKER_BSS))
         LONG (SIZEOF(.TFM_PSA_ROT_LINKER_BSS) / 4)    /* Aligment checked after the section */
 

--- a/platform/ext/common/gcc/tfm_common_s.ld.template
+++ b/platform/ext/common/gcc/tfm_common_s.ld.template
@@ -228,6 +228,7 @@ SECTIONS
         . = ALIGN(4);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
+        PROVIDE(__bothinit_array_start = __preinit_array_start);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
@@ -237,6 +238,7 @@ SECTIONS
         KEEP(*(SORT(.init_array.*)))
         KEEP(*(.init_array))
         PROVIDE_HIDDEN (__init_array_end = .);
+        PROVIDE(__bothinit_array_end = __init_array_end);
 
         . = ALIGN(4);
         /* finit data */
@@ -412,8 +414,10 @@ SECTIONS
         __end__ = .;
         PROVIDE(end = .);
         __HeapBase = .;
+        PROVIDE(__heap_start = __HeapBase);
         . += __heap_size__;
         __HeapLimit = .;
+        PROVIDE(__heap_end = __HeapLimit);
         __heap_limit = .; /* Add for _sbrk */
     } > RAM
 #endif

--- a/platform/ext/common/gcc/tfm_isolation_s.ld.template
+++ b/platform/ext/common/gcc/tfm_isolation_s.ld.template
@@ -350,6 +350,9 @@ SECTIONS
         . = ALIGN(4); /* This alignment is needed to make the section size 4 bytes aligned */
     } > CODE_RAM AT > FLASH
 
+    /* Reset current position for subsequent sections */
+    . = LOADADDR(.ER_CODE_SRAM) + SIZEOF(.ER_CODE_SRAM);
+
     ASSERT(S_RAM_CODE_START % 4 == 0, "S_RAM_CODE_START must be divisible by 4")
 
     Image$$ER_CODE_SRAM$$RO$$Base = ADDR(.ER_CODE_SRAM);

--- a/platform/ext/common/gcc/tfm_isolation_s.ld.template
+++ b/platform/ext/common/gcc/tfm_isolation_s.ld.template
@@ -218,6 +218,7 @@ SECTIONS
         . = ALIGN(4);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
+        PROVIDE(__bothinit_array_start = __preinit_array_start);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
@@ -227,6 +228,7 @@ SECTIONS
         KEEP(*(SORT(.init_array.*)))
         KEEP(*(.init_array))
         PROVIDE_HIDDEN (__init_array_end = .);
+        PROVIDE(__bothinit_array_end = __init_array_end);
 
         . = ALIGN(4);
         /* finit data */
@@ -516,8 +518,10 @@ SECTIONS
         __end__ = .;
         PROVIDE(end = .);
         __HeapBase = .;
+        PROVIDE(__heap_start = __HeapBase);
         . += __heap_size__;
         __HeapLimit = .;
+        PROVIDE(__heap_end = __HeapLimit);
         __heap_limit = .; /* Add for _sbrk */
     } > RAM
 #endif

--- a/platform/ext/common/gcc/tfm_isolation_s.ld.template
+++ b/platform/ext/common/gcc/tfm_isolation_s.ld.template
@@ -264,6 +264,9 @@ SECTIONS
         /* .zero.table */
         . = ALIGN(4);
         __zero_table_start__ = .;
+        LONG (ADDR(.TFM_BSS))
+        LONG (SIZEOF(.TFM_BSS) / 4)
+
 {% for partition in partitions %}
         LONG (ADDR(.ER_{{partition.manifest.name}}_BSS))
         LONG (SIZEOF(.ER_{{partition.manifest.name}}_BSS) / 4)    /* Aligment checked after the section */

--- a/platform/ext/common/llvm/tfm_common_ns.ldc
+++ b/platform/ext/common/llvm/tfm_common_ns.ldc
@@ -42,6 +42,7 @@ SECTIONS
         . = ALIGN(4);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
+        PROVIDE(__bothinit_array_start = __preinit_array_start);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
@@ -51,6 +52,7 @@ SECTIONS
         KEEP(*(SORT(.init_array.*)))
         KEEP(*(.init_array))
         PROVIDE_HIDDEN (__init_array_end = .);
+        PROVIDE(__bothinit_array_end = __init_array_end);
 
         . = ALIGN(4);
         /* finit data */

--- a/platform/ext/common/llvm/tfm_isolation_s.ld.template
+++ b/platform/ext/common/llvm/tfm_isolation_s.ld.template
@@ -323,6 +323,9 @@ SECTIONS
         . = ALIGN(4); /* This alignment is needed to make the section size 4 bytes aligned */
     } > CODE_RAM AT > FLASH
 
+    /* Reset current position for subsequent sections */
+    . = LOADADDR(.ER_CODE_SRAM) + SIZEOF(.ER_CODE_SRAM);
+
     ASSERT(S_RAM_CODE_START % 4 == 0, "S_RAM_CODE_START must be divisible by 4")
 
     Image$$ER_CODE_SRAM$$RO$$Base = ADDR(.ER_CODE_SRAM);

--- a/platform/ext/common/llvm/tfm_isolation_s.ld.template
+++ b/platform/ext/common/llvm/tfm_isolation_s.ld.template
@@ -192,6 +192,7 @@ SECTIONS
     {
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
+        PROVIDE(__bothinit_array_start = __preinit_array_start);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
@@ -201,6 +202,7 @@ SECTIONS
         KEEP(*(SORT(.init_array.*)))
         KEEP(*(.init_array))
         PROVIDE_HIDDEN (__init_array_end = .);
+        PROVIDE(__bothinit_array_end = __init_array_end);
 
         . = ALIGN(4);
         /* finit data */

--- a/platform/ext/common/picolibc.c
+++ b/platform/ext/common/picolibc.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025, Keith Packard <keithp@keithp.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#include <stdint.h>
+#include <string.h>
+#include "config_impl.h"
+
+#ifdef __PICOLIBC__
+
+/*
+ * Picolibc's startup code only initializes a single data and bss
+ * segment. Replace that to initialize all of the segments using
+ * the lists provided by the linker script.
+ */
+
+void __libc_init_array(void);
+void _start(void);
+int main(int, char **);
+
+void
+_start(void)
+{
+    typedef struct __copy_table {
+        uint32_t const* src;
+        uint32_t* dest;
+        uint32_t  wlen;
+    } __copy_table_t;
+
+    typedef struct __zero_table {
+        uint32_t* dest;
+        uint32_t  wlen;
+    } __zero_table_t;
+
+    extern const __copy_table_t __copy_table_start__;
+    extern const __copy_table_t __copy_table_end__;
+    extern const __zero_table_t __zero_table_start__;
+    extern const __zero_table_t __zero_table_end__;
+
+    for (__copy_table_t const* pTable = &__copy_table_start__; pTable < &__copy_table_end__; ++pTable) {
+        memcpy(pTable->dest, pTable->src, pTable->wlen << 2);
+    }
+
+    for (__zero_table_t const* pTable = &__zero_table_start__; pTable < &__zero_table_end__; ++pTable) {
+        memset(pTable->dest, 0, pTable->wlen << 2);
+    }
+
+    __libc_init_array();
+    main(0, NULL);
+    return;
+}
+
+#endif /* __PICOLIBC__ */

--- a/platform/ext/common/provisioning_bundle/CMakeLists.txt
+++ b/platform/ext/common/provisioning_bundle/CMakeLists.txt
@@ -54,6 +54,7 @@ target_sources(provisioning_bundle
     PRIVATE
         ./provisioning_code.c
         ./provisioning_data.c
+        $<$<BOOL:${CONFIG_PICOLIBC}>:${CMAKE_SOURCE_DIR}/platform/ext/common/picolibc.c>
         $<$<BOOL:${CONFIG_GNU_SYSCALL_STUB_ENABLED}>:${CMAKE_SOURCE_DIR}/platform/ext/common/syscalls_stub.c>
 )
 

--- a/platform/ext/common/syscalls_stub.c
+++ b/platform/ext/common/syscalls_stub.c
@@ -14,6 +14,14 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef __PICOLIBC__
+__attribute__((weak))
+void _exit(int status)
+{
+    (void) status;
+    for(;;);
+}
+#else
 __attribute__((weak))
 void _close(void)
 {
@@ -53,3 +61,5 @@ __attribute__((weak))
 void _write(void)
 {
 }
+
+#endif /* !__PICOLIBC__ */

--- a/platform/ext/common/uart_stdout.c
+++ b/platform/ext/common/uart_stdout.c
@@ -85,7 +85,7 @@ int fputc(int ch, FILE *f)
 /* Redirect sdtio for PicoLib in LLVM toolchain
    as per https://github.com/picolibc/picolibc/blob/main/doc/os.md
    'fputch()' named intentionally different from 'fputc()' from picolib */
-#elif defined(__clang_major__)
+#elif defined(__PICOLIBC__)
 
 int fputch(char ch, struct __file *f)
 {

--- a/platform/ext/target/adi/max32657/device/gcc/max32657_sla.ld
+++ b/platform/ext/target/adi/max32657/device/gcc/max32657_sla.ld
@@ -50,6 +50,7 @@ SECTIONS
         . = ALIGN(4);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
+        PROVIDE(__bothinit_array_start = __preinit_array_start);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
@@ -59,6 +60,7 @@ SECTIONS
         KEEP(*(SORT(.init_array.*)))
         KEEP(*(.init_array))
         PROVIDE_HIDDEN (__init_array_end = .);
+        PROVIDE(__bothinit_array_end = __init_array_end);
 
         . = ALIGN(4);
         /* finit data */
@@ -196,8 +198,10 @@ SECTIONS
         __end__ = .;
         PROVIDE(end = .);
         __HeapBase = .;
+        PROVIDE(__heap_start = __HeapBase);
         . += __heap_size__;
         __HeapLimit = .;
+        PROVIDE(__heap_end = __HeapLimit);
         __heap_limit = .; /* Add for _sbrk */
     } > RAM
     Image$$ARM_LIB_HEAP$$ZI$$Limit = ADDR(.heap) + SIZEOF(.heap);

--- a/platform/ext/target/arm/corstone1000/Device/Source/gcc/corstone1000_bl1_1.ld
+++ b/platform/ext/target/arm/corstone1000/Device/Source/gcc/corstone1000_bl1_1.ld
@@ -47,6 +47,7 @@ SECTIONS
         . = ALIGN(4);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
+        PROVIDE(__bothinit_array_start = __preinit_array_start);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
@@ -56,6 +57,7 @@ SECTIONS
         KEEP(*(SORT(.init_array.*)))
         KEEP(*(.init_array))
         PROVIDE_HIDDEN (__init_array_end = .);
+        PROVIDE(__bothinit_array_end = __init_array_end);
 
         . = ALIGN(4);
         /* finit data */
@@ -172,8 +174,10 @@ SECTIONS
         __end__ = .;
         PROVIDE(end = .);
         __HeapBase = .;
+        PROVIDE(__heap_start = __HeapBase);
         . += __heap_size__;
         __HeapLimit = .;
+        PROVIDE(__heap_end = __HeapLimit);
         __heap_limit = .; /* Add for _sbrk */
     } > RAM
     Image$$ARM_LIB_HEAP$$ZI$$Limit = ADDR(.heap) + SIZEOF(.heap);

--- a/platform/ext/target/arm/corstone1000/Device/Source/gcc/corstone1000_bl1_2.ld
+++ b/platform/ext/target/arm/corstone1000/Device/Source/gcc/corstone1000_bl1_2.ld
@@ -47,6 +47,7 @@ SECTIONS
         . = ALIGN(4);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
+        PROVIDE(__bothinit_array_start = __preinit_array_start);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
@@ -56,6 +57,7 @@ SECTIONS
         KEEP(*(SORT(.init_array.*)))
         KEEP(*(.init_array))
         PROVIDE_HIDDEN (__init_array_end = .);
+        PROVIDE(__bothinit_array_end = __init_array_end);
 
         . = ALIGN(4);
         /* finit data */
@@ -176,8 +178,10 @@ SECTIONS
         __end__ = .;
         PROVIDE(end = .);
         __HeapBase = .;
+        PROVIDE(__heap_start = __HeapBase);
         . += __heap_size__;
         __HeapLimit = .;
+        PROVIDE(__heap_end = __HeapLimit);
         __heap_limit = .; /* Add for _sbrk */
     } > RAM
     Image$$ARM_LIB_HEAP$$ZI$$Limit = ADDR(.heap) + SIZEOF(.heap);

--- a/platform/ext/target/arm/mps4/common/device/source/gcc/mps4_corstone3xx_bl1_1.ld
+++ b/platform/ext/target/arm/mps4/common/device/source/gcc/mps4_corstone3xx_bl1_1.ld
@@ -50,6 +50,7 @@ SECTIONS
         . = ALIGN(4);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
+        PROVIDE(__bothinit_array_start = __preinit_array_start);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
@@ -59,6 +60,7 @@ SECTIONS
         KEEP(*(SORT(.init_array.*)))
         KEEP(*(.init_array))
         PROVIDE_HIDDEN (__init_array_end = .);
+        PROVIDE(__bothinit_array_end = __init_array_end);
 
         . = ALIGN(4);
         /* finit data */
@@ -191,8 +193,10 @@ SECTIONS
         __end__ = .;
         PROVIDE(end = .);
         __HeapBase = .;
+        PROVIDE(__heap_start = __HeapBase);
         . += __heap_size__;
         __HeapLimit = .;
+        PROVIDE(__heap_end = __HeapLimit);
         __heap_limit = .; /* Add for _sbrk */
     } > RAM
     Image$$ARM_LIB_HEAP$$ZI$$Limit = ADDR(.heap) + SIZEOF(.heap);

--- a/platform/ext/target/arm/mps4/common/device/source/gcc/mps4_corstone3xx_bl1_2.ld
+++ b/platform/ext/target/arm/mps4/common/device/source/gcc/mps4_corstone3xx_bl1_2.ld
@@ -50,6 +50,7 @@ SECTIONS
         . = ALIGN(4);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
+        PROVIDE(__bothinit_array_start = __preinit_array_start);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
@@ -59,6 +60,7 @@ SECTIONS
         KEEP(*(SORT(.init_array.*)))
         KEEP(*(.init_array))
         PROVIDE_HIDDEN (__init_array_end = .);
+        PROVIDE(__bothinit_array_end = __init_array_end);
 
         . = ALIGN(4);
         /* finit data */
@@ -192,8 +194,10 @@ SECTIONS
         __end__ = .;
         PROVIDE(end = .);
         __HeapBase = .;
+        PROVIDE(__heap_start = __HeapBase);
         . += __heap_size__;
         __HeapLimit = .;
+        PROVIDE(__heap_end = __HeapLimit);
         __heap_limit = .; /* Add for _sbrk */
     } > RAM
     Image$$ARM_LIB_HEAP$$ZI$$Limit = ADDR(.heap) + SIZEOF(.heap);

--- a/platform/ext/target/arm/mps4/common/provisioning/bundle_cm/CMakeLists.txt
+++ b/platform/ext/target/arm/mps4/common/provisioning/bundle_cm/CMakeLists.txt
@@ -62,6 +62,7 @@ target_sources(cm_provisioning_bundle
     PRIVATE
         cm_provisioning_code.c
         cm_provisioning_data.c
+        $<$<BOOL:${CONFIG_PICOLIBC}>:${CMAKE_SOURCE_DIR}/platform/ext/common/picolibc.c>
         $<$<BOOL:${CONFIG_GNU_SYSCALL_STUB_ENABLED}>:${CMAKE_SOURCE_DIR}/platform/ext/common/syscalls_stub.c>
 )
 

--- a/platform/ext/target/arm/mps4/common/provisioning/bundle_dm/CMakeLists.txt
+++ b/platform/ext/target/arm/mps4/common/provisioning/bundle_dm/CMakeLists.txt
@@ -65,6 +65,7 @@ target_sources(dm_provisioning_bundle
     PRIVATE
         dm_provisioning_code.c
         dm_provisioning_data.c
+        $<$<BOOL:${CONFIG_PICOLIBC}>:${CMAKE_SOURCE_DIR}/platform/ext/common/picolibc.c>
         $<$<BOOL:${CONFIG_GNU_SYSCALL_STUB_ENABLED}>:${CMAKE_SOURCE_DIR}/platform/ext/common/syscalls_stub.c>
 )
 

--- a/platform/ext/target/arm/musca_b1/Device/Source/gcc/musca_bl2.ld
+++ b/platform/ext/target/arm/musca_b1/Device/Source/gcc/musca_bl2.ld
@@ -72,6 +72,7 @@ SECTIONS
         . = ALIGN(4);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
+        PROVIDE(__bothinit_array_start = __preinit_array_start);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
@@ -81,6 +82,7 @@ SECTIONS
         KEEP(*(SORT(.init_array.*)))
         KEEP(*(.init_array))
         PROVIDE_HIDDEN (__init_array_end = .);
+        PROVIDE(__bothinit_array_end = __init_array_end);
 
         . = ALIGN(4);
         /* finit data */
@@ -208,8 +210,10 @@ SECTIONS
         __end__ = .;
         PROVIDE(end = .);
         __HeapBase = .;
+        PROVIDE(__heap_start = __HeapBase);
         . += __heap_size__;
         __HeapLimit = .;
+        PROVIDE(__heap_end = __HeapLimit);
         __heap_limit = .; /* Add for _sbrk */
     } > RAM
     Image$$ARM_LIB_HEAP$$ZI$$Limit = ADDR(.heap) + SIZEOF(.heap);

--- a/platform/ext/target/arm/musca_b1/Device/Source/gcc/musca_bl2.ld
+++ b/platform/ext/target/arm/musca_b1/Device/Source/gcc/musca_bl2.ld
@@ -58,6 +58,10 @@ SECTIONS
         *libflash_drivers.o(.rodata*)
         . = ALIGN(4); /* This alignment is needed to make the section size 4 bytes aligned */
     } > CODE_RAM AT > FLASH
+
+    /* Reset current position for subsequent sections */
+    . = LOADADDR(.ER_CODE_SRAM) + SIZEOF(.ER_CODE_SRAM);
+
     Image$$ER_CODE_SRAM$$Base = ADDR(.ER_CODE_SRAM);
     Image$$ER_CODE_SRAM$$Limit = ADDR(.ER_CODE_SRAM) + SIZEOF(.ER_CODE_SRAM);
 

--- a/platform/ext/target/arm/musca_b1/Device/Source/gcc/musca_ns.ld
+++ b/platform/ext/target/arm/musca_b1/Device/Source/gcc/musca_ns.ld
@@ -47,6 +47,7 @@ SECTIONS
         . = ALIGN(4);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
+        PROVIDE(__bothinit_array_start = __preinit_array_start);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
@@ -56,6 +57,7 @@ SECTIONS
         KEEP(*(SORT(.init_array.*)))
         KEEP(*(.init_array))
         PROVIDE_HIDDEN (__init_array_end = .);
+        PROVIDE(__bothinit_array_end = __init_array_end);
 
         . = ALIGN(4);
         /* finit data */
@@ -164,8 +166,10 @@ SECTIONS
         __end__ = .;
         PROVIDE(end = .);
         __HeapBase = .;
+        PROVIDE(__heap_start = __HeapBase);
         . += __heap_size__;
         __HeapLimit = .;
+        PROVIDE(__heap_end = __HeapLimit);
         __heap_limit = .; /* Add for _sbrk */
     } > RAM
 

--- a/platform/ext/target/arm/musca_b1/Device/Source/llvm/musca_bl2.ld
+++ b/platform/ext/target/arm/musca_b1/Device/Source/llvm/musca_bl2.ld
@@ -57,6 +57,10 @@ SECTIONS
         *libflash_drivers.o(.rodata*)
         . = ALIGN(4); /* This alignment is needed to make the section size 4 bytes aligned */
     } > CODE_RAM AT > FLASH
+
+    /* Reset current position for subsequent sections */
+    . = LOADADDR(.ER_CODE_SRAM) + SIZEOF(.ER_CODE_SRAM);
+
     Image$$ER_CODE_SRAM$$Base = ADDR(.ER_CODE_SRAM);
     Image$$ER_CODE_SRAM$$Limit = ADDR(.ER_CODE_SRAM) + SIZEOF(.ER_CODE_SRAM);
 

--- a/platform/ext/target/arm/musca_b1/Device/Source/llvm/musca_ns.ldc
+++ b/platform/ext/target/arm/musca_b1/Device/Source/llvm/musca_ns.ldc
@@ -43,6 +43,7 @@ SECTIONS
         . = ALIGN(4);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
+        PROVIDE(__bothinit_array_start = __preinit_array_start);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
@@ -52,6 +53,7 @@ SECTIONS
         KEEP(*(SORT(.init_array.*)))
         KEEP(*(.init_array))
         PROVIDE_HIDDEN (__init_array_end = .);
+        PROVIDE(__bothinit_array_end = __init_array_end);
 
         . = ALIGN(4);
         /* finit data */

--- a/platform/ext/target/arm/rse/common/device/source/gcc/rse_bl1_1.ld
+++ b/platform/ext/target/arm/rse/common/device/source/gcc/rse_bl1_1.ld
@@ -48,6 +48,7 @@ SECTIONS
         . = ALIGN(4);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
+        PROVIDE(__bothinit_array_start = __preinit_array_start);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
@@ -57,6 +58,7 @@ SECTIONS
         KEEP(*(SORT(.init_array.*)))
         KEEP(*(.init_array))
         PROVIDE_HIDDEN (__init_array_end = .);
+        PROVIDE(__bothinit_array_end = __init_array_end);
 
         . = ALIGN(4);
         /* finit data */
@@ -181,8 +183,10 @@ SECTIONS
         __end__ = .;
         PROVIDE(end = .);
         __HeapBase = .;
+        PROVIDE(__heap_start = __HeapBase);
         . += __heap_size__;
         __HeapLimit = .;
+        PROVIDE(__heap_end = __HeapLimit);
         __heap_limit = .; /* Add for _sbrk */
     } > RAM
     Image$$ARM_LIB_HEAP$$ZI$$Limit = ADDR(.heap) + SIZEOF(.heap);

--- a/platform/ext/target/arm/rse/common/device/source/gcc/rse_bl1_2.ld
+++ b/platform/ext/target/arm/rse/common/device/source/gcc/rse_bl1_2.ld
@@ -47,6 +47,7 @@ SECTIONS
         . = ALIGN(4);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
+        PROVIDE(__bothinit_array_start = __preinit_array_start);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
@@ -56,6 +57,7 @@ SECTIONS
         KEEP(*(SORT(.init_array.*)))
         KEEP(*(.init_array))
         PROVIDE_HIDDEN (__init_array_end = .);
+        PROVIDE(__bothinit_array_end = __init_array_end);
 
         . = ALIGN(4);
         /* finit data */
@@ -174,8 +176,10 @@ SECTIONS
         __end__ = .;
         PROVIDE(end = .);
         __HeapBase = .;
+        PROVIDE(__heap_start = __HeapBase);
         . += __heap_size__;
         __HeapLimit = .;
+        PROVIDE(__heap_end = __HeapLimit);
         __heap_limit = .; /* Add for _sbrk */
     } > RAM
     Image$$ARM_LIB_HEAP$$ZI$$Limit = ADDR(.heap) + SIZEOF(.heap);

--- a/platform/ext/target/arm/rse/common/provisioning/bundle/CMakeLists.txt
+++ b/platform/ext/target/arm/rse/common/provisioning/bundle/CMakeLists.txt
@@ -67,6 +67,7 @@ macro(create_provisioning_code_target target)
 
     target_sources(${target}_provisioning_code
         PRIVATE
+            $<$<BOOL:${CONFIG_PICOLIBC}>:${CMAKE_SOURCE_DIR}/platform/ext/common/picolibc.c>
             $<$<BOOL:${CONFIG_GNU_SYSCALL_STUB_ENABLED}>:${CMAKE_SOURCE_DIR}/platform/ext/common/syscalls_stub.c>
     )
 

--- a/platform/ext/target/arm/rse/common/tests/rse_test_executable/rse_tests.ld
+++ b/platform/ext/target/arm/rse/common/tests/rse_test_executable/rse_tests.ld
@@ -47,6 +47,7 @@ SECTIONS
         . = ALIGN(4);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
+        PROVIDE(__bothinit_array_start = __preinit_array_start);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
@@ -56,6 +57,7 @@ SECTIONS
         KEEP(*(SORT(.init_array.*)))
         KEEP(*(.init_array))
         PROVIDE_HIDDEN (__init_array_end = .);
+        PROVIDE(__bothinit_array_end = __init_array_end);
 
         . = ALIGN(4);
         /* finit data */
@@ -173,8 +175,10 @@ SECTIONS
         __end__ = .;
         PROVIDE(end = .);
         __HeapBase = .;
+        PROVIDE(__heap_start = __HeapBase);
         . += __heap_size__;
         __HeapLimit = .;
+        PROVIDE(__heap_end = __HeapLimit);
         __heap_limit = .; /* Add for _sbrk */
     } > RAM
     Image$$ARM_LIB_HEAP$$ZI$$Limit = ADDR(.heap) + SIZEOF(.heap);

--- a/platform/ext/target/armchina/mps3/common/provisioning/CMakeLists.txt
+++ b/platform/ext/target/armchina/mps3/common/provisioning/CMakeLists.txt
@@ -50,6 +50,7 @@ target_sources(provisioning_bundle
     PRIVATE
         ./provisioning_code.c
         ./provisioning_data.c
+        $<$<BOOL:${CONFIG_PICOLIBC}>:${CMAKE_SOURCE_DIR}/platform/ext/common/picolibc.c>
         $<$<BOOL:${CONFIG_GNU_SYSCALL_STUB_ENABLED}>:${CMAKE_SOURCE_DIR}/platform/ext/common/syscalls_stub.c>
 )
 

--- a/platform/ext/target/cypress/psoc64/Device/Source/gcc/psoc6_ns.ld
+++ b/platform/ext/target/cypress/psoc64/Device/Source/gcc/psoc6_ns.ld
@@ -116,6 +116,7 @@ SECTIONS
         . = ALIGN(4);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
+        PROVIDE(__bothinit_array_start = __preinit_array_start);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
@@ -125,6 +126,7 @@ SECTIONS
         KEEP(*(SORT(.init_array.*)))
         KEEP(*(.init_array))
         PROVIDE_HIDDEN (__init_array_end = .);
+        PROVIDE(__bothinit_array_end = __init_array_end);
 
         . = ALIGN(4);
         /* finit data */
@@ -267,11 +269,13 @@ SECTIONS
     .heap (NOLOAD):
     {
         __HeapBase = .;
+        PROVIDE(__heap_start = __HeapBase);
         __end__ = .;
         PROVIDE(end = .);
         end = __end__;
         . += __heap_size__;
         __HeapLimit = .;
+        PROVIDE(__heap_end = __HeapLimit);
         __heap_limit = .; /* Add for _sbrk */
     } > ram
 

--- a/platform/ext/target/nuvoton/m2351/device/source/gcc/m2351_bl2.ld
+++ b/platform/ext/target/nuvoton/m2351/device/source/gcc/m2351_bl2.ld
@@ -47,6 +47,7 @@ SECTIONS
         . = ALIGN(4);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
+        PROVIDE(__bothinit_array_start = __preinit_array_start);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
@@ -56,6 +57,7 @@ SECTIONS
         KEEP(*(SORT(.init_array.*)))
         KEEP(*(.init_array))
         PROVIDE_HIDDEN (__init_array_end = .);
+        PROVIDE(__bothinit_array_end = __init_array_end);
 
         . = ALIGN(4);
         /* finit data */
@@ -171,8 +173,10 @@ SECTIONS
         __end__ = .;
         PROVIDE(end = .);
         __HeapBase = .;
+        PROVIDE(__heap_start = __HeapBase);
         . += __heap_size__;
         __HeapLimit = .;
+        PROVIDE(__heap_end = __HeapLimit);
         __heap_limit = .; /* Add for _sbrk */
     } > RAM
     Image$$ARM_LIB_HEAP$$ZI$$Limit = ADDR(.heap) + SIZEOF(.heap);

--- a/platform/ext/target/nuvoton/m2351/device/source/gcc/m2351_ns.ld
+++ b/platform/ext/target/nuvoton/m2351/device/source/gcc/m2351_ns.ld
@@ -47,6 +47,7 @@ SECTIONS
         . = ALIGN(4);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
+        PROVIDE(__bothinit_array_start = __preinit_array_start);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
@@ -56,6 +57,7 @@ SECTIONS
         KEEP(*(SORT(.init_array.*)))
         KEEP(*(.init_array))
         PROVIDE_HIDDEN (__init_array_end = .);
+        PROVIDE(__bothinit_array_end = __init_array_end);
 
         . = ALIGN(4);
         /* finit data */
@@ -157,8 +159,10 @@ SECTIONS
         __end__ = .;
         PROVIDE(end = .);
         __HeapBase = .;
+        PROVIDE(__heap_start = __HeapBase);
         . += __heap_size__;
         __HeapLimit = .;
+        PROVIDE(__heap_end = __HeapLimit);
         __heap_limit = .; /* Add for _sbrk */
     } > RAM
 

--- a/platform/ext/target/nuvoton/m2354/device/source/gcc/m2354_bl2.ld
+++ b/platform/ext/target/nuvoton/m2354/device/source/gcc/m2354_bl2.ld
@@ -47,6 +47,7 @@ SECTIONS
         . = ALIGN(4);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
+        PROVIDE(__bothinit_array_start = __preinit_array_start);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
@@ -56,6 +57,7 @@ SECTIONS
         KEEP(*(SORT(.init_array.*)))
         KEEP(*(.init_array))
         PROVIDE_HIDDEN (__init_array_end = .);
+        PROVIDE(__bothinit_array_end = __init_array_end);
 
         . = ALIGN(4);
         /* finit data */
@@ -171,8 +173,10 @@ SECTIONS
         __end__ = .;
         PROVIDE(end = .);
         __HeapBase = .;
+        PROVIDE(__heap_start = __HeapBase);
         . += __heap_size__;
         __HeapLimit = .;
+        PROVIDE(__heap_end = __HeapLimit);
         __heap_limit = .; /* Add for _sbrk */
     } > RAM
     Image$$ARM_LIB_HEAP$$ZI$$Limit = ADDR(.heap) + SIZEOF(.heap);

--- a/platform/ext/target/nuvoton/m2354/device/source/gcc/m2354_ns.ld
+++ b/platform/ext/target/nuvoton/m2354/device/source/gcc/m2354_ns.ld
@@ -47,6 +47,7 @@ SECTIONS
         . = ALIGN(4);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
+        PROVIDE(__bothinit_array_start = __preinit_array_start);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
@@ -56,6 +57,7 @@ SECTIONS
         KEEP(*(SORT(.init_array.*)))
         KEEP(*(.init_array))
         PROVIDE_HIDDEN (__init_array_end = .);
+        PROVIDE(__bothinit_array_end = __init_array_end);
 
         . = ALIGN(4);
         /* finit data */
@@ -157,8 +159,10 @@ SECTIONS
         __end__ = .;
         PROVIDE(end = .);
         __HeapBase = .;
+        PROVIDE(__heap_start = __HeapBase);
         . += __heap_size__;
         __HeapLimit = .;
+        PROVIDE(__heap_end = __HeapLimit);
         __heap_limit = .; /* Add for _sbrk */
     } > RAM
 

--- a/platform/ext/target/rpi/rp2350/linker_bl2.ld
+++ b/platform/ext/target/rpi/rp2350/linker_bl2.ld
@@ -39,6 +39,7 @@ SECTIONS
         . = ALIGN(4);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
+        PROVIDE(__bothinit_array_start = __preinit_array_start);
         KEEP(*(SORT(.preinit_array.*)))
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
@@ -48,6 +49,7 @@ SECTIONS
         KEEP(*(SORT(.init_array.*)))
         KEEP(*(.init_array))
         PROVIDE_HIDDEN (__init_array_end = .);
+        PROVIDE(__bothinit_array_end = __init_array_end);
         . = ALIGN(4);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
@@ -241,9 +243,11 @@ SECTIONS
         __end__ = .;
         PROVIDE(end = .);
         __HeapBase = .;
+        PROVIDE(__heap_start = __HeapBase);
         KEEP(*(.heap*))
         . += __heap_size__;
         __HeapLimit = .;
+        PROVIDE(__heap_end = __HeapLimit);
         __heap_limit = .; /* Add for _sbrk */
     } > RAM
     Image$$ARM_LIB_HEAP$$ZI$$Limit = ADDR(.heap) + SIZEOF(.heap);

--- a/platform/ext/target/rpi/rp2350/linker_ns.ld
+++ b/platform/ext/target/rpi/rp2350/linker_ns.ld
@@ -67,6 +67,7 @@ SECTIONS
         . = ALIGN(4);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
+        PROVIDE(__bothinit_array_start = __preinit_array_start);
         KEEP(*(SORT(.preinit_array.*)))
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
@@ -77,6 +78,7 @@ SECTIONS
         KEEP(*(SORT(.init_array.*)))
         KEEP(*(.init_array))
         PROVIDE_HIDDEN (__init_array_end = .);
+        PROVIDE(__bothinit_array_end = __init_array_end);
 
         . = ALIGN(4);
         /* finit data */
@@ -196,8 +198,10 @@ SECTIONS
         __end__ = .;
         PROVIDE(end = .);
         __HeapBase = .;
+        PROVIDE(__heap_start = __HeapBase);
         . += __heap_size__;
         __HeapLimit = .;
+        PROVIDE(__heap_end = __HeapLimit);
         __heap_limit = .; /* Add for _sbrk */
     } > RAM
 

--- a/platform/ext/target/rpi/rp2350/linker_s.ld
+++ b/platform/ext/target/rpi/rp2350/linker_s.ld
@@ -200,6 +200,7 @@ SECTIONS
         . = ALIGN(4);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
+        PROVIDE(__bothinit_array_start = __preinit_array_start);
         KEEP(*(SORT(.preinit_array.*)))
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
@@ -210,6 +211,7 @@ SECTIONS
         KEEP(*(SORT(.init_array.*)))
         KEEP(*(.init_array))
         PROVIDE_HIDDEN (__init_array_end = .);
+        PROVIDE(__bothinit_array_end = __init_array_end);
 
         . = ALIGN(4);
         /* finit data */
@@ -379,9 +381,11 @@ SECTIONS
         end = __end__;
         PROVIDE(end = .);
         __HeapBase = .;
+        PROVIDE(__heap_start = __HeapBase);
         KEEP(*(.heap*))
         . += __heap_size__;
         __HeapLimit = .;
+        PROVIDE(__heap_end = __HeapLimit);
         __heap_limit = .;
     } > RAM
 #else

--- a/platform/ext/target/rpi/rp2350/linker_s.ld
+++ b/platform/ext/target/rpi/rp2350/linker_s.ld
@@ -150,6 +150,9 @@ SECTIONS
         . = ALIGN(4); /* This alignment is needed to make the section size 4 bytes aligned */
     } > CODE_RAM AT > FLASH
 
+    /* Reset current position for subsequent sections */
+    . = LOADADDR(.ER_CODE_SRAM) + SIZEOF(.ER_CODE_SRAM);
+
     ASSERT(S_RAM_CODE_START % 4 == 0, "S_RAM_CODE_START must be divisible by 4")
 
     Image$$ER_CODE_SRAM$$RO$$Base = ADDR(.ER_CODE_SRAM);

--- a/platform/ext/target/stm/common/hal/template/gcc/appli_ns.ld
+++ b/platform/ext/target/stm/common/hal/template/gcc/appli_ns.ld
@@ -47,6 +47,7 @@ SECTIONS
         . = ALIGN(4);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
+        PROVIDE(__bothinit_array_start = __preinit_array_start);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
@@ -56,6 +57,7 @@ SECTIONS
         KEEP(*(SORT(.init_array.*)))
         KEEP(*(.init_array))
         PROVIDE_HIDDEN (__init_array_end = .);
+        PROVIDE(__bothinit_array_end = __init_array_end);
 
         . = ALIGN(4);
         /* finit data */
@@ -170,8 +172,10 @@ SECTIONS
         __end__ = .;
         PROVIDE(end = .);
         __HeapBase = .;
+        PROVIDE(__heap_start = __HeapBase);
         . += __heap_size__;
         __HeapLimit = .;
+        PROVIDE(__heap_end = __HeapLimit);
         __heap_limit = .; /* Add for _sbrk */
     } > RAM
 

--- a/platform/ext/target/stm/common/hal/template/gcc/bl2.ld
+++ b/platform/ext/target/stm/common/hal/template/gcc/bl2.ld
@@ -88,6 +88,7 @@ SECTIONS
         . = ALIGN(4);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
+        PROVIDE(__bothinit_array_start = __preinit_array_start);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
@@ -97,6 +98,7 @@ SECTIONS
         KEEP(*(SORT(.init_array.*)))
         KEEP(*(.init_array))
         PROVIDE_HIDDEN (__init_array_end = .);
+        PROVIDE(__bothinit_array_end = __init_array_end);
 
         . = ALIGN(4);
         /* finit data */
@@ -202,8 +204,10 @@ SECTIONS
         __end__ = .;
         PROVIDE(end = .);
         __HeapBase = .;
+        PROVIDE(__heap_start = __HeapBase);
         . += __heap_size__;
         __HeapLimit = .;
+        PROVIDE(__heap_end = __HeapLimit);
         __heap_limit = .; /* Add for _sbrk */
     } > RAM
 

--- a/platform/ext/target/stm/common/stm32h5xx/Device/Source/gcc/tfm_common_s.ld
+++ b/platform/ext/target/stm/common/stm32h5xx/Device/Source/gcc/tfm_common_s.ld
@@ -219,8 +219,10 @@ SECTIONS
         __end__ = .;
         PROVIDE(end = .);
         __HeapBase = .;
+        PROVIDE(__heap_start = __HeapBase);
         . += __heap_size__;
         __HeapLimit = .;
+        PROVIDE(__heap_end = __HeapLimit);
         __heap_limit = .; /* Add for _sbrk */
     } > RAM
 #endif /* TFM_ISOLATION_LEVEL == 1 */
@@ -249,8 +251,10 @@ SECTIONS
         __end__ = .;
         PROVIDE(end = .);
         __HeapBase = .;
+        PROVIDE(__heap_start = __HeapBase);
         . += __heap_size__;
         __HeapLimit = .;
+        PROVIDE(__heap_end = __HeapLimit);
         __heap_limit = .; /* Add for _sbrk */
 
         . = ALIGN(32);
@@ -261,8 +265,10 @@ SECTIONS
         __end__ = .;
         PROVIDE(end = .);
         __HeapBase = .;
+        PROVIDE(__heap_start = __HeapBase);
         . += __heap_size__;
         __HeapLimit = .;
+        PROVIDE(__heap_end = __HeapLimit);
         __heap_limit = .; /* Add for _sbrk */
     } > RAM AT> RAM
 #endif /* TFM_PARTITION_TEST_SECURE_SERVICES */
@@ -318,6 +324,7 @@ SECTIONS
         . = ALIGN(4);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
+        PROVIDE(__bothinit_array_start = __preinit_array_start);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
@@ -327,6 +334,7 @@ SECTIONS
         KEEP(*(SORT(.init_array.*)))
         KEEP(*(.init_array))
         PROVIDE_HIDDEN (__init_array_end = .);
+        PROVIDE(__bothinit_array_end = __init_array_end);
 
         . = ALIGN(4);
         /* finit data */

--- a/platform/ext/target/stm/common/stm32h5xx/template/gcc/bl2.ld
+++ b/platform/ext/target/stm/common/stm32h5xx/template/gcc/bl2.ld
@@ -78,6 +78,7 @@ SECTIONS
         . = ALIGN(4);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
+        PROVIDE(__bothinit_array_start = __preinit_array_start);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
@@ -87,6 +88,7 @@ SECTIONS
         KEEP(*(SORT(.init_array.*)))
         KEEP(*(.init_array))
         PROVIDE_HIDDEN (__init_array_end = .);
+        PROVIDE(__bothinit_array_end = __init_array_end);
 
         . = ALIGN(4);
         /* finit data */
@@ -192,8 +194,10 @@ SECTIONS
         __end__ = .;
         PROVIDE(end = .);
         __HeapBase = .;
+        PROVIDE(__heap_start = __HeapBase);
         . += __heap_size__;
         __HeapLimit = .;
+        PROVIDE(__heap_end = __HeapLimit);
         __heap_limit = .; /* Add for _sbrk */
     } > RAM
 

--- a/platform/ext/target/stm/common/stm32u5xx/Device/Source/gcc/tfm_common_s.ld
+++ b/platform/ext/target/stm/common/stm32u5xx/Device/Source/gcc/tfm_common_s.ld
@@ -108,6 +108,7 @@ SECTIONS
         . = ALIGN(4);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
+        PROVIDE(__bothinit_array_start = __preinit_array_start);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
@@ -117,6 +118,7 @@ SECTIONS
         KEEP(*(SORT(.init_array.*)))
         KEEP(*(.init_array))
         PROVIDE_HIDDEN (__init_array_end = .);
+        PROVIDE(__bothinit_array_end = __init_array_end);
 
         . = ALIGN(4);
         /* finit data */
@@ -238,8 +240,10 @@ SECTIONS
         __end__ = .;
         PROVIDE(end = .);
         __HeapBase = .;
+        PROVIDE(__heap_start = __HeapBase);
         . += __heap_size__;
         __HeapLimit = .;
+        PROVIDE(__heap_end = __HeapLimit);
         __heap_limit = .; /* Add for _sbrk */
     } > RAM
 #endif /* TFM_ISOLATION_LEVEL == 1 */
@@ -268,8 +272,10 @@ SECTIONS
         __end__ = .;
         PROVIDE(end = .);
         __HeapBase = .;
+        PROVIDE(__heap_start = __HeapBase);
         . += __heap_size__;
         __HeapLimit = .;
+        PROVIDE(__heap_end = __HeapLimit);
         __heap_limit = .; /* Add for _sbrk */
 
         . = ALIGN(32);
@@ -280,8 +286,10 @@ SECTIONS
         __end__ = .;
         PROVIDE(end = .);
         __HeapBase = .;
+        PROVIDE(__heap_start = __HeapBase);
         . += __heap_size__;
         __HeapLimit = .;
+        PROVIDE(__heap_end = __HeapLimit);
         __heap_limit = .; /* Add for _sbrk */
     } > RAM AT> RAM
 #endif /* TFM_PARTITION_TEST_SECURE_SERVICES */

--- a/platform/ext/target/stm/common/stm32wbaxx/Device/Source/gcc/tfm_common_s.ld
+++ b/platform/ext/target/stm/common/stm32wbaxx/Device/Source/gcc/tfm_common_s.ld
@@ -119,6 +119,7 @@ SECTIONS
         . = ALIGN(4);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
+        PROVIDE(__bothinit_array_start = __preinit_array_start);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
@@ -128,6 +129,7 @@ SECTIONS
         KEEP(*(SORT(.init_array.*)))
         KEEP(*(.init_array))
         PROVIDE_HIDDEN (__init_array_end = .);
+        PROVIDE(__bothinit_array_end = __init_array_end);
 
         . = ALIGN(4);
         /* finit data */
@@ -249,8 +251,10 @@ SECTIONS
         __end__ = .;
         PROVIDE(end = .);
         __HeapBase = .;
+        PROVIDE(__heap_start = __HeapBase);
         . += __heap_size__;
         __HeapLimit = .;
+        PROVIDE(__heap_end = __HeapLimit);
         __heap_limit = .; /* Add for _sbrk */
     } > RAM
 #endif /* TFM_ISOLATION_LEVEL == 1 */
@@ -279,8 +283,10 @@ SECTIONS
         __end__ = .;
         PROVIDE(end = .);
         __HeapBase = .;
+        PROVIDE(__heap_start = __HeapBase);
         . += __heap_size__;
         __HeapLimit = .;
+        PROVIDE(__heap_end = __HeapLimit);
         __heap_limit = .; /* Add for _sbrk */
 
         . = ALIGN(32);
@@ -291,8 +297,10 @@ SECTIONS
         __end__ = .;
         PROVIDE(end = .);
         __HeapBase = .;
+        PROVIDE(__heap_start = __HeapBase);
         . += __heap_size__;
         __HeapLimit = .;
+        PROVIDE(__heap_end = __HeapLimit);
         __heap_limit = .; /* Add for _sbrk */
     } > RAM AT> RAM
 #endif /* TFM_PARTITION_TEST_SECURE_SERVICES */

--- a/platform/ns/toolchain_ns_GNUARM.cmake
+++ b/platform/ns/toolchain_ns_GNUARM.cmake
@@ -176,9 +176,32 @@ string(APPEND CMAKE_ASM_LINK_FLAGS " " ${LINKER_CP_OPTION})
 # For GNU Arm Embedded Toolchain doesn't emit __ARM_ARCH_8_1M_MAIN__, adding this macro manually.
 add_compile_definitions($<$<STREQUAL:${TFM_SYSTEM_ARCHITECTURE},armv8.1-m.main>:__ARM_ARCH_8_1M_MAIN__=1>)
 
+if(NOT DEFINED CONFIG_PICOLIBC)
+    set(CONFIG_PICOLIBC TRUE)
+endif()
+
+if (CONFIG_PICOLIBC)
+    set(LIBC_COMPILE_OPTIONS
+        -specs=picolibc.specs
+        )
+    set(LIBC_LINK_OPTIONS
+        -specs=picolibc.specs
+        -nostartfiles
+        -u main
+        )
+else()
+    set(LIBC_COMPILE_OPTIONS
+        -specs=nano.specs
+        -specs=nosys.specs
+        )
+    set(LIBC_LINK_OPTIONS
+        -specs=nano.specs
+        -specs=nosys.specs
+        )
+endif()
+
 add_compile_options(
-    -specs=nano.specs
-    -specs=nosys.specs
+    ${LIBC_COMPILE_OPTIONS}
     -Wall
     -Wno-format
     -Warray-parameter
@@ -200,8 +223,8 @@ add_compile_options(
 
 add_link_options(
     --entry=Reset_Handler
-    -specs=nano.specs
-    -specs=nosys.specs
+    ${LIBC_LINK_OPTIONS}
+    -mthumb
     LINKER:-check-sections
     LINKER:-fatal-warnings
     LINKER:--gc-sections

--- a/secure_fw/partitions/lib/runtime/CMakeLists.txt
+++ b/secure_fw/partitions/lib/runtime/CMakeLists.txt
@@ -18,6 +18,7 @@ target_include_directories(tfm_sprt
 
 target_sources(tfm_sprt
     PUBLIC
+        $<$<BOOL:${CONFIG_PICOLIBC}>:${CMAKE_SOURCE_DIR}/platform/ext/common/picolibc.c>
         $<$<BOOL:${CONFIG_GNU_SYSCALL_STUB_ENABLED}>:${CMAKE_SOURCE_DIR}/platform/ext/common/syscalls_stub.c>
     PRIVATE
         crt_memcmp.c

--- a/toolchain_GNUARM.cmake
+++ b/toolchain_GNUARM.cmake
@@ -106,9 +106,32 @@ if(GCC_VERSION VERSION_GREATER_EQUAL "8.0.0")
     endif()
 endif()
 
+if(NOT DEFINED CONFIG_PICOLIBC)
+    set(CONFIG_PICOLIBC TRUE)
+endif()
+
+if (CONFIG_PICOLIBC)
+    set(LIBC_COMPILE_OPTIONS
+        -specs=picolibc.specs
+        )
+    set(LIBC_LINK_OPTIONS
+        -specs=picolibc.specs
+        -nostartfiles
+        -u main
+        )
+else()
+    set(LIBC_COMPILE_OPTIONS
+        -specs=nano.specs
+        -specs=nosys.specs
+        )
+    set(LIBC_LINK_OPTIONS
+        -specs=nano.specs
+        -specs=nosys.specs
+        )
+endif()
+
 add_compile_options(
-    -specs=nano.specs
-    -specs=nosys.specs
+    ${LIBC_COMPILE_OPTIONS}
     -Wall
     -Wno-format
     -Warray-parameter
@@ -147,8 +170,8 @@ endif()
 
 add_link_options(
     --entry=Reset_Handler
-    -specs=nano.specs
-    -specs=nosys.specs
+    ${LIBC_LINK_OPTIONS}
+    -mthumb
     LINKER:-check-sections
     LINKER:-fatal-warnings
     LINKER:--gc-sections


### PR DESCRIPTION
     1. Add picolibc bits to linker scripts. Picolibc uses thread local storage
        for unshared data, and the picolibc startup code relies on carefully
        constructed linker script that allocates one TLS block in RAM for
        applications that don't have explicit TLS support. The picolibc
        startup code also uses different symbols than the tf-m startup code.
    
     2. Support picolibc stdio. There was already picolibc support code
        present in the library for the ARM LLVM toolchain. The
        conditionals which selected it have been changed to use
        __PICOLIBC__ instead of __clang_major__.
    
     3. Add _exit stub. Code using assert or abort end up calling _exit
        through the picolibc signal handling code.
    
     4. Switch to picolibc.specs. This is needed for toolchains which
        don't use picolibc by default, and can also be used without
        trouble in toolchains where picolibc is the default.
