### PR TITLE
[zep fromtree] platform: nordic_nrf: Rename CONFIG_SOC_NRF71_TFM_MRAM…

### DIFF
--- a/platform/ext/target/nordic_nrf/common/core/services/include/tfm_ioctl_core_api.h
+++ b/platform/ext/target/nordic_nrf/common/core/services/include/tfm_ioctl_core_api.h
@@ -91,7 +91,7 @@ struct tfm_gpio_service_out {
 	uint32_t result;
 };
 
-#if defined(CONFIG_SOC_NRF71_TFM_MRAMC_SERVICE)
+#if defined(CONFIG_SOC_NRF7120_TFM_MRAMC_SERVICE)
 struct tfm_mramc_set_wen_service_args_t {
 	uint32_t write_mode;
 };
@@ -159,7 +159,7 @@ enum tfm_write32_service_result {
 enum tfm_platform_err_t tfm_platform_gpio_pin_mcu_select(uint32_t pin_number, uint32_t mcu,
 							 uint32_t *result);
 
-#if defined(CONFIG_SOC_NRF71_TFM_MRAMC_SERVICE)
+#if defined(CONFIG_SOC_NRF7120_TFM_MRAMC_SERVICE)
 /**
  * @brief Initialise MRAMC peripheral.
  *
@@ -177,7 +177,7 @@ enum tfm_platform_err_t tfm_platform_mramc_init(void);
  *         values as specified by the \ref tfm_platform_err_t
  */
 enum tfm_platform_err_t tfm_platform_mramc_set_wen(uint32_t write_mode);
-#endif /* SOC_NRF71_TFM_MRAMC_SERVICE */
+#endif /* SOC_NRF7120_TFM_MRAMC_SERVICE */
 
 #ifdef __cplusplus
 }

--- a/platform/ext/target/nordic_nrf/common/core/services/src/tfm_ioctl_core_ns_api.c
+++ b/platform/ext/target/nordic_nrf/common/core/services/src/tfm_ioctl_core_ns_api.c
@@ -95,7 +95,7 @@ enum tfm_platform_err_t tfm_platform_mem_write32(uint32_t addr, uint32_t value,
 	return ret;
 }
 
-#if defined(CONFIG_SOC_NRF71_TFM_MRAMC_SERVICE)
+#if defined(CONFIG_SOC_NRF7120_TFM_MRAMC_SERVICE)
 enum tfm_platform_err_t tfm_platform_mramc_init(void)
 {
 	return tfm_platform_ioctl(TFM_PLATFORM_IOCTL_MRAMC_INIT_SERVICE, NULL,


### PR DESCRIPTION
…C_SERVICE in ioctl

Rename CONFIG_SOC_NRF71_TFM_MRAMC_SERVICE to CONFIG_SOC_NRF7120_TFM_MRAMC_SERVICE as required by zephyr upstream Kconfig naming guideline.

Change-Id: I17e42db67cade40906cffbb0f108a0f2a523d455

(cherry picked from commit fda87e5cf22cfd8a18027e25d014a69250c5b6c1)