### PR TITLE
Support for RSA encrypted images in BL2

### DIFF
--- a/bl2/CMakeLists.txt
+++ b/bl2/CMakeLists.txt
@@ -33,6 +33,8 @@ target_compile_definitions(bl2_crypto_config
         $<${is_ec_signature}:MCUBOOT_SIGN_EC${SIG_LEN}>
         $<$<BOOL:${MCUBOOT_IMAGE_BINDING}>:MCUBOOT_IMAGE_BINDING>
         $<$<BOOL:${MCUBOOT_ENC_IMAGES}>:MCUBOOT_ENC_IMAGES>
+        $<$<BOOL:${MCUBOOT_ENCRYPT_RSA}>:MCUBOOT_ENCRYPT_RSA>
+        $<$<BOOL:${MCUBOOT_ENCRYPT_KW}>:MCUBOOT_ENCRYPT_KW>
 )
 
 target_include_directories(bl2_crypto_config

--- a/bl2/ext/mcuboot/config/mcuboot_crypto_config.h
+++ b/bl2/ext/mcuboot/config/mcuboot_crypto_config.h
@@ -73,6 +73,11 @@
 #define PSA_WANT_ALG_ECB_NO_PADDING         1
 #define PSA_WANT_ALG_CTR                    1
 #define PSA_WANT_KEY_TYPE_AES               1
+#if defined(MCUBOOT_ENCRYPT_RSA)
+#define PSA_WANT_ALG_RSA_OAEP                 1
+#define PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_BASIC  1
+#define PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_IMPORT 1
+#endif
 #endif
 
 #ifdef CRYPTO_HW_ACCELERATOR_OTP_PROVISIONING

--- a/bl2/ext/mcuboot/include/mcuboot_config/mcuboot_config.h.in
+++ b/bl2/ext/mcuboot/include/mcuboot_config/mcuboot_config.h.in
@@ -69,8 +69,12 @@ extern "C" {
 #define MAX_BOOT_RECORD_SZ  (132u)
 #endif /* MCUBOOT_SIGN_EC384 */
 
+#ifndef MCUBOOT_ENCRYPT_RSA
 #cmakedefine MCUBOOT_ENCRYPT_RSA
+#endif
+#ifndef MCUBOOT_ENCRYPT_KW
 #cmakedefine MCUBOOT_ENCRYPT_KW
+#endif
 
 #ifdef MCUBOOT_ENC_IMAGES
 #define MCUBOOT_AES_@MCUBOOT_ENC_KEY_LEN@

--- a/bl2/ext/mcuboot/mcuboot_default_config.cmake
+++ b/bl2/ext/mcuboot/mcuboot_default_config.cmake
@@ -36,6 +36,7 @@ set_property(CACHE MCUBOOT_UPGRADE_STRATEGY PROPERTY STRINGS "OVERWRITE_ONLY;SWA
 set_property(CACHE MCUBOOT_ALIGN_VAL PROPERTY STRINGS "1;2;4;8;16;32")
 
 set(MCUBOOT_HW_ROLLBACK_PROT            ON          CACHE BOOL      "Enable security counter validation against non-volatile HW counters")
+set(MCUBOOT_USE_PSA_CRYPTO              ON          CACHE BOOL      "Use PSA Crypto in MCUboot")
 set(MCUBOOT_ENC_IMAGES                  OFF         CACHE BOOL      "Enable image encryption (AES)")
 set(MCUBOOT_ENC_KEY_LEN                 128         CACHE STRING    "Length of the AES key for encrypting images")
 set(MCUBOOT_ENCRYPT_RSA                 OFF         CACHE BOOL      "Use RSA-OAEP for encryption key wrapping")

--- a/lib/ext/thin-psa-crypto-core/thin_psa_crypto_core.c
+++ b/lib/ext/thin-psa-crypto-core/thin_psa_crypto_core.c
@@ -1709,6 +1709,49 @@ psa_status_t psa_unwrap_key(const psa_key_attributes_t *attributes,
 
     return PSA_SUCCESS;
 }
+
+psa_status_t psa_asymmetric_decrypt(mbedtls_svc_key_id_t key,
+                                    psa_algorithm_t alg,
+                                    const uint8_t *input,
+                                    size_t input_length,
+                                    const uint8_t *salt,
+                                    size_t salt_length,
+                                    uint8_t *output,
+                                    size_t output_size,
+                                    size_t *output_length)
+{
+    psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
+    psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+    const uint8_t *key_buffer;
+    size_t key_buffer_size;
+
+    assert(output != NULL);
+    assert(output_length != NULL);
+
+    if (g_key_slot.is_valid && (g_key_slot.key_id == key)) {
+        status = psa_get_key_attributes(key, &attributes);
+        if (status != PSA_SUCCESS) {
+            FATAL_ERR(status);
+            return status;
+        }
+        key_buffer      = g_key_slot.buf;
+        key_buffer_size = g_key_slot.len;
+    } else {
+        FATAL_ERR(PSA_ERROR_INVALID_HANDLE);
+        return PSA_ERROR_INVALID_HANDLE;
+    }
+
+    status = psa_driver_wrapper_asymmetric_decrypt(
+                &attributes, key_buffer, key_buffer_size,
+                alg, input, input_length, salt, salt_length,
+                output, output_size, output_length);
+    if (status != PSA_SUCCESS) {
+        FATAL_ERR(status);
+        return status;
+    }
+
+    return PSA_SUCCESS;
+}
 #endif /* MCUBOOT_ENC_IMAGES */
 
 /* Set the key for a multipart authenticated encryption operation. */

--- a/lib/ext/thin-psa-crypto-core/thin_psa_crypto_core.c
+++ b/lib/ext/thin-psa-crypto-core/thin_psa_crypto_core.c
@@ -1056,14 +1056,30 @@ psa_status_t psa_import_key(const psa_key_attributes_t *attributes,
     assert(data_length > 0);
     assert(key != NULL);
 
-#if PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY == 1
+#if (PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY == 1) || (PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_IMPORT == 1)
     if (PSA_KEY_TYPE_IS_RSA(psa_get_key_type(attributes))) {
         /* This is either a 2048, 3072 or 4096 bit RSA key, hence the TLV must place
-        * the length at index (6,7) with a leading 0x00. The leading 0x00 is due to
-        * the fact that the MSB will always be set for RSA keys where the length is
-        * a multiple of 8 bits.
-        */
-        bits = PSA_BYTES_TO_BITS((((uint16_t)data[6]) << 8) | (uint16_t)data[7]) - 8;
+         * the modulus length with a leading 0x00. The leading 0x00 is due to the
+         * fact that the MSB will always be set for RSA keys where the length is a
+         * multiple of 8 bits.
+         *
+         * RSA public key (PKCS#1v2 RSAPublicKey):
+         *   SEQUENCE { INTEGER modulus, INTEGER publicExponent }
+         *   -> modulus length at index (6,7)
+         *
+         * RSA private key (PKCS#1v2 RSAPrivateKey):
+         *   SEQUENCE { INTEGER version, INTEGER modulus, INTEGER publicExponent, ... }
+         *   -> the fixed 3-byte version INTEGER (02 01 00) shifts the
+         *      modulus length to index (9,10)
+         */
+#if (PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_IMPORT == 1)
+        if (PSA_KEY_TYPE_IS_KEY_PAIR(psa_get_key_type(attributes))) {
+            bits = PSA_BYTES_TO_BITS((((uint16_t)data[9]) << 8) | (uint16_t)data[10]) - 8;
+        } else
+#endif /* PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_IMPORT == 1 */
+        {
+            bits = PSA_BYTES_TO_BITS((((uint16_t)data[6]) << 8) | (uint16_t)data[7]) - 8;
+        }
     }
 #elif PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY == 1
     if (PSA_KEY_TYPE_IS_ECC(psa_get_key_type(attributes))) {

--- a/platform/ext/target/arm/mps2/an521/CMakeLists.txt
+++ b/platform/ext/target/arm/mps2/an521/CMakeLists.txt
@@ -44,6 +44,7 @@ if(BL2)
             ${TF_PSA_CRYPTO_PATH}/drivers/builtin/src/cipher.c
             ${TF_PSA_CRYPTO_PATH}/drivers/builtin/src/cipher_wrap.c
             ${TF_PSA_CRYPTO_PATH}/drivers/builtin/src/psa_crypto_cipher.c
+            ${CMAKE_CURRENT_SOURCE_DIR}/bl2_pseudo_rng.c
     )
     target_include_directories(bl2
         PRIVATE

--- a/platform/ext/target/arm/mps2/an521/bl2_pseudo_rng.c
+++ b/platform/ext/target/arm/mps2/an521/bl2_pseudo_rng.c
@@ -1,0 +1,103 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The TrustedFirmware-M Contributors
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+/**
+ * \file bl2_pseudo_rng.c
+ *
+ * \brief Pseudo-RNG implementation for BL2 on MPS2/AN521, which has no
+ *        hardware TRNG. Provides random bytes required by MbedTLS RSA
+ *        blinding during private key operations (e.g. RSA-OAEP decrypt
+ *        for encrypted firmware images).
+ *
+ * \note  NOT suitable for production use. The AN521 is a development/QEMU
+ *        target with dummy provisioning; this PRNG is seeded from a fixed
+ *        value and is only meant to unblock RSA operations in BL2.
+ */
+
+#include <stdint.h>
+#include <string.h>
+#include "psa/crypto.h"
+
+#ifdef MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG
+/* xoshiro128 state */
+static uint32_t s[4];
+static int prng_initialised;
+
+static uint32_t rotl(const uint32_t x, int k)
+{
+    return (x << k) | (x >> (32 - k));
+}
+
+static uint32_t xoshiro128ss(void)
+{
+    const uint32_t result = rotl(s[1] * 5, 7) * 9;
+    const uint32_t t = s[1] << 9;
+
+    s[2] ^= s[0];
+    s[3] ^= s[1];
+    s[1] ^= s[2];
+    s[0] ^= s[3];
+
+    s[2] ^= t;
+    s[3] = rotl(s[3], 11);
+
+    return result;
+}
+
+static void prng_seed(void)
+{
+    static const uint8_t dummy_seed[16] = {
+        0x12, 0x13, 0x23, 0x34, 0x0a, 0x05, 0x89, 0x78,
+        0xa3, 0x66, 0x8c, 0x0d, 0x97, 0x55, 0x53, 0xca,
+    };
+
+    memcpy(s, dummy_seed, sizeof(s));
+
+    /* Warm up the generator */
+    for (int i = 0; i < 20; i++) {
+        (void)xoshiro128ss();
+    }
+
+    prng_initialised = 1;
+}
+
+/*
+ * Override the __weak stub in bl2/src/psa_stub_rng.c.
+ * This strong definition will be preferred by the linker.
+ */
+psa_status_t mbedtls_psa_external_get_random(
+    mbedtls_psa_external_random_context_t *context,
+    uint8_t *output, size_t output_size, size_t *output_length)
+{
+    (void)context;
+    size_t generated = 0;
+
+    if (!prng_initialised) {
+        prng_seed();
+    }
+
+    /* Generate 4 bytes at a time */
+    while (generated + 4 <= output_size) {
+        uint32_t r = xoshiro128ss();
+        memcpy(output + generated, &r, 4);
+        generated += 4;
+    }
+
+    /* Handle remaining bytes */
+    if (generated < output_size) {
+        uint32_t r = xoshiro128ss();
+        memcpy(output + generated, &r, output_size - generated);
+        generated = output_size;
+    }
+
+    if (output_length) {
+        *output_length = generated;
+    }
+
+    return PSA_SUCCESS;
+}
+#endif /* MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG */


### PR DESCRIPTION
Cherry-pick fixes required for support of RSA encrypted images in BL2.