### PR TITLE
[zep noup] platform: corstone1000: initialise secure partition RW data

### DIFF
--- a/platform/ext/target/arm/corstone1000/Device/Source/startup_corstone1000.c
+++ b/platform/ext/target/arm/corstone1000/Device/Source/startup_corstone1000.c
@@ -22,6 +22,7 @@
  */
 
 #include "tfm_hal_device_header.h"
+#include "tfm_copy_zero_tables.h"
 
 /*----------------------------------------------------------------------------
   External References
@@ -144,5 +145,6 @@ extern const VECTOR_TABLE_Type __VECTOR_TABLE[48];
 void Reset_Handler(void)
 {
     SystemInit();                             /* CMSIS System Initialization */
+    tfm_copy_zero_tables();                   /* picolibc crt0 inits one region only */
     __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
 }

--- a/platform/include/tfm_copy_zero_tables.h
+++ b/platform/include/tfm_copy_zero_tables.h
@@ -1,0 +1,63 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The TrustedFirmware-M Contributors
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef __TFM_COPY_ZERO_TABLES_H__
+#define __TFM_COPY_ZERO_TABLES_H__
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    uint32_t const *src;
+    uint32_t       *dest;
+    uint32_t        wlen;
+} tfm_copy_table_t;
+
+typedef struct {
+    uint32_t *dest;
+    uint32_t  wlen;
+} tfm_zero_table_t;
+
+/* Emitted by the scatter linker scripts; weak so images without them link. */
+extern const tfm_copy_table_t __copy_table_start__[] __attribute__((weak));
+extern const tfm_copy_table_t __copy_table_end__[]   __attribute__((weak));
+extern const tfm_zero_table_t __zero_table_start__[] __attribute__((weak));
+extern const tfm_zero_table_t __zero_table_end__[]   __attribute__((weak));
+
+/*
+ * Initialise the RW data and bss regions described by the CMSIS scatter
+ * __copy_table__/__zero_table__. Needed by startups that enter a C library
+ * whose own crt0 (e.g. picolibc when CONFIG_TFM_INCLUDE_STDLIBC is enabled)
+ * initialises only the single __data/__bss region. Inlined so it links into
+ * every image sharing the startup (BL1, BL2, SPE) without extra build wiring.
+ */
+static inline void tfm_copy_zero_tables(void)
+{
+    const tfm_copy_table_t *ct;
+    const tfm_zero_table_t *zt;
+    uint32_t i;
+
+    for (ct = __copy_table_start__; ct < __copy_table_end__; ct++) {
+        for (i = 0u; i < ct->wlen; i++) {
+            ct->dest[i] = ct->src[i];
+        }
+    }
+
+    for (zt = __zero_table_start__; zt < __zero_table_end__; zt++) {
+        for (i = 0u; i < zt->wlen; i++) {
+            zt->dest[i] = 0u;
+        }
+    }
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __TFM_COPY_ZERO_TABLES_H__ */


### PR DESCRIPTION
picolibc's crt0 (the `__PROGRAM_START()` entry used by the corstone1000 `Reset_Handler`) initialises only the single `__data`/`__bss` region. TF-M puts each secure partition's RW data in its own section (LMA != VMA) and relies on the CMSIS scatter `__copy_table__`/`__zero_table__` to initialise them, which newlib's `__cmsis_start()` walked but picolibc does not. The result is that every partition's `.data` stays zero: the ITS `fs_cfg_its.flash_dev` driver pointer is NULL and the Secure Enclave faults the moment Internal Trusted Storage initialises.

This walks both tables in `Reset_Handler` before `__PROGRAM_START()`, restoring the per-partition initialisation. Table symbols are weak so BL1 images that do not emit them still link.

Validated on the Corstone-1000-A320 FVP: with this fix the SE boots TF-M, brings up the host, and Zephyr runs on the Cortex-A320.