### PR TITLE
[zep noup] Adjust legacy Mbed TLS crypto from PSA Crypto

### DIFF
--- a/interface/include/mbedtls/config_psa.h
+++ b/interface/include/mbedtls/config_psa.h
@@ -34,7 +34,7 @@
  * before we deduce what built-ins are required. */
 #include "psa/crypto_adjust_config_key_pair_types.h"
 
-#if defined(MBEDTLS_PSA_CRYPTO_C)
+#if defined(MBEDTLS_PSA_CRYPTO_C) || defined(__ZEPHYR__)
 /* If we are implementing PSA crypto ourselves, then we want to enable the
  * required built-ins. Otherwise, PSA features will be provided by the server. */
 #include "mbedtls/config_adjust_legacy_from_psa.h"


### PR DESCRIPTION
Zephyr is transitioning to PSA Crypto API and removing usage of legacy crypto. Unfortunately in Mbed TLS 3.6 there are still checks (in "check_config.h") that rely on legacy crypto configurations.

Normally in Mbed TLS legacy crypto configurations are auto-adjusted in "config_adjust_legacy_from_psa.h". This wasn't happening in TF-M build because on the NS side MBEDTLS_PSA_CRYPTO_C is not set.