### PR TITLE
platform: stm: disable HW accelerator in BL2

### DIFF
--- a/platform/ext/accelerator/stm/CMakeLists.txt
+++ b/platform/ext/accelerator/stm/CMakeLists.txt
@@ -58,7 +58,6 @@ if (BL2)
     target_link_libraries(platform_bl2
         PUBLIC
             bl2_crypto_config
-            crypto_service_crypto_hw
     )
 
     target_compile_definitions(bl2_crypto
@@ -66,7 +65,7 @@ if (BL2)
             # Uncomment when BL2 specific accelerator config files are provided, which
             # don't enable any _ALT feature which are going to be deprecated
             # MBEDTLS_ACCELERATOR_CONFIG_FILE="${PLATFORM_DIR}/ext/target/${TFM_PLATFORM}/accelerator/mbedtls_accelerator_config.h"
-            MBEDTLS_ACCELERATOR_PSA_CRYPTO_CONFIG_FILE="${PLATFORM_DIR}/ext/target/${TFM_PLATFORM}/accelerator/crypto_accelerator_config.h"
+            # MBEDTLS_ACCELERATOR_PSA_CRYPTO_CONFIG_FILE="${PLATFORM_DIR}/ext/target/${TFM_PLATFORM}/accelerator/crypto_accelerator_config.h"
     )
 endif()
 include(${PLATFORM_DIR}/ext/target/${TFM_PLATFORM}/accelerator/CMakeLists.txt)

--- a/platform/ext/accelerator/stm/CMakeLists.txt
+++ b/platform/ext/accelerator/stm/CMakeLists.txt
@@ -66,6 +66,11 @@ if (BL2)
             # don't enable any _ALT feature which are going to be deprecated
             # MBEDTLS_ACCELERATOR_CONFIG_FILE="${PLATFORM_DIR}/ext/target/${TFM_PLATFORM}/accelerator/mbedtls_accelerator_config.h"
             # MBEDTLS_ACCELERATOR_PSA_CRYPTO_CONFIG_FILE="${PLATFORM_DIR}/ext/target/${TFM_PLATFORM}/accelerator/crypto_accelerator_config.h"
+
+            # Since TF-M 2.2.x and MCUBoot 2.2.0 require BL2 HW crypto
+            # accelerator to implement the PSA unified driver API, force
+            # disabling of use of STM HW accelerator in BL2 until they comply.
+            MBEDTLS_ACCELERATOR_PSA_CRYPTO_CONFIG_FILE="${PLATFORM_DIR}/ext/accelerator/stm/bl2_disabled_crypto_accelerator_config.h"
     )
 endif()
 include(${PLATFORM_DIR}/ext/target/${TFM_PLATFORM}/accelerator/CMakeLists.txt)


### PR DESCRIPTION
Disable HW crypto accelerator in STM BL2 stage since embedding them requires their drivers integrate through the PSA unified driver API. This is a requirement from TF-M since it moved to MCUBoot 2.2.0. We'll be enable to restore them once they comply with PSA driver API.

Note that in mainline TF-M, STM HW accelerator driver are currently not embedded in BL2 firmware so this change provides at least the same embedded feature set as mainline TF-M branch 2.2.x.

We do this by reverting the commit that caused trouble and finally highlight the issue (https://github.com/zephyrproject-rtos/zephyr/issues/92446) and proposing a non invasive commit (regarding TF-M mainline source tree) to ensure HW accelerator drivers are not attempted to be embedded in BL2 firmware.
