### PR TITLE
[zep fromtree] platform: nordic_nrf: nrf7120: fix LMAC boot address r…

### DIFF
--- a/platform/ext/target/nordic_nrf/common/nrf7120/nrf71_init.c
+++ b/platform/ext/target/nordic_nrf/common/nrf7120/nrf71_init.c
@@ -40,7 +40,7 @@ void __attribute__((weak)) wifi_setup(void){
 	/* Kickstart the LMAC processor */
 	NRF_WIFICORE_LRCCONF_LRC0->POWERON =
 		(LRCCONF_POWERON_MAIN_AlwaysOn << LRCCONF_POWERON_MAIN_Pos);
-	NRF_WIFICORE_LMAC_VPR->INITPC = NRF_WICR->RESERVED[0];
+	NRF_WIFICORE_LMAC_VPR->INITPC = (uint32_t)(uintptr_t)NRF_WICR->FIRMWARE.LMACINITPC;
 	NRF_WIFICORE_LMAC_VPR->CPURUN = (VPR_CPURUN_EN_Running << VPR_CPURUN_EN_Pos);
 }
 #endif


### PR DESCRIPTION
…ead from WICR

nrfx 4.5.0 restructured NRF_WICR_Type. The Wi-Fi core boot address previously sat inside an anonymous reserved block, so wifi_setup() read it as NRF_WICR->RESERVED[0], which resolved to WICR + 0x000.

The new layout names that region as the FIRMWARE group:

  __IOM NRF_WICR_FIRMWARE_Type  FIRMWARE;    /* 0x000 */
  __IM  uint32_t                RESERVED[28];
  __IOM NRF_WICR_IPCCONFIG_Type IPCCONFIG;   /* 0x080 */

FIRMWARE occupies 0x000..0x00F, so RESERVED[0] silently moved from 0x000 to 0x010. The code still compiles, but now reads an unprogrammed word instead of the LMAC boot address. The LMAC VPR is started at a bogus PC, so the Wi-Fi core never boots and the IPC endpoint never binds, leaving the non-secure Wi-Fi driver to time out during device init.

Read the named FIRMWARE.LMACINITPC field instead, so the boot address is picked up from the same offset it is programmed at.

Upstream review:
https://review.trustedfirmware.org/c/TF-M/trusted-firmware-m/+/53253

Change-Id: Idb24e926d8396a62c823fff16dfc562a5247a243

(cherry picked from commit ae070bf472f6912be8dfdbed5a6c61ded3e9a5b1)