### PR TITLE
[zep fromtree] platform: stm: CMSIS_Driver: Fix stale pFlash state

### DIFF
--- a/platform/ext/target/stm/common/hal/CMSIS_Driver/low_level_flash.c
+++ b/platform/ext/target/stm/common/hal/CMSIS_Driver/low_level_flash.c
@@ -569,7 +569,7 @@ static int32_t Flash_ProgramData(uint32_t addr,
   stm32_icache_disable();
 #endif /* TFM_ICACHE_ENABLE */
 
-  if (IS_FLASH_SECURE_OPERATION()) {
+  if (is_range_secure(&ARM_FLASH0_DEV, addr, cnt)) {
     HAL_FLASH_Unlock_SEC();
   } else {
     HAL_FLASH_Unlock_NS();
@@ -603,7 +603,7 @@ static int32_t Flash_ProgramData(uint32_t addr,
 
   ARM_FLASH0_STATUS.busy = DRIVER_STATUS_IDLE;
 
-  if (IS_FLASH_SECURE_OPERATION()) {
+  if (is_range_secure(&ARM_FLASH0_DEV, addr, cnt)) {
     HAL_FLASH_Lock_SEC();
   } else {
     HAL_FLASH_Lock_NS();
@@ -711,7 +711,7 @@ static int32_t Flash_EraseSector(uint32_t addr)
 #endif /* TFM_ICACHE_ENABLE */
 
   ARM_FLASH0_STATUS.error = DRIVER_STATUS_NO_ERROR;
-  if (IS_FLASH_SECURE_OPERATION()) {
+  if (is_range_secure(&ARM_FLASH0_DEV, addr, 4)) {
     HAL_FLASH_Unlock_SEC();
   } else {
     HAL_FLASH_Unlock_NS();
@@ -719,7 +719,7 @@ static int32_t Flash_EraseSector(uint32_t addr)
   ARM_FLASH0_STATUS.busy = DRIVER_STATUS_BUSY;
   err = HAL_FLASHEx_Erase(&EraseInit, &pageError);
   ARM_FLASH0_STATUS.busy = DRIVER_STATUS_IDLE;
-  if (IS_FLASH_SECURE_OPERATION()) {
+  if (is_range_secure(&ARM_FLASH0_DEV, addr, 4)) {
     HAL_FLASH_Lock_SEC();
   } else {
     HAL_FLASH_Lock_NS();


### PR DESCRIPTION
IS_FLASH_SECURE_OPERATION() reads pFlash.ProcedureOnGoing which is only set inside HAL_FLASH_Program()/HAL_FLASHEx_Erase(), after the unlock call. On boot pFlash is zero-initialized, so IS_FLASH_SECURE_OPERATION() always returns true (secure), causing HAL_FLASH_Unlock_SEC() to be called even for non-secure flash regions. The subsequent HAL erase/write then uses the NSCR register which is still locked, failing with HAL_ERROR and triggering an MCUboot swap panic on image index 1.

Replace IS_FLASH_SECURE_OPERATION() with is_range_secure() in the lock/unlock paths, matching the existing pattern used for write_type and EraseInit.TypeErase selection in the same functions.

Change-Id: I31ab30bbf4b50212c859d4dbbb7a8c3c62c45fae
(cherry picked from commit e3ee9161bb775bd1e2b1cea70a117b0648df0168)