### PR TITLE
platform: corstone1000: picolibc build support for the Zephyr SDK toolchain

### DIFF
--- a/bl2/ext/mcuboot/scripts/wrapper.py
+++ b/bl2/ext/mcuboot/scripts/wrapper.py
@@ -21,7 +21,7 @@ sys.path = [cwd] + sys.path
 import imgtool
 import imgtool.main
 
-parser_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '../'))
+parser_path = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(parser_path)
 import macro_parser
 

--- a/platform/ext/common/gcc/tfm_isolation_s.ld.template
+++ b/platform/ext/common/gcc/tfm_isolation_s.ld.template
@@ -632,6 +632,10 @@ SECTIONS
         KEEP(*(.jcr*))
         . = ALIGN(TFM_LINKER_TFM_DATA_ALIGNMENT);
     } > RAM AT > FLASH :tfm_data
+    /* Symbols required by picolibc's crt0 (_start). */
+    __data_start = ADDR(.TFM_DATA);
+    __data_source = LOADADDR(.TFM_DATA);
+    __data_size = SIZEOF(.TFM_DATA);
 
 #ifdef S_RUNTIME_ITCM_START
     .ER_ITCM_CODE :
@@ -680,8 +684,13 @@ SECTIONS
         *(SORT_BY_ALIGNMENT(.cy_sharedmem*)) /* Cypress shared memory */
 
         . = ALIGN(TFM_LINKER_TFM_BSS_ALIGNMENT);
+        __tls_base = . ;                /* to satisfy crt0 */
+        __arm32_tls_tcb_offset = . ;    /* to satisfy crt0 */
         __bss_end__ = .;
     } > RAM
+    /* Symbols required by picolibc's crt0 (_start). */
+    __bss_start = ADDR(.TFM_BSS);
+    __bss_size = SIZEOF(.TFM_BSS);
     Image$$ER_PART_RT_POOL$$ZI$$Base = __partition_runtime_start__;
     Image$$ER_PART_RT_POOL$$ZI$$Limit = __partition_runtime_end__;
     Image$$ER_SERV_RT_POOL$$ZI$$Base = __service_runtime_start__;

--- a/platform/ext/common/syscalls_stub.c
+++ b/platform/ext/common/syscalls_stub.c
@@ -53,3 +53,11 @@ __attribute__((weak))
 void _write(void)
 {
 }
+
+__attribute__((weak, noreturn))
+void _exit(int status)
+{
+    (void)status;
+    while (1) {
+    }
+}

--- a/platform/ext/common/uart_stdout.c
+++ b/platform/ext/common/uart_stdout.c
@@ -142,7 +142,7 @@ void _sys_exit(int returncode)
  *  as per https://github.com/picolibc/picolibc/blob/main/doc/os.md
  *  'fputch()' named intentionally different from 'fputc()' from picolib
  */
-#elif defined(__clang_major__)
+#elif defined(__clang_major__) || defined(__PICOLIBC__)
 
 int fputch(char ch, struct __file *f)
 {

--- a/platform/ext/target/arm/corstone1000/Device/Source/gcc/corstone1000_bl1_1.ld
+++ b/platform/ext/target/arm/corstone1000/Device/Source/gcc/corstone1000_bl1_1.ld
@@ -148,6 +148,10 @@ SECTIONS
 
     } > RAM AT > FLASH
     Image$$ER_DATA$$Base = ADDR(.data);
+    /* Symbols required by picolibc's crt0 (_start). */
+    __data_start = ADDR(.data);
+    __data_source = LOADADDR(.data);
+    __data_size = SIZEOF(.data);
 
     .bss :
     {
@@ -157,7 +161,12 @@ SECTIONS
         *(COMMON)
         . = ALIGN(4);
         __bss_end__ = .;
+        __tls_base = . ;                /* to satisfy picolibc crt0 */
+        __arm32_tls_tcb_offset = . ;    /* to satisfy picolibc crt0 */
     } > RAM
+    /* Symbols required by picolibc's crt0 (_start). */
+    __bss_start = ADDR(.bss);
+    __bss_size = SIZEOF(.bss);
 
     bss_size = __bss_end__ - __bss_start__;
 

--- a/platform/ext/target/arm/corstone1000/Device/Source/gcc/corstone1000_bl1_2.ld
+++ b/platform/ext/target/arm/corstone1000/Device/Source/gcc/corstone1000_bl1_2.ld
@@ -152,6 +152,10 @@ SECTIONS
 
     } > RAM AT > FLASH
     Image$$ER_DATA$$Base = ADDR(.data);
+    /* Symbols required by picolibc's crt0 (_start). */
+    __data_start = ADDR(.data);
+    __data_source = LOADADDR(.data);
+    __data_size = SIZEOF(.data);
 
     .bss :
     {
@@ -161,7 +165,12 @@ SECTIONS
         *(COMMON)
         . = ALIGN(4);
         __bss_end__ = .;
+        __tls_base = . ;                /* to satisfy picolibc crt0 */
+        __arm32_tls_tcb_offset = . ;    /* to satisfy picolibc crt0 */
     } > RAM
+    /* Symbols required by picolibc's crt0 (_start). */
+    __bss_start = ADDR(.bss);
+    __bss_size = SIZEOF(.bss);
 
     bss_size = __bss_end__ - __bss_start__;
 


### PR DESCRIPTION
Corstone-1000 is built in Zephyr with the GNU arm-zephyr-eabi toolchain and picolibc, while upstream validates it with Arm Clang. Two `[zep noup]` commits cover the gaps that the GNU+picolibc build hits on this platform:

1. picolibc crt0/stdio support: the BL1 and isolation-S linker scripts gain the picolibc crt0 symbols (matching what the common linker scripts already define), `uart_stdout.c` routes picolibc's `fputch()` hook, and `syscalls_stub.c` provides a weak `_exit()`.
2. a `wrapper.py` fix so `macro_parser` is imported from the script's own directory (it sits next to `wrapper.py`), rather than the parent.

Validated together with the partition-data-init fix (#203) on the Corstone-1000-A320 FVP: the Secure Enclave boots TF-M, brings up the host, and Zephyr runs on the Cortex-A320.