### PR TITLE
stm32: port mainline fixes for non-secure flash locking conflict

### DIFF
--- a/platform/ext/target/stm/common/hal/CMSIS_Driver/low_level_flash.c
+++ b/platform/ext/target/stm/common/hal/CMSIS_Driver/low_level_flash.c
@@ -569,7 +569,12 @@ static int32_t Flash_ProgramData(uint32_t addr,
   stm32_icache_disable();
 #endif /* TFM_ICACHE_ENABLE */
 
-  HAL_FLASH_Unlock();
+  if (IS_FLASH_SECURE_OPERATION()) {
+    HAL_FLASH_Unlock_SEC();
+  } else {
+    HAL_FLASH_Unlock_NS();
+  }
+
   ARM_FLASH0_STATUS.busy = DRIVER_STATUS_BUSY;
   do
   {
@@ -597,7 +602,12 @@ static int32_t Flash_ProgramData(uint32_t addr,
   } while ((loop != cnt) && (err == HAL_OK));
 
   ARM_FLASH0_STATUS.busy = DRIVER_STATUS_IDLE;
-  HAL_FLASH_Lock();
+
+  if (IS_FLASH_SECURE_OPERATION()) {
+    HAL_FLASH_Lock_SEC();
+  } else {
+    HAL_FLASH_Lock_NS();
+  }
 
 #ifdef TFM_ICACHE_ENABLE
   icache_wait_for_invalidate_complete();
@@ -701,11 +711,19 @@ static int32_t Flash_EraseSector(uint32_t addr)
 #endif /* TFM_ICACHE_ENABLE */
 
   ARM_FLASH0_STATUS.error = DRIVER_STATUS_NO_ERROR;
-  HAL_FLASH_Unlock();
+  if (IS_FLASH_SECURE_OPERATION()) {
+    HAL_FLASH_Unlock_SEC();
+  } else {
+    HAL_FLASH_Unlock_NS();
+  }
   ARM_FLASH0_STATUS.busy = DRIVER_STATUS_BUSY;
   err = HAL_FLASHEx_Erase(&EraseInit, &pageError);
   ARM_FLASH0_STATUS.busy = DRIVER_STATUS_IDLE;
-  HAL_FLASH_Lock();
+  if (IS_FLASH_SECURE_OPERATION()) {
+    HAL_FLASH_Lock_SEC();
+  } else {
+    HAL_FLASH_Lock_NS();
+  }
 
 #ifdef TFM_ICACHE_ENABLE
   icache_wait_for_invalidate_complete();

--- a/platform/ext/target/stm/common/stm32h5xx/hal/Inc/stm32h5xx_hal_flash.h
+++ b/platform/ext/target/stm/common/stm32h5xx/hal/Inc/stm32h5xx_hal_flash.h
@@ -640,6 +640,10 @@ void HAL_FLASH_OperationErrorCallback(uint32_t ReturnValue);
   * @{
   */
 /* Peripheral Control functions */
+HAL_StatusTypeDef HAL_FLASH_Unlock_NS(void);
+HAL_StatusTypeDef HAL_FLASH_Unlock_SEC(void);
+HAL_StatusTypeDef HAL_FLASH_Lock_NS(void);
+HAL_StatusTypeDef HAL_FLASH_Lock_SEC(void);
 HAL_StatusTypeDef HAL_FLASH_Unlock(void);
 HAL_StatusTypeDef HAL_FLASH_Lock(void);
 HAL_StatusTypeDef HAL_FLASH_OB_Unlock(void);

--- a/platform/ext/target/stm/common/stm32l5xx/hal/Inc/stm32l5xx_hal_flash.h
+++ b/platform/ext/target/stm/common/stm32l5xx/hal/Inc/stm32l5xx_hal_flash.h
@@ -892,8 +892,13 @@ void               HAL_FLASH_OperationErrorCallback(uint32_t ReturnValue);
 /** @addtogroup FLASH_Exported_Functions_Group2
   * @{
   */
+HAL_StatusTypeDef  HAL_FLASH_Unlock_NS(void);
+HAL_StatusTypeDef  HAL_FLASH_Unlock_SEC(void);
+HAL_StatusTypeDef  HAL_FLASH_Lock_NS(void);
+HAL_StatusTypeDef  HAL_FLASH_Lock_SEC(void);
 HAL_StatusTypeDef  HAL_FLASH_Unlock(void);
 HAL_StatusTypeDef  HAL_FLASH_Lock(void);
+
 /* Option bytes control */
 HAL_StatusTypeDef  HAL_FLASH_OB_Unlock(void);
 HAL_StatusTypeDef  HAL_FLASH_OB_Lock(void);

--- a/platform/ext/target/stm/common/stm32l5xx/hal/Src/stm32l5xx_hal_flash.c
+++ b/platform/ext/target/stm/common/stm32l5xx/hal/Src/stm32l5xx_hal_flash.c
@@ -411,76 +411,132 @@ __weak void HAL_FLASH_OperationErrorCallback(uint32_t ReturnValue)
   */
 
 /**
-  * @brief  Unlock the FLASH control register access.
+  * @brief  Unlock the non-secure FLASH control registers access
+  * @retval HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASH_Unlock_NS(void)
+{
+  HAL_StatusTypeDef status = HAL_ERROR;
+
+  if (READ_BIT(FLASH->NSCR, FLASH_NSCR_NSLOCK) != 0U)
+  {
+    /* Authorize the FLASH Control Register access */
+    WRITE_REG(FLASH->NSKEYR, FLASH_KEY1);
+    WRITE_REG(FLASH->NSKEYR, FLASH_KEY2);
+
+    /* Verify Flash CR is unlocked */
+    if (READ_BIT(FLASH->NSCR, FLASH_NSCR_NSLOCK) == 0U)
+    {
+      status = HAL_OK;
+    }
+  }
+
+  return status;
+}
+
+/**
+  * @brief  Unlock the secure FLASH control registers access
+  * @retval HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASH_Unlock_SEC(void)
+{
+  HAL_StatusTypeDef status = HAL_ERROR;
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  if (READ_BIT(FLASH->SECCR, FLASH_SECCR_SECLOCK) != 0U)
+  {
+    /* Authorize the FLASH Control Register access */
+    WRITE_REG(FLASH->SECKEYR, FLASH_KEY1);
+    WRITE_REG(FLASH->SECKEYR, FLASH_KEY2);
+
+    /* verify Flash CR is unlocked */
+    if (READ_BIT(FLASH->SECCR, FLASH_SECCR_SECLOCK) == 0U)
+    {
+      status = HAL_OK;
+    }
+  }
+#endif /* __ARM_FEATURE_CMSE && __ARM_FEATURE_CMSE == 3U */
+
+  return status;
+}
+
+/**
+  * @brief  Unlock the FLASH control registers access
   * @retval HAL Status
   */
 HAL_StatusTypeDef HAL_FLASH_Unlock(void)
 {
   HAL_StatusTypeDef status = HAL_OK;
 
-  if(READ_BIT(FLASH->NSCR, FLASH_NSCR_NSLOCK) != 0u)
-  {
-    /* Authorize the FLASH Registers access */
-    WRITE_REG(FLASH->NSKEYR, FLASH_KEY1);
-    WRITE_REG(FLASH->NSKEYR, FLASH_KEY2);
-
-    /* verify Flash is unlocked */
-    if (READ_BIT(FLASH->NSCR, FLASH_NSCR_NSLOCK) != 0u)
-    {
-      status = HAL_ERROR;
-    }
-  }
+  status = HAL_FLASH_Unlock_NS();
 
 #if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
-  if (status == HAL_OK)
-  {
-    if(READ_BIT(FLASH->SECCR, FLASH_SECCR_SECLOCK) != 0u)
-    {
-      /* Authorize the FLASH Registers access */
-      WRITE_REG(FLASH->SECKEYR, FLASH_KEY1);
-      WRITE_REG(FLASH->SECKEYR, FLASH_KEY2);
-
-      /* verify Flash is unlocked */
-      if (READ_BIT(FLASH->SECCR, FLASH_SECCR_SECLOCK) != 0u)
-      {
-        status = HAL_ERROR;
-      }
-    }
+  if (status == HAL_OK) {
+    status = HAL_FLASH_Unlock_SEC();
   }
-#endif
+#endif /* __ARM_FEATURE_CMSE && __ARM_FEATURE_CMSE == 3U */
 
   return status;
 }
 
 /**
-  * @brief  Lock the FLASH control register access.
+  * @brief  Locks the non-secure FLASH control registers access
   * @retval HAL Status
   */
-HAL_StatusTypeDef HAL_FLASH_Lock(void)
+HAL_StatusTypeDef HAL_FLASH_Lock_NS(void)
 {
   HAL_StatusTypeDef status = HAL_ERROR;
 
-  /* Set the LOCK Bit to lock the FLASH Registers access */
+  /* Set the LOCK Bit to lock the FLASH Control Register access */
   SET_BIT(FLASH->NSCR, FLASH_NSCR_NSLOCK);
 
-  /* verify Flash is locked */
-  if (READ_BIT(FLASH->NSCR, FLASH_NSCR_NSLOCK) != 0u)
+  /* Verify Flash is locked */
+  if (READ_BIT(FLASH->NSCR, FLASH_NSCR_NSLOCK) != 0U)
   {
     status = HAL_OK;
   }
 
-#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
-  if (status == HAL_OK)
-  {
-    SET_BIT(FLASH->SECCR, FLASH_SECCR_SECLOCK);
+  return status;
+}
 
-    /* verify Flash is locked */
-    if (READ_BIT(FLASH->SECCR, FLASH_SECCR_SECLOCK) != 0u)
-    {
-      status = HAL_OK;
-    }
+
+/**
+  * @brief  Locks the secure FLASH control registers access
+  * @retval HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASH_Lock_SEC(void)
+{
+  HAL_StatusTypeDef status = HAL_ERROR;
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  /* Set the LOCK Bit to lock the FLASH Control Register access */
+  SET_BIT(FLASH->SECCR, FLASH_SECCR_SECLOCK);
+
+  /* verify Flash is locked */
+  if (READ_BIT(FLASH->SECCR, FLASH_SECCR_SECLOCK) != 0U)
+  {
+    status = HAL_OK;
   }
-#endif
+#endif /* __ARM_FEATURE_CMSE && __ARM_FEATURE_CMSE == 3U */
+
+  return status;
+}
+
+/**
+  * @brief  Locks the FLASH control registers access
+  * @retval HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASH_Lock(void)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  status = HAL_FLASH_Lock_NS();
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  if (status == HAL_OK) {
+    status = HAL_FLASH_Lock_SEC();
+  }
+#endif /* __ARM_FEATURE_CMSE && __ARM_FEATURE_CMSE == 3U */
 
   return status;
 }

