### PR TITLE
[zep fromtree] platform: nordic: Remove FLPR reserved memory from Nor…

### DIFF
--- a/platform/ext/target/nordic_nrf/common/nrf54l10/partition/flash_layout.h
+++ b/platform/ext/target/nordic_nrf/common/nrf54l10/partition/flash_layout.h
@@ -21,14 +21,14 @@
 #error "BL2 is not supported for this platform"
 #endif
 
-/* Flash layout on NRF54L15 Application MCU without BL2:
+/* Flash layout on NRF54L10 Application MCU without BL2:
  *
  * 0x0000_0000 Secure image primary (384 KB)
  * 0x0006_0000 Protected Storage Area (16 KB)
  * 0x0006_4000 Internal Trusted Storage Area (16 KB)
  * 0x0006_8000 OTP / NV counters area (8 KB)
- * 0x0006_A000 Non-secure image primary (494 KB)
- * 0x000E_5800 Non-secure storage, used when built with NRF_NS_STORAGE=ON,
+ * 0x0006_A000 Non-secure image primary (556 KB)
+ * 0x000F_5000 Non-secure storage, used when built with NRF_NS_STORAGE=ON,
  *             otherwise unused (32 KB)
  */
 
@@ -42,20 +42,16 @@
 /* Use Flash memory to store Code data */
 #define FLASH_BASE_ADDRESS                  (0x0)
 
-/* nRF54L10 has 1012 kB of non volatile memory (RRAM) but the last 62kB are reserved
- * for FLPR MCU in Zephyr. For simplicity and for possible support for running FLPR along
- * with TF-M later FLPR non volatile memory is not used by TF-M. */
-#define FLASH_TOTAL_SIZE                    (0xED800)         /* 950 kB since the last 62kB are reserved for FLPR */
+/* nRF54L10 has 1012 kB of non volatile memory (RRAM) */
+#define FLASH_TOTAL_SIZE                    (0xFD000)
 #define TOTAL_ROM_SIZE                       FLASH_TOTAL_SIZE
 
-/* nRF54L10 has 192 kB of volatile memory (SRAM) but the last 48kB are reserved
- * for FLPR MCU in Zephyr. For simplicity and for possible support for running FLPR along
- * with TF-M later FLPR volatile memory is not used by TF-M. */
+/* nRF54L10 has 192 kB of volatile memory (SRAM) */
 #define SRAM_BASE_ADDRESS                   (0x20000000)
-#define TOTAL_RAM_SIZE                      (0x00024000)       /* 144 kB since the last 48kB are reserved for FLPR */
+#define TOTAL_RAM_SIZE                      (0x00030000)
 
 #define FLASH_S_PARTITION_SIZE                (0x60000)       /* S partition: 384 kB*/
-#define FLASH_NS_PARTITION_SIZE               (0x7B800)       /* NS partition: 494 kB*/
+#define FLASH_NS_PARTITION_SIZE               (0x8B000)       /* NS partition: 556 kB*/
 
 #define S_ROM_ALIAS_BASE   FLASH_BASE_ADDRESS
 #define NS_ROM_ALIAS_BASE  FLASH_BASE_ADDRESS

--- a/platform/ext/target/nordic_nrf/common/nrf54l15/partition/flash_layout.h
+++ b/platform/ext/target/nordic_nrf/common/nrf54l15/partition/flash_layout.h
@@ -27,8 +27,8 @@
  * 0x0008_0000 Protected Storage Area (16 KB)
  * 0x0008_4000 Internal Trusted Storage Area (16 KB)
  * 0x0008_8000 OTP / NV counters area (8 KB)
- * 0x0008_A000 Non-secure image primary (844 KB)
- * 0x0015_D000 Non-secure storage, used when built with NRF_NS_STORAGE=ON,
+ * 0x0008_A000 Non-secure image primary (940 KB)
+ * 0x0017_5000 Non-secure storage (32 KB), used when built with NRF_NS_STORAGE=ON,
  *             otherwise unused (32 KB)
  */
 
