### PR TITLE
[zep noup] toolchain: lower minimum clang version to 19

### DIFF
--- a/toolchain_ARMCLANG.cmake
+++ b/toolchain_ARMCLANG.cmake
@@ -8,10 +8,14 @@ cmake_minimum_required(VERSION 3.21)
 
 SET(CMAKE_SYSTEM_NAME Generic)
 
+find_program(CMAKE_C_COMPILER armclang)
+if(CMAKE_C_COMPILER STREQUAL "CMAKE_C_COMPILER-NOTFOUND")
+    message(FATAL_ERROR "Could not find compiler: 'armclang'")
+endif()
+
 # C++ support is not quaranted. This settings is to compile with RPi Pico SDK.
-set(CMAKE_ASM_COMPILER armclang)
-set(CMAKE_C_COMPILER   armclang)
-set(CMAKE_CXX_COMPILER armclang)
+set(CMAKE_ASM_COMPILER ${CMAKE_C_COMPILER})
+set(CMAKE_CXX_COMPILER ${CMAKE_C_COMPILER})
 
 set(CMAKE_C_STANDARD   11)
 

--- a/toolchain_ATFE.cmake
+++ b/toolchain_ATFE.cmake
@@ -10,17 +10,25 @@
 #
 set(CMAKE_SYSTEM_NAME Generic)
 
-set(CMAKE_C_COMPILER clang)
+find_program(CMAKE_C_COMPILER clang)
+if(CMAKE_C_COMPILER STREQUAL "CMAKE_C_COMPILER-NOTFOUND")
+    message(FATAL_ERROR "Could not find compiler: 'clang'")
+endif()
+
 set(CMAKE_C_COMPILER_FORCED TRUE)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_COMPILER_TARGET ${CROSS_COMPILE})
 
-set(CMAKE_ASM_COMPILER clang)
+set(CMAKE_ASM_COMPILER ${CMAKE_C_COMPILER})
 set(CMAKE_ASM_COMPILER_FORCED TRUE)
 set(CMAKE_ASM_COMPILER_TARGET ${CROSS_COMPILE})
 
 # C++ support is not quaranted. This settings is to compile with RPi Pico SDK.
-set(CMAKE_CXX_COMPILER clang++)
+find_program(CMAKE_CXX_COMPILER clang++)
+if(CMAKE_CXX_COMPILER STREQUAL "CMAKE_CXX_COMPILER-NOTFOUND")
+    message(WARNING "Could not find compiler: 'clang++'")
+endif()
+
 set(CMAKE_CXX_COMPILER_FORCED TRUE)
 set(CMAKE_CXX_STANDARD 11)
 

