### PR TITLE
[zep noup] modules: tf-m: Add fallback __assert_no_args

### DIFF
--- a/secure_fw/partitions/lib/runtime/assert.c
+++ b/secure_fw/partitions/lib/runtime/assert.c
@@ -39,3 +39,14 @@ void __assert_puts(const char *msg)
     }
 }
 #endif /* __ARMCC_VERSION*/
+
+/* picolibc's <assert.h> expands assert() into a call to __assert_no_args() when
+ * NDEBUG and ASSERT_VERBOSE are not defined. The TF-M secure image is linked with -nostdlib
+ * (since it defaults to TFM_INCLUDE_STDLIBC=n), so  in some configurations this results
+ * to undefined reference to __assert_no_args() when assert() is used in the TF-M secure image.
+ * Make it weak so that that acts a fallback implementation.
+ */
+__WEAK __NO_RETURN void __assert_no_args(void)
+{
+	tfm_core_panic();
+}


### PR DESCRIPTION
This fixes a build issue when building TF-M debug configurations. Adds a weak implementation of "__assert_no_args" which simply calls TF-M core panic.
The issue was triggered by the "buildsystem.debug.build" sample on the "nrf54lm20dk/nrf54lm20a/cpuapp/ns".