### PR TITLE
[zep fromtree dirty] align TF-M to nrfx 4.1

### DIFF
--- a/platform/ext/target/nordic_nrf/common/core/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/core/CMakeLists.txt
@@ -26,13 +26,13 @@ endif()
 # hardcode this information here instead.
 if((NRF_SOC_VARIANT MATCHES "^nrf54l1[05]$") OR
    (NRF_SOC_VARIANT MATCHES "^nrf54lv10a?$") OR
-   (NRF_SOC_VARIANT MATCHES "^nrf54lm20a?$") OR
+   (NRF_SOC_VARIANT MATCHES "^nrf54lm20[ab]?$") OR
    (TFM_PLATFORM MATCHES "nordic_nrf/nrf54l15dk_nrf54l1[05]_cpuapp") OR
    (TFM_PLATFORM MATCHES "nordic_nrf/nrf54lv10dk_nrf54lv10a?_cpuapp") OR
-   (TFM_PLATFORM MATCHES "nordic_nrf/nrf54lm20dk_nrf54lm20a?_cpuapp") OR
+   (TFM_PLATFORM MATCHES "nordic_nrf/nrf54lm20dk_nrf54lm20[ab]?_cpuapp") OR
    (PSA_API_TEST_TARGET MATCHES "^nrf54l1[05]$") OR
    (PSA_API_TEST_TARGET MATCHES "^nrf54lv10a?$") OR
-   (PSA_API_TEST_TARGET MATCHES "^nrf54lm20a?$"))
+   (PSA_API_TEST_TARGET MATCHES "^nrf54lm20[ab]?$"))
   # Maybe we only need to check one of these options but these
   # variables keep changing so we check both to be future proof
   set(HAS_RRAMC 1)
@@ -236,8 +236,8 @@ if((NRF_SOC_VARIANT MATCHES "^nrf54l1[05]$") OR
    (TFM_PLATFORM MATCHES "nordic_nrf/nrf54l15dk_nrf54l1[05]_cpuapp"))
     # nrf54l10 and nrf54l15 share the same startup file
     set(startup_file "startup_nrf54lx.c")
