### PR TITLE
[zep fromtree] platform: nordic_nrf: Add mramc service for nrf7120

### DIFF
--- a/platform/ext/target/nordic_nrf/common/core/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/core/CMakeLists.txt
@@ -165,6 +165,13 @@ if(TFM_SPM_LOG_RAW_ENABLED OR SECURE_UART1)
     )
 endif()
 
+if(TFM_NRF_MRAMC_SERVICE)
+    target_compile_definitions(platform_s
+        PUBLIC
+            TFM_NRF_MRAMC_SERVICE
+    )
+endif()
+
 target_compile_options(platform_s
     PUBLIC
         ${COMPILER_CMSE_FLAG}

--- a/platform/ext/target/nordic_nrf/common/core/services/include/tfm_ioctl_core_api.h
+++ b/platform/ext/target/nordic_nrf/common/core/services/include/tfm_ioctl_core_api.h
@@ -31,6 +31,8 @@ enum tfm_platform_ioctl_core_reqest_types_t {
 	TFM_PLATFORM_IOCTL_READ_SERVICE,
 	TFM_PLATFORM_IOCTL_WRITE32_SERVICE,
 	TFM_PLATFORM_IOCTL_GPIO_SERVICE,
+	TFM_PLATFORM_IOCTL_MRAMC_INIT_SERVICE,
+	TFM_PLATFORM_IOCTL_MRAMC_SET_WEN_SERVICE,
 	/* Last core service, start platform specific from this value. */
 	TFM_PLATFORM_IOCTL_CORE_LAST
 };
@@ -88,6 +90,12 @@ struct tfm_gpio_service_args {
 struct tfm_gpio_service_out {
 	uint32_t result;
 };
+
+#if defined(CONFIG_TFM_NRF_MRAMC_SERVICE)
+struct tfm_mramc_set_wen_service_args_t {
+	uint32_t write_mode;
+};
+#endif
 
 /**
  * @brief Perform a read operation.
@@ -151,6 +159,25 @@ enum tfm_write32_service_result {
 enum tfm_platform_err_t tfm_platform_gpio_pin_mcu_select(uint32_t pin_number, uint32_t mcu,
 							 uint32_t *result);
 
+#if defined(CONFIG_TFM_NRF_MRAMC_SERVICE)
+/**
+ * @brief Initialise MRAMC peripheral.
+ *
+ * @return On success the processor will initialise MRAMC, in case of error it returns
+ *         values as specified by the \ref tfm_platform_err_t
+ */
+enum tfm_platform_err_t tfm_platform_mramc_init(void);
+
+/**
+ * @brief Setting write permission for MRAMC peripheral.
+ *
+ * @param write_mode    Write mode for MRAMC peripheral.
+ *
+ * @return On success the processor will set MRAMC config write mode, in case of error it returns
+ *         values as specified by the \ref tfm_platform_err_t
+ */
+enum tfm_platform_err_t tfm_platform_mramc_set_wen(uint32_t write_mode);
+#endif /* TFM_NRF_MRAMC_SERVICE */
 
 #ifdef __cplusplus
 }

--- a/platform/ext/target/nordic_nrf/common/core/services/include/tfm_platform_hal_ioctl.h
+++ b/platform/ext/target/nordic_nrf/common/core/services/include/tfm_platform_hal_ioctl.h
@@ -31,6 +31,12 @@ enum tfm_platform_err_t
 tfm_platform_hal_write32_service(const psa_invec  *in_vec,
 				 const psa_outvec *out_vec);
 
+enum tfm_platform_err_t
+tfm_platform_hal_mramc_init_service(void);
+
+enum tfm_platform_err_t
+tfm_platform_hal_mramc_set_wen_service(const psa_invec *in_vec);
+
 #ifdef __cplusplus
 }
 #endif

