### PR TITLE
[zep fromtree] platform: nordic_nrf: align system file paths to Split MDK

### DIFF
--- a/platform/ext/target/nordic_nrf/common/nrf5340/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/nrf5340/CMakeLists.txt
@@ -28,7 +28,7 @@ endif()
 
 target_sources(platform_s
     PRIVATE
-        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/system_nrf5340_application.c
+        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/nrf53/nrf5340/system_nrf5340_application.c
 )
 
 target_compile_definitions(platform_s
@@ -44,7 +44,7 @@ if(BL2)
 
     target_sources(platform_bl2
         PRIVATE
-            ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/system_nrf5340_application.c
+            ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/nrf53/nrf5340/system_nrf5340_application.c
     )
 
     target_compile_definitions(platform_bl2

--- a/platform/ext/target/nordic_nrf/common/nrf5340/ns/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/nrf5340/ns/CMakeLists.txt
@@ -18,7 +18,7 @@ target_include_directories(platform_ns
 
 target_sources(platform_ns
     PRIVATE
-        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/system_nrf5340_application.c
+        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/nrf53/nrf5340/system_nrf5340_application.c
 )
 
 target_compile_definitions(platform_ns

--- a/platform/ext/target/nordic_nrf/common/nrf54l10/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/nrf54l10/CMakeLists.txt
@@ -28,7 +28,7 @@ endif()
 
 target_sources(platform_s
     PRIVATE
-        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/system_nrf54l.c
+        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/nrf54l/system_nrf54l.c
         ../nrf54l/nrf54l_init.c
 )
 

--- a/platform/ext/target/nordic_nrf/common/nrf54l10/ns/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/nrf54l10/ns/CMakeLists.txt
@@ -18,7 +18,7 @@ target_include_directories(platform_ns
 
 target_sources(platform_ns
     PRIVATE
-        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/system_nrf54l.c
+        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/nrf54l/system_nrf54l.c
 )
 
 target_compile_definitions(platform_ns

--- a/platform/ext/target/nordic_nrf/common/nrf54l15/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/nrf54l15/CMakeLists.txt
@@ -28,7 +28,7 @@ endif()
 
 target_sources(platform_s
     PRIVATE
-        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/system_nrf54l.c
+        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/nrf54l/system_nrf54l.c
         ../nrf54l/nrf54l_init.c
 )
 

--- a/platform/ext/target/nordic_nrf/common/nrf54l15/ns/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/nrf54l15/ns/CMakeLists.txt
@@ -18,7 +18,7 @@ target_include_directories(platform_ns
 
 target_sources(platform_ns
     PRIVATE
-        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/system_nrf54l.c
+        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/nrf54l/system_nrf54l.c
 )
 
 target_compile_definitions(platform_ns

--- a/platform/ext/target/nordic_nrf/common/nrf54lm20a/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/nrf54lm20a/CMakeLists.txt
@@ -28,7 +28,7 @@ endif()
 
 target_sources(platform_s
     PRIVATE
-        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/system_nrf54l.c
+        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/nrf54l/system_nrf54l.c
         ../nrf54l/nrf54l_init.c
 )
 

--- a/platform/ext/target/nordic_nrf/common/nrf54lm20a/ns/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/nrf54lm20a/ns/CMakeLists.txt
@@ -18,7 +18,7 @@ target_include_directories(platform_ns
 
 target_sources(platform_ns
     PRIVATE
-        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/system_nrf54l.c
+        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/nrf54l/system_nrf54l.c
 )
 
 target_compile_definitions(platform_ns

--- a/platform/ext/target/nordic_nrf/common/nrf54lm20b/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/nrf54lm20b/CMakeLists.txt
@@ -28,7 +28,7 @@ endif()
 
 target_sources(platform_s
     PRIVATE
-        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/system_nrf54l.c
+        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/nrf54l/system_nrf54l.c
         ../nrf54l/nrf54l_init.c
 )
 

--- a/platform/ext/target/nordic_nrf/common/nrf54lm20b/ns/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/nrf54lm20b/ns/CMakeLists.txt
@@ -18,7 +18,7 @@ target_include_directories(platform_ns
 
 target_sources(platform_ns
     PRIVATE
-        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/system_nrf54l.c
+        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/nrf54l/system_nrf54l.c
 )
 
 target_compile_definitions(platform_ns

--- a/platform/ext/target/nordic_nrf/common/nrf54lv10a/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/nrf54lv10a/CMakeLists.txt
@@ -28,7 +28,7 @@ endif()
 
 target_sources(platform_s
     PRIVATE
-        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/system_nrf54l.c
+        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/nrf54l/system_nrf54l.c
         ../nrf54l/nrf54l_init.c
 )
 

--- a/platform/ext/target/nordic_nrf/common/nrf54lv10a/ns/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/nrf54lv10a/ns/CMakeLists.txt
@@ -18,7 +18,7 @@ target_include_directories(platform_ns
 
 target_sources(platform_ns
     PRIVATE
-        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/system_nrf54l.c
+        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/nrf54l/system_nrf54l.c
 )
 
 target_compile_definitions(platform_ns

--- a/platform/ext/target/nordic_nrf/common/nrf7120/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/nrf7120/CMakeLists.txt
@@ -27,7 +27,7 @@ endif()
 
 target_sources(platform_s
     PRIVATE
-        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/system_nrf7120_enga.c
+        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/nrf71/nrf7120_enga/system_nrf7120_enga.c
         ./nrf71_init.c
 )
 

--- a/platform/ext/target/nordic_nrf/common/nrf7120/ns/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/nrf7120/ns/CMakeLists.txt
@@ -18,7 +18,7 @@ target_include_directories(platform_ns
 
 target_sources(platform_ns
     PRIVATE
-        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/system_nrf7120_enga.c
+        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/nrf71/nrf7120_enga/system_nrf7120_enga.c
 )
 
 target_compile_definitions(platform_ns

--- a/platform/ext/target/nordic_nrf/common/nrf91/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/nrf91/CMakeLists.txt
@@ -28,7 +28,7 @@ endif()
 
 target_sources(platform_s
     PRIVATE
-        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/system_nrf91.c
+        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/nrf91/system_nrf91.c
 )
 
 target_compile_definitions(platform_s
@@ -46,7 +46,7 @@ if(BL2)
 
     target_sources(platform_bl2
         PRIVATE
-            ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/system_nrf91.c
+            ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/nrf91/system_nrf91.c
     )
 
     target_compile_definitions(platform_bl2

--- a/platform/ext/target/nordic_nrf/common/nrf91/ns/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/nrf91/ns/CMakeLists.txt
@@ -21,7 +21,7 @@ target_include_directories(platform_ns
 
 target_sources(platform_ns
     PRIVATE
-        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/system_nrf91.c
+        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/nrf91/system_nrf91.c
 )
 
 target_compile_definitions(platform_ns


### PR DESCRIPTION
Split MDK introduces individual per-device directories. Align paths to new structure.

Change-Id: I63e4ae9bad361e7a564c36bd2a407999d690ed6e