-elseif((NRF_SOC_VARIANT MATCHES "^nrf54lm20a?$") OR
-       (TFM_PLATFORM MATCHES "nordic_nrf/nrf54lm20dk_nrf54lm20a?_cpuapp"))
+elseif((NRF_SOC_VARIANT MATCHES "^nrf54lm20[ab]?$") OR
+       (TFM_PLATFORM MATCHES "nordic_nrf/nrf54lm20dk_nrf54lm20[ab]?_cpuapp"))
     # nrf54lm20 has its own startup file
     set(startup_file "startup_nrf54lm.c")
 elseif((NRF_SOC_VARIANT MATCHES "^nrf54lv10a?$") OR

--- a/platform/ext/target/nordic_nrf/common/core/target_cfg_54l.c
+++ b/platform/ext/target/nordic_nrf/common/core/target_cfg_54l.c
@@ -57,7 +57,7 @@
 /* On nRF54LV10A XL1 and XL2 are(P1.13) and XL2(P1.14) */
 #define PIN_XL1 45
 #define PIN_XL2 46
-#elif defined(NRF54LM20A_ENGA_XXAA)
+#elif defined(NRF54LM20A_ENGA_XXAA) || defined(NRF54LM20B_XXAA)
 /* On nRF54LM20A XL1 and XL2 are(P1.13) and XL2(P1.14) */
 #define PIN_XL1 45
 #define PIN_XL2 46
@@ -65,7 +65,7 @@
 /* On nRF54L15 XL1 and XL2 are(P1.00) and XL2(P1.01) */
 #define PIN_XL1 32
 #define PIN_XL2 33
-#endif /* SOC_NRF54LV10A_ENGA || SOC_NRF54LM20A_ENGA */
+#endif /* SOC_NRF54LV10A_ENGA || SOC_NRF54LM20A_ENGA || SOC_NRF54LM20B */
 
 /* During TF-M system initialization we invoke a function that comes
  * from Zephyr. This function does not have a header file so we

--- a/platform/ext/target/nordic_nrf/common/core/target_cfg_54l.c
+++ b/platform/ext/target/nordic_nrf/common/core/target_cfg_54l.c
@@ -53,11 +53,11 @@
 #define GET_SPU_INSTANCE(periph)                                                                   \
 	((NRF_SPU_Type *)(SPU_ADDRESS_REGION | (periph.periph_start & 0x00FC0000)))
 
-#if defined(NRF54LV10A_ENGA_XXAA)
+#if defined(NRF54LV10A_XXAA)
 /* On nRF54LV10A XL1 and XL2 are(P1.13) and XL2(P1.14) */
 #define PIN_XL1 45
 #define PIN_XL2 46
-#elif defined(NRF54LM20A_ENGA_XXAA) || defined(NRF54LM20B_XXAA)
+#elif defined(NRF54LM20A_XXAA) || defined(NRF54LM20B_XXAA)
 /* On nRF54LM20A XL1 and XL2 are(P1.13) and XL2(P1.14) */
 #define PIN_XL1 45
 #define PIN_XL2 46
@@ -65,7 +65,7 @@
 /* On nRF54L15 XL1 and XL2 are(P1.00) and XL2(P1.01) */
 #define PIN_XL1 32
 #define PIN_XL2 33
-#endif /* SOC_NRF54LV10A_ENGA || SOC_NRF54LM20A_ENGA || SOC_NRF54LM20B */
+#endif /* SOC_NRF54LV10A || SOC_NRF54LM20A || SOC_NRF54LM20B */
 
 /* During TF-M system initialization we invoke a function that comes
  * from Zephyr. This function does not have a header file so we

--- a/platform/ext/target/nordic_nrf/common/core/target_cfg_71.c
+++ b/platform/ext/target/nordic_nrf/common/core/target_cfg_71.c
@@ -111,7 +111,7 @@ static void init_mpc_region_override(struct mpc_region_override *override)
 	override->permmask = MPC_OVERRIDE_PERM_SECATTR_Msk;
 }
 
-static nrfx_err_t mramc_configuration(void)
+static int mramc_configuration(void)
 {
 	nrfx_mramc_config_t config = NRFX_MRAMC_DEFAULT_CONFIG();
 
@@ -122,12 +122,12 @@ static nrfx_err_t mramc_configuration(void)
 	 */
 	nrfx_mramc_evt_handler_t handler = NULL;
 
-	nrfx_err_t err = nrfx_mramc_init(&config, handler);
-	if (err != NRFX_SUCCESS && err != NRFX_ERROR_ALREADY) {
+	int err = nrfx_mramc_init(&config, handler);
+	if (err != 0 && err != -EALREADY) {
 		return err;
 	}
 
-	return NRFX_SUCCESS;
+	return 0;
 }
 
 enum tfm_plat_err_t init_debug(void)
@@ -433,8 +433,8 @@ enum tfm_plat_err_t spu_periph_init_cfg(void)
 
 	nrf_cache_enable(NRF_ICACHE);
 
-	nrfx_err_t nrfx_err = mramc_configuration();
-	if (nrfx_err != NRFX_SUCCESS) {
+	int nrfx_err = mramc_configuration();
+	if (nrfx_err != 0) {
 		return TFM_PLAT_ERR_SYSTEM_ERR;
 	}
 

--- a/platform/ext/target/nordic_nrf/common/nrf54lm20a/cpuarch.cmake
+++ b/platform/ext/target/nordic_nrf/common/nrf54lm20a/cpuarch.cmake
@@ -15,7 +15,7 @@ set(TFM_SYSTEM_ARCHITECTURE armv8-m.main)
 set(CONFIG_TFM_FP_ARCH "fpv5-sp-d16")
 
 add_compile_definitions(
-  NRF54LM20A_ENGA_XXAA
+  NRF54LM20A_XXAA
   NRF54L_SERIES
   NRF_APPLICATION
   # SKIP configuring the SAU from the MDK as it does not fit TF-M's needs

--- a/platform/ext/target/nordic_nrf/common/nrf54lm20b/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/nrf54lm20b/CMakeLists.txt
@@ -1,0 +1,58 @@
+#-------------------------------------------------------------------------------
+# Copyright (c) 2020-2022, Arm Limited. All rights reserved.
+# Copyright (c) 2020, Nordic Semiconductor ASA.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+#-------------------------------------------------------------------------------
+cmake_policy(SET CMP0076 NEW)
+set(CMAKE_CURRENT_SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR})
+
+set(target nrf54l)
+add_subdirectory(../core nrf_common)
+
+#========================= Platform Secure ====================================#
+
+target_include_directories(platform_s
+    PUBLIC
+        .
+	../nrf54l
+)
+
+if(NOT NRF_DIR)
+    target_include_directories(platform_s
+        PUBLIC
+            memory_service_ranges
+)
+endif()
+
+target_sources(platform_s
+    PRIVATE
+        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/system_nrf54l.c
+        ../nrf54l/nrf54l_init.c
+)
+
+target_compile_definitions(platform_s
+    PUBLIC
+        NRF_SKIP_FICR_NS_COPY_TO_RAM
+)
+
+#========================= tfm_spm ============================================#
+
+target_sources(tfm_spm
+    PRIVATE
+        $<$<OR:$<BOOL:${CONFIG_TFM_FLIH_API}>,$<BOOL:${CONFIG_TFM_SLIH_API}>>:${CMAKE_CURRENT_SOURCE_DIR}/../nrf54l/tfm_interrupts.c>
+)
+
+#========================= Files for building NS side platform ================#
+
+install(FILES       ../nrf54l/config.cmake
+                    ns/CMakeLists.txt
+                    cpuarch.cmake
+        DESTINATION ${INSTALL_PLATFORM_NS_DIR}/common/nrf54lm20b
+)
+
+install(DIRECTORY    partition
+                     tests
+        DESTINATION  ${INSTALL_PLATFORM_NS_DIR}/common/nrf54lm20b
+)

--- a/platform/ext/target/nordic_nrf/common/nrf54lm20b/config.cmake
+++ b/platform/ext/target/nordic_nrf/common/nrf54lm20b/config.cmake
@@ -1,0 +1,12 @@
+#-------------------------------------------------------------------------------
+# Copyright (c) 2020, Nordic Semiconductor ASA.
+# Copyright (c) 2020-2023, Arm Limited. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+#-------------------------------------------------------------------------------
+
+include(${PLATFORM_PATH}/common/nrf54l/config.cmake)
+
+# Override UART instance for nRF54LM20B - it uses UART30, not UART20
+set(NRF_SECURE_UART_INSTANCE            30         CACHE STRING    "The UART instance number to use for secure UART" FORCE)

--- a/platform/ext/target/nordic_nrf/common/nrf54lm20b/cpuarch.cmake
+++ b/platform/ext/target/nordic_nrf/common/nrf54lm20b/cpuarch.cmake
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2023, Nordic Semiconductor ASA.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# cpuarch.cmake is used to set things that related to the platform that are both
+# immutable and global, which is to say they should apply to any kind of project
+# that uses this platform. In practice this is normally compiler definitions and
+# variables related to hardware.
+
+# Set architecture and CPU
+set(TFM_SYSTEM_PROCESSOR cortex-m33)
+set(TFM_SYSTEM_ARCHITECTURE armv8-m.main)
+set(CONFIG_TFM_FP_ARCH "fpv5-sp-d16")
+
+add_compile_definitions(
+  NRF54LM20B_XXAA
+  NRF54L_SERIES
+  NRF_APPLICATION
+  # SKIP configuring the SAU from the MDK as it does not fit TF-M's needs
+  NRF_SKIP_SAU_CONFIGURATION
+  NRF_SKIP_FICR_NS_COPY_TO_RAM
+)

--- a/platform/ext/target/nordic_nrf/common/nrf54lm20b/memory_service_ranges/tfm_platform_user_memory_ranges.h
+++ b/platform/ext/target/nordic_nrf/common/nrf54lm20b/memory_service_ranges/tfm_platform_user_memory_ranges.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef TFM_PLATFORM_USER_MEMORY_RANGES_H__
+#define TFM_PLATFORM_USER_MEMORY_RANGES_H__
+
+#include <tfm_ioctl_core_api.h>
+
+#include <nrfx.h>
+
+
+static const struct tfm_read_service_range ranges[] = {
+	{ .start = 0xFFFFFFFF, .size = 0x0},
+};
+
+static const struct tfm_write32_service_address tfm_write32_service_addresses[] = {
+	/* This is a dummy value because this table cannot be empty */
+	{.addr = 0xFFFFFFFF, .mask = 0x0, .allowed_values = NULL, .allowed_values_array_size = 0},
+};
+
+#endif /* TFM_PLATFORM_USER_MEMORY_RANGES_H__ */

--- a/platform/ext/target/nordic_nrf/common/nrf54lm20b/ns/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/nrf54lm20b/ns/CMakeLists.txt
@@ -1,0 +1,29 @@
+#-------------------------------------------------------------------------------
+# Copyright (c) 2023, Arm Limited. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+#-------------------------------------------------------------------------------
+
+cmake_policy(SET CMP0076 NEW)
+set(CMAKE_CURRENT_SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR})
+
+set(target nrf54l)
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../core nrf_common)
+
+target_include_directories(platform_ns
+    PUBLIC
+        ${CMAKE_CURRENT_LIST_DIR}
+)
+
+target_sources(platform_ns
+    PRIVATE
+        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/system_nrf54l.c
+)
+
+target_compile_definitions(platform_ns
+    PUBLIC
+        NRF_TRUSTZONE_NONSECURE
+        NRF_SKIP_CLOCK_CONFIGURATION
+        DOMAIN_NS=1
+)

