### PR TITLE
[zep fromtree] platform: frdmmcxn947 with BL2

### DIFF
--- a/docs/platform/nxp/frdmmcxn947/README.rst
+++ b/docs/platform/nxp/frdmmcxn947/README.rst
@@ -22,22 +22,41 @@ Prepare the tf-m-tests repository inside the TF-M base folder.
     cd <TF-M base folder>
     git clone https://git.trustedfirmware.org/TF-M/tf-m-tests.git
 
-Currently FRDM-MCXN947 only supports builds without secondary bootloader (BL2).
+There are two options for the TF-M build - with or without secondary bootloader (BL2).
 
-1.1 Building TF-M demo without BL2
+1.1 Building TF-M demo with BL2
+===============================
+To build S and NS application image with BL2, run the following commands:
+
+.. code:: bash
+
+    cd <TF-M base folder>/tf-m-test/tests_reg
+    cmake -S spe -B build_spe \
+        -DTFM_PLATFORM=nxp/frdmmcxn947 \
+        -DCONFIG_TFM_SOURCE_PATH=<TF-M base folder>/trusted-firmware-m \
+        -G "Unix Makefiles" -DBL2=ON -DTFM_BL2_LOG_LEVEL=LOG_LEVEL_INFO
+    cmake --build build_spe -- install
+    cmake -S . -B build_test -G"Unix Makefiles" \
+        -DCONFIG_SPE_PATH=<TF-M base folder>/tf-m-tests/tests_reg/build_spe/api_ns
+    cmake --build build_test
+
+
+1.2 Building TF-M demo without BL2
 ==================================
 To build S and NS application image without a BL2, run the following commands:
 
 .. code:: bash
 
     cd <TF-M base folder>/tf-m-test/tests_reg
-    cmake -S spe -B build_spe -DTFM_PLATFORM=nxp/frdmmcxn947 -DCONFIG_TFM_SOURCE_PATH=<TF-M base folder>/trusted-firmware-m -G"Unix Makefiles" -DBL2=OFF
+    cmake -S spe -B build_spe -DTFM_PLATFORM=nxp/frdmmcxn947 \
+          -DCONFIG_TFM_SOURCE_PATH=<TF-M base folder>/trusted-firmware-m \
+          -G"Unix Makefiles" -DBL2=OFF
     cmake --build build_spe -- install
-    cmake -S . -B build_test -G"Unix Makefiles" -DCONFIG_SPE_PATH=<TF-M base folder>/tf-m-tests/tests_reg/build_spe/api_ns
+    cmake -S . -B build_test -G"Unix Makefiles" \
+          -DCONFIG_SPE_PATH=<TF-M base folder>/tf-m-tests/tests_reg/build_spe/api_ns
     cmake --build build_test
 
-
-1.2 Building TF-M regression tests
+1.3 Building TF-M regression tests
 ==================================
 
 To build the S and NS regression tests without BL2, run the following commands:
@@ -47,9 +66,32 @@ To build the S and NS regression tests without BL2, run the following commands:
 .. code:: bash
 
     cd <TF-M base folder>/tf-m-test/tests_reg
-    cmake -S spe -B build_spe -DTFM_PLATFORM=nxp/frdmmcxn947 -DCONFIG_TFM_SOURCE_PATH=<TF-M base folder>/trusted-firmware-m -G"Unix Makefiles" -DTFM_PROFILE=profile_medium -DTEST_S=ON -DTEST_NS=ON -DBL2=OFF
+    cmake -S spe -B build_spe -DTFM_PLATFORM=nxp/frdmmcxn947 \
+          -DCONFIG_TFM_SOURCE_PATH=<TF-M base folder>/trusted-firmware-m \
+          -G"Unix Makefiles" -DTFM_PROFILE=profile_medium \
+          -DTEST_S=ON -DTEST_NS=ON -DBL2=OFF
     cmake --build build_spe -- install
