### PR TITLE
platform: ext: common: template: Fix FOTA upgrade

### DIFF
--- a/platform/ext/common/template/flash_otp_nv_counters_backend.h
+++ b/platform/ext/common/template/flash_otp_nv_counters_backend.h
@@ -58,7 +58,7 @@ __PACKED_STRUCT flash_otp_nv_counters_region_t {
         uint8_t implementation_id[32];
         uint8_t cert_ref[32];
         uint8_t verification_service_url[32];
-        uint8_t profile_definition[48];
+        uint8_t profile_definition[32];
 
 #ifdef BL2
         uint8_t bl2_rotpk_0[BL2_ROTPK_SIZE];


### PR DESCRIPTION
The trusted-firmware-m/31755 changes modified `profile_definition` from 32 to 48 bytes in the platform/ext/common/template/flash_otp_nv_counters_backend.h file.

This change moved fields that are necessary to perform an image upgrade. The issue is visible only when upgrading from an old image (without the changes) to a new one or vice versa. This means that TF-M 2.1.1 do not allow upgrade/downgrade to/from TF-M 2.2.0 or newer versions.

This revert the change to allow migration from Zephyr 3.7.1 LTS to newer images like 4.2.0.

More details from the change can be visualized in: https://review.trustedfirmware.org/c/TF-M/trusted-firmware-m/+/31755