### PR TITLE
[zep noup] add callback for __assert_no_args for BL2

### DIFF
--- a/bl2/CMakeLists.txt
+++ b/bl2/CMakeLists.txt
@@ -141,6 +141,7 @@ endif()
 
 add_executable(bl2
     src/flash_map.c
+    src/crt_assert.c
     $<$<C_COMPILER_ID:GNU,Clang>:
         ${CMAKE_SOURCE_DIR}/secure_fw/partitions/lib/runtime/crt_start.c
         ${CMAKE_SOURCE_DIR}/secure_fw/partitions/lib/runtime/crt_memcmp.c

--- a/bl2/src/crt_assert.c
+++ b/bl2/src/crt_assert.c
@@ -1,0 +1,16 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: Copyright The TrustedFirmware-M Contributors
+ */
+
+#include <stdlib.h>
+#include "cmsis_compiler.h"
+
+/* picolibc's <assert.h> expands assert() into a call to __assert_no_args() when
+ * NDEBUG and ASSERT_VERBOSE are not defined.
+ */
+__WEAK __NO_RETURN void __assert_no_args(void)
+{
+    while (1)
+        ;
+}


### PR DESCRIPTION
Add a callback for "__assert_no_args()" in BL2. This mimics what has been done for TF-M in commit
"[zep noup] modules: tf-m: Add fallback __assert_no_args". It's not possible to use the same solution here (i.e. psa_panic()) because BL2 has a limited support for TF-M libraries. So the solution is to copy what has been done in "crt_exit.c" in the same folder.