-    cmake -S . -B build_test -G"Unix Makefiles" -DCONFIG_SPE_PATH=<TF-M base folder>/tf-m-tests/tests_reg/build_spe/api_ns
+    cmake -S . -B build_test -G"Unix Makefiles" \
+          -DCONFIG_SPE_PATH=<TF-M base folder>/tf-m-tests/tests_reg/build_spe/api_ns
+    cmake --build build_test
+
+1.4 Building TF-M regression tests with BL2
+===========================================
+
+To build the S and NS regression tests With BL2, run the following commands:
+
+* Profile Medium:
+
+.. code:: bash
+
+    cd <TF-M base folder>/tf-m-test/tests_reg
+    cmake -S spe -B build_spe -DTFM_PLATFORM=nxp/frdmmcxn947 \
+          -DCONFIG_TFM_SOURCE_PATH=<TF-M base folder>/trusted-firmware-m \
+          -G"Unix Makefiles" -DTFM_PROFILE=profile_medium -DTEST_S=ON \
+          -DTEST_NS=ON -DBL2=ON -DTFM_BL2_LOG_LEVEL=LOG_LEVEL_INFO
+    cmake --build build_spe -- install
+    cmake -S . -B build_test -G"Unix Makefiles" \
+          -DCONFIG_SPE_PATH=<TF-M base folder>/tf-m-tests/tests_reg/build_spe/api_ns
     cmake --build build_test
 
 * Profile Small:
@@ -57,9 +99,16 @@ To build the S and NS regression tests without BL2, run the following commands:
 .. code:: bash
 
     cd <TF-M base folder>/tf-m-test/tests_reg
-	cmake -S spe -B build_spe_small -DTFM_PLATFORM=nxp/frdmmcxn947 -DCONFIG_TFM_SOURCE_PATH=C:/Code/tfm-upstream/trusted-firmware-m -G"Unix Makefiles" -DBL2=OFF -DTFM_PROFILE=profile_small -DTEST_S=ON   -DTEST_NS=ON   -DTEST_S_CRYPTO=ON   -DTEST_NS_CRYPTO=ON   -DTEST_S_ATTESTATION=OFF   -DTEST_S_STORAGE=OFF   -DTEST_S_PLATFORM=OFF   -DTEST_NS_ATTESTATION=OFF   -DTEST_NS_STORAGE=OFF -DTEST_NS_PLATFORM=OFF -DTEST_S_PLATFORM=OFF -DTEST_NS_SFN_BACKEND=OFF -DTEST_S_SFN_BACKEND=OFF
+    cmake -S spe -B build_spe_small -DTFM_PLATFORM=nxp/frdmmcxn947 \
+        -DCONFIG_TFM_SOURCE_PATH=C:/Code/tfm-upstream/trusted-firmware-m \
+        -G"Unix Makefiles" -DBL2=ON -DTFM_PROFILE=profile_small -DTEST_S=ON   \
+        -DTEST_NS=ON   -DTEST_S_CRYPTO=ON   -DTEST_NS_CRYPTO=ON   -DTEST_S_ATTESTATION=OFF \
+        -DTEST_S_STORAGE=OFF   -DTEST_S_PLATFORM=OFF   -DTEST_NS_ATTESTATION=OFF  \
+        -DTEST_NS_STORAGE=OFF -DTEST_NS_PLATFORM=OFF -DTEST_S_PLATFORM=OFF \
+        -DTEST_NS_SFN_BACKEND=OFF -DTEST_S_SFN_BACKEND=OFF -DTFM_BL2_LOG_LEVEL=LOG_LEVEL_INFO
     cmake --build build_spe_small -- install
-    cmake -S . -B build_test_small -G"Unix Makefiles" -DCONFIG_SPE_PATH=C:/Code/tfm-upstream/tf-m-tests/tests_reg/build_spe_small/api_ns
+    cmake -S . -B build_test_small -G"Unix Makefiles" \
+        -DCONFIG_SPE_PATH=C:/Code/tfm-upstream/tf-m-tests/tests_reg/build_spe_small/api_ns
     cmake --build build_test_small
 
 
@@ -79,15 +128,30 @@ Flash them with JLink as follows:
 
 .. code-block:: console
 
-
     JLinkExe -device MCXN947_M33_0 -if swd -speed 4000 -autoconnect 1
+    J-Link>unlock LPC5460x
     J-Link>exec EnableEraseAllFlashBanks
