### PR TITLE
platform: nordic_nrf: nrf7120 init signature

### DIFF
--- a/platform/ext/target/nordic_nrf/common/core/target_cfg_71.c
+++ b/platform/ext/target/nordic_nrf/common/core/target_cfg_71.c
@@ -51,7 +51,7 @@
  * from Zephyr. This function does not have a header file so we
  * declare its prototype here.
  */
-int soc_early_init_hook(void);
+int nordicsemi_nrf71_init(void);
 
 extern const struct memory_region_limits memory_regions;
 
@@ -533,7 +533,7 @@ enum tfm_plat_err_t spu_periph_init_cfg(void)
 	}
 
 	/* SOC configuration from Zephyr's soc.c. */
-	int soc_err = soc_early_init_hook();
+	int soc_err = nordicsemi_nrf71_init();
 	if (soc_err) {
 		return TFM_PLAT_ERR_SYSTEM_ERR;
 	}

--- a/platform/ext/target/nordic_nrf/common/nrf71/nrf71_init.c
+++ b/platform/ext/target/nordic_nrf/common/nrf71/nrf71_init.c
@@ -43,8 +43,8 @@ void __attribute__((weak)) wifi_setup(void){
 }
 #endif
 
-int soc_early_init_hook(void){
-    nrfx_ram_ctrl_retention_enable_all_set(false);
+int nordicsemi_nrf71_init(void){
+	nrfx_ram_ctrl_retention_enable_all_set(false);
 
 #if defined (CONFIG_SOC_NRF7120_WICR_SETUP)
 	if (wicr_setup() != 0) {


### PR DESCRIPTION
Cherry-pick of merged TF-M Gerrit change:
https://review.trustedfirmware.org/c/TF-M/trusted-firmware-m/+/54179

Original commit:
a8b112afcdfa2d865f091a690dbe9da42c1098b2

This keeps Zephyr's `zephyr_tf-m_v2.3.1` branch aligned with the upstream TF-M fix.

Made with [Cursor](https://cursor.com)