### PR TITLE
bl2: mcuboot: fix build warning related to flash_map

### DIFF
--- a/bl2/ext/mcuboot/include/flash_map/flash_map.h
+++ b/bl2/ext/mcuboot/include/flash_map/flash_map.h
@@ -165,6 +165,22 @@ uint32_t flash_area_align(const struct flash_area *area);
 int flash_area_get_sectors(int fa_id, uint32_t *count,
   struct flash_sector *sectors);
 
+/* Retrieve the flash sector a given offset belongs to.
+ *
+ * Returns 0 on success, or an error code on failure.
+ */
+int flash_area_sector_from_off(uint32_t off, struct flash_sector *sector);
+
+/* Retrieve the flash sector a given offset, within flash area.
+ *
+ * @param fa        flash area.
+ * @param off       offset of sector.
+ * @param sector    pointer to structure for obtained information.
+ * Returns 0 on success, or an error code on failure.
+ */
+int flash_area_get_sector(const struct flash_area *fa, uint32_t off,
+  struct flash_sector *sector);
+
 /*
  * Similar to flash_area_get_sectors(), but return the values in an
  * array of struct flash_area instead.


### PR DESCRIPTION
Declare `flash_area_sector_from_off()` and `flash_area_get_sector()` that where added in MCUBoot and declared in mainline TF-M repository from commit 1329d18c7f90 ("BL2: Update MCUboot tag to v2.2.0-rc1") nut not considered in the Zephyr TF-M 2.2.x branch when bumping to MCUBoot 2.2.x in commit 969addde675d ("BL2: MCUboot: Use v2.2.0").