--- a/platform/ext/target/nordic_nrf/common/nrf54lm20b/partition/flash_layout.h
+++ b/platform/ext/target/nordic_nrf/common/nrf54lm20b/partition/flash_layout.h
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __FLASH_LAYOUT_H__
+#define __FLASH_LAYOUT_H__
+
+#ifdef BL2
+#error "BL2 is not supported for this platform"
+#endif
+
+/* Flash layout on NRF54LM20A Application MCU without BL2:
+ *
+ * 0x0000_0000 Secure image primary (512 KB)
+ * 0x0008_0000 Protected Storage Area (16 KB)
+ * 0x0008_4000 Internal Trusted Storage Area (16 KB)
+ * 0x0008_8000 OTP / NV counters area (8 KB)
+ * 0x0008_A000 Non-secure image primary (1452 KB)
+ * 0x001F_5000 Non-secure storage, used when built with NRF_NS_STORAGE=ON,
+ *             otherwise unused (32 KB)
+ */
+
+/* This header file is included from linker scatter file as well, where only a
+ * limited C constructs are allowed. Therefore it is not possible to include
+ * here the platform_base_address.h to access flash related defines. To resolve
+ * this some of the values are redefined here with different names, these are
+ * marked with comment.
+ */
+
+/* Use Flash memory to store Code data */
+#define FLASH_BASE_ADDRESS                  (0x0)
+
+/* nRF54LM20A has 2036 kB of non volatile memory (RRAM) */
+#define FLASH_TOTAL_SIZE                    (0x1FD000)
+#define TOTAL_ROM_SIZE                       FLASH_TOTAL_SIZE
+
+/* nRF54LM20A has 512 kB of volatile memory (SRAM) */
+#define SRAM_BASE_ADDRESS                   (0x20000000)
+#define TOTAL_RAM_SIZE                      (0x00080000)
+
+#define FLASH_S_PARTITION_SIZE                (0x80000)       /* S partition: 512 kB*/
+#define FLASH_NS_PARTITION_SIZE               (0x16B000)      /* NS partition: 1452 kB*/
+
+#define S_ROM_ALIAS_BASE   FLASH_BASE_ADDRESS
+#define NS_ROM_ALIAS_BASE  FLASH_BASE_ADDRESS
+
+/* Use SRAM memory to store RW data */
+#define S_RAM_ALIAS_BASE  SRAM_BASE_ADDRESS
+#define NS_RAM_ALIAS_BASE SRAM_BASE_ADDRESS
+
+/* Sector size of the embedded flash hardware (erase/program) */
+#define FLASH_AREA_IMAGE_SECTOR_SIZE        (0x1000)           /* 4 KB. Flash memory program/erase operations have a page granularity. */
+
+#if (FLASH_S_PARTITION_SIZE > FLASH_NS_PARTITION_SIZE)
+#define FLASH_MAX_PARTITION_SIZE FLASH_S_PARTITION_SIZE
+#else
+#define FLASH_MAX_PARTITION_SIZE FLASH_NS_PARTITION_SIZE
+#endif
+
+/* Offset and size definition in flash area used by assemble.py */
+#define SECURE_IMAGE_MAX_SIZE           FLASH_S_PARTITION_SIZE
+#define NON_SECURE_IMAGE_MAX_SIZE       FLASH_NS_PARTITION_SIZE
+
+#define SECURE_STORAGE_PARTITIONS_START       (FLASH_BASE_ADDRESS + FLASH_S_PARTITION_SIZE)
+
+/* Protected Storage (PS) Service definitions */
+#define FLASH_PS_AREA_OFFSET            (SECURE_STORAGE_PARTITIONS_START)
+#define FLASH_PS_AREA_SIZE              (0x4000)   /* 16 KB */
+
+/* Internal Trusted Storage (ITS) Service definitions */
+#define FLASH_ITS_AREA_OFFSET           (FLASH_PS_AREA_OFFSET + FLASH_PS_AREA_SIZE)
+#define FLASH_ITS_AREA_SIZE             (0x4000)   /* 16 KB */
+
+/* OTP_definitions */
+#define FLASH_OTP_NV_COUNTERS_AREA_OFFSET (FLASH_ITS_AREA_OFFSET + FLASH_ITS_AREA_SIZE)
+#define FLASH_OTP_NV_COUNTERS_AREA_SIZE   (0x2000) /* 8KB */
+
+#define FLASH_OTP_NV_COUNTERS_SECTOR_SIZE FLASH_AREA_IMAGE_SECTOR_SIZE
+
+#define SECURE_STORAGE_PARTITIONS_END     (FLASH_OTP_NV_COUNTERS_AREA_OFFSET + FLASH_OTP_NV_COUNTERS_AREA_SIZE)
+/* END OF PARTITIONS LAYOUT */
+
+#define SECURE_IMAGE_OFFSET                   (0x0)
+#define NON_SECURE_IMAGE_OFFSET               (SECURE_STORAGE_PARTITIONS_END)
+
+/* Non-secure storage region */
+#define NRF_FLASH_NS_STORAGE_AREA_SIZE      (0x8000)   /* 32 KB */
+#define NRF_FLASH_NS_STORAGE_AREA_OFFSET    (FLASH_TOTAL_SIZE - \
+                                             NRF_FLASH_NS_STORAGE_AREA_SIZE)
+
+/* Flash device name used by BL2
+ * Name is defined in flash driver file: Driver_Flash.c
+ */
+//#define FLASH_DEV_NAME Driver_FLASH0
+/* Smallest flash programmable unit in bytes */
+#define TFM_HAL_FLASH_PROGRAM_UNIT       (0x4)
+
+/* Protected Storage (PS) Service definitions
+ * Note: Further documentation of these definitions can be found in the
+ * TF-M PS Integration Guide.
+ */
+#define TFM_HAL_PS_FLASH_DRIVER Driver_FLASH0
+
+/* In this target the CMSIS driver requires only the offset from the base
+ * address instead of the full memory address.
+ */
+/* Base address of dedicated flash area for PS */
+#define TFM_HAL_PS_FLASH_AREA_ADDR    FLASH_PS_AREA_OFFSET
+/* Size of dedicated flash area for PS */
+#define TFM_HAL_PS_FLASH_AREA_SIZE    FLASH_PS_AREA_SIZE
+#define PS_RAM_FS_SIZE                TFM_HAL_PS_FLASH_AREA_SIZE
+/* Number of physical erase sectors per logical FS block */
+#define TFM_HAL_PS_SECTORS_PER_BLOCK  (1)
+/* Smallest flash programmable unit in bytes */
+#define TFM_HAL_PS_PROGRAM_UNIT       (0x4)
+
+/* Internal Trusted Storage (ITS) Service definitions
+ * Note: Further documentation of these definitions can be found in the
+ * TF-M ITS Integration Guide. The ITS should be in the internal flash, but is
+ * allocated in the external flash just for development platforms that don't
+ * have internal flash available.
+ */
+#define TFM_HAL_ITS_FLASH_DRIVER Driver_FLASH0
+
+/* In this target the CMSIS driver requires only the offset from the base
+ * address instead of the full memory address.
+ */
+/* Base address of dedicated flash area for ITS */
+#define TFM_HAL_ITS_FLASH_AREA_ADDR    FLASH_ITS_AREA_OFFSET
+/* Size of dedicated flash area for ITS */
+#define TFM_HAL_ITS_FLASH_AREA_SIZE    FLASH_ITS_AREA_SIZE
+#define ITS_RAM_FS_SIZE                TFM_HAL_ITS_FLASH_AREA_SIZE
+/* Number of physical erase sectors per logical FS block */
+#define TFM_HAL_ITS_SECTORS_PER_BLOCK  (1)
+/* Smallest flash programmable unit in bytes */
+#define TFM_HAL_ITS_PROGRAM_UNIT       (0x4)
+
+/* OTP / NV counter definitions */
+#define TFM_OTP_NV_COUNTERS_AREA_SIZE   (FLASH_OTP_NV_COUNTERS_AREA_SIZE / 2)
+#define TFM_OTP_NV_COUNTERS_AREA_ADDR   FLASH_OTP_NV_COUNTERS_AREA_OFFSET
+#define TFM_OTP_NV_COUNTERS_SECTOR_SIZE FLASH_OTP_NV_COUNTERS_SECTOR_SIZE
+#define TFM_OTP_NV_COUNTERS_BACKUP_AREA_ADDR (TFM_OTP_NV_COUNTERS_AREA_ADDR + \
+                                              TFM_OTP_NV_COUNTERS_AREA_SIZE)
+
+
+#endif /* __FLASH_LAYOUT_H__ */

