### PR TITLE
[zep fromtree] BL2: Add watchdog support

### DIFF
--- a/bl2/CMakeLists.txt
+++ b/bl2/CMakeLists.txt
@@ -142,6 +142,7 @@ endif()
 add_executable(bl2
     src/flash_map.c
     src/crt_assert.c
+    src/watchdog.c
     $<$<C_COMPILER_ID:GNU,Clang>:
         ${CMAKE_SOURCE_DIR}/secure_fw/partitions/lib/runtime/crt_start.c
         ${CMAKE_SOURCE_DIR}/secure_fw/partitions/lib/runtime/crt_memcmp.c

--- a/bl2/ext/mcuboot/include/mcuboot_config/mcuboot_config.h.in
+++ b/bl2/ext/mcuboot/include/mcuboot_config/mcuboot_config.h.in
@@ -88,10 +88,8 @@ extern "C" {
 /*
  * Watchdog feeding
  */
-#define MCUBOOT_WATCHDOG_FEED()     \
-    do {                            \
-        /* Do nothing. */           \
-    } while (0)
+extern void mcuboot_watchdog_feed(void);
+#define MCUBOOT_WATCHDOG_FEED() mcuboot_watchdog_feed()
 
 #ifdef __cplusplus
 }

--- a/bl2/src/watchdog.c
+++ b/bl2/src/watchdog.c
@@ -1,0 +1,15 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: Copyright The TrustedFirmware-M Contributors
+ */
+
+#include "cmsis_compiler.h"
+
+/*
+ * This is a stub implementation.
+ * Platforms can supply their own implementation to feed
+ * a watchdog during boot.
+ */
+__WEAK void mcuboot_watchdog_feed(void)
+{
+}


### PR DESCRIPTION
Cherry-pick watchdog support for BL2 from https://review.trustedfirmware.org/c/TF-M/trusted-firmware-m/+/53338.