--- a/platform/ext/target/nordic_nrf/common/core/services/src/tfm_ioctl_core_ns_api.c
+++ b/platform/ext/target/nordic_nrf/common/core/services/src/tfm_ioctl_core_ns_api.c
@@ -94,3 +94,26 @@ enum tfm_platform_err_t tfm_platform_mem_write32(uint32_t addr, uint32_t value,
 
 	return ret;
 }
+
+#if defined(CONFIG_TFM_NRF_MRAMC_SERVICE)
+enum tfm_platform_err_t tfm_platform_mramc_init(void)
+{
+	return tfm_platform_ioctl(TFM_PLATFORM_IOCTL_MRAMC_INIT_SERVICE, NULL,
+			    NULL);
+}
+
+enum tfm_platform_err_t tfm_platform_mramc_set_wen(uint32_t write_mode)
+{
+	psa_invec in_vec;
+
+	struct tfm_mramc_set_wen_service_args_t args;
+
+	args.write_mode = write_mode;
+
+	in_vec.base = (const void *)&args;
+	in_vec.len = sizeof(struct tfm_mramc_set_wen_service_args_t);
+
+	return tfm_platform_ioctl(TFM_PLATFORM_IOCTL_MRAMC_SET_WEN_SERVICE, &in_vec,
+				NULL);
+}
+#endif

--- a/platform/ext/target/nordic_nrf/common/core/services/src/tfm_platform_hal_ioctl.c
+++ b/platform/ext/target/nordic_nrf/common/core/services/src/tfm_platform_hal_ioctl.c
@@ -22,6 +22,10 @@
 #include <nrfx_nvmc.h>
 #endif
 
+#if TFM_NRF_MRAMC_SERVICE
+#include <nrfx_mramc.h>
+#endif
+
 #include "handle_attr.h"
 
 enum tfm_platform_err_t
@@ -232,3 +236,39 @@ enum tfm_platform_err_t tfm_platform_hal_write32_service(const psa_invec *in_vec
 
 	return err;
 }
+
+#if TFM_NRF_MRAMC_SERVICE
+enum tfm_platform_err_t tfm_platform_hal_mramc_init_service(void)
+{
+	nrfx_mramc_config_t config = NRFX_MRAMC_DEFAULT_CONFIG();
+	int ret = nrfx_mramc_init(&config, NULL);
+
+	if (ret == -EALREADY) {
+		/* Driver is initialise by ITS or PS at the ealier stage*/
+		return TFM_PLATFORM_ERR_SUCCESS;
+	} else if (ret != 0) {
+		return TFM_PLATFORM_ERR_SYSTEM_ERROR;
+	}
+
+	return TFM_PLATFORM_ERR_SUCCESS;
+}
+
+enum tfm_platform_err_t tfm_platform_hal_mramc_set_wen_service(const psa_invec *in_vec)
+{
+	struct tfm_mramc_set_wen_service_args_t *args;
+
+	if (in_vec->len != sizeof(struct tfm_mramc_set_wen_service_args_t)) {
+		return TFM_PLATFORM_ERR_INVALID_PARAM;
+	}
+
+	args = (struct tfm_mramc_set_wen_service_args_t *)in_vec->base;
+	uint32_t write_mode = args->write_mode;
+
+	while(!nrfx_mramc_ready_check()) {
+	/* Wait until MRAMC is ready for the next operation */
+	}
+	nrfx_mramc_config_write_mode_set(write_mode);
+
+	return TFM_PLATFORM_ERR_SUCCESS;
+}
+#endif /* TFM_NRF_MRAMC_SERVICE */


### PR DESCRIPTION
nrf7120 zephyr mramc driver needs to access some configuration registers in mramc which is secure only, nrf_mramc service is created to access MRAMC initialise and change write config of mramc. MRAMC service functions is added under iotcl service type.

Change-Id: I93e411a0a51c8d96f1c5239efa006afab304c72e

(cherry picked from commit 66503e7c7c9d644f39a9ca35550d6c5af4792cd5)