--- a/platform/ext/target/nordic_nrf/common/nrf54lm20b/partition/region_defs.h
+++ b/platform/ext/target/nordic_nrf/common/nrf54lm20b/partition/region_defs.h
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __REGION_DEFS_H__
+#define __REGION_DEFS_H__
+
+#include "flash_layout.h"
+
+#ifdef ENABLE_HEAP
+    #define S_HEAP_SIZE         (0x0002000) /* 8k */
+#endif
+
+#define S_MSP_STACK_SIZE        (0x0002000) /* 8k */
+#define S_PSP_STACK_SIZE        (0x0002000) /* 8k */
+
+#define NS_HEAP_SIZE            (0x00002000) /* 8k */
+#define NS_STACK_SIZE           (0x00002000) /* 8k */
+
+/* Size of nRF MPC regions is 4k */
+#define MPC_FLASH_REGION_SIZE   (0x00001000)
+#define MPC_SRAM_REGION_SIZE    (0x00001000)
+
+#ifdef NRF_NS_SECONDARY
+#error "NRF_NS_SECONDARY is not supported for this platform"
+#endif /* NRF_NS_SECONDARY */
+
+/* Alias definitions for secure and non-secure areas*/
+#define S_ROM_ALIAS(x)  (S_ROM_ALIAS_BASE + (x))
+#define NS_ROM_ALIAS(x) (NS_ROM_ALIAS_BASE + (x))
+
+#define S_RAM_ALIAS(x)  (S_RAM_ALIAS_BASE + (x))
+#define NS_RAM_ALIAS(x) (NS_RAM_ALIAS_BASE + (x))
+
+/* Secure regions */
+#define S_CODE_START    (S_ROM_ALIAS(SECURE_IMAGE_OFFSET))
+#define S_CODE_SIZE     (FLASH_S_PARTITION_SIZE)
+#define S_CODE_LIMIT    (S_CODE_START + S_CODE_SIZE - 1)
+
+#define S_DATA_START    (S_RAM_ALIAS(0x0))
+#define S_DATA_SIZE     (TOTAL_RAM_SIZE / 2)
+#define S_DATA_LIMIT    (S_DATA_START + S_DATA_SIZE - 1)
+
+/* Copied from the CONFIG_TFM_S_CODE_VECTOR_TABLE_SIZE in sdk-nrf */
+#define S_CODE_VECTOR_TABLE_SIZE (0x4D0)
+
+#if defined(NULL_POINTER_EXCEPTION_DETECTION) && S_CODE_START == 0
+/* If this image is placed at the beginning of flash make sure we
+ * don't put any code in the first 256 bytes of flash as that area
+ * is used for null-pointer dereference detection.
+ */
+#define TFM_LINKER_CODE_START_RESERVED (256)
+#if S_CODE_VECTOR_TABLE_SIZE < TFM_LINKER_CODE_START_RESERVED
+#error "The interrupt table is too short too for null pointer detection"
+#endif
+#endif
+
+/* Non-secure regions */
+#define NS_CODE_START   (NS_ROM_ALIAS(SECURE_STORAGE_PARTITIONS_END))
+#define NS_CODE_SIZE    (FLASH_NS_PARTITION_SIZE)
+#define NS_CODE_LIMIT   (NS_CODE_START + NS_CODE_SIZE - 1)
+
+#define NS_DATA_START   (NS_RAM_ALIAS(S_DATA_SIZE))
+
+#ifdef PSA_API_TEST_IPC
+/* Last SRAM region must be kept secure for PSA FF tests */
+#define NS_DATA_SIZE    (TOTAL_RAM_SIZE - S_DATA_SIZE - MPC_SRAM_REGION_SIZE)
+#else
+#define NS_DATA_SIZE    (TOTAL_RAM_SIZE - S_DATA_SIZE)
+#endif
+#define NS_DATA_LIMIT   (NS_DATA_START + NS_DATA_SIZE - 1)
+
+/* NS partition information is used for SAU and MPC configuration */
+#define NS_PARTITION_START NS_CODE_START
+#define NS_PARTITION_SIZE (FLASH_NS_PARTITION_SIZE)
+
+/* Non-secure storage region */
+#ifdef NRF_NS_STORAGE
+#define NRF_NS_STORAGE_PARTITION_START \
+            (NS_ROM_ALIAS(NRF_FLASH_NS_STORAGE_AREA_OFFSET))
+#define NRF_NS_STORAGE_PARTITION_SIZE (NRF_FLASH_NS_STORAGE_AREA_SIZE)
+#endif /* NRF_NS_STORAGE */
+
+/* Regions used by psa-arch-tests to keep state */
+#define PSA_TEST_SCRATCH_AREA_SIZE (0x400)
+
+/* Even though BL2 is not supported now this needs to be defined becaused it is used by scatter files */
+#define BOOT_TFM_SHARED_DATA_BASE S_RAM_ALIAS_BASE
+#define BOOT_TFM_SHARED_DATA_SIZE (0x0)
+#define BOOT_TFM_SHARED_DATA_LIMIT (BOOT_TFM_SHARED_DATA_BASE + BOOT_TFM_SHARED_DATA_SIZE - 1)
+#define SHARED_BOOT_MEASUREMENT_BASE BOOT_TFM_SHARED_DATA_BASE
+#define SHARED_BOOT_MEASUREMENT_SIZE BOOT_TFM_SHARED_DATA_SIZE
+#define SHARED_BOOT_MEASUREMENT_LIMIT BOOT_TFM_SHARED_DATA_LIMIT
+
+#ifdef PSA_API_TEST_IPC
+/* Firmware Framework test suites */
+#define FF_TEST_PARTITION_SIZE 0x100
+#define PSA_TEST_SCRATCH_AREA_BASE (NS_DATA_LIMIT + 1 - \
+                                    PSA_TEST_SCRATCH_AREA_SIZE - \
+                                    FF_TEST_PARTITION_SIZE)
+
+/* The psa-arch-tests implementation requires that the test partitions are
+ * placed in this specific order:
+ * TEST_NSPE_MMIO < TEST_SERVER < TEST_DRIVER
+ *
+ * TEST_NSPE_MMIO region must be in the NSPE, while TEST_SERVER and TEST_DRIVER
+ * must be in SPE.
+ *
+ * The TEST_NSPE_MMIO region is defined in the psa-arch-tests implementation,
+ * and it should be placed at the end of the NSPE area, after
+ * PSA_TEST_SCRATCH_AREA.
+ */
+#define FF_TEST_SERVER_PARTITION_MMIO_START  (NS_DATA_LIMIT + 1)
+#define FF_TEST_SERVER_PARTITION_MMIO_END    (FF_TEST_SERVER_PARTITION_MMIO_START + \
+                                              FF_TEST_PARTITION_SIZE - 1)
+#define FF_TEST_DRIVER_PARTITION_MMIO_START  (FF_TEST_SERVER_PARTITION_MMIO_END + 1)
+#define FF_TEST_DRIVER_PARTITION_MMIO_END    (FF_TEST_DRIVER_PARTITION_MMIO_START + \
+                                              FF_TEST_PARTITION_SIZE - 1)
+#else
+/* Development APIs test suites */
+#define PSA_TEST_SCRATCH_AREA_BASE (NS_DATA_LIMIT + 1 - \
+                                    PSA_TEST_SCRATCH_AREA_SIZE)
+#endif /* PSA_API_TEST_IPC */
+
+#endif /* __REGION_DEFS_H__ */

