### PR TITLE
[zep fromtree] platform: stm/adi: fix builds without Crypto partition

### DIFF
--- a/platform/ext/target/adi/max32657/accelerator/CMakeLists.txt
+++ b/platform/ext/target/adi/max32657/accelerator/CMakeLists.txt
@@ -9,6 +9,11 @@
 
 ############################ Crypto Service ####################################
 
+target_include_directories(platform_s
+    PUBLIC
+        ${PLATFORM_DIR}/ext/target/${TFM_PLATFORM}/accelerator/include
+)
+
 if(TFM_PARTITION_CRYPTO)
     target_sources(crypto_service_crypto_hw
         PUBLIC
@@ -24,11 +29,6 @@ if(TFM_PARTITION_CRYPTO)
             ${PLATFORM_DIR}/ext/target/${TFM_PLATFORM}/accelerator/include
             ${HAL_ADI_PERIPH_INC_DIR}
             ${HAL_ADI_CMSIS_INC_DIR}
-    )
-
-    target_include_directories(platform_s
-        PUBLIC
-            ${PLATFORM_DIR}/ext/target/${TFM_PLATFORM}/accelerator/include
     )
 
     target_link_libraries(crypto_service_crypto_hw

--- a/platform/ext/target/stm/b_u585i_iot02a/accelerator/CMakeLists.txt
+++ b/platform/ext/target/stm/b_u585i_iot02a/accelerator/CMakeLists.txt
@@ -8,6 +8,11 @@
 
 ############################ Crypto Service ####################################
 
+target_include_directories(platform_s
+    PUBLIC
+        ${PLATFORM_DIR}/ext/target/${TFM_PLATFORM}/accelerator/include
+)
+
 if (TFM_PARTITION_CRYPTO)
     target_sources(crypto_service_crypto_hw
         PRIVATE
@@ -23,11 +28,6 @@ if (TFM_PARTITION_CRYPTO)
             ${PLATFORM_DIR}/ext/target/${TFM_PLATFORM}/include/
             ${PLATFORM_DIR}/ext/target/stm/common/stm32u5xx/hal/Inc/
             ${PLATFORM_DIR}/ext/target/stm/common/stm32u5xx/Device/Include/
-    )
-
-    target_include_directories(platform_s
-        PUBLIC
-            ${PLATFORM_DIR}/ext/target/${TFM_PLATFORM}/accelerator/include
     )
 
     target_link_libraries(crypto_service_crypto_hw

--- a/platform/ext/target/stm/nucleo_l552ze_q/accelerator/CMakeLists.txt
+++ b/platform/ext/target/stm/nucleo_l552ze_q/accelerator/CMakeLists.txt
@@ -8,6 +8,11 @@
 
 ############################ Crypto Service ####################################
 
+target_include_directories(platform_s
+    PUBLIC
+        ${PLATFORM_DIR}/ext/target/${TFM_PLATFORM}/accelerator/include
+)
+
 if(TFM_PARTITION_CRYPTO)
     target_sources(crypto_service_crypto_hw
         PRIVATE
@@ -31,11 +36,6 @@ if(TFM_PARTITION_CRYPTO)
             ${PLATFORM_DIR}/ext/target/stm/common/hal/Native_Driver/
             ${PLATFORM_DIR}/ext/target/stm/common/stm32l5xx/hal/Inc/
             ${PLATFORM_DIR}/ext/target/stm/common/stm32l5xx/Device/Include/
-    )
-
-    target_include_directories(platform_s
-        PUBLIC
-            ${PLATFORM_DIR}/ext/target/stm/common/hal/accelerator/include
     )
 
     target_link_libraries(crypto_service_crypto_hw

--- a/platform/ext/target/stm/nucleo_u3c5zi_q/accelerator/CMakeLists.txt
+++ b/platform/ext/target/stm/nucleo_u3c5zi_q/accelerator/CMakeLists.txt
@@ -8,6 +8,11 @@
 
 ############################ Crypto Service ####################################
 
+target_include_directories(platform_s
+    PUBLIC
+        ${PLATFORM_DIR}/ext/target/${TFM_PLATFORM}/accelerator/include
+)
+
 if (TFM_PARTITION_CRYPTO)
     target_sources(crypto_service_crypto_hw
         PRIVATE
@@ -23,11 +28,6 @@ if (TFM_PARTITION_CRYPTO)
             ${PLATFORM_DIR}/ext/target/${TFM_PLATFORM}/include/
             ${PLATFORM_DIR}/ext/target/stm/common/stm32u3xx/hal/Inc/
             ${PLATFORM_DIR}/ext/target/stm/common/stm32u3xx/Device/Include/
-    )
-
-    target_include_directories(platform_s
-        PUBLIC
-            ${PLATFORM_DIR}/ext/target/${TFM_PLATFORM}/accelerator/include
     )
 
     target_link_libraries(crypto_service_crypto_hw

--- a/platform/ext/target/stm/stm32h573i_dk/accelerator/CMakeLists.txt
+++ b/platform/ext/target/stm/stm32h573i_dk/accelerator/CMakeLists.txt
@@ -8,6 +8,11 @@
 
 ############################ Crypto Service ####################################
 
+target_include_directories(platform_s
+    PUBLIC
+        ${PLATFORM_DIR}/ext/target/${TFM_PLATFORM}/accelerator/include
+)
+
 if (TFM_PARTITION_CRYPTO)
     target_sources(crypto_service_crypto_hw
         PRIVATE
@@ -22,12 +27,7 @@ if (TFM_PARTITION_CRYPTO)
             ${PLATFORM_DIR}/ext/target/stm/common/hal/Native_Driver/
             ${PLATFORM_DIR}/ext/target/${TFM_PLATFORM}/include/
             ${PLATFORM_DIR}/ext/target/stm/common/stm32h5xx/hal/Inc/
-            ${PLATFORM_DIR}/ext/target/stm/common/stm32h5xx/Device/Include/	
-    )
-
-    target_include_directories(platform_s
-        PUBLIC
-            ${PLATFORM_DIR}/ext/target/${TFM_PLATFORM}/accelerator/include
+            ${PLATFORM_DIR}/ext/target/stm/common/stm32h5xx/Device/Include/
     )
 
     target_link_libraries(crypto_service_crypto_hw

--- a/platform/ext/target/stm/stm32l562e_dk/accelerator/CMakeLists.txt
+++ b/platform/ext/target/stm/stm32l562e_dk/accelerator/CMakeLists.txt
@@ -8,6 +8,11 @@
 
 ############################ Crypto Service ####################################
 
+target_include_directories(platform_s
+    PUBLIC
+        ${PLATFORM_DIR}/ext/target/${TFM_PLATFORM}/accelerator/include
+)
+
 if(TFM_PARTITION_CRYPTO)
     target_sources(crypto_service_crypto_hw
         PRIVATE
@@ -23,11 +28,6 @@ if(TFM_PARTITION_CRYPTO)
             ${PLATFORM_DIR}/ext/target/stm/common/hal/Native_Driver/
             ${PLATFORM_DIR}/ext/target/stm/common/stm32l5xx/hal/Inc/
             ${PLATFORM_DIR}/ext/target/stm/common/stm32l5xx/Device/Include/
-    )
-
-    target_include_directories(platform_s
-        PUBLIC
-            ${PLATFORM_DIR}/ext/target/stm/common/hal/accelerator/include
     )
 
     target_link_libraries(crypto_service_crypto_hw

--- a/platform/ext/target/stm/stm32wba65i_dk/accelerator/CMakeLists.txt
+++ b/platform/ext/target/stm/stm32wba65i_dk/accelerator/CMakeLists.txt
@@ -8,6 +8,11 @@
 
 ############################ Crypto Service ####################################
 
+target_include_directories(platform_s
+    PUBLIC
+        ${PLATFORM_DIR}/ext/target/${TFM_PLATFORM}/accelerator/include
+)
+
 if (TFM_PARTITION_CRYPTO)
     target_sources(crypto_service_crypto_hw
         PRIVATE
@@ -23,11 +28,6 @@ if (TFM_PARTITION_CRYPTO)
             ${PLATFORM_DIR}/ext/target/${TFM_PLATFORM}/include/
             ${PLATFORM_DIR}/ext/target/stm/common/stm32wbaxx/hal/Inc/
             ${PLATFORM_DIR}/ext/target/stm/common/stm32wbaxx/Device/Include/
-    )
-
-    target_include_directories(platform_s
-        PUBLIC
-            ${PLATFORM_DIR}/ext/target/${TFM_PLATFORM}/accelerator/include
     )
 
     target_link_libraries(crypto_service_crypto_hw


### PR DESCRIPTION
The affected platforms enable CRYPTO_HW_ACCELERATOR, which results in the TF_PSA_CRYPTO_CONFIG_FILE
(lib/ext/tf-psa-crypto/tfpsacrypto_config/crypto_config_default.h) to include tf_psa_crypto_accelerator_config.h.

However those platforms added the required include directory only when the Crypto partition was enabled.
Attempting to build would fail in platform/ext/common/provisioning.c which includes psa/crypto.h just to get the value of PSA_ECC_FAMILY_SECP_R1.

Add the include directory to the platform_s target also when the Crypto partition is disabled to fix this, and at the same time fix two of those paths which were erroneous.