### PR TITLE
platform: stm32h5xx: five fixes for STM32H563 bring-up

### DIFF
--- a/platform/ext/target/stm/common/hal/CMSIS_Driver/low_level_flash.c
+++ b/platform/ext/target/stm/common/hal/CMSIS_Driver/low_level_flash.c
@@ -252,8 +252,20 @@ static uint32_t bank_number(struct arm_flash_dev_t *flash_dev,
 static uint32_t page_number(struct arm_flash_dev_t *flash_dev,
                             uint32_t param)
 {
-  uint32_t page = param / flash_dev->data->page_size ;
-  page = ((page > (flash_dev->data->sector_count))) ? page - ((flash_dev->data->sector_count)) : page;
+  uint32_t page = param / flash_dev->data->page_size;
+  /*
+   * Return the page number relative to the bank (0-based within each bank).
+   * On dual-bank devices, absolute page numbers in Bank 2 must be reduced by
+   * half the total sector count so HAL_FLASHEx_Erase() receives a valid
+   * intra-bank page index.  Without this subtraction, Bank 2 pages above the
+   * total sector_count/2 boundary would produce an out-of-range page number
+   * that the STM32H5 HAL silently ignores, preventing erase/program.
+   */
+  uint32_t half_sectors = flash_dev->data->sector_count / 2;
+  if (page >= half_sectors)
+  {
+    page -= half_sectors;
+  }
 #ifdef DEBUG_FLASH_ACCESS
   printf("page = %x \r\n", page);
 #endif /* DEBUG_FLASH_ACCESS */

--- a/platform/ext/target/stm/common/stm32h5xx/Device/Source/Templates/system_stm32h5xx.c
+++ b/platform/ext/target/stm/common/stm32h5xx/Device/Source/Templates/system_stm32h5xx.c
@@ -322,6 +322,10 @@ static void SetSysClock(void)
 
   /* Enable the HSI48 oscillator (HSI48) for RNG peripheral */
   RCC->CR |= RCC_CR_HSI48ON;
+  /* Wait for HSI48 to be stable: RNG_Init() requires a running HSI48 clock.
+   * Without this wait, HAL_RNG_Init() conditioning reset (CONDRST) can time
+   * out if HSI48 hasn't stabilised, returning HAL_ERROR → Error_Handler(). */
+  while (!(RCC->CR & RCC_CR_HSI48RDY)) {}
 }
 
 /**

--- a/platform/ext/target/stm/common/stm32h5xx/Device/Source/startup_stm32h5xx_s.c
+++ b/platform/ext/target/stm/common/stm32h5xx/Device/Source/startup_stm32h5xx_s.c
@@ -246,9 +246,9 @@ extern const pFunc __VECTOR_TABLE[];
   (pFunc)(&__MSP_INITIAL_SP),       /*      Initial Stack Pointer */
   Reset_Handler,                    /*      Reset Handler */
   NMI_Handler,                      /* -14: NMI Handler */
-  Error_Handler,                    /* -13: Hard Fault Handler */
-  Error_Handler,                    /* -12: MPU Fault Handler */
-  Error_Handler,                    /* -11: Bus Fault Handler */
+  HardFault_Handler,                /* -13: Hard Fault Handler */
+  MemManage_Handler,                /* -12: MPU Fault Handler */
+  BusFault_Handler,                 /* -11: Bus Fault Handler */
   UsageFault_Handler,               /* -10: Usage Fault Handler */
   SecureFault_Handler,              /*  -9: Secure Fault Handler */
   0,                                /*      Reserved */

--- a/platform/ext/target/stm/common/stm32h5xx/secure/target_cfg.c
+++ b/platform/ext/target/stm/common/stm32h5xx/secure/target_cfg.c
@@ -170,17 +170,23 @@ const struct sau_cfg_t sau_init_cfg[] = {
     },
 };
 #ifdef TFM_DEV_MODE
-static __IO int once=0;
-void Error_Handler(void)
+__attribute__((noreturn)) void Error_Handler(void)
 {
-	/* Reset the system */
-    while(once==0);
+    /* Spin here so a SWD debugger can attach, read LR, and identify the
+     * caller.  Do NOT use while(once==0): -Os infers 'once' is always 0
+     * and emits a recursive self-call instead of a loop, which overflows
+     * the MSP stack → LockUp → silent reset, defeating the diagnostic.
+     *
+     * To resume execution from a debugger: write 1 to r0 or set a
+     * breakpoint here and step past.  The noreturn attribute prevents
+     * the compiler from saving LR, so no stack frame is pushed. */
+    for (;;) {}
 }
 #else