--- a/platform/ext/target/nordic_nrf/common/nrf54lm20b/tests/psa_arch_tests_config.cmake
+++ b/platform/ext/target/nordic_nrf/common/nrf54lm20b/tests/psa_arch_tests_config.cmake
@@ -1,0 +1,9 @@
+#-------------------------------------------------------------------------------
+# Copyright (c) 2023, Arm Limited. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+#-------------------------------------------------------------------------------
+
+# Platform-specific configurations
+set(PSA_API_TEST_TARGET                 "nrf54lm20b")

--- a/platform/ext/target/nordic_nrf/common/nrf54lv10a/cpuarch.cmake
+++ b/platform/ext/target/nordic_nrf/common/nrf54lv10a/cpuarch.cmake
@@ -15,7 +15,7 @@ set(TFM_SYSTEM_ARCHITECTURE armv8-m.main)
 set(CONFIG_TFM_FP_ARCH "fpv5-sp-d16")
 
 add_compile_definitions(
-  NRF54LV10A_ENGA_XXAA
+  NRF54LV10A_XXAA
   NRF54L_SERIES
   NRF_APPLICATION
   # SKIP configuring the SAU from the MDK as it does not fit TF-M's needs

--- a/platform/ext/target/nordic_nrf/nrf54lm20dk_nrf54lm20b_cpuapp/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/nrf54lm20dk_nrf54lm20b_cpuapp/CMakeLists.txt
@@ -1,0 +1,60 @@
+#-------------------------------------------------------------------------------
+# Copyright (c) 2020, Nordic Semiconductor ASA.
+# Copyright (c) 2022, Arm Limited. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+#-------------------------------------------------------------------------------
+
+cmake_policy(SET CMP0076 NEW)
+set(CMAKE_CURRENT_SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR})
+set(NRF_BOARD_SELECTED True)
+
+add_subdirectory(../common/nrf54lm20b nrf54lm20b)
+
+target_include_directories(platform_region_defs
+    BEFORE INTERFACE
+        ../common/nrf54lm20b/partition
+)
+
+target_sources(platform_s
+    PRIVATE
+        $<$<BOOL:${TFM_PARTITION_PLATFORM}>:${CMAKE_CURRENT_SOURCE_DIR}/services/src/tfm_platform_system.c>
+)
+
+target_include_directories(platform_s
+    PUBLIC
+        .
+        ../common/nrf54lm20b/partition
+        services/include
+)
+
+#========================= tfm_spm ============================================#
+
+target_sources(tfm_spm
+    PRIVATE
+        tfm_hal_platform.c
+)
+
+#========================= Files for building NS side platform ================#
+
+install(FILES       ${CMAKE_CURRENT_LIST_DIR}/ns/cpuarch_ns.cmake
+        DESTINATION ${INSTALL_PLATFORM_NS_DIR}
+        RENAME      cpuarch.cmake)
+
+if (TFM_PARTITION_PLATFORM)
+    install(FILES       services/include/tfm_ioctl_api.h
+            DESTINATION ${INSTALL_INTERFACE_INC_DIR}
+)
+endif()
+
+install(FILES       RTE_Device.h
+                    device_cfg.h
+                    ns/CMakeLists.txt
+                    config.cmake
+        DESTINATION ${INSTALL_PLATFORM_NS_DIR}
+)
+
+install(DIRECTORY   tests
+        DESTINATION ${INSTALL_PLATFORM_NS_DIR}
+)