--- a/toolchain_ATFE.cmake
+++ b/toolchain_ATFE.cmake
@@ -43,8 +43,8 @@ set(CMAKE_USER_MAKE_RULES_OVERRIDE ${CMAKE_CURRENT_LIST_DIR}/cmake/set_extension
 
 # CMAKE_C_COMPILER_VERSION is not initialised at this moment so do it manually
 EXECUTE_PROCESS( COMMAND ${CMAKE_C_COMPILER} -dumpversion OUTPUT_VARIABLE CMAKE_C_COMPILER_VERSION )
-if (CMAKE_C_COMPILER_VERSION VERSION_LESS 20.1.0)
-    message(FATAL_ERROR "Please use newer ATfE toolchain version starting from 20.1.0")
+if (CMAKE_C_COMPILER_VERSION VERSION_LESS 19.1.0)
+    message(FATAL_ERROR "Please use newer ATfE toolchain version starting from 19.1.0")
 endif()
 
 include(mcpu_features)

--- a/toolchain_GNUARM.cmake
+++ b/toolchain_GNUARM.cmake
@@ -7,14 +7,22 @@
 
 set(CMAKE_SYSTEM_NAME Generic)
 
-set(CMAKE_C_COMPILER ${CROSS_COMPILE}-gcc)
+find_program(CMAKE_C_COMPILER ${CROSS_COMPILE}-gcc)
+if(CMAKE_C_COMPILER STREQUAL "CMAKE_C_COMPILER-NOTFOUND")
+    message(FATAL_ERROR "Could not find compiler: '${CROSS_COMPILE}-gcc'")
+endif()
+
 set(CMAKE_C_COMPILER_FORCED TRUE)
 set(CMAKE_C_STANDARD 11)
 
 set(CMAKE_ASM_COMPILER ${CMAKE_C_COMPILER})
 
 # C++ support is not quaranted. This settings is to compile with RPi Pico SDK.
-set(CMAKE_CXX_COMPILER ${CROSS_COMPILE}-g++)
+find_program(CMAKE_CXX_COMPILER ${CROSS_COMPILE}-g++)
+if(CMAKE_CXX_COMPILER STREQUAL "CMAKE_CXX_COMPILER-NOTFOUND")
+    message(WARNING "Could not find compiler: '${CROSS_COMPILE}-g++'")
+endif()
+
 set(CMAKE_CXX_COMPILER_FORCED TRUE)
 set(CMAKE_CXX_STANDARD 11)
 

--- a/toolchain_GNUARM.cmake
+++ b/toolchain_GNUARM.cmake
@@ -7,22 +7,14 @@
 
 set(CMAKE_SYSTEM_NAME Generic)
 
-find_program(CMAKE_C_COMPILER ${CROSS_COMPILE}-gcc)
-if(CMAKE_C_COMPILER STREQUAL "CMAKE_C_COMPILER-NOTFOUND")
-    message(FATAL_ERROR "Could not find compiler: '${CROSS_COMPILE}-gcc'")
-endif()
-
+set(CMAKE_C_COMPILER ${CROSS_COMPILE}-gcc)
 set(CMAKE_C_COMPILER_FORCED TRUE)
 set(CMAKE_C_STANDARD 11)
 
 set(CMAKE_ASM_COMPILER ${CMAKE_C_COMPILER})
 
 # C++ support is not quaranted. This settings is to compile with RPi Pico SDK.
-find_program(CMAKE_CXX_COMPILER ${CROSS_COMPILE}-g++)
-if(CMAKE_CXX_COMPILER STREQUAL "CMAKE_CXX_COMPILER-NOTFOUND")
-    message(WARNING "Could not find compiler: '${CROSS_COMPILE}-g++'")
-endif()
-
+set(CMAKE_CXX_COMPILER ${CROSS_COMPILE}-g++)
 set(CMAKE_CXX_COMPILER_FORCED TRUE)
 set(CMAKE_CXX_STANDARD 11)
 

--- a/toolchain_IARARM.cmake
+++ b/toolchain_IARARM.cmake
@@ -20,10 +20,18 @@ else()
     set(CMAKE_ASM_COMPILER_TARGET    arm-arm-none-eabi)
 endif()
 
-set(CMAKE_C_COMPILER iccarm)
+find_program(CMAKE_C_COMPILER iccarm)
+if(CMAKE_C_COMPILER STREQUAL "CMAKE_C_COMPILER-NOTFOUND")
+    message(FATAL_ERROR "Could not find compiler: 'iccarm'")
+endif()
+
 set(CMAKE_C_STANDARD 11)
-set(CMAKE_CXX_COMPILER iccarm)
-set(CMAKE_ASM_COMPILER iasmarm)
+set(CMAKE_CXX_COMPILER ${CMAKE_C_COMPILER})
+
+find_program(CMAKE_ASM_COMPILER iasmarm)
+if(CMAKE_ASM_COMPILER STREQUAL "CMAKE_ASM_COMPILER-NOTFOUND")
+    message(FATAL_ERROR "Could not find assembler: 'iasmarm'")
+endif()
 
 set(LINKER_VENEER_OUTPUT_FLAG --import_cmse_lib_out= )
 set(COMPILER_CMSE_FLAG --cmse)


### PR DESCRIPTION
Lower the minimum required clang version from 20.1.0 to 19.1.0 for the ATfE/clang toolchain. The Zephyr SDK currently ships with clang 19, so enforcing version 20 (which upstream requires since clang 19 reached end-of-life) would break builds using the Zephyr SDK toolchain.