@@ -42,20 +42,16 @@
 /* Use Flash memory to store Code data */
 #define FLASH_BASE_ADDRESS                  (0x0)
 
-/* nRF54L15 has 1524 kB of non volatile memory (RRAM) but the last 96kB are reserved
- * for FLPR MCU in Zephyr. For simplicity and for possible support for running FLPR along
- * with TF-M later FLPR non volatile memory is not used by TF-M. */
-#define FLASH_TOTAL_SIZE                    (0x165000)         /* 1428 kB since the last 96kB are reserved for FLPR */
+/* nRF54L15 has 1524 kB of non volatile memory (RRAM) */
+#define FLASH_TOTAL_SIZE                    (0x17D000)
 #define TOTAL_ROM_SIZE                       FLASH_TOTAL_SIZE
 
-/* nRF54L15 has 256 kB of volatile memory (SRAM) but the last 96kB are reserved
- * for FLPR MCU in Zephyr. For simplicity and for possible support for running FLPR along
- * with TF-M later FLPR volatile memory is not used by TF-M. */
+/* nRF54L15 has 256 kB of volatile memory (SRAM) */
 #define SRAM_BASE_ADDRESS                   (0x20000000)
-#define TOTAL_RAM_SIZE                      (0x00028000)       /* 160 kB, since the last 96kB are reserved for FLPR */
+#define TOTAL_RAM_SIZE                      (0x00040000)
 
 #define FLASH_S_PARTITION_SIZE                (0x80000)       /* S partition: 512 kB*/
-#define FLASH_NS_PARTITION_SIZE               (0xD3000)       /* NS partition: 844 kB*/
+#define FLASH_NS_PARTITION_SIZE               (0xEB000)       /* NS partition: 940 kB*/
 
 #define S_ROM_ALIAS_BASE   FLASH_BASE_ADDRESS
 #define NS_ROM_ALIAS_BASE  FLASH_BASE_ADDRESS

--- a/platform/ext/target/nordic_nrf/common/nrf54lm20a/partition/flash_layout.h
+++ b/platform/ext/target/nordic_nrf/common/nrf54lm20a/partition/flash_layout.h
@@ -27,8 +27,8 @@
  * 0x0008_0000 Protected Storage Area (16 KB)
  * 0x0008_4000 Internal Trusted Storage Area (16 KB)
  * 0x0008_8000 OTP / NV counters area (8 KB)
- * 0x0008_A000 Non-secure image primary (1356 KB)
- * 0x001F_2000 Non-secure storage, used when built with NRF_NS_STORAGE=ON,
+ * 0x0008_A000 Non-secure image primary (1452 KB)
+ * 0x001F_5000 Non-secure storage, used when built with NRF_NS_STORAGE=ON,
  *             otherwise unused (32 KB)
  */
 
@@ -42,20 +42,16 @@
 /* Use Flash memory to store Code data */
 #define FLASH_BASE_ADDRESS                  (0x0)
 
-/* nRF54LM20A has 2036 kB of non volatile memory (RRAM) but the last 96kB are reserved
- * for FLPR MCU in Zephyr. For simplicity and for possible support for running FLPR along
- * with TF-M later FLPR non volatile memory is not used by TF-M. */
-#define FLASH_TOTAL_SIZE                    (0x1E5000)        /* 1940 kB since the last 96kB are reserved for FLPR */
+/* nRF54LM20A has 2036 kB of non volatile memory (RRAM) */
+#define FLASH_TOTAL_SIZE                    (0x1FD000)
 #define TOTAL_ROM_SIZE                       FLASH_TOTAL_SIZE
 
-/* nRF54LM20A has 512 kB of volatile memory (SRAM) but the last 96kB are reserved
- * for FLPR MCU in Zephyr. For simplicity and for possible support for running FLPR along
- * with TF-M later FLPR volatile memory is not used by TF-M. */
+/* nRF54LM20A has 512 kB of volatile memory (SRAM) */
 #define SRAM_BASE_ADDRESS                   (0x20000000)