--- a/platform/ext/target/nordic_nrf/nrf54lm20dk_nrf54lm20b_cpuapp/RTE_Device.h
+++ b/platform/ext/target/nordic_nrf/nrf54lm20dk_nrf54lm20b_cpuapp/RTE_Device.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2019 Arm Limited. All rights reserved.
+ * Copyright (c) 2020 Nordic Semiconductor ASA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __RTE_DEVICE_H
+#define __RTE_DEVICE_H
+
+#define RTE_USART20 1
+
+#define RTE_USART20_PINS          \
+{                                 \
+        NRF_PSEL(UART_TX,  0, 36),\
+        NRF_PSEL(UART_RX,  0, 37),\
+        NRF_PSEL(UART_RTS, 0, 38),\
+        NRF_PSEL(UART_CTS, 0, 39),\
+}
+
+
+#define RTE_USART30 1
+
+#define RTE_USART30_PINS         \
+{                                \
+        NRF_PSEL(UART_TX,  0, 0),\
+        NRF_PSEL(UART_RX,  0, 1),\
+        NRF_PSEL(UART_RTS, 0, 2),\
+        NRF_PSEL(UART_CTS, 0, 3),\
+}
+
+
+#define RTE_FLASH0 1
+
+#endif  /* __RTE_DEVICE_H */

