### PR TITLE
[zep noup] Do not install Mbed TLS includes in interface dir

### DIFF
--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -82,33 +82,35 @@ if (TFM_PARTITION_INTERNAL_TRUSTED_STORAGE)
 endif()
 
 if (TFM_PARTITION_CRYPTO)
-    install(FILES       ${INTERFACE_INC_DIR}/psa/README.rst
-                        ${INTERFACE_INC_DIR}/psa/build_info.h
-                        ${INTERFACE_INC_DIR}/psa/crypto.h
-                        ${INTERFACE_INC_DIR}/psa/crypto_adjust_auto_enabled.h
-                        ${INTERFACE_INC_DIR}/psa/crypto_adjust_config_dependencies.h
-                        ${INTERFACE_INC_DIR}/psa/crypto_adjust_config_key_pair_types.h
-                        ${INTERFACE_INC_DIR}/psa/crypto_adjust_config_synonyms.h
-                        ${INTERFACE_INC_DIR}/psa/crypto_builtin_composites.h
-                        ${INTERFACE_INC_DIR}/psa/crypto_builtin_key_derivation.h
-                        ${INTERFACE_INC_DIR}/psa/crypto_builtin_primitives.h
-                        ${INTERFACE_INC_DIR}/psa/crypto_compat.h
-                        ${INTERFACE_INC_DIR}/psa/crypto_driver_common.h
-                        ${INTERFACE_INC_DIR}/psa/crypto_driver_contexts_composites.h
-                        ${INTERFACE_INC_DIR}/psa/crypto_driver_contexts_key_derivation.h
-                        ${INTERFACE_INC_DIR}/psa/crypto_driver_contexts_primitives.h
-                        ${INTERFACE_INC_DIR}/psa/crypto_extra.h
-                        ${INTERFACE_INC_DIR}/psa/crypto_legacy.h
-                        ${INTERFACE_INC_DIR}/psa/crypto_platform.h
-                        ${INTERFACE_INC_DIR}/psa/crypto_se_driver.h
-                        ${INTERFACE_INC_DIR}/psa/crypto_sizes.h
-                        ${INTERFACE_INC_DIR}/psa/crypto_struct.h
-                        ${INTERFACE_INC_DIR}/psa/crypto_types.h
-                        ${INTERFACE_INC_DIR}/psa/crypto_values.h
-            DESTINATION ${INSTALL_INTERFACE_INC_DIR}/psa)
+    if (TFM_INSTALL_MBEDTLS_HEADERS)
+        install(FILES       ${INTERFACE_INC_DIR}/psa/README.rst
+                            ${INTERFACE_INC_DIR}/psa/build_info.h
+                            ${INTERFACE_INC_DIR}/psa/crypto.h
+                            ${INTERFACE_INC_DIR}/psa/crypto_adjust_auto_enabled.h
+                            ${INTERFACE_INC_DIR}/psa/crypto_adjust_config_dependencies.h
+                            ${INTERFACE_INC_DIR}/psa/crypto_adjust_config_key_pair_types.h
+                            ${INTERFACE_INC_DIR}/psa/crypto_adjust_config_synonyms.h
+                            ${INTERFACE_INC_DIR}/psa/crypto_builtin_composites.h
+                            ${INTERFACE_INC_DIR}/psa/crypto_builtin_key_derivation.h
+                            ${INTERFACE_INC_DIR}/psa/crypto_builtin_primitives.h
+                            ${INTERFACE_INC_DIR}/psa/crypto_compat.h
+                            ${INTERFACE_INC_DIR}/psa/crypto_driver_common.h
+                            ${INTERFACE_INC_DIR}/psa/crypto_driver_contexts_composites.h
+                            ${INTERFACE_INC_DIR}/psa/crypto_driver_contexts_key_derivation.h
+                            ${INTERFACE_INC_DIR}/psa/crypto_driver_contexts_primitives.h
+                            ${INTERFACE_INC_DIR}/psa/crypto_extra.h
+                            ${INTERFACE_INC_DIR}/psa/crypto_legacy.h
+                            ${INTERFACE_INC_DIR}/psa/crypto_platform.h
+                            ${INTERFACE_INC_DIR}/psa/crypto_se_driver.h
+                            ${INTERFACE_INC_DIR}/psa/crypto_sizes.h
+                            ${INTERFACE_INC_DIR}/psa/crypto_struct.h
+                            ${INTERFACE_INC_DIR}/psa/crypto_types.h
+                            ${INTERFACE_INC_DIR}/psa/crypto_values.h
+                DESTINATION ${INSTALL_INTERFACE_INC_DIR}/psa)
+        install(DIRECTORY   ${INTERFACE_INC_DIR}/mbedtls
+                DESTINATION ${INSTALL_INTERFACE_INC_DIR})
+    endif()
     install(FILES       ${INTERFACE_INC_DIR}/tfm_crypto_defs.h
-            DESTINATION ${INSTALL_INTERFACE_INC_DIR})
-    install(DIRECTORY   ${INTERFACE_INC_DIR}/mbedtls
             DESTINATION ${INSTALL_INTERFACE_INC_DIR})
 endif()
 

--- a/config/config_base.cmake
+++ b/config/config_base.cmake
@@ -170,6 +170,8 @@ set(TFM_MBEDCRYPTO_CONFIG_CLIENT_PATH         "${CMAKE_SOURCE_DIR}/lib/ext/mbedc
 set(TFM_MBEDCRYPTO_PSA_CRYPTO_CONFIG_PATH     "${CMAKE_SOURCE_DIR}/lib/ext/mbedcrypto/mbedcrypto_config/crypto_config_default.h" CACHE PATH "Config to use PSA Crypto setting for Mbed Crypto.")
 set(TFM_MBEDCRYPTO_PLATFORM_EXTRA_CONFIG_PATH ""    CACHE PATH      "Config to append to standard Mbed Crypto config, used by platforms to configure feature support")
 
+set(TFM_INSTALL_MBEDTLS_HEADERS    OFF         CACHE BOOL      "Install Mbed TLS include files to interface directory")
+
 ########################## TF-M performance ####################################
 
 set(CONFIG_TFM_ENABLE_PROFILING OFF CACHE BOOL "Enable profiling for TF-M")


### PR DESCRIPTION
This is required because upstream Zephyr is now using Mbed TLS 4.x and adding Mbed TLS 3.6.5 includes (which is what it being used in this version of TF-M) would create conflicts due to mixing of versions.

Once TF-M will be bumped to v2.3 this commit can be discarded.

This is integrated and tested upstream by https://github.com/zephyrproject-rtos/zephyr/pull/106258