--- a/platform/ext/target/stm/common/stm32u5xx/hal/Inc/stm32u5xx_hal_flash.h
+++ b/platform/ext/target/stm/common/stm32u5xx/hal/Inc/stm32u5xx_hal_flash.h
@@ -902,6 +902,10 @@ void               HAL_FLASH_OperationErrorCallback(uint32_t ReturnValue);
 /** @addtogroup FLASH_Exported_Functions_Group2
   * @{
   */
+HAL_StatusTypeDef  HAL_FLASH_Unlock_NS(void);
+HAL_StatusTypeDef  HAL_FLASH_Unlock_SEC(void);
+HAL_StatusTypeDef  HAL_FLASH_Lock_NS(void);
+HAL_StatusTypeDef  HAL_FLASH_Lock_SEC(void);
 HAL_StatusTypeDef  HAL_FLASH_Unlock(void);
 HAL_StatusTypeDef  HAL_FLASH_Lock(void);
 /* Option bytes control */

--- a/platform/ext/target/stm/common/stm32u5xx/hal/Src/stm32u5xx_hal_flash.c
+++ b/platform/ext/target/stm/common/stm32u5xx/hal/Src/stm32u5xx_hal_flash.c
@@ -440,76 +440,132 @@ __weak void HAL_FLASH_OperationErrorCallback(uint32_t ReturnValue)
   */
 
 /**
-  * @brief  Unlock the FLASH control register access.
+  * @brief  Unlock the non-secure FLASH control registers access
+  * @retval HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASH_Unlock_NS(void)
+{
+  HAL_StatusTypeDef status = HAL_ERROR;
+
+  if (READ_BIT(FLASH->NSCR, FLASH_NSCR_LOCK) != 0U)
+  {
+    /* Authorize the FLASH Control Register access */
+    WRITE_REG(FLASH->NSKEYR, FLASH_KEY1);
+    WRITE_REG(FLASH->NSKEYR, FLASH_KEY2);
+
+    /* Verify Flash CR is unlocked */
+    if (READ_BIT(FLASH->NSCR, FLASH_NSCR_LOCK) == 0U)
+    {
+      status = HAL_OK;
+    }
+  }
+
+  return status;
+}
+
+/**
+  * @brief  Unlock the secure FLASH control registers access
+  * @retval HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASH_Unlock_SEC(void)
+{
+  HAL_StatusTypeDef status = HAL_ERROR;
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  if (READ_BIT(FLASH->SECCR, FLASH_SECCR_LOCK) != 0U)
+  {
+    /* Authorize the FLASH Control Register access */
+    WRITE_REG(FLASH->SECKEYR, FLASH_KEY1);
+    WRITE_REG(FLASH->SECKEYR, FLASH_KEY2);
+
+    /* verify Flash CR is unlocked */
+    if (READ_BIT(FLASH->SECCR, FLASH_SECCR_LOCK) == 0U)
+    {
+      status = HAL_OK;
+    }
+  }
+#endif /* __ARM_FEATURE_CMSE && __ARM_FEATURE_CMSE == 3U */
+
+  return status;
+}
+
+/**
+  * @brief  Unlock the FLASH control registers access
   * @retval HAL Status
   */
 HAL_StatusTypeDef HAL_FLASH_Unlock(void)
 {
   HAL_StatusTypeDef status = HAL_OK;
 
-  if (READ_BIT(FLASH->NSCR, FLASH_NSCR_LOCK) != 0U)
-  {
-    /* Authorize the FLASH Registers access */
-    WRITE_REG(FLASH->NSKEYR, FLASH_KEY1);
-    WRITE_REG(FLASH->NSKEYR, FLASH_KEY2);
-
-    /* verify Flash is unlocked */
-    if (READ_BIT(FLASH->NSCR, FLASH_NSCR_LOCK) != 0U)
-    {
-      status = HAL_ERROR;
-    }
-  }
+  status = HAL_FLASH_Unlock_NS();
 
 #if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
-  if (status == HAL_OK)
-  {
-    if (READ_BIT(FLASH->SECCR, FLASH_SECCR_LOCK) != 0U)
-    {
-      /* Authorize the FLASH Registers access */
-      WRITE_REG(FLASH->SECKEYR, FLASH_KEY1);
-      WRITE_REG(FLASH->SECKEYR, FLASH_KEY2);
-
-      /* verify Flash is unlocked */
-      if (READ_BIT(FLASH->SECCR, FLASH_SECCR_LOCK) != 0U)
-      {
-        status = HAL_ERROR;
-      }
-    }
+  if (status == HAL_OK) {
+    status = HAL_FLASH_Unlock_SEC();
   }
-#endif /* __ARM_FEATURE_CMSE */
+#endif /* __ARM_FEATURE_CMSE && __ARM_FEATURE_CMSE == 3U */
 
   return status;
 }
 
 /**
-  * @brief  Lock the FLASH control register access.
+  * @brief  Locks the non-secure FLASH control registers access
   * @retval HAL Status
   */
-HAL_StatusTypeDef HAL_FLASH_Lock(void)
+HAL_StatusTypeDef HAL_FLASH_Lock_NS(void)
 {
   HAL_StatusTypeDef status = HAL_ERROR;
 
-  /* Set the LOCK Bit to lock the FLASH Registers access */
+  /* Set the LOCK Bit to lock the FLASH Control Register access */
   SET_BIT(FLASH->NSCR, FLASH_NSCR_LOCK);
 
-  /* verify Flash is locked */
+  /* Verify Flash is locked */
   if (READ_BIT(FLASH->NSCR, FLASH_NSCR_LOCK) != 0U)
   {
     status = HAL_OK;
   }
 
-#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
-  if (status == HAL_OK)
-  {
-    SET_BIT(FLASH->SECCR, FLASH_SECCR_LOCK);
+  return status;
+}
 
-    /* verify Flash is locked */
-    if (READ_BIT(FLASH->SECCR, FLASH_SECCR_LOCK) != 0U)
-    {
-      status = HAL_OK;
-    }
+
+/**
+  * @brief  Locks the secure FLASH control registers access
+  * @retval HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASH_Lock_SEC(void)
+{
+  HAL_StatusTypeDef status = HAL_ERROR;
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  /* Set the LOCK Bit to lock the FLASH Control Register access */
+  SET_BIT(FLASH->SECCR, FLASH_SECCR_LOCK);
+
+  /* verify Flash is locked */
+  if (READ_BIT(FLASH->SECCR, FLASH_SECCR_LOCK) != 0U)
+  {
+    status = HAL_OK;
   }
-#endif /* __ARM_FEATURE_CMSE */
+#endif /* __ARM_FEATURE_CMSE && __ARM_FEATURE_CMSE == 3U */
+
+  return status;
+}
+
+/**
+  * @brief  Locks the FLASH control registers access
+  * @retval HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASH_Lock(void)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  status = HAL_FLASH_Lock_NS();
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  if (status == HAL_OK) {
+    status = HAL_FLASH_Lock_SEC();
+  }
+#endif /* __ARM_FEATURE_CMSE && __ARM_FEATURE_CMSE == 3U */
 
   return status;
 }

--- a/platform/ext/target/stm/common/stm32wbaxx/hal/Inc/stm32wbaxx_hal_flash.h
+++ b/platform/ext/target/stm/common/stm32wbaxx/hal/Inc/stm32wbaxx_hal_flash.h
@@ -1031,6 +1031,10 @@ void               HAL_FLASH_OperationErrorCallback(uint32_t ReturnValue);
 /** @addtogroup FLASH_Exported_Functions_Group2
   * @{
   */
+HAL_StatusTypeDef  HAL_FLASH_Unlock_NS(void);
+HAL_StatusTypeDef  HAL_FLASH_Unlock_SEC(void);
+HAL_StatusTypeDef  HAL_FLASH_Lock_NS(void);
+HAL_StatusTypeDef  HAL_FLASH_Lock_SEC(void);
 HAL_StatusTypeDef  HAL_FLASH_Unlock(void);
 HAL_StatusTypeDef  HAL_FLASH_Lock(void);
 /* Option bytes control */


### PR DESCRIPTION
Backport (cherry-pick) now merged change to address STM32 non-secure flash locking issue reported by https://github.com/zephyrproject-rtos/zephyr/issues/102189 for STM32L5 but also applicable to U3, U5 and WBA6 targets.