### PR TITLE
Cherry-pick fixes for image encryption support for BL2

### DIFF
--- a/bl2/CMakeLists.txt
+++ b/bl2/CMakeLists.txt
@@ -63,7 +63,7 @@ set(build_sha_256    "$<NOT:${build_sha_384}>")
 set(build_p256m      "$<IF:$<BOOL:${MBEDTLS_P256M_ENABLED}>,$<AND:${is_ec_signature},${is_256_bit_curve}>,0>")
 
 list(APPEND BL2_CRYPTO_SRC
-    $<$<OR:$<BOOL:${MCUBOOT_USE_PSA_CRYPTO}>,$<BOOL:${MCUBOOT_USE_MBED_TLS}>>:${CMAKE_SOURCE_DIR}/lib/ext/thin-psa-crypto-core/thin_psa_crypto_core.c>
+    $<$<BOOL:${MCUBOOT_USE_PSA_CRYPTO}>:${CMAKE_SOURCE_DIR}/lib/ext/thin-psa-crypto-core/thin_psa_crypto_core.c>
     $<$<BOOL:${MCUBOOT_ENC_IMAGES}>:${TF_PSA_CRYPTO_PATH}/drivers/builtin/src/aes.c>
     ${TF_PSA_CRYPTO_PATH}/platform/platform.c
     ${TF_PSA_CRYPTO_PATH}/platform/platform_util.c

--- a/bl2/CMakeLists.txt
+++ b/bl2/CMakeLists.txt
@@ -64,7 +64,7 @@ set(build_p256m      "$<IF:$<BOOL:${MBEDTLS_P256M_ENABLED}>,$<AND:${is_ec_signat
 
 list(APPEND BL2_CRYPTO_SRC
     $<$<OR:$<BOOL:${MCUBOOT_USE_PSA_CRYPTO}>,$<BOOL:${MCUBOOT_USE_MBED_TLS}>>:${CMAKE_SOURCE_DIR}/lib/ext/thin-psa-crypto-core/thin_psa_crypto_core.c>
-    ${TF_PSA_CRYPTO_PATH}/drivers/builtin/src/aes.c
+    $<$<BOOL:${MCUBOOT_ENC_IMAGES}>:${TF_PSA_CRYPTO_PATH}/drivers/builtin/src/aes.c>
     ${TF_PSA_CRYPTO_PATH}/platform/platform.c
     ${TF_PSA_CRYPTO_PATH}/platform/platform_util.c
     ${TF_PSA_CRYPTO_PATH}/platform/memory_buffer_alloc.c
@@ -93,7 +93,7 @@ list(APPEND BL2_CRYPTO_SRC
     $<${is_rsa_signature}:${TF_PSA_CRYPTO_PATH}/extras/md.c>
     $<$<AND:${is_ec_signature},${build_p256m}>:${TF_PSA_CRYPTO_PATH}/drivers/p256-m/p256-m_driver_entrypoints.c>
     $<$<AND:${is_ec_signature},${build_p256m}>:${TF_PSA_CRYPTO_PATH}/drivers/p256-m/p256-m/p256-m.c>
-    $<$<BOOL:${MCUBOOT_ENCRYPT_KW}>:${TF_PSA_CRYPTO_PATH}/drivers/builtin/src/nist_kw.c>
+    $<$<BOOL:${MCUBOOT_ENCRYPT_KW}>:${TF_PSA_CRYPTO_PATH}/extras/nist_kw.c>
     $<$<BOOL:${MCUBOOT_ENCRYPT_KW}>:${TF_PSA_CRYPTO_PATH}/utilities/constant_time.c>
     # Include __weak stub implementation, serving as a fallback for random number generation in case no other RNG is provided.
     $<$<NOT:$<BOOL:${CRYPTO_HW_ACCELERATOR}>>:src/psa_stub_rng.c>

--- a/bl2/CMakeLists.txt
+++ b/bl2/CMakeLists.txt
@@ -25,12 +25,12 @@ add_library(bl2_crypto_config INTERFACE)
 
 target_compile_definitions(bl2_crypto_config
     INTERFACE
+        MCUBOOT_USE_PSA_CRYPTO
         TF_PSA_CRYPTO_CONFIG_FILE="${MCUBOOT_PSA_CRYPTO_CONFIG_FILEPATH}"
         # The config files have conditional includes based on these four definitions
         $<${is_rsa_signature}:MCUBOOT_SIGN_RSA>
         $<${is_rsa_signature}:MCUBOOT_SIGN_RSA_LEN=${SIG_LEN}>
         $<${is_ec_signature}:MCUBOOT_SIGN_EC${SIG_LEN}>
-        $<$<BOOL:${MCUBOOT_USE_PSA_CRYPTO}>:MCUBOOT_USE_PSA_CRYPTO>
         $<$<BOOL:${MCUBOOT_IMAGE_BINDING}>:MCUBOOT_IMAGE_BINDING>
         $<$<BOOL:${MCUBOOT_ENC_IMAGES}>:MCUBOOT_ENC_IMAGES>
 )
@@ -63,7 +63,7 @@ set(build_sha_256    "$<NOT:${build_sha_384}>")
 set(build_p256m      "$<IF:$<BOOL:${MBEDTLS_P256M_ENABLED}>,$<AND:${is_ec_signature},${is_256_bit_curve}>,0>")
 
 list(APPEND BL2_CRYPTO_SRC
-    $<$<BOOL:${MCUBOOT_USE_PSA_CRYPTO}>:${CMAKE_SOURCE_DIR}/lib/ext/thin-psa-crypto-core/thin_psa_crypto_core.c>
+    ${CMAKE_SOURCE_DIR}/lib/ext/thin-psa-crypto-core/thin_psa_crypto_core.c
     $<$<BOOL:${MCUBOOT_ENC_IMAGES}>:${TF_PSA_CRYPTO_PATH}/drivers/builtin/src/aes.c>
     ${TF_PSA_CRYPTO_PATH}/platform/platform.c
     ${TF_PSA_CRYPTO_PATH}/platform/platform_util.c

--- a/bl2/ext/mcuboot/Kconfig
+++ b/bl2/ext/mcuboot/Kconfig
@@ -144,15 +144,21 @@ config MCUBOOT_HW_ROLLBACK_PROT
     default y
 
 config MCUBOOT_ENC_IMAGES
-    bool "Enable encrypted image upgrade support"
-    default n
-
-config MCUBOOT_BOOTSTRAP
-    bool "Support initial state with empty primary slot and images installed from secondary slots"
+    bool "Enable image encryption (AES)"
     default n
 
 config MCUBOOT_ENCRYPT_RSA
-    bool "Use RSA for encrypted image upgrade support"
+    bool "Use RSA-OAEP for encryption key wrapping"
+    default n
+    depends on MCUBOOT_ENC_IMAGES
+
+config MCUBOOT_ENCRYPT_KW
+    bool "Use AES-KW for encryption key wrapping"
+    default n
+    depends on MCUBOOT_ENC_IMAGES
+
+config MCUBOOT_BOOTSTRAP
+    bool "Support initial state with empty primary slot and images installed from secondary slots"
     default n
 
 choice MCUBOOT_FIH_PROFILE_CHOICE

--- a/bl2/ext/mcuboot/Kconfig
+++ b/bl2/ext/mcuboot/Kconfig
@@ -42,10 +42,6 @@ config MCUBOOT_EXECUTION_SLOT
     int "Slot from which to execute the image, used for XIP mode"
     default 1
 
-config MCUBOOT_USE_PSA_CRYPTO
-    bool "Enable cryptography through PSA Crypto APIs"
-    default n
-
 choice MCUBOOT_HW_KEY_CHOICE
     prompt "Hardware key options for signature verification"
     optional

--- a/bl2/ext/mcuboot/bl2_main.c
+++ b/bl2/ext/mcuboot/bl2_main.c
@@ -37,7 +37,6 @@
 #include "mcuboot_suites.h"
 #endif /* TEST_BL2 */
 
-#if defined(MCUBOOT_USE_PSA_CRYPTO)
 #include "psa/crypto.h"
 /* A few macros for stringification */
 #define str(X) #X
@@ -47,7 +46,6 @@ static const char *key_type_str = ", using builtin keys";
 #else
 static const char *key_type_str = "";
 #endif
-#endif /* MCUBOOT_USE_PSA_CRYPTO */
 
 /* Avoids the semihosting issue */
 #if defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
@@ -179,8 +177,7 @@ int main(void)
         boot_platform_error_state(err);
     }
 
-#if defined(MCUBOOT_USE_PSA_CRYPTO)
-    /* If the bootloader is configured to use PSA Crypto APIs in the
+    /* Since bootloader is configured to use PSA Crypto APIs in the
      * abstraction layer, the component needs to be explicitly initialized
      * before MCUboot APIs, as the crypto abstraction expects that the init
      * has already happened
@@ -191,7 +188,6 @@ int main(void)
         boot_platform_error_state(status);
     }
     BOOT_LOG_INF("PSA Crypto init done, sig_type: %s%s", xstr(MCUBOOT_SIGNATURE_TYPE), key_type_str);
-#endif /* MCUBOOT_USE_PSA_CRYPTO */
 
 #ifdef TEST_BL2
     (void)run_mcuboot_testsuite();
@@ -269,8 +265,6 @@ int crypto_hw_accelerator_init(void)
 
 int crypto_hw_accelerator_finish(void)
 {
-#if defined(MCUBOOT_USE_PSA_CRYPTO)
     mbedtls_psa_crypto_free();
-#endif /* MCUBOOT_USE_PSA_CRYPTO */
     return 0;
 }

--- a/bl2/ext/mcuboot/config/mcuboot_crypto_config.h
+++ b/bl2/ext/mcuboot/config/mcuboot_crypto_config.h
@@ -69,10 +69,8 @@
 #define PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY    1
 #endif
 
-#define PSA_WANT_ALG_ECB_NO_PADDING         1
-#define PSA_WANT_ALG_CTR                    1       /* TODO: condition? */
-
 #if defined(MCUBOOT_ENC_IMAGES)
+#define PSA_WANT_ALG_ECB_NO_PADDING         1
 #define PSA_WANT_ALG_CTR                    1
 #define PSA_WANT_KEY_TYPE_AES               1
 #endif
@@ -109,7 +107,10 @@
  */
 
 #define MBEDTLS_MD_C
+
+#if defined(MCUBOOT_ENC_IMAGES)
 #define MBEDTLS_NIST_KW_C
+#endif
 
  /** \} name SECTION: Cryptographic mechanism selection (extended API) */
 

--- a/bl2/ext/mcuboot/include/mcuboot_config/mcuboot_config.h.in
+++ b/bl2/ext/mcuboot/include/mcuboot_config/mcuboot_config.h.in
@@ -79,17 +79,6 @@ extern "C" {
 #define MCUBOOT_BOOT_MAX_ALIGN @MCUBOOT_BOOT_MAX_ALIGN@
 
 /*
- * Cryptographic settings
- */
-/* MCUboot and TF-M also supports the usage of PSA Crypto API along with
- * Mbed TLS as the source of cryptographic primitives. However, the support for
- * MCUBOOT_USE_PSA_CRYPTO is still limited and it doesn't cover all the
- * crypto abstractions of MCUboot. For this reason it's allowed to have both
- * of them defined, in which case MCUBOOT_USE_PSA_CRYPTO will take precedence.
- */
-#define MCUBOOT_USE_MBED_TLS
-
-/*
  * Logging
  */
 #define MCUBOOT_HAVE_LOGGING    1

--- a/bl2/ext/mcuboot/mcuboot_default_config.cmake
+++ b/bl2/ext/mcuboot/mcuboot_default_config.cmake
@@ -42,7 +42,6 @@ set(MCUBOOT_ENCRYPT_RSA                 OFF         CACHE BOOL      "Use RSA-OAE
 set(MCUBOOT_ENCRYPT_KW                  OFF         CACHE BOOL      "Use AES-KW for encryption key wrapping")
 set(MCUBOOT_BOOTSTRAP                   OFF         CACHE BOOL      "Support initial state with empty primary slot and images installed from secondary slots")
 set(MCUBOOT_FIH_PROFILE                 OFF         CACHE STRING    "Fault injection hardening profile [OFF, LOW, MEDIUM, HIGH]")
-set(MCUBOOT_USE_PSA_CRYPTO              ON          CACHE BOOL      "The crypto abstraction layer must use PSA Crypto APIs")
 if(${MCUBOOT_UPGRADE_STRATEGY} STREQUAL DIRECT_XIP)
     set(MCUBOOT_DIRECT_XIP_REVERT       ON          CACHE BOOL      "Enable the revert mechanism in direct-xip mode")
 else()

--- a/bl2/ext/mcuboot/mcuboot_default_config.cmake
+++ b/bl2/ext/mcuboot/mcuboot_default_config.cmake
@@ -36,11 +36,11 @@ set_property(CACHE MCUBOOT_UPGRADE_STRATEGY PROPERTY STRINGS "OVERWRITE_ONLY;SWA
 set_property(CACHE MCUBOOT_ALIGN_VAL PROPERTY STRINGS "1;2;4;8;16;32")
 
 set(MCUBOOT_HW_ROLLBACK_PROT            ON          CACHE BOOL      "Enable security counter validation against non-volatile HW counters")
-set(MCUBOOT_ENC_IMAGES                  OFF         CACHE BOOL      "Enable encrypted image upgrade support")
+set(MCUBOOT_ENC_IMAGES                  OFF         CACHE BOOL      "Enable image encryption (AES)")
+set(MCUBOOT_ENC_KEY_LEN                 128         CACHE STRING    "Length of the AES key for encrypting images")
+set(MCUBOOT_ENCRYPT_RSA                 OFF         CACHE BOOL      "Use RSA-OAEP for encryption key wrapping")
+set(MCUBOOT_ENCRYPT_KW                  OFF         CACHE BOOL      "Use AES-KW for encryption key wrapping")
 set(MCUBOOT_BOOTSTRAP                   OFF         CACHE BOOL      "Support initial state with empty primary slot and images installed from secondary slots")
-set(MCUBOOT_ENCRYPT_RSA                 OFF         CACHE BOOL      "Use RSA for encrypted image upgrade support")
-set(MCUBOOT_ENCRYPT_KW                  OFF         CACHE BOOL      "Use AES-KW for encrypted images")
-set(MCUBOOT_ENCRYPT_AES                 ON          CACHE BOOL      "Enable AES encryption")
 set(MCUBOOT_FIH_PROFILE                 OFF         CACHE STRING    "Fault injection hardening profile [OFF, LOW, MEDIUM, HIGH]")
 set(MCUBOOT_USE_PSA_CRYPTO              ON          CACHE BOOL      "The crypto abstraction layer must use PSA Crypto APIs")
 if(${MCUBOOT_UPGRADE_STRATEGY} STREQUAL DIRECT_XIP)
@@ -86,7 +86,6 @@ set(MCUBOOT_SECURITY_COUNTER_S          1           CACHE STRING    "Security co
 set(MCUBOOT_SECURITY_COUNTER_NS         1           CACHE STRING    "Security counter for NS image. auto sets it to IMAGE_VERSION_NS")
 set(MCUBOOT_S_IMAGE_MIN_VER             0.0.0+0     CACHE STRING    "Minimum version of secure image required by the non-secure image for upgrade to this non-secure image. If MCUBOOT_IMAGE_NUMBER == 1 this option has no effect")
 set(MCUBOOT_NS_IMAGE_MIN_VER            0.0.0+0     CACHE STRING    "Minimum version of non-secure image required by the secure image for upgrade to this secure image. If MCUBOOT_IMAGE_NUMBER == 1 this option has no effect")
-set(MCUBOOT_ENC_KEY_LEN                 128         CACHE STRING    "Length of the AES key for encrypting images")
 
 set(MCUBOOT_PSA_CRYPTO_CONFIG_FILEPATH  "${CMAKE_SOURCE_DIR}/bl2/ext/mcuboot/config/mcuboot_crypto_config.h" CACHE FILEPATH "TF-PSA-Crypto config file to use with MCUboot")
 

--- a/config/check_config.cmake
+++ b/config/check_config.cmake
@@ -37,8 +37,6 @@ tfm_invalid_config(BL2 AND (NOT MCUBOOT_UPGRADE_STRATEGY STREQUAL "DIRECT_XIP" A
 # Maximum number of MCUBoot images supported by TF-M NV counters and ROTPKs
 tfm_invalid_config(MCUBOOT_IMAGE_NUMBER GREATER 9)
 
-# Since moving TF-PSA-Crypto Mbed TLS legacy APIs are not available anymore
-tfm_invalid_config(BL2 AND NOT MCUBOOT_USE_PSA_CRYPTO)
 tfm_invalid_config(MCUBOOT_SIGNATURE_TYPE STREQUAL "RSA-2048" AND MCUBOOT_BUILTIN_KEY)
 tfm_invalid_config(MCUBOOT_SIGNATURE_TYPE STREQUAL "RSA-3072" AND MCUBOOT_BUILTIN_KEY)
 

--- a/lib/ext/thin-psa-crypto-core/thin_psa_crypto_core.c
+++ b/lib/ext/thin-psa-crypto-core/thin_psa_crypto_core.c
@@ -1406,6 +1406,8 @@ EXTERNAL_PSA_API(psa_cipher_abort,
         (psa_cipher_operation_t *operation),
         operation)
 {
+#if defined(PSA_WANT_ALG_CTR) || \
+    defined(PSA_WANT_ALG_ECB_NO_PADDING)
     assert(operation != NULL);
 
     if (operation->id == 0) {
@@ -1422,8 +1424,14 @@ EXTERNAL_PSA_API(psa_cipher_abort,
     operation->iv_required = 0;
 
     FIH_RET(PSA_SUCCESS);
+#else
+    FATAL_ERR(PSA_ERROR_NOT_SUPPORTED);
+    FIH_RET(PSA_ERROR_NOT_SUPPORTED);
+#endif /* PSA_WANT_ALG_CTR || PSA_WANT_ALG_ECB_NO_PADDING */
 }
 
+#if defined(PSA_WANT_ALG_CTR) || \
+    defined(PSA_WANT_ALG_ECB_NO_PADDING)
 static psa_status_t psa_cipher_setup(psa_cipher_operation_t *operation,
                                      psa_key_id_t key,
                                      psa_algorithm_t alg,
@@ -1492,12 +1500,15 @@ static psa_status_t psa_cipher_setup(psa_cipher_operation_t *operation,
 
     return PSA_SUCCESS;
 }
+#endif /* PSA_WANT_ALG_CTR || PSA_WANT_ALG_ECB_NO_PADDING */
 
 EXTERNAL_PSA_API(psa_cipher_update,
         (psa_cipher_operation_t *operation, const uint8_t *input_external,
          size_t input_length, uint8_t *output_external, size_t output_size, size_t *output_length),
         operation, input_external, input_length, output_external, output_size, output_length)
 {
+#if defined(PSA_WANT_ALG_CTR) || \
+    defined(PSA_WANT_ALG_ECB_NO_PADDING)
     psa_status_t status;
 
     assert(operation != NULL);
@@ -1519,30 +1530,50 @@ EXTERNAL_PSA_API(psa_cipher_update,
     }
 
     FIH_RET(PSA_SUCCESS);
+#else
+    FATAL_ERR(PSA_ERROR_NOT_SUPPORTED);
+    FIH_RET(PSA_ERROR_NOT_SUPPORTED);
+#endif /* PSA_WANT_ALG_CTR || PSA_WANT_ALG_ECB_NO_PADDING */
 }
 
 EXTERNAL_PSA_API(psa_cipher_encrypt_setup,
         (psa_cipher_operation_t *operation, psa_key_id_t key, psa_algorithm_t alg),
         operation, key, alg)
 {
+#if defined(PSA_WANT_ALG_CTR) || \
+    defined(PSA_WANT_ALG_ECB_NO_PADDING)
     assert(operation != NULL);
 
     FIH_RET(psa_cipher_setup(operation, key, alg, MBEDTLS_ENCRYPT));
+
+#else
+    FATAL_ERR(PSA_ERROR_NOT_SUPPORTED);
+    FIH_RET(PSA_ERROR_NOT_SUPPORTED);
+#endif /* PSA_WANT_ALG_CTR || PSA_WANT_ALG_ECB_NO_PADDING */
 }
 
 EXTERNAL_PSA_API(psa_cipher_decrypt_setup,
         (psa_cipher_operation_t *operation, psa_key_id_t key, psa_algorithm_t alg),
         operation, key, alg)
 {
+#if defined(PSA_WANT_ALG_CTR) || \
+    defined(PSA_WANT_ALG_ECB_NO_PADDING)
     assert(operation != NULL);
 
     FIH_RET(psa_cipher_setup(operation, key, alg, MBEDTLS_DECRYPT));
+
+#else
+    FATAL_ERR(PSA_ERROR_NOT_SUPPORTED);
+    FIH_RET(PSA_ERROR_NOT_SUPPORTED);
+#endif /* PSA_WANT_ALG_CTR || PSA_WANT_ALG_ECB_NO_PADDING */
 }
 
 EXTERNAL_PSA_API(psa_cipher_set_iv,
         (psa_cipher_operation_t *operation, const uint8_t *iv_external, size_t iv_length),
         operation, iv_external, iv_length)
 {
+#if defined(PSA_WANT_ALG_CTR) || \
+    defined(PSA_WANT_ALG_ECB_NO_PADDING)
     psa_status_t status;
 
     assert(operation != NULL);
@@ -1563,6 +1594,10 @@ EXTERNAL_PSA_API(psa_cipher_set_iv,
     operation->iv_set = 1;
 
     FIH_RET(PSA_SUCCESS);
+#else
+    FATAL_ERR(PSA_ERROR_NOT_SUPPORTED);
+    FIH_RET(PSA_ERROR_NOT_SUPPORTED);
+#endif /* PSA_WANT_ALG_CTR || PSA_WANT_ALG_ECB_NO_PADDING */
 }
 
 EXTERNAL_PSA_API(psa_cipher_finish,
@@ -1570,6 +1605,8 @@ EXTERNAL_PSA_API(psa_cipher_finish,
          size_t output_size, size_t *output_length),
         operation, output_external, output_size, output_length)
 {
+#if defined(PSA_WANT_ALG_CTR) || \
+    defined(PSA_WANT_ALG_ECB_NO_PADDING)
     psa_status_t status;
 
     assert(operation != NULL);
@@ -1594,6 +1631,10 @@ EXTERNAL_PSA_API(psa_cipher_finish,
     }
 
     FIH_RET(PSA_SUCCESS);
+#else
+    FATAL_ERR(PSA_ERROR_NOT_SUPPORTED);
+    FIH_RET(PSA_ERROR_NOT_SUPPORTED);
+#endif /* PSA_WANT_ALG_CTR || PSA_WANT_ALG_ECB_NO_PADDING */
 }
 
 #if defined(MCUBOOT_ENC_IMAGES)

--- a/platform/ext/common/boot_hal_bl2.c
+++ b/platform/ext/common/boot_hal_bl2.c
@@ -19,9 +19,7 @@
 #include "tfm_boot_status.h"
 #include "tfm_boot_measurement.h"
 #endif /* TFM_MEASURED_BOOT_API */
-#if defined(MCUBOOT_USE_PSA_CRYPTO)
 #include "psa/crypto.h"
-#endif /* MCUBOOT_USE_PSA_CRYPTO */
 
 /* Flash device names must be specified by target */
 #ifdef FLASH_DEV_NAME
@@ -176,9 +174,7 @@ __WEAK void boot_platform_start_next_image(struct boot_arm_vector_table *vt)
     static struct boot_arm_vector_table *vt_cpy;
     int32_t result;
 
-#if defined(MCUBOOT_USE_PSA_CRYPTO)
     mbedtls_psa_crypto_free();
-#endif /* MCUBOOT_USE_PSA_CRYPTO */
 
 #ifdef FLASH_DEV_NAME
     result = FLASH_DEV_NAME.Uninitialize();

--- a/platform/ext/target/arm/rse/common/config.cmake
+++ b/platform/ext/target/arm/rse/common/config.cmake
@@ -130,9 +130,8 @@ set(MCUBOOT_VERSION                   "e2a6d0b"        CACHE STRING    "The vers
 set(MCUBOOT_PATCH_DIR                 ""               CACHE PATH      "Path to local folder which contains patches for MCUboot")
 set(MCUBOOT_IMAGE_NUMBER              4                CACHE STRING    "Number of images supported by MCUBoot")
 set(MCUBOOT_SIGNATURE_TYPE            "EC-P256"        CACHE STRING    "Algorithm to use for signature validation [RSA-2048, RSA-3072, EC-P256, EC-P384]")
-set(MCUBOOT_ENC_IMAGES                OFF              CACHE BOOL      "Enable image encryption")
-set(MCUBOOT_ENCRYPT_KW                OFF              CACHE BOOL      "Enable Key Wrapping encryption")
-set(MCUBOOT_ENCRYPT_AES               ON              CACHE BOOL      "Enable AES encryption")
+set(MCUBOOT_ENC_IMAGES                OFF              CACHE BOOL      "Enable image encryption (AES)")
+set(MCUBOOT_ENCRYPT_KW                OFF              CACHE BOOL      "Use AES-KW for encryption key wrapping")
 
 set(MCUBOOT_HW_KEY                    ON               CACHE BOOL      "Whether to embed the entire public key in the image metadata instead of the hash only")
 set(MCUBOOT_BUILTIN_KEY               OFF              CACHE BOOL      "Use builtin key(s) for validation, no public key data is embedded into the image metadata")

--- a/platform/ext/target/stm/b_u585i_iot02a/config.cmake
+++ b/platform/ext/target/stm/b_u585i_iot02a/config.cmake
@@ -16,8 +16,8 @@ set(MCUBOOT_UPGRADE_STRATEGY      "SWAP_USING_SCRATCH" CACHE STRING    "Upgrade 
 set(MCUBOOT_USE_PSA_CRYPTO                 ON          CACHE BOOL      "Enable the cryptographic abstraction layer to use PSA Crypto APIs")
 set(TFM_PARTITION_PLATFORM                 ON          CACHE BOOL      "Enable platform partition")
 set(MCUBOOT_BOOTSTRAP                      ON          CACHE BOOL      "Allow initial state with images in secondary slots(empty primary slots)")
-set(MCUBOOT_ENC_IMAGES                     OFF         CACHE BOOL      "Enable encrypted image upgrade support")
-set(MCUBOOT_ENCRYPT_RSA                    OFF         CACHE BOOL      "Use RSA for encrypted image upgrade support")
+set(MCUBOOT_ENC_IMAGES                     OFF         CACHE BOOL      "Enable image encryption (AES)")
+set(MCUBOOT_ENCRYPT_RSA                    OFF         CACHE BOOL      "Use RSA-OAEP for encryption key wrapping")
 set(MCUBOOT_DATA_SHARING                   ON          CACHE BOOL      "Enable Data Sharing")
 ################################## Dependencies ################################################################################################
 set(TFM_PARTITION_INTERNAL_TRUSTED_STORAGE ON          CACHE BOOL      "Enable Internal Trusted Storage partition")

--- a/platform/ext/target/stm/b_u585i_iot02a/config.cmake
+++ b/platform/ext/target/stm/b_u585i_iot02a/config.cmake
@@ -13,7 +13,6 @@ set(MCUBOOT_IMAGE_NUMBER                   2           CACHE STRING    "Whether 
 set(BL2_TRAILER_SIZE                       0x2000      CACHE STRING    "Trailer size")
 set(MCUBOOT_ALIGN_VAL                      16          CACHE STRING    "Align option to build image with imgtool")
 set(MCUBOOT_UPGRADE_STRATEGY      "SWAP_USING_SCRATCH" CACHE STRING    "Upgrade strategy for images")
-set(MCUBOOT_USE_PSA_CRYPTO                 ON          CACHE BOOL      "Enable the cryptographic abstraction layer to use PSA Crypto APIs")
 set(TFM_PARTITION_PLATFORM                 ON          CACHE BOOL      "Enable platform partition")
 set(MCUBOOT_BOOTSTRAP                      ON          CACHE BOOL      "Allow initial state with images in secondary slots(empty primary slots)")
 set(MCUBOOT_ENC_IMAGES                     OFF         CACHE BOOL      "Enable image encryption (AES)")

--- a/platform/ext/target/stm/nucleo_l552ze_q/config.cmake
+++ b/platform/ext/target/stm/nucleo_l552ze_q/config.cmake
@@ -12,7 +12,6 @@
 
 set(MCUBOOT_IMAGE_NUMBER                2           CACHE STRING    "Whether to combine S and NS into either 1 image, or sign each seperately")
 set(BL2_TRAILER_SIZE                    0x2000      CACHE STRING    "Trailer size")
-set(MCUBOOT_USE_PSA_CRYPTO              ON          CACHE BOOL      "Enable the cryptographic abstraction layer to use PSA Crypto APIs")
 
 ################################## Dependencies ################################
 set(CRYPTO_HW_ACCELERATOR               ON          CACHE BOOL      "Whether to enable the crypto hardware accelerator on supported platforms")

--- a/platform/ext/target/stm/nucleo_u3c5zi_q/config.cmake
+++ b/platform/ext/target/stm/nucleo_u3c5zi_q/config.cmake
@@ -42,5 +42,4 @@ set(FWU_DEVICE_CONFIG_FILE                 ""          CACHE STRING    "The devi
 set(MCUBOOT_DATA_SHARING                  ON           CACHE BOOL      "Add sharing of application specific data using the same shared data area as for the measured boot")
 #set(TEST_S_FWU                            ON)
 #set(TEST_NS_FWU                           ON)
-set(MCUBOOT_USE_PSA_CRYPTO            ON               CACHE BOOL      "Enable the cryptographic abstraction layer to use PSA Crypto APIs")
 #set(MCUBOOT_PATH      "set mcuboot PATH"  CACHE PATH      "Path to MCUboot (or DOWNLOAD to fetch automatically")

--- a/platform/ext/target/stm/stm32h573i_dk/config.cmake
+++ b/platform/ext/target/stm/stm32h573i_dk/config.cmake
@@ -12,7 +12,6 @@ set(BL2_HEADER_SIZE                        0x400       CACHE STRING    "Header s
 set(BL2_TRAILER_SIZE                       0x2000      CACHE STRING    "Trailer size")
 set(MCUBOOT_ALIGN_VAL                      16          CACHE STRING    "Align option to build image with imgtool")
 set(MCUBOOT_UPGRADE_STRATEGY        "SWAP_USING_SCRATCH"      CACHE STRING    "Upgrade strategy for images")
-set(MCUBOOT_USE_PSA_CRYPTO                 ON          CACHE BOOL      "Enable the cryptographic abstraction layer to use PSA Crypto APIs")
 set(TFM_PARTITION_PLATFORM                 ON          CACHE BOOL      "Enable platform partition")
 set(MCUBOOT_DATA_SHARING                   ON          CACHE BOOL      "Enable Data Sharing")
 set(MCUBOOT_BOOTSTRAP                      ON          CACHE BOOL      "Allow initial state with images in secondary slots(empty primary slots)")

--- a/platform/ext/target/stm/stm32h573i_dk/config.cmake
+++ b/platform/ext/target/stm/stm32h573i_dk/config.cmake
@@ -16,8 +16,8 @@ set(MCUBOOT_USE_PSA_CRYPTO                 ON          CACHE BOOL      "Enable t
 set(TFM_PARTITION_PLATFORM                 ON          CACHE BOOL      "Enable platform partition")
 set(MCUBOOT_DATA_SHARING                   ON          CACHE BOOL      "Enable Data Sharing")
 set(MCUBOOT_BOOTSTRAP                      ON          CACHE BOOL      "Allow initial state with images in secondary slots(empty primary slots)")
-set(MCUBOOT_ENC_IMAGES                     OFF          CACHE BOOL      "Enable encrypted image upgrade support")
-set(MCUBOOT_ENCRYPT_RSA                    OFF          CACHE BOOL      "Use RSA for encrypted image upgrade support")
+set(MCUBOOT_ENC_IMAGES                     OFF          CACHE BOOL     "Enable image encryption (AES)")
+set(MCUBOOT_ENCRYPT_RSA                    OFF          CACHE BOOL     "Use RSA-OAEP for encryption key wrapping")
 ################################## Dependencies ########################################
 set(TFM_PARTITION_INTERNAL_TRUSTED_STORAGE ON          CACHE BOOL      "Enable Internal Trusted Storage partition")
 set(TFM_PARTITION_CRYPTO                   ON          CACHE BOOL      "Enable Crypto partition")

--- a/platform/ext/target/stm/stm32l562e_dk/config.cmake
+++ b/platform/ext/target/stm/stm32l562e_dk/config.cmake
@@ -12,7 +12,6 @@
 
 set(MCUBOOT_IMAGE_NUMBER                2           CACHE STRING    "Whether to combine S and NS into either 1 image, or sign each seperately")
 set(BL2_TRAILER_SIZE                    0x2000      CACHE STRING    "Trailer size")
-set(MCUBOOT_USE_PSA_CRYPTO              ON          CACHE BOOL      "Enable the cryptographic abstraction layer to use PSA Crypto APIs")
 
 ################################## Dependencies ################################
 set(CRYPTO_HW_ACCELERATOR               ON          CACHE BOOL      "Whether to enable the crypto hardware accelerator on supported platforms")

--- a/platform/ext/target/stm/stm32wba65i_dk/config.cmake
+++ b/platform/ext/target/stm/stm32wba65i_dk/config.cmake
@@ -40,6 +40,4 @@ set(TFM_CONFIG_FWU_MAX_WRITE_SIZE          1024        CACHE STRING    "The maxi
 set(TFM_CONFIG_FWU_MAX_MANIFEST_SIZE       0           CACHE STRING    "The maximum permitted size for manifest in psa_fwu_start(), in bytes.")
 set(FWU_DEVICE_CONFIG_FILE                 ""          CACHE STRING    "The device configuration file for Firmware Update partition")
 set(MCUBOOT_DATA_SHARING                  ON           CACHE BOOL      "Add sharing of application specific data using the same shared data area as for the measured boot")
-set(MCUBOOT_USE_PSA_CRYPTO                ON           CACHE BOOL      "Enable the cryptographic abstraction layer to use PSA Crypto APIs")
 #set(MCUBOOT_PATH      "set mcuboot PATH here if used"  CACHE PATH      "Path to MCUboot (or DOWNLOAD to fetch automatically")
-


### PR DESCRIPTION
This PR cherry-picks upstream patches to fix image encryption support for BL2 (`MCUBOOT_ENC_IMAGES`).

TF-M v2.3.0 always defines `MCUBOOT_USE_PSA_CRYPTO` while it was missed to remove the conflicting option `MCUBOOT_USE_MBED_TLS` before the release, which causes mcuboot to fail to compile: https://github.com/mcu-tools/mcuboot/blob/79d374c1a893aec7af4217428626a7745bb28d49/boot/bootutil/include/bootutil/crypto/aes_ctr.h#L16-L21

In addition, the path for `nist_kw.c` was wrong and resulted in compile failures when compiling with `MCUBOOT_ENCRYPT_KW`.