### PR TITLE
Cherry-pick implementation of __assert_no_args in platform/ext/common

### DIFF
--- a/platform/ext/common/tfm_assert.c
+++ b/platform/ext/common/tfm_assert.c
@@ -32,3 +32,16 @@ void __assert_puts(const char *msg)
     __builtin_unreachable();
 }
 #endif /* __ARMCC_VERSION */
+
+/* The picolibc <assert.h> defines assert() as a call to __assert_no_args() when
+ * NDEBUG and ASSERT_VERBOSE are not defined.
+ */
+void __assert_no_args(void)
+{
+    if (stdio_is_initialized()) {
+        ERROR("Assertion failed\n");
+    }
+
+    FIH_PANIC;
+    __builtin_unreachable();
+}


### PR DESCRIPTION
The lack of this function causes build errors on the `buildsystem.debug.build` test on non-secure Arm FVPs, since this test enables full assertions.