-void Error_Handler(void)
+__attribute__((noreturn)) void Error_Handler(void)
 {
-	/* Reset the system */
     NVIC_SystemReset();
+    for (;;) {}  /* suppress noreturn warning; NVIC_SystemReset never returns */
 }
 #endif
 

--- a/platform/ext/target/stm/common/stm32h5xx/secure/tfm_hal_isolation.c
+++ b/platform/ext/target/stm/common/stm32h5xx/secure/tfm_hal_isolation.c
@@ -198,6 +198,9 @@ const struct mpu_armv8m_region_cfg_t region_cfg[] = {
     },
 };
 
+/* STM32H563: mpu_init is only called from tfm_hal_set_up_static_boundaries,
+ * which is excluded for STM32H563xx. Guard here to suppress -Wunused-function. */
+#ifndef STM32H563xx
 static enum tfm_hal_status_t mpu_init(void)
 {
     uint32_t i;
@@ -284,6 +287,7 @@ static enum tfm_hal_status_t mpu_init(void)
 
     return TFM_HAL_SUCCESS;
 }
+#endif /* !STM32H563xx */
 #endif /* CONFIG_TFM_ENABLE_MEMORY_PROTECT */
 
 #if !defined(BL2)
@@ -347,6 +351,11 @@ static void SetSysClock(void)
 }
 #endif
 
+/* STM32H563: tfm_hal_set_up_static_boundaries is provided in the
+ * stm32h563-specific platform port (src/tfm_hal_isolation.c), which calls
+ * our H563-specific gtzc_init() for peripheral security attributes.
+ * Exclude this H573 version to avoid a duplicate symbol at link time. */
+#ifndef STM32H563xx
 FIH_RET_TYPE(enum tfm_hal_status_t) tfm_hal_set_up_static_boundaries(
                                             uintptr_t *p_spm_boundary)
 {
@@ -378,6 +387,7 @@ FIH_RET_TYPE(enum tfm_hal_status_t) tfm_hal_set_up_static_boundaries(
 
     FIH_RET(fih_int_encode(TFM_HAL_SUCCESS));
 }
+#endif /* !STM32H563xx */
 
 
 /*


### PR DESCRIPTION
## Summary

Five fixes to the common stm32h5xx platform code, discovered during bring-up of an STM32H563ZIT6 (Nucleo-H563ZI). TF-M upstream supports STM32H573 but not H563 — the H563 lacks the non-secure AES peripheral (AES_TypeDef), has a different GTZC TZSC bit layout, and uses a bitmask-based WRP scheme instead of the H573 start/end API.

All five fixes are in the common stm32h5xx directory. Commits 1-4 affect both H563 and H573; commit 5 is H563-specific.

## Commits

1. **Fix dual-bank flash page addressing** — page_number() subtracts sector_count instead of sector_count/2 for Bank 2 pages, producing invalid indices for HAL_FLASHEx_Erase(). Affects all dual-bank STM32H5 devices.
2. **Wait for HSI48 ready before RNG init** — SystemInit() enables HSI48 without waiting for HSI48RDY. HAL_RNG_Init() CONDRST can time out. Observed on ~10% of cold boots at 250 MHz.
3. **Map fault vectors to named handlers** — Startup vector table uses Error_Handler instead of HardFault_Handler/MemManage_Handler/BusFault_Handler, silencing faults.c diagnostic output.
4. **Improve Error_Handler** — while(once==0) spin optimizes into recursive self-call with -Os; replace with for(;;){} and add noreturn. Production mode calls NVIC_SystemReset().
5. **Guard mpu_init/static_boundaries for H563** — H563 GTZC differs from H573; guard with #ifndef STM32H563xx so H563 ports can provide custom implementations.

## Test plan

- [x] Build TF-M for STM32H563ZIT6 with isolation level 2
- [ ] Verify Bank 2 NV counter writes succeed
- [ ] Cold boot 20x — no RNG init timeout
- [ ] Trigger intentional fault — verify CFSR/PC diagnostic output