### PR TITLE
Cherry-pick fixes for unused variable warnings

### DIFF
--- a/bl1/bl1_2/main.c
+++ b/bl1/bl1_2/main.c
@@ -120,13 +120,16 @@ static fih_ret validate_image_signature(struct bl1_2_image_t *img,
     uint8_t rotpk[TFM_BL1_2_ROTPK_MAX_SIZE];
     uint8_t *p_rotpk = rotpk;
     size_t rotpk_size;
+    enum tfm_bl1_key_type_t key_type;
 #if defined(TFM_BL1_2_EMBED_ROTPK_IN_IMAGE) || defined(TFM_MEASURED_BOOT_API)
     uint8_t rotpk_hash[TFM_BL1_2_ROTPK_HASH_MAX_SIZE];
     enum tfm_bl1_hash_alg_t key_hash_alg;
-#endif /* TFM_BL1_2_EMBED_ROTPK_IN_IMAGE || TFM_MEASURED_BOOT_API */
-    enum tfm_bl1_key_type_t key_type;
-    size_t dummy;
     psa_status_t status;
+#endif /* TFM_BL1_2_EMBED_ROTPK_IN_IMAGE || TFM_MEASURED_BOOT_API */
+
+#ifdef TFM_BL1_2_EMBED_ROTPK_IN_IMAGE
+    size_t dummy;
+#endif /* TFM_BL1_2_EMBED_ROTPK_IN_IMAGE */
 
     if (sig->sig_len > sizeof(sig->sig)) {
         ERROR("Invalid signature length\n");

--- a/lib/ext/thin-psa-crypto-core/thin_psa_crypto_core.c
+++ b/lib/ext/thin-psa-crypto-core/thin_psa_crypto_core.c
@@ -769,9 +769,13 @@ static psa_status_t psa_sp800_108_counter_cmac_input(psa_sp800_108_cmac_key_deri
         const size_t ctx_input_offset = (step == PSA_KEY_DERIVATION_INPUT_LABEL) ?
                                             SP800_108_INPUT_LABEL_OFFSET(kdf) :
                                             SP800_108_INPUT_CONTEXT_OFFSET(kdf);
+
+#ifndef NDEBUG
         const size_t ctx_input_max_size = (step == PSA_KEY_DERIVATION_INPUT_LABEL) ?
                                             SP800_108_LABEL_MAX_SIZE :
                                             SP800_108_CONTEXT_MAX_SIZE;
+#endif /* NDEBUG */
+
         size_t *ctx_input_length = (step == PSA_KEY_DERIVATION_INPUT_LABEL) ?
                                             &kdf->label_length :
                                             &kdf->context_length;


### PR DESCRIPTION
The following two commits fix some warnings seen on the majority of tests when run on Corstone 320 non-secure FVP. These tests are currently disabled on Zephyr but in order to take steps toward improving test coverage, we should fix the warnings so CI can pass with the tests enabled.