--- a/platform/ext/target/nordic_nrf/nrf54lm20dk_nrf54lm20b_cpuapp/config.cmake
+++ b/platform/ext/target/nordic_nrf/nrf54lm20dk_nrf54lm20b_cpuapp/config.cmake
@@ -1,0 +1,10 @@
+#-------------------------------------------------------------------------------
+# Copyright (c) 2025, Nordic Semiconductor ASA.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+#-------------------------------------------------------------------------------
+
+# This file is used by the upstream TF-M, the file in the common folder is used when
+# TF-M is build with upstream Zephyr.
+include(${PLATFORM_PATH}/common/nrf54lm20b/config.cmake)

--- a/platform/ext/target/nordic_nrf/nrf54lm20dk_nrf54lm20b_cpuapp/cpuarch.cmake
+++ b/platform/ext/target/nordic_nrf/nrf54lm20dk_nrf54lm20b_cpuapp/cpuarch.cmake
@@ -1,0 +1,10 @@
+#-------------------------------------------------------------------------------
+# Copyright (c) 2024, Nordic Semiconductor ASA.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+#-------------------------------------------------------------------------------
+
+set(PLATFORM_PATH platform/ext/target/${TFM_PLATFORM}/..)
+
+include(${PLATFORM_PATH}/common/nrf54lm20b/cpuarch.cmake)

--- a/platform/ext/target/nordic_nrf/nrf54lm20dk_nrf54lm20b_cpuapp/device_cfg.h
+++ b/platform/ext/target/nordic_nrf/nrf54lm20dk_nrf54lm20b_cpuapp/device_cfg.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2016-2019 ARM Limited
+ *
+ * Licensed under the Apache License Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ARM_LTD_DEVICE_CFG_H__
+#define __ARM_LTD_DEVICE_CFG_H__
+
+/**
+ * \file device_cfg.h
+ * \brief
+ * This is the default device configuration file with all peripherals
+ * defined and configured to be use via the secure and/or non-secure base
+ * address.
+ */
+
+#define DEFAULT_UART_CONTROL 0
+#define DEFAULT_UART_BAUDRATE  115200
+
+
+#endif /* __ARM_LTD_DEVICE_CFG_H__ */

