### PR TITLE
[zep fromtree] platform: stm: workaround compiler error

### DIFF
--- a/platform/ext/target/stm/common/stm32h5xx/hal/Src/stm32h5xx_hal_dma_ex.c
+++ b/platform/ext/target/stm/common/stm32h5xx/hal/Src/stm32h5xx_hal_dma_ex.c
@@ -534,7 +534,11 @@ static void DMA_List_BuildNode(DMA_NodeConfTypeDef const *const pNodeConfig,
                                DMA_NodeTypeDef *const pNode);
 static void DMA_List_GetNodeConfig(DMA_NodeConfTypeDef *const pNodeConfig,
                                    DMA_NodeTypeDef const *const pNode);
+#if (__GNUC__ == 11) || (__GNUC__ == 12)
+static __attribute__((noinline)) uint32_t DMA_List_CheckNodesBaseAddresses(DMA_NodeTypeDef const *const pNode1,
+#else
 static uint32_t DMA_List_CheckNodesBaseAddresses(DMA_NodeTypeDef const *const pNode1,
+#endif
                                                  DMA_NodeTypeDef const *const pNode2,
                                                  DMA_NodeTypeDef const *const pNode3);
 static uint32_t DMA_List_CheckNodesTypes(DMA_NodeTypeDef const *const pNode1,
@@ -4071,7 +4075,11 @@ static void DMA_List_GetNodeConfig(DMA_NodeConfTypeDef *const pNodeConfig,
   * @param  pNode3 : Pointer to a DMA_NodeTypeDef structure that contains linked-list node 3 registers configurations.
   * @retval Return 0 when nodes addresses are compatible, 1 otherwise.
   */
+#if (__GNUC__ == 11) || (__GNUC__ == 12)
+static __attribute__((noinline)) uint32_t DMA_List_CheckNodesBaseAddresses(DMA_NodeTypeDef const *const pNode1,
+#else
 static uint32_t DMA_List_CheckNodesBaseAddresses(DMA_NodeTypeDef const *const pNode1,
+#endif
                                                  DMA_NodeTypeDef const *const pNode2,
                                                  DMA_NodeTypeDef const *const pNode3)
 {


### PR DESCRIPTION
Make local function DMA_List_CheckNodesBaseAddresses() never inlined.

This fixes a build issue faced with with STM32H5 DMA HAL when building TF-M for regression tests with GCC11 and GCC12 compilers with optimization directives. The build issue is not very explicit, as reported by the build error trace message below:

during GIMPLE pass: evrp
/__w/zephyr/modules/tee/tf-m/trusted-firmware-m/platform/ext/target/stm/common/stm32h5xx/hal/Src/stm32h5xx_hal_dma_ex.c: In function 'HAL_DMAEx_List_ReplaceNode_Head': /__w/zephyr/modules/tee/tf-m/trusted-firmware-m/platform/ext/target/stm/common/stm32h5xx/hal/Src/stm32h5xx_hal_dma_ex.c:4683:1: internal compiler error: Segmentation fault
 4683 | }
      | ^
0x7f6e24cfb32f ???
	./signal/../sysdeps/unix/sysv/linux/x86_64/libc_sigaction.c:0
0x7f6e24ce01c9 __libc_start_call_main
	../sysdeps/nptl/libc_start_call_main.h:58
0x7f6e24ce028a __libc_start_main_impl
	../csu/libc-start.c:360
Please submit a full bug report, with preprocessed source (by using -freport-bug). Please include the complete backtrace with any bug report. See <https://github.com/zephyrproject-rtos/sdk-ng/issues> for instructions.

The issue was tracked in GCC [1] and has been addressed in GCC 13 and later.

This fix is equivalent to a fix already applied to HAL driver of stm32u5 and stm32wbaxx platforms, see commit 578a6f4 and ec61e69.

Link: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=106878 [1]