### PR TITLE
[zep fromtree] platform: nordic_nrf: Allow reading FICR in nRF91

### DIFF
--- a/platform/ext/target/nordic_nrf/common/nrf91/memory_service_ranges/tfm_platform_user_memory_ranges.h
+++ b/platform/ext/target/nordic_nrf/common/nrf91/memory_service_ranges/tfm_platform_user_memory_ranges.h
@@ -11,9 +11,11 @@
 
 #include <nrfx.h>
 
+#define FICR_INFO_ADDR          (NRF_FICR_S_BASE + offsetof(NRF_FICR_Type, INFO))
+#define FICR_INFO_SIZE          (sizeof(FICR_INFO_Type))
 
 static const struct tfm_read_service_range ranges[] = {
-	{ .start = 0xFFFFFFFF, .size = 0x0},
+	{ .start = FICR_INFO_ADDR, .size = FICR_INFO_SIZE },
 };
 
 static const struct tfm_write32_service_address tfm_write32_service_addresses[] = {


### PR DESCRIPTION
In the nRF91 series the FICR is configured as secure and thus it cannot be read directly from the NS app. Add the FICR info addresses to the memory read service so that they can be read by the NS.

Change-Id: I8e85bb830a35922971275cbd16f9055d4552e2a5