--- a/platform/ext/target/nordic_nrf/nrf54lm20dk_nrf54lm20b_cpuapp/ns/cpuarch_ns.cmake
+++ b/platform/ext/target/nordic_nrf/nrf54lm20dk_nrf54lm20b_cpuapp/ns/cpuarch_ns.cmake
@@ -1,0 +1,13 @@
+#-------------------------------------------------------------------------------
+# Copyright (c) 2024, Nordic Semiconductor ASA.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+#-------------------------------------------------------------------------------
+
+set(PLATFORM_DIR  ${CMAKE_CURRENT_LIST_DIR})
+set(PLATFORM_PATH ${CMAKE_CURRENT_LIST_DIR})
+
+add_compile_definitions(NRF_CONFIG_CPU_FREQ_MHZ=128)
+
+include(${CMAKE_CURRENT_LIST_DIR}/common/nrf54lm20b/cpuarch.cmake)

--- a/platform/ext/target/nordic_nrf/nrf54lm20dk_nrf54lm20b_cpuapp/services/src/tfm_platform_system.c
+++ b/platform/ext/target/nordic_nrf/nrf54lm20dk_nrf54lm20b_cpuapp/services/src/tfm_platform_system.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2019-2024, Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#include "platform/include/tfm_platform_system.h"
+#include "tfm_hal_device_header.h"
+#include "tfm_platform_hal_ioctl.h"
+#include "tfm_ioctl_core_api.h"
+
+void tfm_platform_hal_system_reset(void)
+{
+	/* Reset the system */
+	NVIC_SystemReset();
+}
+
+enum tfm_platform_err_t tfm_platform_hal_ioctl(tfm_platform_ioctl_req_t request,
+                                               psa_invec  *in_vec,
+                                               psa_outvec *out_vec)
+{
+	/* Core IOCTL services */
+	switch (request) {
+	/* Not a supported IOCTL service.*/
+	default:
+		return TFM_PLATFORM_ERR_NOT_SUPPORTED;
+	}
+
+}

--- a/platform/ext/target/nordic_nrf/nrf54lm20dk_nrf54lm20b_cpuapp/tests/psa_arch_tests_config.cmake
+++ b/platform/ext/target/nordic_nrf/nrf54lm20dk_nrf54lm20b_cpuapp/tests/psa_arch_tests_config.cmake
@@ -1,0 +1,8 @@
+#-------------------------------------------------------------------------------
+# Copyright (c) 2023, Arm Limited. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+#-------------------------------------------------------------------------------
+
+include(${PLATFORM_PATH}/common/nrf54lm20b/tests/psa_arch_tests_config.cmake)

--- a/platform/ext/target/nordic_nrf/nrf54lm20dk_nrf54lm20b_cpuapp/tests/tfm_tests_config.cmake
+++ b/platform/ext/target/nordic_nrf/nrf54lm20dk_nrf54lm20b_cpuapp/tests/tfm_tests_config.cmake
@@ -1,0 +1,8 @@
+#-------------------------------------------------------------------------------
+# Copyright (c) 2023, Arm Limited. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+#-------------------------------------------------------------------------------
+
+include(${PLATFORM_PATH}/common/core/tests/tfm_tests_config.cmake)

--- a/platform/ext/target/nordic_nrf/nrf54lm20dk_nrf54lm20b_cpuapp/tfm_hal_platform.c
+++ b/platform/ext/target/nordic_nrf/nrf54lm20dk_nrf54lm20b_cpuapp/tfm_hal_platform.c
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2021, Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#include "tfm_hal_defs.h"
+#include "tfm_hal_platform_common.h"
+
+enum tfm_hal_status_t tfm_hal_platform_init(void)
+{
+    return tfm_hal_platform_common_init();
+}

--- a/platform/ext/target/nordic_nrf/nrf54lm20dk_nrf54lm20b_cpuapp/tfm_peripherals_config.h
+++ b/platform/ext/target/nordic_nrf/nrf54lm20dk_nrf54lm20b_cpuapp/tfm_peripherals_config.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2021, Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#ifndef TFM_PERIPHERALS_CONFIG_H__
+#define TFM_PERIPHERALS_CONFIG_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef SECURE_UART1
+#if NRF_SECURE_UART_INSTANCE == 30
+#define TFM_PERIPHERAL_UARTE30_SECURE 1
+#endif
+#endif
+
+
+/* Explicitly configure UART20 as non-secure for NS world */
+#define TFM_PERIPHERAL_UARTE20_SECURE 0
+
+/* The target_cfg.c requires this to be set */
+#define TFM_PERIPHERAL_GPIO0_PIN_MASK_SECURE 0
+
+#if defined(NRF54L_SERIES)
+    #include <tfm_peripherals_config_nrf54l.h>
+#else
+    #error "Unknown device."
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TFM_PERIPHERAL_CONFIG_H__ */


### PR DESCRIPTION
Removed Eng A naming from platforms in Trusted-Firmware-M to align with nrfx 4.1.

Added support for nRF54LM20B platform.