-    J-Link>erase 0x00 0x180000
+    J-Link>erase
     J-Link>r
 
 * Flash Write:
 
-.. code-block:: console	
+
+If you built TF-M with the BL2 secondary bootloader, use the following commands:
+
+.. code-block:: console
+
+    JLinkExe -device MCXN947_M33_0 -if swd -speed 4000 -autoconnect 1
+    J-Link>r
+    J-Link>h
+    J-Link>loadfile build_spe/bin/bl2.bin 0x00
+    J-Link>h
+    J-Link>loadfile build_test/bin/tfm_s_ns_signed.bin 0x10000
+    J-Link>r
+
+When BL2 is disabled, flash the generated hex secure and non-secure images:
+
+.. code-block:: console
 
     JLinkExe -device MCXN947_M33_0 -if swd -speed 4000 -autoconnect 1
     J-Link>r

--- a/platform/ext/target/nxp/common/CMSIS_Driver/Driver_LPUART.c
+++ b/platform/ext/target/nxp/common/CMSIS_Driver/Driver_LPUART.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2013-2021 Arm Limited. All rights reserved.
- * Copyright 2019-2022, 2025 NXP
+ * Copyright 2019-2022, 2025-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -87,15 +87,12 @@ static ARM_USART_CAPABILITIES ARM_LPUART_GetCapabilities(void)
 
 int32_t ARM_LPUARTx_Initialize(UARTx_Resources* uart_dev)
 {
-    
-#if (__ARM_FEATURE_CMSE & 0x2) /* Initialize once in S */
     uint32_t lpuartClkFreq;
 
     lpuartClkFreq = BOARD_DEBUG_UART_CLK_FREQ;
 
     LPUART_Init(uart_dev->base, &uart_dev->config, lpuartClkFreq);
-#endif
-    
+
     return ARM_DRIVER_OK;
 }
 

--- a/platform/ext/target/nxp/frdmmcxn947/CMakeLists.txt
+++ b/platform/ext/target/nxp/frdmmcxn947/CMakeLists.txt
@@ -1,5 +1,5 @@
 #-------------------------------------------------------------------------------
-# Copyright 2025 NXP
+# Copyright 2025-2026 NXP
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -172,7 +172,83 @@ target_sources(tfm_s
 )
 
 #========================= Platform BL2 =======================================#