-#define TOTAL_RAM_SIZE                      (0x00068000)       /* 416 kB since the last 96kB are reserved for FLPR */
+#define TOTAL_RAM_SIZE                      (0x00080000)
 
 #define FLASH_S_PARTITION_SIZE                (0x80000)       /* S partition: 512 kB*/
-#define FLASH_NS_PARTITION_SIZE               (0x153000)      /* NS partition: 1356 kB*/
+#define FLASH_NS_PARTITION_SIZE               (0x16B000)      /* NS partition: 1452 kB*/
 
 #define S_ROM_ALIAS_BASE   FLASH_BASE_ADDRESS
 #define NS_ROM_ALIAS_BASE  FLASH_BASE_ADDRESS

--- a/platform/ext/target/nordic_nrf/common/nrf54lv10a/partition/flash_layout.h
+++ b/platform/ext/target/nordic_nrf/common/nrf54lv10a/partition/flash_layout.h
@@ -27,8 +27,8 @@
  * 0x0006_0000 Protected Storage Area (16 KB)
  * 0x0006_4000 Internal Trusted Storage Area (16 KB)
  * 0x0006_8000 OTP / NV counters area (8 KB)
- * 0x0006_A000 Non-secure image primary (504 KB)
- * 0x000E_8000 Non-secure storage, used when built with NRF_NS_STORAGE=ON,
+ * 0x0006_A000 Non-secure image primary (556 KB)
+ * 0x000F_5000 Non-secure storage, used when built with NRF_NS_STORAGE=ON,
  *             otherwise unused (32 KB)
  */
 
@@ -42,20 +42,16 @@
 /* Use Flash memory to store Code data */
 #define FLASH_BASE_ADDRESS                  (0x0)
 
-/* nRF54LV10A has 1012 kB of non volatile memory (RRAM) but the last 62kB are reserved
- * for FLPR MCU in Zephyr. For simplicity and for possible support for running FLPR along
- * with TF-M later FLPR non volatile memory is not used by TF-M. */
-#define FLASH_TOTAL_SIZE                    (0xF0000)         /* 960 kB since the last 62kB are reserved for FLPR */
+/* nRF54LV10A has 1012 kB of non volatile memory (RRAM) */
+#define FLASH_TOTAL_SIZE                    (0xFD000)
 #define TOTAL_ROM_SIZE                       FLASH_TOTAL_SIZE
 
-/* nRF54LV10A has 192 kB of volatile memory (SRAM) but the last 48kB are reserved
- * for FLPR MCU in Zephyr. For simplicity and for possible support for running FLPR along
- * with TF-M later FLPR volatile memory is not used by TF-M. */
+/* nRF54LV10A has 192 kB of volatile memory (SRAM) */
 #define SRAM_BASE_ADDRESS                   (0x20000000)
-#define TOTAL_RAM_SIZE                      (0x00024000)       /* 144 kB since the last 48kB are reserved for FLPR */
+#define TOTAL_RAM_SIZE                      (0x00030000)
 
 #define FLASH_S_PARTITION_SIZE                (0x60000)       /* S partition: 384 kB*/
-#define FLASH_NS_PARTITION_SIZE               (0x7E000)       /* NS partition: 504 kB*/
+#define FLASH_NS_PARTITION_SIZE               (0x8B000)       /* NS partition: 556 kB*/
 
 #define S_ROM_ALIAS_BASE   FLASH_BASE_ADDRESS
 #define NS_ROM_ALIAS_BASE  FLASH_BASE_ADDRESS


### PR DESCRIPTION
…dic boards

Remove the FLPR reserved non-volatile and volatile memory for all Nordic boards since it is not yet supported with TF-M.


Change-Id: I6bb513d52a55b9571e10392b567b9b77a686d79b