### PR TITLE
Fix various build warnings

### DIFF
--- a/platform/ext/common/template/flash_otp_nv_counters_backend.c
+++ b/platform/ext/common/template/flash_otp_nv_counters_backend.c
@@ -19,7 +19,9 @@
 
 #include <string.h>
 
+#if defined(OTP_WRITEABLE)
 static enum tfm_plat_err_t create_or_restore_layout(void);
+#endif
 
 #if OTP_NV_COUNTERS_RAM_EMULATION
 
@@ -119,7 +121,9 @@ static enum tfm_plat_err_t make_backup(void);
 #endif
 /* End of compilation time checks to be sure the defines are well defined */
 
+#if defined(OTP_WRITEABLE)
 static uint8_t block[OTP_NV_COUNTERS_WRITE_BLOCK_SIZE];
+#endif
 
 /* Import the CMSIS flash device driver */
 extern ARM_DRIVER_FLASH OTP_NV_COUNTERS_FLASH_DEV;
@@ -169,7 +173,6 @@ enum tfm_plat_err_t init_otp_nv_counters_flash(void)
     enum tfm_plat_err_t err = TFM_PLAT_ERR_SUCCESS;
     uint32_t init_value;
     uint32_t swap_count;
-    uint32_t backup_swap_count;
 
     if ((TFM_OTP_NV_COUNTERS_AREA_SIZE) < sizeof(struct flash_otp_nv_counters_region_t)) {
         return TFM_PLAT_ERR_SYSTEM_ERR;
@@ -200,6 +203,8 @@ enum tfm_plat_err_t init_otp_nv_counters_flash(void)
     }
     else
     {
+        uint32_t backup_swap_count;
+
         err = read_otp_nv_counters_flash(offsetof(struct flash_otp_nv_counters_region_t, swap_count)
                 + TFM_OTP_NV_COUNTERS_AREA_SIZE,
                 &backup_swap_count, sizeof(backup_swap_count));
@@ -307,7 +312,7 @@ static enum tfm_plat_err_t copy_data_into_block(uint32_t data_offset,
                                                 const uint8_t *data,
                                                 uint32_t block_offset,
                                                 size_t block_size,
-                                                uint8_t *block)
+                                                uint8_t *block_ptr)
 {
     uint32_t copy_start_offset;
     uint32_t copy_end_offset;
@@ -327,7 +332,7 @@ static enum tfm_plat_err_t copy_data_into_block(uint32_t data_offset,
             copy_end_offset = data_offset + data_size;
         }
 
-        memcpy(block + (copy_start_offset - block_offset),
+        memcpy(block_ptr + (copy_start_offset - block_offset),
                data + (copy_start_offset - data_offset),
                copy_end_offset - copy_start_offset);
     }

--- a/platform/ext/target/stm/common/hal/Native_Driver/nv_counters.c
+++ b/platform/ext/target/stm/common/hal/Native_Driver/nv_counters.c
@@ -105,7 +105,7 @@ enum tfm_plat_err_t tfm_plat_init_nv_counter(void)
     ret = DEVICE_NV_COUNTERS_FLASH_NAME.ReadData(VALID_ADDRESS,
                                              &nv_counters,
                                              sizeof(struct nv_counters_t) / data_width);
-    if (ret != (sizeof(struct nv_counters_t) / data_width)) {
+    if (ret != (int32_t)(sizeof(struct nv_counters_t) / data_width)) {
         return TFM_PLAT_ERR_SYSTEM_ERR;
     }
 
@@ -117,7 +117,7 @@ enum tfm_plat_err_t tfm_plat_init_nv_counter(void)
     ret = DEVICE_NV_COUNTERS_FLASH_NAME.ReadData(BACKUP_ADDRESS,
                                              &nv_counters,
                                              sizeof(struct nv_counters_t) / data_width);
-    if (ret != (sizeof(struct nv_counters_t) / data_width)) {
+    if (ret != (int32_t)(sizeof(struct nv_counters_t) / data_width)) {
         return TFM_PLAT_ERR_SYSTEM_ERR;
     }
 
@@ -132,7 +132,7 @@ enum tfm_plat_err_t tfm_plat_init_nv_counter(void)
         ret = DEVICE_NV_COUNTERS_FLASH_NAME.ProgramData(VALID_ADDRESS,
                                                     &nv_counters,
                                                     sizeof(struct nv_counters_t) / data_width);
-        if (ret != (sizeof(struct nv_counters_t) / data_width)) {
+        if (ret != (int32_t)(sizeof(struct nv_counters_t) / data_width)) {
             return TFM_PLAT_ERR_SYSTEM_ERR;
         }
 
@@ -153,7 +153,7 @@ enum tfm_plat_err_t tfm_plat_init_nv_counter(void)
     ret = DEVICE_NV_COUNTERS_FLASH_NAME.ProgramData(VALID_ADDRESS,
                                                 &nv_counters,
                                                 sizeof(struct nv_counters_t)  / data_width);
-    if (ret != (sizeof(struct nv_counters_t) / data_width)) {
+    if (ret != (int32_t)(sizeof(struct nv_counters_t) / data_width)) {
         return TFM_PLAT_ERR_SYSTEM_ERR;
     }
 
@@ -185,7 +185,7 @@ enum tfm_plat_err_t tfm_plat_read_nv_counter(enum tfm_nv_counter_t counter_id,
     data_width = data_width_byte[DriverCapabilities.data_width];
 
     ret = DEVICE_NV_COUNTERS_FLASH_NAME.ReadData(flash_addr, val, NV_COUNTER_SIZE / data_width);
-    if (ret != (NV_COUNTER_SIZE / data_width)) {
+    if (ret != (int32_t)(NV_COUNTER_SIZE / data_width)) {
         return TFM_PLAT_ERR_SYSTEM_ERR;
     }
 
@@ -205,16 +205,16 @@ enum tfm_plat_err_t tfm_plat_set_nv_counter(enum tfm_nv_counter_t counter_id,
         sizeof(uint16_t),
         sizeof(uint32_t),
     };
-    
+
     DriverCapabilities = DEVICE_NV_COUNTERS_FLASH_NAME.GetCapabilities();
     /* Since struct nv_counter is aligned on 32 bits , a single read /write is possible */
     data_width = data_width_byte[DriverCapabilities.data_width];
-    
+
     /* Read the whole sector so we can write it back to flash later */
     ret = DEVICE_NV_COUNTERS_FLASH_NAME.ReadData(VALID_ADDRESS,
                                              &nv_counters,
                                              sizeof(struct nv_counters_t) / data_width);
-    if (ret != (sizeof(struct nv_counters_t) / data_width)) {
+    if (ret != (int32_t)(sizeof(struct nv_counters_t) / data_width)) {
         return TFM_PLAT_ERR_SYSTEM_ERR;
     }
 
@@ -238,7 +238,7 @@ enum tfm_plat_err_t tfm_plat_set_nv_counter(enum tfm_nv_counter_t counter_id,
         ret = DEVICE_NV_COUNTERS_FLASH_NAME.ProgramData(BACKUP_ADDRESS,
                                                     &nv_counters,
                                                     sizeof(struct nv_counters_t) / data_width);
-        if (ret != (sizeof(struct nv_counters_t) / data_width)) {
+        if (ret != (int32_t)(sizeof(struct nv_counters_t) / data_width)) {
             return TFM_PLAT_ERR_SYSTEM_ERR;
         }
 
@@ -252,7 +252,7 @@ enum tfm_plat_err_t tfm_plat_set_nv_counter(enum tfm_nv_counter_t counter_id,
         ret = DEVICE_NV_COUNTERS_FLASH_NAME.ProgramData(VALID_ADDRESS,
                                                     &nv_counters,
                                                     sizeof(struct nv_counters_t) / data_width);
-        if (ret != (sizeof(struct nv_counters_t) / data_width)) {
+        if (ret != (int32_t)(sizeof(struct nv_counters_t) / data_width)) {
             return TFM_PLAT_ERR_SYSTEM_ERR;
         }
     }

--- a/platform/ext/target/stm/common/hal/accelerator/ecp_alt.h
+++ b/platform/ext/target/stm/common/hal/accelerator/ecp_alt.h
@@ -132,9 +132,6 @@ mbedtls_ecp_group;
  * \{
  */
 
-#define MBEDTLS_ECP_MAX_BYTES    ( ( MBEDTLS_ECP_MAX_BITS + 7 ) / 8 )
-#define MBEDTLS_ECP_MAX_PT_LEN   ( 2 * MBEDTLS_ECP_MAX_BYTES + 1 )
-
 #if !defined(MBEDTLS_ECP_WINDOW_SIZE)
 /*
  * Maximum "window" size used for point multiplication.

--- a/platform/ext/target/stm/common/hal/accelerator/sha256_alt.c
+++ b/platform/ext/target/stm/common/hal/accelerator/sha256_alt.c
@@ -222,7 +222,7 @@ int mbedtls_sha256_update(mbedtls_sha256_context *ctx, const unsigned char *inpu
     return 0;
 }
 
-int mbedtls_sha256_finish(mbedtls_sha256_context *ctx, unsigned char output[32])
+int mbedtls_sha256_finish(mbedtls_sha256_context *ctx, unsigned char *output)
 {
     SHA256_VALIDATE_RET( ctx != NULL );
     SHA256_VALIDATE_RET( (unsigned char *)output != NULL );

--- a/platform/ext/target/stm/common/stm32u5xx/secure/tfm_hal_isolation.c
+++ b/platform/ext/target/stm/common/stm32u5xx/secure/tfm_hal_isolation.c
@@ -361,8 +361,8 @@ FIH_RET_TYPE(enum tfm_hal_status_t) tfm_hal_bind_boundary(
     bool ns_agent;
     uint32_t partition_attrs = 0;
     const struct asset_desc_t *p_asset;
-    struct platform_data_t *plat_data_ptr;
 #if TFM_ISOLATION_LEVEL == 2
+    struct platform_data_t *plat_data_ptr;
     struct mpu_armv8m_region_cfg_t localcfg;
 #endif
 


### PR DESCRIPTION
Fix various build warnings found on STM platforms but also on other platforms.

All these commits are cherry-picked from mainline TF-M repository.
Despite almost all their commit message header lie start with `STM32WBA6: `, none is dedicated to STM32WBA6 platforms, but rather either to STM platforms or to generic components.