-# to be added 
+if(BL2)
+
+    target_compile_definitions(platform_bl2
+        PUBLIC
+            ${TFM_LPUART_FEATURE_COMPILE_DEFINITION}
+    )
+
+    target_include_directories(platform_bl2
+        PUBLIC
+            partition
+            Device/Include
+            project_template/bl2
+            project_template/s
+            ${PLATFORM_DIR}/ext/target/nxp/common
+            ${PLATFORM_DIR}/ext/target/nxp/common/CMSIS_Driver
+            ${PLATFORM_DIR}/ext/target/nxp/common/Device/Config
+            ${PLATFORM_DIR}/ext/target/nxp/common/Device/Include
+            ${NXP_HAL_FILE_PATH}/frdmmcxn947/Native_Driver
+            ${NXP_HAL_FILE_PATH}/frdmmcxn947/Native_Driver/periph
+            ${NXP_HAL_FILE_PATH}/frdmmcxn947/Native_Driver/drivers
+            ${NXP_HAL_FILE_PATH}/frdmmcxn947/Native_Driver/drivers/romapi/flash/
+            ${NXP_HAL_FILE_PATH}/common/Native_Driver
+            ${NXP_HAL_FILE_PATH}/common/Native_Driver/components/uart
+            ${NXP_HAL_FILE_PATH}/common/Native_Driver/utilities/debug_console_lite
+            ${NXP_HAL_FILE_PATH}/common/Native_Driver/utilities/str
+            ${NXP_HAL_FILE_PATH}/common/Native_Driver/drivers
+            ${NXP_HAL_FILE_PATH}/common/Native_Driver/drivers/common
+            ${NXP_HAL_FILE_PATH}/common/Native_Driver/drivers/lpflexcomm
+            ${NXP_HAL_FILE_PATH}/common/Native_Driver/drivers/lpflexcomm/lpuart
+            ${NXP_HAL_FILE_PATH}/common/Native_Driver/drivers/ctimer
+            ${NXP_HAL_FILE_PATH}/common/Native_Driver/drivers/gpio
+            ${NXP_HAL_FILE_PATH}/common/Native_Driver/drivers/mcx_spc
+            ${NXP_HAL_FILE_PATH}/common/Native_Driver/drivers/port
+
+        PRIVATE
+            .
+            ${PLATFORM_DIR}/ext/target/nxp/common/Device/Config
+            ${PLATFORM_DIR}/ext/target/nxp/common/Device/Include
+            ${NXP_HAL_FILE_PATH}/common/Native_Driver/components/serial_manager
+            ${NXP_HAL_FILE_PATH}/common/Native_Driver/components/lists
+            ${NXP_HAL_FILE_PATH}/common/Native_Driver/components/uart
+            ${NXP_HAL_FILE_PATH}/common/Native_Driver/utilities/debug_console
+            ${NXP_HAL_FILE_PATH}/common/Native_Driver/utilities/str
+            ${NXP_HAL_FILE_PATH}/common/Native_Driver/utilities/assert
+    )
+    target_sources(platform_bl2
+        PRIVATE
+            project_template/s/board.c
+            project_template/s/clock_config.c
+            project_template/s/pin_mux.c
+            ${NXP_COMMON_DIR}/CMSIS_Driver/Driver_Flash_iap_n4a.c
+            ${NXP_COMMON_DIR}/CMSIS_Driver/Driver_LPUART.c
+            ${NXP_HAL_FILE_PATH}/frdmmcxn947/Native_Driver/system_MCXN947_cm33_core0.c
+            ${NXP_HAL_FILE_PATH}/frdmmcxn947/Native_Driver/drivers/romapi/flash/src/fsl_flash.c
+            ${NXP_HAL_FILE_PATH}/frdmmcxn947/Native_Driver/drivers/fsl_clock.c
+            ${NXP_HAL_FILE_PATH}/frdmmcxn947/Native_Driver/drivers/fsl_reset.c
+            ${NXP_HAL_FILE_PATH}/common/Native_Driver/drivers/lpflexcomm/fsl_lpflexcomm.c
+            ${NXP_HAL_FILE_PATH}/common/Native_Driver/drivers/lpflexcomm/lpuart/fsl_lpuart.c
+            ${NXP_HAL_FILE_PATH}/common/Native_Driver/drivers/ctimer/fsl_ctimer.c
+            ${NXP_HAL_FILE_PATH}/common/Native_Driver/drivers/gpio/fsl_gpio.c
+            ${NXP_HAL_FILE_PATH}/common/Native_Driver/drivers/mcx_spc/fsl_spc.c
+            ${NXP_HAL_FILE_PATH}/common/Native_Driver/components/uart/fsl_adapter_lpuart.c
+            ${NXP_HAL_FILE_PATH}/common/Native_Driver/utilities/assert/fsl_assert.c
+            ${NXP_HAL_FILE_PATH}/common/Native_Driver/utilities/debug_console_lite/fsl_debug_console.c
+            ${NXP_HAL_FILE_PATH}/common/Native_Driver/utilities/str/fsl_str.c
+    )
+
+    # GNU ld has some strange behaviour to do with weak functions, and does not deal
+    # well with strong functions in static libraries overriding weak functions in
+    # object files. For this reason, the file hardware_init is linked directly to
+    # the s binary as an object file. This issue does not affect armclang, but the
+    # fix is compatible.
+    target_sources(bl2
+    PRIVATE
+        project_template/bl2/hardware_init.c
+    )
+endif()
 
 #========================= tfm_spm ============================================#
 

--- a/platform/ext/target/nxp/frdmmcxn947/config.cmake
+++ b/platform/ext/target/nxp/frdmmcxn947/config.cmake
@@ -1,6 +1,6 @@
 #-------------------------------------------------------------------------------
 # Copyright (c) 2020-2023, Arm Limited. All rights reserved.
