### PR TITLE
[zep fromtree] platform: nordic_nrf: align RAM control Kconfig guard

### DIFF
--- a/platform/ext/target/nordic_nrf/common/core/services/include/tfm_ioctl_core_api.h
+++ b/platform/ext/target/nordic_nrf/common/core/services/include/tfm_ioctl_core_api.h
@@ -100,7 +100,7 @@ struct tfm_mramc_set_wen_service_args_t {
 };
 #endif
 
-#if defined(CONFIG_NRF_TFM_RAM_CTRL_SERVICE) || defined(TFM_NRF_RAM_CTRL_SERVICE)
+#if defined(CONFIG_SOC_SERIES_NRF71_TFM_RAM_CTRL_SERVICE) || defined(TFM_NRF_RAM_CTRL_SERVICE)
 /** @brief RAM-control operation selector. */
 enum tfm_ram_ctrl_op {
 	/** System ON power (MEMCONF CONTROL), applied immediately. */
@@ -210,7 +210,7 @@ enum tfm_platform_err_t tfm_platform_mramc_init(void);
 enum tfm_platform_err_t tfm_platform_mramc_set_wen(uint32_t write_mode);
 #endif /* SOC_NRF7120_TFM_MRAMC_SERVICE */
 
-#if defined(CONFIG_NRF_TFM_RAM_CTRL_SERVICE)
+#if defined(CONFIG_SOC_SERIES_NRF71_TFM_RAM_CTRL_SERVICE)
 /**
  * @brief Power up/down a non-secure RAM range in System ON (MEMCONF CONTROL).
  *

--- a/platform/ext/target/nordic_nrf/common/core/services/src/tfm_ioctl_core_ns_api.c
+++ b/platform/ext/target/nordic_nrf/common/core/services/src/tfm_ioctl_core_ns_api.c
@@ -118,7 +118,7 @@ enum tfm_platform_err_t tfm_platform_mramc_set_wen(uint32_t write_mode)
 }
 #endif
 
-#if defined(CONFIG_NRF_TFM_RAM_CTRL_SERVICE)
+#if defined(CONFIG_SOC_SERIES_NRF71_TFM_RAM_CTRL_SERVICE)
 static enum tfm_platform_err_t ram_ctrl_set(uint32_t op, uint32_t addr, uint32_t len, bool on)
 {
 	psa_invec in_vec;


### PR DESCRIPTION
Rename the Zephyr-facing RAM control service guard to follow the SoC-series Kconfig naming convention.

Change-Id: I477106a42883b54e1a128a99daaa2cbd1acdaa03

(cherry picked from commit 3afad94183e4c99cbdf1f8fd83ecf076076546c7)