-# Copyright 2025 NXP
+# Copyright 2025-2026 NXP
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -12,6 +12,12 @@ set(TFM_PLATFORM_NXP_HAL_FILE_PATH         "LOCAL"      CACHE STRING     "Path t
 ############################# Platform ##########################################
 set(CONFIG_TFM_USE_TRUSTZONE               ON           CACHE BOOL      "Use TrustZone")
 set(TFM_MULTI_CORE_TOPOLOGY                OFF          CACHE BOOL      "Platform has multi core")
+
+if(BL2)
+############################ BL2 ########################################
+set(BL2_S_IMAGE_START                  "0x10000"   CACHE STRING    "Base address of the secure image in configuration with BL2")
+set(BL2_NS_IMAGE_START                 "0x58000"   CACHE STRING    "Base address of the non secure image in configuration with BL2")
+endif()
 
 ############################ Platform features ##########################################
 set(MCUX_PSA_CRYPTO_DRIVER_ELS_PKC         OFF          CACHE BOOL      "Use psa-crypto-driver to use HW acceleration via driver wrappers")

--- a/platform/ext/target/nxp/frdmmcxn947/partition/region_defs.h
+++ b/platform/ext/target/nxp/frdmmcxn947/partition/region_defs.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017-2023 Arm Limited. All rights reserved.
- * Copyright 2019-2025 NXP
+ * Copyright 2019-2026 NXP
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,10 @@
 
 #include "flash_layout.h"
 
+#ifdef BL2
+#define BL2_HEAP_SIZE           (0x0001000)
+#define BL2_MSP_STACK_SIZE      (0x0001800)
+#endif
 
 #ifdef ENABLE_HEAP
     #define S_HEAP_SIZE         (0x0001000)
@@ -63,8 +67,6 @@
  * by the bootloader.
  */
 #ifdef BL2
-#define BL2_HEADER_SIZE      (0x400)       /* 1 KB */
-#define BL2_TRAILER_SIZE     (0x400)       /* 1 KB */
 #if (MCUBOOT_IMAGE_NUMBER == 1) && \
     (NS_IMAGE_PRIMARY_PARTITION_OFFSET > S_IMAGE_PRIMARY_PARTITION_OFFSET)
 /* If secure image and nonsecure image are concatenated, and nonsecure image
@@ -74,7 +76,7 @@
 #define IMAGE_S_CODE_SIZE \
             (FLASH_S_PARTITION_SIZE - BL2_HEADER_SIZE)
 #endif
-#else
+#else /* BL2 */
 #ifndef BL2_HEADER_SIZE /* if BL2_HEADER_SIZE is not defined by config.cmake, then define it*/
 /* No header if no bootloader, but keep IMAGE_CODE_SIZE the same */
 #define BL2_HEADER_SIZE      (0x0)
@@ -129,14 +131,14 @@
 #define NS_DATA_LIMIT                   (NS_DATA_START + NS_DATA_SIZE - 1)
 
 /* Flash is divided into 32 kB sub-regions. Each sub-region can be assigned individual
-security tier by programing corresponding registers in secure AHB controller.*/
+security tier by programming corresponding registers in secure AHB controller.*/
 #define FLASH_SUBREGION_SIZE    (0x8000)     /* 32 kB */
 
 #define FLASH_REGION0_SUBREGION_NUMBER          32
 #define FLASH_REGION0_SIZE                      (1024 * 1024)
-                          
+
 #define FLASH_REGION1_SUBREGION_NUMBER          32
-#define FLASH_REGION1_SIZE                      (1024 * 1024)                           
+#define FLASH_REGION1_SIZE                      (1024 * 1024)
 
 /* RAM is divided into 4 kB sub-regions. Each sub-region can be assigned individual
 security tier by programing corresponding registers in secure AHB controller. */
@@ -164,7 +166,7 @@ security tier by programing corresponding registers in secure AHB controller. */
 #define BL2_CODE_SIZE     (FLASH_AREA_BL2_SIZE)
 #define BL2_CODE_LIMIT    (BL2_CODE_START + BL2_CODE_SIZE - 1)
 
-#define BL2_DATA_START    (S_RAM_ALIAS(0x0))
+#define BL2_DATA_START    (S_RAM_ALIAS(S_DATA_OFFSET + RESERVED_RAM_SIZE))
 #define BL2_DATA_SIZE     (TOTAL_RAM_SIZE)
 #define BL2_DATA_LIMIT    (BL2_DATA_START + BL2_DATA_SIZE - 1)
 #endif /* BL2 */

--- a/platform/ext/target/nxp/frdmmcxn947/project_template/bl2/hardware_init.c
+++ b/platform/ext/target/nxp/frdmmcxn947/project_template/bl2/hardware_init.c
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*${header:start}*/
+#include "pin_mux.h"
+#include "clock_config.h"
+#include "board.h"
+#include "cmsis.h"
+
+#include "fsl_lpuart.h"
+#include "fsl_lpflexcomm.h"
+
+/*${header:end}*/
+
+/*${variable:start}*/
+
+/*${variable:end}*/
+/*${function:start}*/
+void BOARD_InitHardware(void)
+{
+
+    /* 1) Initialize system clocks first (sets up FRO/PLL baseline) */
+    BOARD_InitBootClocks();   // Do NOT attach UART clocks before this call
+
+    /* 2) Pin mux for LPUART4 TX/RX (ensure BOARD_InitPins maps the right pins to FC4) */
+    BOARD_InitDEBUG_UARTPins();
+
+    /* 3) Choose ONE clock source and attach it to LP-FLEXCOMM4 */
+    /* Option A: FRO 12 MHz — simple and good enough for 115200 */
+    CLOCK_SetClkDiv(kCLOCK_DivFlexcom4Clk, 1U);
+    CLOCK_AttachClk(kFRO12M_to_FLEXCOMM4);
+
+    /* 4) Release peripheral reset on FC4 AFTER clock is attached */
+    RESET_PeripheralReset(kFC4_RST_SHIFT_RSTn);
+
+    /* 5) Ungate and deassert reset for LP‑FLEXCOMM4 */
+    CLOCK_EnableClock(kCLOCK_LPFlexComm4);
+    /* Reset driver usage */
+    RESET_PeripheralReset(kFC4_RST_SHIFT_RSTn);
+
+    /*LPUART_Init() is done in driver_lpuart*/
+
+}
+
+void SystemInit(void)
+{
+
+#if ((__FPU_PRESENT == 1) && (__FPU_USED == 1))
+    SCB->CPACR |= ((3UL << 10 * 2) | (3UL << 11 * 2));    /* set CP10, CP11 Full Access in Secure mode */
+#endif                                                    /* ((__FPU_PRESENT == 1) && (__FPU_USED == 1)) */
+
+    SCB->CPACR |= ((3UL << 0 * 2) | (3UL << 1 * 2));    /* set CP0, CP1 Full Access in Secure mode (enable PowerQuad) */
+
+    SCB->NSACR |= ((3UL << 0) | (3UL << 10));           /* enable CP0, CP1, CP10, CP11 Non-secure Access */
+
+    extern void *__VECTOR_TABLE[];
+    SCB->VTOR = (uint32_t) & (__VECTOR_TABLE[0]);
+
+    SYSCON->TRACECLKDIV = 0;
+
+    /******************* TBD -> Recheck these settings based on Secure world TFM */
+
+    /* enable the flash cache LPCAC */
+    SYSCON->LPCAC_CTRL &= ~SYSCON_LPCAC_CTRL_DIS_LPCAC_MASK;
+
+    /* Disable aGDET trigger the CHIP_RESET */
+    ITRC0->OUT_SEL[4][0] = (ITRC0->OUT_SEL[4][0] & ~ITRC_OUT_SEL_IN9_SELn_MASK) | (ITRC_OUT_SEL_IN9_SELn(0x2));
+    ITRC0->OUT_SEL[4][1] = (ITRC0->OUT_SEL[4][1] & ~ITRC_OUT_SEL_IN9_SELn_MASK) | (ITRC_OUT_SEL_IN9_SELn(0x2));
+    /* Disable aGDET interrupt and reset */
+    SPC0->ACTIVE_CFG |= SPC_ACTIVE_CFG_GLITCH_DETECT_DISABLE_MASK;
+    SPC0->GLITCH_DETECT_SC &= ~SPC_GLITCH_DETECT_SC_LOCK_MASK;
+    SPC0->GLITCH_DETECT_SC = 0x3C;
+    SPC0->GLITCH_DETECT_SC |= SPC_GLITCH_DETECT_SC_LOCK_MASK;
+
+    /* Disable dGDET trigger the CHIP_RESET */
+    ITRC0->OUT_SEL[4][0] = (ITRC0->OUT_SEL[4][0] & ~ ITRC_OUT_SEL_IN0_SELn_MASK) | (ITRC_OUT_SEL_IN0_SELn(0x2));
+    ITRC0->OUT_SEL[4][1] = (ITRC0->OUT_SEL[4][1] & ~ ITRC_OUT_SEL_IN0_SELn_MASK) | (ITRC_OUT_SEL_IN0_SELn(0x2));
+    GDET0->GDET_ENABLE1 = 0;
+    GDET1->GDET_ENABLE1 = 0;
+
+    /* Board specific HW init*/
+    BOARD_InitHardware();
+}
+
+/*${function:end}*/

--- a/platform/ext/target/nxp/frdmmcxn947/target_cfg.c
+++ b/platform/ext/target/nxp/frdmmcxn947/target_cfg.c
@@ -167,8 +167,8 @@ int32_t mpc_init_cfg(void)
 #ifdef BL2 /* Set secondary image region to NS, when BL2 is enabled */
     /* The regions have to be alligned to 32 kB to cover the AHB Flash Region. */
     assert(memory_regions.secondary_partition_base >= NS_ROM_ALIAS_BASE);
-    assert(((memory_regions.secondary_partition_base - NS_ROM_ALIAS_BASE) % FLASH_REGION0_SUBREGION_SIZE) == 0);
-    assert(((memory_regions.secondary_partition_limit - NS_ROM_ALIAS_BASE + 1) % FLASH_REGION0_SUBREGION_SIZE)
+    assert(((memory_regions.secondary_partition_base - NS_ROM_ALIAS_BASE) % FLASH_SUBREGION_SIZE) == 0);
+    assert(((memory_regions.secondary_partition_limit - NS_ROM_ALIAS_BASE + 1) % FLASH_SUBREGION_SIZE)
                == 0);
     enable_mem_rule_for_partition(memory_regions.secondary_partition_base, memory_regions.secondary_partition_limit);
 

--- a/platform/ext/target/nxp/frdmmcxn947/target_cfg.c
+++ b/platform/ext/target/nxp/frdmmcxn947/target_cfg.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018-2022 Arm Limited. All rights reserved.
- * Copyright 2019-2025 NXP
+ * Copyright 2019-2026 NXP
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -163,6 +163,16 @@ int32_t mpc_init_cfg(void)
 #ifdef TFM_EL2GO_CMPA_REGION
 	enable_mem_rule_for_partition(memory_regions.el2go_cmpa_region_base, memory_regions.el2go_cmpa_region_limit);
 #endif /* TFM_EL2GO_CMPA_REGION */
+
+#ifdef BL2 /* Set secondary image region to NS, when BL2 is enabled */
+    /* The regions have to be alligned to 32 kB to cover the AHB Flash Region. */
+    assert(memory_regions.secondary_partition_base >= NS_ROM_ALIAS_BASE);
+    assert(((memory_regions.secondary_partition_base - NS_ROM_ALIAS_BASE) % FLASH_REGION0_SUBREGION_SIZE) == 0);
+    assert(((memory_regions.secondary_partition_limit - NS_ROM_ALIAS_BASE + 1) % FLASH_REGION0_SUBREGION_SIZE)
+               == 0);
+    enable_mem_rule_for_partition(memory_regions.secondary_partition_base, memory_regions.secondary_partition_limit);
+
+#endif
 
     /* == ROM region == */
 


### PR DESCRIPTION
The commit adds support for BL2 enablement with
NXP frdmmcxn947. Cmake and config files are updated to support both builds with and without Bl2.

Change-Id: I4cbb44338bfe5bea78218a46d0eb007626d146e2

(cherry picked from commit f0a73a04055106b7659d9304baf4c5bb8609fca7)